### PR TITLE
Fix Inverter page blank when dashboard endpoint fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.2] - 2026-02-27
+
+### Fixed
+
+- Inverter page no longer shows blank/zero data when the dashboard endpoint fails. Changed `Promise.all` to `Promise.allSettled` so each API fetch succeeds or fails independently. A failing `/api/dashboard` (e.g. when no optimization schedule exists) no longer discards successful results from inverter status, schedule, and battery settings endpoints.
+
 ## [6.1.1] - 2026-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2026-02-27
+
+### Fixed
+
+- `get_tomorrow_prices()` now catches `PriceDataUnavailableError` in addition to `ValueError`, so the "return empty list if not yet available" fallback actually works for Octopus Energy.
+- Octopus Energy rate validation accepts 46-48 rates instead of requiring exactly 48. Octopus publishes rates incrementally and the last couple of half-hours may arrive slightly later.
+
+## [6.1.0] - 2026-02-27
+
+### Added
+
+- Octopus Energy Agile tariff support as a new price source alongside Nordpool. Fetches import and export rates from HA event entities at 30-minute resolution with VAT-inclusive GBP/kWh prices.
+- `price_provider` configuration field to select between `nordpool`, `nordpool_official`, and `octopus` price sources.
+- Separate import and export rate entities for Octopus Energy, allowing direct sell price data instead of calculated fallback.
+- `period_duration_hours` on `PriceSource` to support different rate resolutions (15-min Nordpool, 30-min Octopus).
+- `get_sell_prices_for_date()` on `PriceSource` for sources that provide direct export/sell rates.
+- Documentation for Octopus Energy setup in README, Installation Guide, and User Guide.
+
 ## [6.0.6] - 2026-02-26
 
 ### Fixed

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,7 +6,7 @@ Complete guide for installing and configuring BESS Battery Manager for Home Assi
 
 - Home Assistant OS, Container, or Supervised
 - Growatt battery system with Home Assistant integration
-- Nordpool integration configured
+- Electricity price integration: **Nordpool** (Nordic markets) or **Octopus Energy** (UK market)
 
 ## Step 1: Install the Add-on
 
@@ -106,11 +106,25 @@ home:
   safety_margin_factor: 0.95        # Safety margin (95%)
 
 electricity_price:
-  area: "SE4"                       # Nordpool area
+  area: "SE4"                       # Nordpool area (or "UK" for Octopus)
   markup_rate: 0.08                 # Markup (per kWh, in your currency)
   vat_multiplier: 1.25              # VAT (1.25 = 25%)
   additional_costs: 1.03            # Additional costs (per kWh)
   tax_reduction: 0.6518             # Tax reduction for sold energy (per kWh)
+
+# Price provider selection (choose one)
+nordpool:
+  price_provider: "nordpool"        # "nordpool", "nordpool_official", or "octopus"
+  use_official_integration: false   # Set true for official HA Nordpool integration
+  config_entry_id: ""               # Required when use_official_integration is true
+
+# Octopus Energy configuration (only needed when price_provider is "octopus")
+# See "Octopus Energy Setup" section below for details
+octopus:
+  import_today_entity: ""
+  import_tomorrow_entity: ""
+  export_today_entity: ""
+  export_tomorrow_entity: ""
 
 sensors:
   # Battery sensors (required)
@@ -132,7 +146,7 @@ sensors:
   # Consumption forecast (required)
   48h_avg_grid_import: "sensor.48h_average_grid_import_power"  # From Step 2
 
-  # Price sensors (required)
+  # Price sensors (required for Nordpool, not needed for Octopus)
   nordpool_kwh_today: "sensor.nordpool_kwh_your_area"
   nordpool_kwh_tomorrow: "sensor.nordpool_kwh_your_area"
 
@@ -156,6 +170,36 @@ sensors:
   # lifetime_export_to_grid: "sensor.your_lifetime_export_to_grid"
   # ev_energy_meter: "sensor.your_ev_energy_meter"
 ```
+
+### Octopus Energy Setup
+
+If you're using Octopus Energy (UK), set `price_provider: "octopus"` and configure the entity IDs.
+
+**1. Find your entity IDs** in Developer Tools > States, search for `octopus_energy_electricity`:
+
+```yaml
+octopus:
+  import_today_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_current_day_rates"
+  import_tomorrow_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_next_day_rates"
+  export_today_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_export_current_day_rates"
+  export_tomorrow_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_export_next_day_rates"
+```
+
+**2. Adjust electricity_price settings** - Octopus prices are already VAT-inclusive in GBP/kWh:
+
+```yaml
+home:
+  currency: "GBP"
+
+electricity_price:
+  area: "UK"
+  markup_rate: 0.0
+  vat_multiplier: 1.0
+  additional_costs: 0.0
+  tax_reduction: 0.0           # Adjust if you receive SEG payments
+```
+
+**3. Set cycle_cost and min_action_profit_threshold in GBP** (see notes below).
 
 ### ⚠️ Important Configuration Notes
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Intelligent Battery Energy Storage System (BESS) management and optimization for
 
 ## Overview
 
-The BESS Battery Manager is a sophisticated Home Assistant add-on that automatically optimizes Growatt inverter battery storage systems using dynamic programming algorithms and Nordic electricity market pricing. It continuously analyzes published electricity prices, solar production forecasts, and consumption predictions to determine optimal charge/discharge schedules that minimize your electricity costs.
+The BESS Battery Manager is a sophisticated Home Assistant add-on that automatically optimizes Growatt inverter battery storage systems using dynamic programming algorithms and electricity market pricing. It continuously analyzes published electricity prices, solar production forecasts, and consumption predictions to determine optimal charge/discharge schedules that minimize your electricity costs.
 
-The system requires the Growatt, Nordpool, and solar forecast (e.g., Solcast) Home Assistant integrations to function, and optionally uses InfluxDB for historical data storage. Unlike simple timer-based systems, BESS Manager makes intelligent decisions by weighing multiple factors: current battery state, published hourly electricity prices, solar weather forecasts, consumption estimates, and battery degradation costs. The system updates its optimization strategy every hour as new sensor data becomes available, ensuring your battery always operates in the most economically beneficial way while respecting technical constraints like charge rates and depth-of-discharge limits.
+The system requires the Growatt, a price source (Nordpool or Octopus Energy), and solar forecast (e.g., Solcast) Home Assistant integrations to function, and optionally uses InfluxDB for historical data storage. Unlike simple timer-based systems, BESS Manager makes intelligent decisions by weighing multiple factors: current battery state, published electricity prices, solar weather forecasts, consumption estimates, and battery degradation costs. The system updates its optimization strategy every hour as new sensor data becomes available, ensuring your battery always operates in the most economically beneficial way while respecting technical constraints like charge rates and depth-of-discharge limits.
 
 ## Key Capabilities
 
 **Dynamic Programming Optimization**: Solves 24-hour battery scheduling as an optimization problem, considering electricity prices, solar forecasts, consumption patterns, and battery constraints to find the globally optimal charge/discharge schedule.
 
-**Nordpool Market Integration**: Automatically retrieves electricity prices from Nordic power markets to be used by optimization algorithm.
+**Electricity Market Integration**: Supports Nordpool (Nordic markets, 15-min resolution) and Octopus Energy Agile tariff (UK market, 30-min resolution with separate import/export rates).
 
 **Battery Wear Economics**: Incorporates battery degradation costs (cycle cost) into optimization calculations to balance immediate savings against long-term battery life.
 
@@ -48,7 +48,7 @@ Tested with MIN/TLX inverters
 
 ### Required Integrations
 
-- 📊 **Nordpool** integration for electricity prices
+- 📊 **Nordpool** or **Octopus Energy** integration for electricity prices
 - 🏠 **Growatt** integration for battery control and energy monitoring
 - ☀️ **Solar forecast** integration (e.g., Solcast) for production predictions
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -174,8 +174,8 @@ The logs show:
 
 **Solutions**:
 
-- Check electricity price sensor is working
-- Verify price spread is significant (>0.50 SEK/kWh difference)
+- Check electricity price integration is working (Nordpool or Octopus Energy)
+- Verify price spread is significant enough to justify battery wear
 - Wait for price volatility periods
 
 ### "Savings are negative"
@@ -235,8 +235,8 @@ The logs show:
 
 ### Price Settings
 
-- **Area**: Must match your actual Nordpool pricing area
-- **Additional Costs**: Include all taxes, fees, and markup for accurate calculations
+- **Area**: Must match your pricing area (Nordpool area code, or "UK" for Octopus)
+- **Additional Costs**: Include all taxes, fees, and markup for accurate calculations (set to 0 for Octopus as prices are VAT-inclusive)
 
 ### Consumption Prediction
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -128,10 +128,11 @@ class BESSController:
             logger.info("Enabling test mode - hardware writes will be simulated")
         self.ha_controller.set_test_mode(test_mode)
 
-        # Extract nordpool configuration
+        # Extract nordpool and octopus configuration
         nordpool_config = options.get("nordpool", {})
+        nordpool_config["octopus"] = options.get("octopus", {})
 
-        # Create Battery System Manager with nordpool configuration
+        # Create Battery System Manager with price provider configuration
         # Let the system manager choose the appropriate price source
         self.system = BatterySystemManager(
             self.ha_controller,

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.0.6"
+version: "6.1.0"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.1.0"
+version: "6.1.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -47,8 +47,14 @@ options:
     additional_costs: 1.03           # Additional costs per kWh in your currency (e.g. SE: 28.90 öre överföringsavgift + 53.50 öre energiskatt + moms)
     tax_reduction: 0.6518            # Tax reduction for sold energy in your currency (e.g. SE: 60 öre skattereduktion + 5.18 öre förlustersättning)
   nordpool:
+    price_provider: "nordpool"  # "nordpool" (legacy sensor), "nordpool_official", or "octopus"
     use_official_integration: true  # Set to true to use official HA Nord Pool integration
     config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888"  # Required when use_official_integration is true
+  octopus:
+    import_today_entity: ""       # HA entity for today's Octopus import rates
+    import_tomorrow_entity: ""    # HA entity for tomorrow's Octopus import rates
+    export_today_entity: ""       # HA entity for today's Octopus export rates
+    export_tomorrow_entity: ""    # HA entity for tomorrow's Octopus export rates
   growatt:
     device_id: "fbafceb07a1cc74c351ef4310fa430a0"  # Growatt device ID for TOU segment operations
   sensors:
@@ -116,8 +122,14 @@ schema:
     additional_costs: float
     tax_reduction: float
   nordpool:
+    price_provider: str
     use_official_integration: bool
     config_entry_id: str
+  octopus:
+    import_today_entity: str
+    import_tomorrow_entity: str
+    export_today_entity: str
+    export_tomorrow_entity: str
   growatt:
     device_id: str
   sensors:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.1.1"
+version: "6.1.2"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -22,6 +22,7 @@ from .ha_api_controller import HomeAssistantAPIController
 from .health_check import run_system_health_checks
 from .historical_data_store import HistoricalDataStore
 from .models import DecisionData, EconomicData, PeriodData, infer_intent_from_flows
+from .octopus_energy_source import OctopusEnergySource
 from .power_monitor import HomePowerMonitor
 from .prediction_snapshot import PredictionSnapshotStore
 from .price_manager import HomeAssistantSource, PriceManager, PriceSource
@@ -89,29 +90,7 @@ class BatterySystemManager:
 
         # Initialize price manager
         if not price_source:
-            # Check if official Nordpool integration should be used
-            nordpool_config = getattr(self, "_nordpool_config", None)
-            if nordpool_config is None:
-                nordpool_config = {}
-            use_official = nordpool_config.get("use_official_integration", False)
-            config_entry_id = nordpool_config.get("config_entry_id")
-
-            if use_official and config_entry_id:
-                # Use official Home Assistant Nordpool integration
-                from .official_nordpool_source import OfficialNordpoolSource
-
-                price_source = OfficialNordpoolSource(
-                    controller,
-                    config_entry_id,
-                    vat_multiplier=self.price_settings.vat_multiplier,
-                )
-                logger.info("Using official Home Assistant Nordpool integration")
-            else:
-                # Use legacy sensor-based approach (current custom component)
-                price_source = HomeAssistantSource(
-                    controller, vat_multiplier=self.price_settings.vat_multiplier
-                )
-                logger.info("Using legacy/custom Nordpool sensor integration")
+            price_source = self._create_price_source(controller)
 
         self._price_manager = PriceManager(
             price_source=price_source,
@@ -146,6 +125,68 @@ class BatterySystemManager:
         if self._controller is None:
             raise RuntimeError("Controller not initialized - system not started")
         return self._controller
+
+    def _create_price_source(self, controller) -> PriceSource:
+        """Create the appropriate price source based on nordpool_config.
+
+        Supports three price providers:
+        - "nordpool" (default): Legacy custom Nordpool sensor component
+        - "nordpool_official": Official HA Nordpool integration via service calls
+        - "octopus": Octopus Energy Agile tariff via HA event entities
+
+        Args:
+            controller: HomeAssistantAPIController instance
+
+        Returns:
+            Configured PriceSource instance
+        """
+        nordpool_config = self._nordpool_config
+        price_provider = nordpool_config.get("price_provider", "nordpool")
+
+        if price_provider == "octopus":
+            octopus_config = nordpool_config.get("octopus", {})
+            price_source = OctopusEnergySource(
+                ha_controller=controller,
+                import_today_entity=octopus_config.get("import_today_entity", ""),
+                import_tomorrow_entity=octopus_config.get("import_tomorrow_entity", ""),
+                export_today_entity=octopus_config.get("export_today_entity", ""),
+                export_tomorrow_entity=octopus_config.get("export_tomorrow_entity", ""),
+            )
+            logger.info("Using Octopus Energy Agile tariff price source")
+            return price_source
+
+        if price_provider == "nordpool_official":
+            config_entry_id = nordpool_config.get("config_entry_id")
+            if config_entry_id:
+                from .official_nordpool_source import OfficialNordpoolSource
+
+                price_source = OfficialNordpoolSource(
+                    controller,
+                    config_entry_id,
+                    vat_multiplier=self.price_settings.vat_multiplier,
+                )
+                logger.info("Using official Home Assistant Nordpool integration")
+                return price_source
+
+        # Also support legacy use_official_integration flag for backward compatibility
+        use_official = nordpool_config.get("use_official_integration", False)
+        config_entry_id = nordpool_config.get("config_entry_id")
+        if use_official and config_entry_id:
+            from .official_nordpool_source import OfficialNordpoolSource
+
+            price_source = OfficialNordpoolSource(
+                controller,
+                config_entry_id,
+                vat_multiplier=self.price_settings.vat_multiplier,
+            )
+            logger.info("Using official Home Assistant Nordpool integration")
+            return price_source
+
+        # Default: legacy sensor-based Nordpool
+        logger.info("Using legacy/custom Nordpool sensor integration")
+        return HomeAssistantSource(
+            controller, vat_multiplier=self.price_settings.vat_multiplier
+        )
 
     def _sync_soc_limits(self) -> None:
         """
@@ -258,7 +299,7 @@ class BatterySystemManager:
             self._handle_special_cases(current_period, prepare_next_day)
 
             # Get price data
-            prices, _ = self._get_price_data(prepare_next_day)
+            prices, price_entries = self._get_price_data(prepare_next_day)
             if not prices:
                 logger.warning("Schedule update aborted: No price data available")
                 return False
@@ -283,11 +324,12 @@ class BatterySystemManager:
 
             optimization_period, optimization_data = optimization_data_result
 
-            # Run optimization using DP algorithm with quarterly resolution
+            # Run optimization using DP algorithm
             optimization_result = self._run_optimization(
                 optimization_period,
                 optimization_data,
                 prices,
+                price_entries,
                 prepare_next_day,
             )
 
@@ -615,16 +657,29 @@ class BatterySystemManager:
 
             prices = [entry["price"] for entry in price_entries]
 
-            # Prices are quarterly (96 periods) - DP algorithm supports variable horizon
-            # Handle DST transitions (quarterly)
-            if len(prices) == 92:
+            # DP algorithm supports variable horizon and period duration
+            # Nordpool: 92-100 quarterly periods (DST), Octopus: 48 half-hourly
+            period_hours = self._price_manager.price_source.period_duration_hours
+            if period_hours == 0.25:
+                # Nordpool quarterly: handle DST transitions
+                if len(prices) == 92:
+                    logger.info(
+                        "Detected DST spring forward transition (92 quarterly periods)"
+                    )
+                elif len(prices) == 100:
+                    logger.info(
+                        "Detected DST fall back transition (100 quarterly periods)"
+                    )
+                elif len(prices) != 96:
+                    logger.warning(
+                        f"Expected 96 quarterly prices but got {len(prices)}"
+                    )
+            else:
+                expected = int(24 / period_hours)
                 logger.info(
-                    "Detected DST spring forward transition (92 quarterly periods)"
+                    f"Got {len(prices)} prices "
+                    f"({period_hours}h periods, expected ~{expected})"
                 )
-            elif len(prices) == 100:
-                logger.info("Detected DST fall back transition (100 quarterly periods)")
-            elif len(prices) != 96:
-                logger.warning(f"Expected 96 quarterly prices but got {len(prices)}")
 
             return prices, price_entries
 
@@ -917,6 +972,7 @@ class BatterySystemManager:
         optimization_period: int,
         optimization_data: dict[str, list[float]],
         prices: list[float],
+        price_entries: list[dict[str, Any]],
         prepare_next_day: bool,
     ) -> OptimizationResult | None:
         """Run optimization - now returns OptimizationResult directly."""
@@ -959,11 +1015,11 @@ class BatterySystemManager:
                 f"Running optimization for {n_periods} periods from {format_period(optimization_period)}"
             )
 
-            # Calculate buy and sell prices
-            buy_prices = self._price_manager.get_buy_prices(raw_prices=remaining_prices)
-            sell_prices = self._price_manager.get_sell_prices(
-                raw_prices=remaining_prices
-            )
+            # Get buy and sell prices from pre-calculated price entries
+            # This preserves direct sell prices from sources like Octopus Energy
+            remaining_entries = price_entries[optimization_period:]
+            buy_prices = [entry["buyPrice"] for entry in remaining_entries]
+            sell_prices = [entry["sellPrice"] for entry in remaining_entries]
 
             # Run DP optimization with strategic intent capture - returns OptimizationResult directly
             result = optimize_battery_schedule(
@@ -974,6 +1030,7 @@ class BatterySystemManager:
                 initial_soe=current_soe,
                 battery_settings=self.battery_settings,
                 initial_cost_basis=initial_cost_basis,
+                period_duration_hours=self._price_manager.price_source.period_duration_hours,
             )
 
             # Add timestamps to period data (algorithm is time-agnostic, operates on relative indices)
@@ -1123,9 +1180,9 @@ class BatterySystemManager:
             for i, period_data in enumerate(period_data_list):
                 target_period = optimization_period + i
                 if target_period < len(full_day_strategic_intents):
-                    full_day_strategic_intents[
-                        target_period
-                    ] = period_data.decision.strategic_intent
+                    full_day_strategic_intents[target_period] = (
+                        period_data.decision.strategic_intent
+                    )
 
             # Store initial SOC in OptimizationResult for DailyViewBuilder
             if self._initial_soe is not None:

--- a/core/bess/octopus_energy_source.py
+++ b/core/bess/octopus_energy_source.py
@@ -14,6 +14,7 @@ from .price_manager import PriceSource
 logger = logging.getLogger(__name__)
 
 EXPECTED_PERIODS_PER_DAY = 48
+MIN_PERIODS_PER_DAY = 46
 
 
 class OctopusEnergySource(PriceSource):
@@ -158,11 +159,20 @@ class OctopusEnergySource(PriceSource):
         # Filter rates for the target date and sort chronologically
         filtered_rates = self._filter_rates_for_date(rates, target_date)
 
-        if len(filtered_rates) != EXPECTED_PERIODS_PER_DAY:
+        if len(filtered_rates) < MIN_PERIODS_PER_DAY:
             raise PriceDataUnavailableError(
                 date=target_date,
                 message=(
-                    f"Expected {EXPECTED_PERIODS_PER_DAY} {rate_type} rates for {target_date}, "
+                    f"Expected at least {MIN_PERIODS_PER_DAY} {rate_type} rates for {target_date}, "
+                    f"got {len(filtered_rates)} from {entity_id}"
+                ),
+            )
+        if len(filtered_rates) > EXPECTED_PERIODS_PER_DAY:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=(
+                    f"Too many {rate_type} rates for {target_date}: "
+                    f"expected at most {EXPECTED_PERIODS_PER_DAY}, "
                     f"got {len(filtered_rates)} from {entity_id}"
                 ),
             )

--- a/core/bess/octopus_energy_source.py
+++ b/core/bess/octopus_energy_source.py
@@ -1,0 +1,261 @@
+"""
+Octopus Energy Agile tariff price source.
+
+Fetches import and export rates from Octopus Energy HA event entities.
+Prices are VAT-inclusive in GBP/kWh at 30-minute resolution (48 periods/day).
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+
+from .exceptions import PriceDataUnavailableError, SystemConfigurationError
+from .price_manager import PriceSource
+
+logger = logging.getLogger(__name__)
+
+EXPECTED_PERIODS_PER_DAY = 48
+
+
+class OctopusEnergySource(PriceSource):
+    """Price source for Octopus Energy Agile tariff via Home Assistant event entities.
+
+    Key differences from Nordpool:
+    - 30-minute periods (48/day) instead of 15-minute (96/day)
+    - Separate import and export rate entities
+    - Prices are already VAT-inclusive final prices in GBP/kWh
+    - Data comes from HA event entity attributes (rates list)
+    """
+
+    def __init__(
+        self,
+        ha_controller,
+        import_today_entity: str,
+        import_tomorrow_entity: str,
+        export_today_entity: str,
+        export_tomorrow_entity: str,
+    ) -> None:
+        """Initialize with Home Assistant controller and Octopus entity IDs.
+
+        Args:
+            ha_controller: Controller with access to Home Assistant API
+            import_today_entity: Entity ID for today's import rates
+            import_tomorrow_entity: Entity ID for tomorrow's import rates
+            export_today_entity: Entity ID for today's export rates
+            export_tomorrow_entity: Entity ID for tomorrow's export rates
+        """
+        self.ha_controller = ha_controller
+        self.import_today_entity = import_today_entity
+        self.import_tomorrow_entity = import_tomorrow_entity
+        self.export_today_entity = export_today_entity
+        self.export_tomorrow_entity = export_tomorrow_entity
+
+    @property
+    def period_duration_hours(self) -> float:
+        """Octopus Energy uses 30-minute periods."""
+        return 0.5
+
+    def get_prices_for_date(self, target_date: date) -> list[float]:
+        """Get import rates from Octopus Energy for the specified date.
+
+        Args:
+            target_date: The date to get import prices for
+
+        Returns:
+            List of 48 import rates in GBP/kWh (VAT-inclusive)
+
+        Raises:
+            PriceDataUnavailableError: If rates cannot be fetched
+            SystemConfigurationError: If date is not today or tomorrow
+        """
+        current_date = datetime.now().date()
+        tomorrow_date = current_date + timedelta(days=1)
+
+        if target_date not in (current_date, tomorrow_date):
+            raise SystemConfigurationError(
+                message=f"Can only fetch today's or tomorrow's prices, not {target_date}"
+            )
+
+        if target_date == current_date:
+            entity_id = self.import_today_entity
+        else:
+            entity_id = self.import_tomorrow_entity
+
+        return self._fetch_rates(entity_id, target_date, "import")
+
+    def get_sell_prices_for_date(self, target_date: date) -> list[float] | None:
+        """Get export rates from Octopus Energy for the specified date.
+
+        Args:
+            target_date: The date to get export prices for
+
+        Returns:
+            List of 48 export rates in GBP/kWh, or None if no export entity configured
+        """
+        if not self.export_today_entity and not self.export_tomorrow_entity:
+            return None
+
+        current_date = datetime.now().date()
+        tomorrow_date = current_date + timedelta(days=1)
+
+        if target_date not in (current_date, tomorrow_date):
+            return None
+
+        if target_date == current_date:
+            entity_id = self.export_today_entity
+        else:
+            entity_id = self.export_tomorrow_entity
+
+        if not entity_id:
+            return None
+
+        try:
+            return self._fetch_rates(entity_id, target_date, "export")
+        except PriceDataUnavailableError:
+            logger.warning(f"Export rates unavailable for {target_date}")
+            return None
+
+    def _fetch_rates(
+        self, entity_id: str, target_date: date, rate_type: str
+    ) -> list[float]:
+        """Fetch rates from a Home Assistant event entity.
+
+        Args:
+            entity_id: HA entity ID to fetch from
+            target_date: Date to filter rates for
+            rate_type: "import" or "export" (for logging)
+
+        Returns:
+            List of 48 rate values (value_inc_vat) sorted chronologically
+
+        Raises:
+            PriceDataUnavailableError: If rates cannot be fetched or validated
+        """
+        try:
+            response = self.ha_controller._api_request(
+                "get", f"/api/states/{entity_id}"
+            )
+        except Exception as e:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"Failed to fetch {rate_type} rates from {entity_id}: {e}",
+            ) from e
+
+        if not response or "attributes" not in response:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"No attributes in response from {entity_id}",
+            )
+
+        attributes = response["attributes"]
+        rates = attributes.get("rates")
+
+        if not rates or not isinstance(rates, list):
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"No rates list in attributes from {entity_id}",
+            )
+
+        # Filter rates for the target date and sort chronologically
+        filtered_rates = self._filter_rates_for_date(rates, target_date)
+
+        if len(filtered_rates) != EXPECTED_PERIODS_PER_DAY:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=(
+                    f"Expected {EXPECTED_PERIODS_PER_DAY} {rate_type} rates for {target_date}, "
+                    f"got {len(filtered_rates)} from {entity_id}"
+                ),
+            )
+
+        # Extract value_inc_vat from each rate entry
+        prices = [float(rate["value_inc_vat"]) for rate in filtered_rates]
+
+        logger.info(
+            f"Fetched {len(prices)} Octopus {rate_type} rates for {target_date}: "
+            f"range {min(prices):.4f} - {max(prices):.4f} GBP/kWh"
+        )
+
+        return prices
+
+    def _filter_rates_for_date(
+        self, rates: list[dict], target_date: date
+    ) -> list[dict]:
+        """Filter and sort rates for a specific date.
+
+        Args:
+            rates: List of rate entries with 'start' timestamps
+            target_date: Date to filter for
+
+        Returns:
+            Filtered and sorted list of rate entries for the target date
+        """
+        filtered = []
+        for rate in rates:
+            start_str = rate.get("start")
+            if not start_str:
+                continue
+
+            try:
+                start_dt = datetime.fromisoformat(start_str)
+                if start_dt.date() == target_date:
+                    filtered.append(rate)
+            except (ValueError, TypeError):
+                continue
+
+        # Sort by start time
+        filtered.sort(key=lambda r: r["start"])
+
+        return filtered
+
+    def perform_health_check(self) -> dict:
+        """Perform health check on Octopus Energy source.
+
+        Returns:
+            dict: Health check result with status and checks
+        """
+        checks = []
+        overall_status = "OK"
+        today = datetime.now().date()
+
+        # Test import rates
+        import_check = {
+            "component": "OctopusEnergySource (Import)",
+            "status": "OK",
+            "message": "",
+        }
+        try:
+            import_prices = self.get_prices_for_date(today)
+            import_check["message"] = (
+                f"Successfully fetched {len(import_prices)} import rates for today"
+            )
+        except Exception as e:
+            import_check["status"] = "ERROR"
+            import_check["message"] = f"Failed to fetch import rates: {e}"
+            overall_status = "ERROR"
+        checks.append(import_check)
+
+        # Test export rates
+        export_check = {
+            "component": "OctopusEnergySource (Export)",
+            "status": "OK",
+            "message": "",
+        }
+        try:
+            export_prices = self.get_sell_prices_for_date(today)
+            if export_prices is not None:
+                export_check["message"] = (
+                    f"Successfully fetched {len(export_prices)} export rates for today"
+                )
+            else:
+                export_check["message"] = "No export entity configured"
+        except Exception as e:
+            export_check["status"] = "WARNING"
+            export_check["message"] = f"Failed to fetch export rates: {e}"
+            if overall_status == "OK":
+                overall_status = "WARNING"
+        checks.append(export_check)
+
+        return {
+            "status": overall_status,
+            "checks": checks,
+        }

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -18,6 +18,15 @@ class PriceSource:
     This defines the interface that all price sources must implement.
     """
 
+    @property
+    def period_duration_hours(self) -> float:
+        """Duration of each price period in hours.
+
+        Returns:
+            0.25 for quarterly (Nordpool), 0.5 for half-hourly (Octopus), etc.
+        """
+        return 0.25
+
     def get_prices_for_date(self, target_date: date) -> list:
         """Get prices for a specific date.
 
@@ -25,12 +34,27 @@ class PriceSource:
             target_date: The date to get prices for
 
         Returns:
-            List of hourly prices for the specified date
+            List of prices for the specified date (one per period)
 
         Raises:
             NotImplementedError: If the source doesn't implement this method
         """
         raise NotImplementedError("Price sources must implement get_prices_for_date")
+
+    def get_sell_prices_for_date(self, target_date: date) -> list[float] | None:
+        """Get separate sell/export prices for a specific date.
+
+        Override this method when the price source provides distinct export rates
+        (e.g., Octopus Energy). Returns None by default, meaning sell prices are
+        calculated from buy prices using markup/tax reduction.
+
+        Args:
+            target_date: The date to get sell prices for
+
+        Returns:
+            List of sell prices per period, or None if not applicable
+        """
+        return None
 
     def perform_health_check(self) -> dict:
         """Perform health check on the price source.
@@ -416,17 +440,27 @@ class PriceManager:
             # Get raw prices from the source
             raw_prices = self.price_source.get_prices_for_date(target_date)
 
+            # Check for separate sell/export prices (e.g., Octopus Energy)
+            direct_sell_prices = self.price_source.get_sell_prices_for_date(target_date)
+
             # Format prices with timestamp and calculations
             price_data = []
             base_timestamp = datetime.combine(target_date, datetime.min.time())
+            period_hours = self.price_source.period_duration_hours
 
-            for hour, price in enumerate(raw_prices):
-                timestamp = base_timestamp + timedelta(hours=hour)
+            for index, price in enumerate(raw_prices):
+                timestamp = base_timestamp + timedelta(hours=index * period_hours)
+
+                if direct_sell_prices is not None:
+                    sell_price = direct_sell_prices[index]
+                else:
+                    sell_price = self._calculate_sell_price(price)
+
                 price_entry = {
                     "timestamp": timestamp.strftime("%Y-%m-%d %H:%M"),
                     "price": price,
                     "buyPrice": self._calculate_buy_price(price),
-                    "sellPrice": self._calculate_sell_price(price),
+                    "sellPrice": sell_price,
                 }
                 price_data.append(price_entry)
 
@@ -527,24 +561,19 @@ class PriceManager:
             price_data = self.get_price_data(target_date)
             return [entry["sellPrice"] for entry in price_data]
 
-
     def get_available_prices(self) -> tuple[list[float], list[float]]:
-        """Get all available prices at quarterly resolution starting at today 00:00.
+        """Get all available prices starting at today 00:00.
 
-        Nordpool provides quarterly prices (96 periods/day) directly.
+        Period count depends on the price source resolution:
+        - Nordpool: 96 periods/day (15-min quarterly)
+        - Octopus Energy: 48 periods/day (30-min half-hourly)
+
         Automatically tries tomorrow, falls back to today only.
 
         Returns:
             (buy_prices, sell_prices) tuple where:
             - Index 0 = today 00:00
-            - Index 96 = tomorrow 00:00 (if available)
-            - Length: 96 (today only) or 192 (today + tomorrow)
-
-        Example at 14:00:
-            buy, sell = get_available_prices()
-            # buy[0] = today 00:00
-            # buy[56] = today 14:00 (current period)
-            # Caller slices: buy[56:] for optimization from now
+            - Length: periods_per_day (today only) or 2x (today + tomorrow)
         """
         today = datetime.now().date()
         tomorrow = today + timedelta(days=1)
@@ -607,14 +636,14 @@ class PriceManager:
 
             price_data = f"\n{title}:\n"
             price_data += "-" * 50 + "\n"
-            price_data += "Hour   | Nordpool Price | Retail Price  | Sell Price\n"
+            price_data += "Time   | Base Price     | Buy Price     | Sell Price\n"
             price_data += "-" * 50 + "\n"
 
             for entry in prices:
-                hour = entry["timestamp"].split()[1][:5]
-                price_str = f"{hour}  | {entry['price']:.4f} SEK    | "
-                buy_str = f"{entry['buyPrice']:.4f} SEK  | "
-                sell_str = f"{entry['sellPrice']:.4f} SEK\n"
+                time_str = entry["timestamp"].split()[1][:5]
+                price_str = f"{time_str}  | {entry['price']:.4f}        | "
+                buy_str = f"{entry['buyPrice']:.4f}       | "
+                sell_str = f"{entry['sellPrice']:.4f}\n"
                 price_data += price_str + buy_str + sell_str
 
             self._logger.info(price_data)

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -501,7 +501,7 @@ class PriceManager:
         tomorrow = datetime.now().date() + timedelta(days=1)
         try:
             return self.get_price_data(tomorrow)
-        except ValueError:
+        except (ValueError, PriceDataUnavailableError):
             return []  # Return empty list instead of raising error
 
     def get_prices(self, target_date: date | None = None) -> list:

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -123,11 +123,42 @@ class TestImportRateFetching:
         with pytest.raises(SystemConfigurationError):
             source.get_prices_for_date(day_after)
 
-    def test_wrong_period_count_raises_error(self):
-        """Rates with fewer than 48 entries should fail validation."""
+    def test_too_few_rates_raises_error(self):
+        """Rates below minimum threshold should fail validation."""
         today = datetime.now().date()
-        rates = _make_rates(today, count=24)  # Only 24 periods
+        rates = _make_rates(today, count=20)  # Well below minimum of 46
         controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_partial_rates_accepted(self):
+        """46-47 rates should be accepted (Octopus publishes incrementally)."""
+        today = datetime.now().date()
+        for count in (46, 47):
+            rates = _make_rates(today, count=count)
+            controller = _make_ha_controller(rates)
+            source = _make_source(controller)
+
+            prices = source.get_prices_for_date(today)
+            assert len(prices) == count
+
+    def test_too_many_rates_raises_error(self):
+        """More than 48 rates for a single date should fail validation."""
+        today = datetime.now().date()
+        rates = _make_rates(today, count=48)
+        # Add duplicate rates that also fall on today to exceed 48
+        extra = _make_rates(today, count=2, base_value=0.50)
+        # Adjust extra start times to be within the same day but unique
+        for i, rate in enumerate(extra):
+            start = datetime.combine(today, datetime.min.time()) + timedelta(
+                minutes=15 * i
+            )
+            rate["start"] = start.isoformat()
+            rate["end"] = (start + timedelta(minutes=15)).isoformat()
+        all_rates = rates + extra
+        controller = _make_ha_controller(all_rates)
         source = _make_source(controller)
 
         with pytest.raises(PriceDataUnavailableError):

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -1,0 +1,343 @@
+"""
+Test the OctopusEnergySource implementation.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.bess.exceptions import PriceDataUnavailableError, SystemConfigurationError
+from core.bess.octopus_energy_source import OctopusEnergySource
+from core.bess.price_manager import MockSource, PriceManager
+
+
+def _make_rates(target_date, count=48, base_value=0.20, export=False):
+    """Create mock Octopus rate entries for a given date.
+
+    Args:
+        target_date: Date to create rates for
+        count: Number of 30-minute periods
+        base_value: Base price value
+        export: If True, use lower values typical of export rates
+
+    Returns:
+        List of rate dicts with start, end, and value_inc_vat
+    """
+    rates = []
+    for i in range(count):
+        start = datetime.combine(target_date, datetime.min.time()) + timedelta(
+            minutes=30 * i
+        )
+        end = start + timedelta(minutes=30)
+        value = (
+            (base_value + i * 0.01) if not export else (base_value * 0.3 + i * 0.005)
+        )
+        rates.append(
+            {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                "value_inc_vat": value,
+            }
+        )
+    return rates
+
+
+def _make_ha_controller(import_rates, export_rates=None):
+    """Create a mock HA controller that returns rates for given entity IDs.
+
+    Args:
+        import_rates: Rates to return for import entities
+        export_rates: Rates to return for export entities (optional)
+    """
+    controller = MagicMock()
+
+    def api_request(method, path):
+        if "import_today" in path or "import_tomorrow" in path:
+            return {"attributes": {"rates": import_rates}}
+        if "export_today" in path or "export_tomorrow" in path:
+            if export_rates is not None:
+                return {"attributes": {"rates": export_rates}}
+            return {"attributes": {}}
+        return {}
+
+    controller._api_request = MagicMock(side_effect=api_request)
+    return controller
+
+
+def _make_source(controller):
+    """Create an OctopusEnergySource with standard test entity IDs."""
+    return OctopusEnergySource(
+        ha_controller=controller,
+        import_today_entity="event.octopus_import_today",
+        import_tomorrow_entity="event.octopus_import_tomorrow",
+        export_today_entity="event.octopus_export_today",
+        export_tomorrow_entity="event.octopus_export_tomorrow",
+    )
+
+
+class TestOctopusEnergySourceProperties:
+    """Test basic properties of OctopusEnergySource."""
+
+    def test_period_duration_hours_is_half_hour(self):
+        controller = MagicMock()
+        source = _make_source(controller)
+        assert source.period_duration_hours == 0.5
+
+    def test_default_price_source_period_duration_is_quarter(self):
+        """Verify the base PriceSource default is 0.25 (Nordpool)."""
+        mock = MockSource([1.0])
+        assert mock.period_duration_hours == 0.25
+
+
+class TestImportRateFetching:
+    """Test fetching import rates from Octopus Energy entities."""
+
+    def test_fetch_today_import_rates(self):
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+
+        assert len(prices) == 48
+        assert prices[0] == rates[0]["value_inc_vat"]
+        assert prices[47] == rates[47]["value_inc_vat"]
+
+    def test_fetch_tomorrow_import_rates(self):
+        tomorrow = datetime.now().date() + timedelta(days=1)
+        rates = _make_rates(tomorrow)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(tomorrow)
+
+        assert len(prices) == 48
+
+    def test_rejects_date_beyond_tomorrow(self):
+        day_after = datetime.now().date() + timedelta(days=2)
+        controller = MagicMock()
+        source = _make_source(controller)
+
+        with pytest.raises(SystemConfigurationError):
+            source.get_prices_for_date(day_after)
+
+    def test_wrong_period_count_raises_error(self):
+        """Rates with fewer than 48 entries should fail validation."""
+        today = datetime.now().date()
+        rates = _make_rates(today, count=24)  # Only 24 periods
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_no_rates_attribute_raises_error(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(
+            return_value={"attributes": {"no_rates_key": []}}
+        )
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_api_failure_raises_error(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+
+class TestExportRateFetching:
+    """Test fetching export/sell rates from Octopus Energy entities."""
+
+    def test_fetch_export_rates(self):
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        sell_prices = source.get_sell_prices_for_date(today)
+
+        assert sell_prices is not None
+        assert len(sell_prices) == 48
+        assert sell_prices[0] == export_rates[0]["value_inc_vat"]
+
+    def test_no_export_entity_returns_none(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        source = OctopusEnergySource(
+            ha_controller=controller,
+            import_today_entity="event.import_today",
+            import_tomorrow_entity="event.import_tomorrow",
+            export_today_entity="",
+            export_tomorrow_entity="",
+        )
+
+        assert source.get_sell_prices_for_date(today) is None
+
+    def test_export_failure_returns_none(self):
+        """Export rate failure should return None, not raise."""
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
+        source = _make_source(controller)
+
+        assert source.get_sell_prices_for_date(today) is None
+
+    def test_default_get_sell_prices_for_date_returns_none(self):
+        """Base PriceSource returns None for sell prices."""
+        mock = MockSource([1.0])
+        assert mock.get_sell_prices_for_date(datetime.now().date()) is None
+
+
+class TestDateFilteringAndSorting:
+    """Test rate filtering by date and chronological sorting."""
+
+    def test_filters_rates_by_date(self):
+        """Only rates matching the target date should be included."""
+        today = datetime.now().date()
+        tomorrow = today + timedelta(days=1)
+
+        # Mix rates from today and tomorrow
+        today_rates = _make_rates(today)
+        tomorrow_rates = _make_rates(tomorrow, count=10)
+        mixed_rates = today_rates + tomorrow_rates
+
+        controller = _make_ha_controller(mixed_rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+        assert len(prices) == 48
+
+    def test_sorts_rates_chronologically(self):
+        """Rates should be sorted by start time regardless of input order."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        # Reverse the order
+        rates.reverse()
+
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+        assert len(prices) == 48
+        # First price should be the midnight rate (lowest index)
+        assert prices[0] == 0.20  # base_value for index 0
+
+
+class TestHealthCheck:
+    """Test health check functionality."""
+
+    def test_healthy_source(self):
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        result = source.perform_health_check()
+
+        assert result["status"] == "OK"
+        assert len(result["checks"]) == 2
+        assert result["checks"][0]["status"] == "OK"
+        assert result["checks"][1]["status"] == "OK"
+
+    def test_unhealthy_import(self):
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("down"))
+        source = _make_source(controller)
+
+        result = source.perform_health_check()
+
+        assert result["status"] == "ERROR"
+        assert result["checks"][0]["status"] == "ERROR"
+
+
+class TestPriceManagerIntegration:
+    """Test OctopusEnergySource integration with PriceManager."""
+
+    def test_price_manager_uses_direct_sell_prices(self):
+        """When source provides sell prices, PriceManager should use them directly."""
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=0.0,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        assert len(price_data) == 48
+        # Sell price should come directly from export rates, not calculated
+        assert price_data[0]["sellPrice"] == export_rates[0]["value_inc_vat"]
+        # Buy price should still be calculated from import rates
+        assert price_data[0]["buyPrice"] == import_rates[0]["value_inc_vat"]
+
+    def test_price_manager_timestamps_use_half_hour_spacing(self):
+        """Timestamps should be 30 minutes apart for Octopus."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=0.0,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        # First entry at 00:00, second at 00:30
+        assert price_data[0]["timestamp"].endswith("00:00")
+        assert price_data[1]["timestamp"].endswith("00:30")
+        assert price_data[2]["timestamp"].endswith("01:00")
+
+    def test_price_manager_fallback_sell_without_export(self):
+        """Without export entity, sell price should use calculated formula."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+
+        source = OctopusEnergySource(
+            ha_controller=controller,
+            import_today_entity="event.octopus_import_today",
+            import_tomorrow_entity="event.octopus_import_tomorrow",
+            export_today_entity="",
+            export_tomorrow_entity="",
+        )
+
+        tax_reduction = 0.05
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=tax_reduction,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        # Sell price should be calculated: base_price + tax_reduction
+        expected_sell = rates[0]["value_inc_vat"] + tax_reduction
+        assert abs(price_data[0]["sellPrice"] - expected_sell) < 1e-6

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -327,17 +327,25 @@ const InverterStatusDashboard: React.FC = () => {
       }
       setError(null);
       
-      const [statusData, scheduleData, batteryData, dashboardDataResult] = await Promise.all([
+      const results = await Promise.allSettled([
         fetchInverterStatus(),
         fetchGrowattSchedule(),
         fetchBatterySettings(),
         fetchDashboardData()
       ]);
-      
-      setInverterStatus(statusData);
-      setGrowattSchedule(scheduleData);
-      setBatterySettings(batteryData);
-      setDashboardData(dashboardDataResult);
+
+      if (results[0].status === 'fulfilled') setInverterStatus(results[0].value);
+      else console.warn('Failed to fetch inverter status:', results[0].reason);
+
+      if (results[1].status === 'fulfilled') setGrowattSchedule(results[1].value);
+      else console.warn('Failed to fetch growatt schedule:', results[1].reason);
+
+      if (results[2].status === 'fulfilled') setBatterySettings(results[2].value);
+      else console.warn('Failed to fetch battery settings:', results[2].reason);
+
+      if (results[3].status === 'fulfilled') setDashboardData(results[3].value);
+      else console.warn('Failed to fetch dashboard data:', results[3].reason);
+
       setLastUpdate(new Date());
       
       if (isInitialLoad) {


### PR DESCRIPTION
## Summary

- Inverter page showed blank/zero data for all fields when `/api/dashboard` returned HTTP 500 (no optimization schedule exists)
- Root cause: `Promise.all` rejects entirely when any single fetch fails, discarding all 4 results
- Switched to `Promise.allSettled` so each API fetch succeeds or fails independently

## Test plan

- [ ] `cd frontend && npm run build` passes with no TypeScript errors
- [ ] With no optimization running, Inverter page shows real SOC, grid charge status, and battery settings
- [ ] Dashboard-dependent fields gracefully show "-" when dashboard endpoint fails