### PR TITLE
Persist historical data across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.2] - 2026-02-27
+
+### Fixed
+
+- Inverter page no longer shows blank/zero data when the dashboard endpoint fails. Changed `Promise.all` to `Promise.allSettled` so each API fetch succeeds or fails independently. A failing `/api/dashboard` (e.g. when no optimization schedule exists) no longer discards successful results from inverter status, schedule, and battery settings endpoints.
+
 ## [6.1.1] - 2026-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.0] - 2026-02-28
+
+### Fixed
+
+- InfluxDB queries now work with both 1.x and 2.x data models. In 1.x, `_measurement` holds the unit of measurement (e.g. `%`, `W`) and the entity ID is stored in an `entity_id` tag; in 2.x, `_measurement` holds the entity ID directly. Query filters now match on either field.
+- CSV response parsers now detect column positions from the header row instead of using hardcoded indices, preventing silent data loss when InfluxDB returns columns in a different order depending on version and tag configuration.
+- Diagnostic logging in batch queries uses header-aware column detection and logs raw response lines when zero sensors are found, making InfluxDB version mismatches immediately visible in logs.
+
 ## [6.1.3] - 2026-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.1] - 2026-02-28
+
+### Fixed
+
+- Octopus Energy prices no longer display at ~1.33 GBP/kWh. The `PriceManager` retained Swedish default pricing parameters (markup=0.08, VAT=1.25, additional=1.03) because `update_settings()` updated the settings dataclass but never propagated the new values to the running `PriceManager`. Settings are now forwarded and the price cache is cleared on update.
+- Octopus Energy 30-minute rates are now expanded to 96 quarterly (15-minute) periods at the source level, ensuring correct timestamps and consistent resolution across all code paths. The previous normalization at the BSM level duplicated price-entry dicts which carried wrong timestamps.
+
 ## [6.2.0] - 2026-02-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.2] - 2026-02-28
+
+### Fixed
+
+- Battery SOC no longer shows impossible values (e.g. 168%) on the Savings page and Dashboard chart for historical periods. The `SensorCollector`, `EnergyFlowCalculator`, and `HistoricalDataStore` were initialized with the default 30 kWh battery capacity, but `update_settings()` only updated `BatterySettings` without propagating the new capacity to these components. State-of-energy was stored using 30 kWh and later displayed using the configured 10 kWh, inflating SOC by 3×. Capacity is now propagated to all dependent components when battery settings are updated.
+
 ## [6.2.1] - 2026-02-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.3] - 2026-02-27
+
+### Fixed
+
+- Octopus Energy prices (48 half-hourly) are now normalized to 15-minute quarterly resolution before entering the optimization pipeline. The system internally uses 96 periods/day (15-min each) for period indices, historical store, and Growatt schedules. Passing 48-element price arrays caused `list assignment index out of range` when the 15-min period index (e.g. 90) exceeded the array size, preventing any optimization from running.
+
 ## [6.1.2] - 2026-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2026-02-27
+
+### Fixed
+
+- `get_tomorrow_prices()` now catches `PriceDataUnavailableError` in addition to `ValueError`, so the "return empty list if not yet available" fallback actually works for Octopus Energy.
+- Octopus Energy rate validation accepts 46-48 rates instead of requiring exactly 48. Octopus publishes rates incrementally and the last couple of half-hours may arrive slightly later.
+
+## [6.1.0] - 2026-02-27
+
+### Added
+
+- Octopus Energy Agile tariff support as a new price source alongside Nordpool. Fetches import and export rates from HA event entities at 30-minute resolution with VAT-inclusive GBP/kWh prices.
+- `price_provider` configuration field to select between `nordpool`, `nordpool_official`, and `octopus` price sources.
+- Separate import and export rate entities for Octopus Energy, allowing direct sell price data instead of calculated fallback.
+- `period_duration_hours` on `PriceSource` to support different rate resolutions (15-min Nordpool, 30-min Octopus).
+- `get_sell_prices_for_date()` on `PriceSource` for sources that provide direct export/sell rates.
+- Documentation for Octopus Energy setup in README, Installation Guide, and User Guide.
+
 ## [6.0.6] - 2026-02-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0] - 2026-02-28
+
+### Added
+
+- Historical data now persists across restarts. Dashboard energy flow chart and Hourly Battery Actions & Savings page retain their data when BESS restarts instead of showing empty charts. Data is saved to `/config/bess_historical_data.json` after each 15-minute recording period and loaded on startup if from today, following the same persistence pattern used by `ScheduleStore`.
+
 ## [6.2.2] - 2026-02-28
 
 ### Fixed

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,7 +6,7 @@ Complete guide for installing and configuring BESS Battery Manager for Home Assi
 
 - Home Assistant OS, Container, or Supervised
 - Growatt battery system with Home Assistant integration
-- Nordpool integration configured
+- Electricity price integration: **Nordpool** (Nordic markets) or **Octopus Energy** (UK market)
 
 ## Step 1: Install the Add-on
 
@@ -106,11 +106,25 @@ home:
   safety_margin_factor: 0.95        # Safety margin (95%)
 
 electricity_price:
-  area: "SE4"                       # Nordpool area
+  area: "SE4"                       # Nordpool area (or "UK" for Octopus)
   markup_rate: 0.08                 # Markup (per kWh, in your currency)
   vat_multiplier: 1.25              # VAT (1.25 = 25%)
   additional_costs: 1.03            # Additional costs (per kWh)
   tax_reduction: 0.6518             # Tax reduction for sold energy (per kWh)
+
+# Price provider selection (choose one)
+nordpool:
+  price_provider: "nordpool"        # "nordpool", "nordpool_official", or "octopus"
+  use_official_integration: false   # Set true for official HA Nordpool integration
+  config_entry_id: ""               # Required when use_official_integration is true
+
+# Octopus Energy configuration (only needed when price_provider is "octopus")
+# See "Octopus Energy Setup" section below for details
+octopus:
+  import_today_entity: ""
+  import_tomorrow_entity: ""
+  export_today_entity: ""
+  export_tomorrow_entity: ""
 
 sensors:
   # Battery sensors (required)
@@ -132,7 +146,7 @@ sensors:
   # Consumption forecast (required)
   48h_avg_grid_import: "sensor.48h_average_grid_import_power"  # From Step 2
 
-  # Price sensors (required)
+  # Price sensors (required for Nordpool, not needed for Octopus)
   nordpool_kwh_today: "sensor.nordpool_kwh_your_area"
   nordpool_kwh_tomorrow: "sensor.nordpool_kwh_your_area"
 
@@ -156,6 +170,36 @@ sensors:
   # lifetime_export_to_grid: "sensor.your_lifetime_export_to_grid"
   # ev_energy_meter: "sensor.your_ev_energy_meter"
 ```
+
+### Octopus Energy Setup
+
+If you're using Octopus Energy (UK), set `price_provider: "octopus"` and configure the entity IDs.
+
+**1. Find your entity IDs** in Developer Tools > States, search for `octopus_energy_electricity`:
+
+```yaml
+octopus:
+  import_today_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_current_day_rates"
+  import_tomorrow_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_next_day_rates"
+  export_today_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_export_current_day_rates"
+  export_tomorrow_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_export_next_day_rates"
+```
+
+**2. Adjust electricity_price settings** - Octopus prices are already VAT-inclusive in GBP/kWh:
+
+```yaml
+home:
+  currency: "GBP"
+
+electricity_price:
+  area: "UK"
+  markup_rate: 0.0
+  vat_multiplier: 1.0
+  additional_costs: 0.0
+  tax_reduction: 0.0           # Adjust if you receive SEG payments
+```
+
+**3. Set cycle_cost and min_action_profit_threshold in GBP** (see notes below).
 
 ### ⚠️ Important Configuration Notes
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Intelligent Battery Energy Storage System (BESS) management and optimization for
 
 ## Overview
 
-The BESS Battery Manager is a sophisticated Home Assistant add-on that automatically optimizes Growatt inverter battery storage systems using dynamic programming algorithms and Nordic electricity market pricing. It continuously analyzes published electricity prices, solar production forecasts, and consumption predictions to determine optimal charge/discharge schedules that minimize your electricity costs.
+The BESS Battery Manager is a sophisticated Home Assistant add-on that automatically optimizes Growatt inverter battery storage systems using dynamic programming algorithms and electricity market pricing. It continuously analyzes published electricity prices, solar production forecasts, and consumption predictions to determine optimal charge/discharge schedules that minimize your electricity costs.
 
-The system requires the Growatt, Nordpool, and solar forecast (e.g., Solcast) Home Assistant integrations to function, and optionally uses InfluxDB for historical data storage. Unlike simple timer-based systems, BESS Manager makes intelligent decisions by weighing multiple factors: current battery state, published hourly electricity prices, solar weather forecasts, consumption estimates, and battery degradation costs. The system updates its optimization strategy every hour as new sensor data becomes available, ensuring your battery always operates in the most economically beneficial way while respecting technical constraints like charge rates and depth-of-discharge limits.
+The system requires the Growatt, a price source (Nordpool or Octopus Energy), and solar forecast (e.g., Solcast) Home Assistant integrations to function, and optionally uses InfluxDB for historical data storage. Unlike simple timer-based systems, BESS Manager makes intelligent decisions by weighing multiple factors: current battery state, published electricity prices, solar weather forecasts, consumption estimates, and battery degradation costs. The system updates its optimization strategy every hour as new sensor data becomes available, ensuring your battery always operates in the most economically beneficial way while respecting technical constraints like charge rates and depth-of-discharge limits.
 
 ## Key Capabilities
 
 **Dynamic Programming Optimization**: Solves 24-hour battery scheduling as an optimization problem, considering electricity prices, solar forecasts, consumption patterns, and battery constraints to find the globally optimal charge/discharge schedule.
 
-**Nordpool Market Integration**: Automatically retrieves electricity prices from Nordic power markets to be used by optimization algorithm.
+**Electricity Market Integration**: Supports Nordpool (Nordic markets, 15-min resolution) and Octopus Energy Agile tariff (UK market, 30-min resolution with separate import/export rates).
 
 **Battery Wear Economics**: Incorporates battery degradation costs (cycle cost) into optimization calculations to balance immediate savings against long-term battery life.
 
@@ -48,7 +48,7 @@ Tested with MIN/TLX inverters
 
 ### Required Integrations
 
-- 📊 **Nordpool** integration for electricity prices
+- 📊 **Nordpool** or **Octopus Energy** integration for electricity prices
 - 🏠 **Growatt** integration for battery control and energy monitoring
 - ☀️ **Solar forecast** integration (e.g., Solcast) for production predictions
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -174,8 +174,8 @@ The logs show:
 
 **Solutions**:
 
-- Check electricity price sensor is working
-- Verify price spread is significant (>0.50 SEK/kWh difference)
+- Check electricity price integration is working (Nordpool or Octopus Energy)
+- Verify price spread is significant enough to justify battery wear
 - Wait for price volatility periods
 
 ### "Savings are negative"
@@ -235,8 +235,8 @@ The logs show:
 
 ### Price Settings
 
-- **Area**: Must match your actual Nordpool pricing area
-- **Additional Costs**: Include all taxes, fees, and markup for accurate calculations
+- **Area**: Must match your pricing area (Nordpool area code, or "UK" for Octopus)
+- **Additional Costs**: Include all taxes, fees, and markup for accurate calculations (set to 0 for Octopus as prices are VAT-inclusive)
 
 ### Consumption Prediction
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -128,10 +128,11 @@ class BESSController:
             logger.info("Enabling test mode - hardware writes will be simulated")
         self.ha_controller.set_test_mode(test_mode)
 
-        # Extract nordpool configuration
+        # Extract nordpool and octopus configuration
         nordpool_config = options.get("nordpool", {})
+        nordpool_config["octopus"] = options.get("octopus", {})
 
-        # Create Battery System Manager with nordpool configuration
+        # Create Battery System Manager with price provider configuration
         # Let the system manager choose the appropriate price source
         self.system = BatterySystemManager(
             self.ha_controller,

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.0.6"
+version: "6.1.0"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.1.0"
+version: "6.1.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -47,8 +47,14 @@ options:
     additional_costs: 1.03           # Additional costs per kWh in your currency (e.g. SE: 28.90 öre överföringsavgift + 53.50 öre energiskatt + moms)
     tax_reduction: 0.6518            # Tax reduction for sold energy in your currency (e.g. SE: 60 öre skattereduktion + 5.18 öre förlustersättning)
   nordpool:
+    price_provider: "nordpool"  # "nordpool" (legacy sensor), "nordpool_official", or "octopus"
     use_official_integration: true  # Set to true to use official HA Nord Pool integration
     config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888"  # Required when use_official_integration is true
+  octopus:
+    import_today_entity: ""       # HA entity for today's Octopus import rates
+    import_tomorrow_entity: ""    # HA entity for tomorrow's Octopus import rates
+    export_today_entity: ""       # HA entity for today's Octopus export rates
+    export_tomorrow_entity: ""    # HA entity for tomorrow's Octopus export rates
   growatt:
     device_id: "fbafceb07a1cc74c351ef4310fa430a0"  # Growatt device ID for TOU segment operations
   sensors:
@@ -116,8 +122,14 @@ schema:
     additional_costs: float
     tax_reduction: float
   nordpool:
+    price_provider: str
     use_official_integration: bool
     config_entry_id: str
+  octopus:
+    import_today_entity: str
+    import_tomorrow_entity: str
+    export_today_entity: str
+    export_tomorrow_entity: str
   growatt:
     device_id: str
   sensors:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.2.0"
+version: "6.2.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.1.1"
+version: "6.1.2"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.2.3"
+version: "6.3.0"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.1.3"
+version: "6.2.0"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.1.2"
+version: "6.1.3"
 slug: "bess_manager"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.2.2"
+version: "6.2.3"
 slug: "bess_manager"
 init: false
 arch:
@@ -28,35 +28,35 @@ options:
     username: "your_db_username_here"
     password: "your_db_password_here"
   home:
-    consumption: 3.5                # default hourly consumption in kWh
-    currency: "SEK"                 # currency for price display and calculations
-    max_fuse_current: 25            # Maximum fuse current in amperes
-    voltage: 230                    # Line voltage in volts
-    safety_margin_factor: 1.0       # Safety margin for power calculations (100% - safe with 5min monitoring)
+    consumption: 3.5 # default hourly consumption in kWh
+    currency: "SEK" # currency for price display and calculations
+    max_fuse_current: 25 # Maximum fuse current in amperes
+    voltage: 230 # Line voltage in volts
+    safety_margin_factor: 1.0 # Safety margin for power calculations (100% - safe with 5min monitoring)
   battery:
-    total_capacity: 30.0             # kWh
-    min_soc: 15                      # Minimum state of charge (%) - synced to inverter on startup
-    max_soc: 95                      # Maximum state of charge (%) - synced to inverter on startup
+    total_capacity: 30.0 # kWh
+    min_soc: 15 # Minimum state of charge (%) - synced to inverter on startup
+    max_soc: 95 # Maximum state of charge (%) - synced to inverter on startup
     max_charge_discharge_power: 15.0 # kW
-    cycle_cost: 0.50                 # Battery wear cost per kWh (excl. VAT) - use your local currency
+    cycle_cost: 0.50 # Battery wear cost per kWh (excl. VAT) - use your local currency
     min_action_profit_threshold: 8.0 # Minimum profit threshold for any battery action (in your currency)
   electricity_price:
-    area: "SE4"                      # Area for Nordpool pricing
-    markup_rate: 0.08                # Electricity markup per kWh (in your currency, e.g. 8 öre/kWh for SEK)
-    vat_multiplier: 1.25             # 25% VAT
-    additional_costs: 1.03           # Additional costs per kWh in your currency (e.g. SE: 28.90 öre överföringsavgift + 53.50 öre energiskatt + moms)
-    tax_reduction: 0.6518            # Tax reduction for sold energy in your currency (e.g. SE: 60 öre skattereduktion + 5.18 öre förlustersättning)
+    area: "SE4" # Area for Nordpool pricing
+    markup_rate: 0.08 # Electricity markup per kWh (in your currency, e.g. 8 öre/kWh for SEK)
+    vat_multiplier: 1.25 # 25% VAT
+    additional_costs: 1.03 # Additional costs per kWh in your currency (e.g. SE: 28.90 öre överföringsavgift + 53.50 öre energiskatt + moms)
+    tax_reduction: 0.6518 # Tax reduction for sold energy in your currency (e.g. SE: 60 öre skattereduktion + 5.18 öre förlustersättning)
   nordpool:
-    price_provider: "nordpool"  # "nordpool" (legacy sensor), "nordpool_official", or "octopus"
-    use_official_integration: true  # Set to true to use official HA Nord Pool integration
-    config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888"  # Required when use_official_integration is true
+    price_provider: "nordpool" # "nordpool" (legacy sensor), "nordpool_official", or "octopus"
+    use_official_integration: true # Set to true to use official HA Nord Pool integration
+    config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888" # Required when use_official_integration is true
   octopus:
-    import_today_entity: ""       # HA entity for today's Octopus import rates
-    import_tomorrow_entity: ""    # HA entity for tomorrow's Octopus import rates
-    export_today_entity: ""       # HA entity for today's Octopus export rates
-    export_tomorrow_entity: ""    # HA entity for tomorrow's Octopus export rates
+    import_today_entity: "" # HA entity for today's Octopus import rates
+    import_tomorrow_entity: "" # HA entity for tomorrow's Octopus import rates
+    export_today_entity: "" # HA entity for today's Octopus export rates
+    export_tomorrow_entity: "" # HA entity for tomorrow's Octopus export rates
   growatt:
-    device_id: "fbafceb07a1cc74c351ef4310fa430a0"  # Growatt device ID for TOU segment operations
+    device_id: "fbafceb07a1cc74c351ef4310fa430a0" # Growatt device ID for TOU segment operations
   sensors:
     # === Battery Control & Status ===
     battery_soc: "sensor.rkm0d7n04x_statement_of_charge_soc"
@@ -66,20 +66,20 @@ options:
     battery_discharging_power_rate: "number.rkm0d7n04x_battery_discharge_power_limit"
     grid_charge: "switch.rkm0d7n04x_ac_charge"
     # === Real-time Power Sensors (Primary - Live Power Flow) ===
-    pv_power: "sensor.rkm0d7n04x_internal_wattage"                    # Total solar DC production
-    local_load_power: "sensor.rkm0d7n04x_local_load_power"           # Home consumption
-    import_power: "sensor.rkm0d7n04x_import_power"                   # Grid import
-    export_power: "sensor.rkm0d7n04x_export_power"                   # Grid export
-    battery_charge_power: "sensor.rkm0d7n04x_battery_1_charging_w"     # Battery charging power
-    battery_discharge_power: "sensor.rkm0d7n04x_battery_1_discharging_w"  # Battery discharging power
+    pv_power: "sensor.rkm0d7n04x_internal_wattage" # Total solar DC production
+    local_load_power: "sensor.rkm0d7n04x_local_load_power" # Home consumption
+    import_power: "sensor.rkm0d7n04x_import_power" # Grid import
+    export_power: "sensor.rkm0d7n04x_export_power" # Grid export
+    battery_charge_power: "sensor.rkm0d7n04x_battery_1_charging_w" # Battery charging power
+    battery_discharge_power: "sensor.rkm0d7n04x_battery_1_discharging_w" # Battery discharging power
     # === Real-time Power Sensors (Advanced/Diagnostic - not required) ===
-    output_power: "sensor.rkm0d7n04x_output_power"                   # Output power
-    self_power: "sensor.rkm0d7n04x_self_power"                       # Solar contributing to AC loads
-    system_power: "sensor.rkm0d7n04x_system_power"                   # System power throughput
+    output_power: "sensor.rkm0d7n04x_output_power" # Output power
+    self_power: "sensor.rkm0d7n04x_self_power" # Solar contributing to AC loads
+    system_power: "sensor.rkm0d7n04x_system_power" # System power throughput
     # === Grid Current Monitoring (not required) ===
-    current_l1: "sensor.current_l1_gustavsgatan_32a"                 # Phase 1 current
-    current_l2: "sensor.current_l2_gustavsgatan_32a"                 # Phase 2 current
-    current_l3: "sensor.current_l3_gustavsgatan_32a"                 # Phase 3 current
+    current_l1: "sensor.current_l1_gustavsgatan_32a" # Phase 1 current
+    current_l2: "sensor.current_l2_gustavsgatan_32a" # Phase 2 current
+    current_l3: "sensor.current_l3_gustavsgatan_32a" # Phase 3 current
     # === Lifetime Energy Totals ===
     lifetime_solar_energy: "sensor.rkm0d7n04x_lifetime_total_solar_energy"
     lifetime_load_consumption: "sensor.rkm0d7n04x_lifetime_total_load_consumption"
@@ -89,12 +89,12 @@ options:
     lifetime_battery_charged: "sensor.rkm0d7n04x_lifetime_total_all_batteries_charged"
     lifetime_battery_discharged: "sensor.rkm0d7n04x_lifetime_total_all_batteries_discharged"
     lifetime_system_production: "sensor.rkm0d7n04x_lifetime_system_production"
-    ev_energy_meter: "sensor.zap263668_energy_meter"                 # EV charging energy (lifetime)
+    ev_energy_meter: "sensor.zap263668_energy_meter" # EV charging energy (lifetime)
     # === Electricity Pricing ===
-    nordpool_kwh_today: "sensor.nordpool_kwh_se4_sek_2_10_025"       # Today's NordPool prices
-    nordpool_kwh_tomorrow: "sensor.nordpool_kwh_se4_sek_2_10_025"    # Tomorrow's NordPool prices
+    nordpool_kwh_today: "sensor.nordpool_kwh_se4_sek_2_10_025" # Today's NordPool prices
+    nordpool_kwh_tomorrow: "sensor.nordpool_kwh_se4_sek_2_10_025" # Tomorrow's NordPool prices
     # === Solar & Consumption Forecasting ===
-    48h_avg_grid_import: "sensor.48h_average_grid_import_power"       # 48h average consumption
+    48h_avg_grid_import: "sensor.48h_average_grid_import_power" # 48h average consumption
     solar_forecast_today: "sensor.solcast_pv_forecast_forecast_today" # Today's solar forecast
 schema:
   influxdb:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.2.1"
+version: "6.2.2"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -22,6 +22,7 @@ from .ha_api_controller import HomeAssistantAPIController
 from .health_check import run_system_health_checks
 from .historical_data_store import HistoricalDataStore
 from .models import DecisionData, EconomicData, PeriodData, infer_intent_from_flows
+from .octopus_energy_source import OctopusEnergySource
 from .power_monitor import HomePowerMonitor
 from .prediction_snapshot import PredictionSnapshotStore
 from .price_manager import HomeAssistantSource, PriceManager, PriceSource
@@ -89,29 +90,7 @@ class BatterySystemManager:
 
         # Initialize price manager
         if not price_source:
-            # Check if official Nordpool integration should be used
-            nordpool_config = getattr(self, "_nordpool_config", None)
-            if nordpool_config is None:
-                nordpool_config = {}
-            use_official = nordpool_config.get("use_official_integration", False)
-            config_entry_id = nordpool_config.get("config_entry_id")
-
-            if use_official and config_entry_id:
-                # Use official Home Assistant Nordpool integration
-                from .official_nordpool_source import OfficialNordpoolSource
-
-                price_source = OfficialNordpoolSource(
-                    controller,
-                    config_entry_id,
-                    vat_multiplier=self.price_settings.vat_multiplier,
-                )
-                logger.info("Using official Home Assistant Nordpool integration")
-            else:
-                # Use legacy sensor-based approach (current custom component)
-                price_source = HomeAssistantSource(
-                    controller, vat_multiplier=self.price_settings.vat_multiplier
-                )
-                logger.info("Using legacy/custom Nordpool sensor integration")
+            price_source = self._create_price_source(controller)
 
         self._price_manager = PriceManager(
             price_source=price_source,
@@ -146,6 +125,68 @@ class BatterySystemManager:
         if self._controller is None:
             raise RuntimeError("Controller not initialized - system not started")
         return self._controller
+
+    def _create_price_source(self, controller) -> PriceSource:
+        """Create the appropriate price source based on nordpool_config.
+
+        Supports three price providers:
+        - "nordpool" (default): Legacy custom Nordpool sensor component
+        - "nordpool_official": Official HA Nordpool integration via service calls
+        - "octopus": Octopus Energy Agile tariff via HA event entities
+
+        Args:
+            controller: HomeAssistantAPIController instance
+
+        Returns:
+            Configured PriceSource instance
+        """
+        nordpool_config = self._nordpool_config
+        price_provider = nordpool_config.get("price_provider", "nordpool")
+
+        if price_provider == "octopus":
+            octopus_config = nordpool_config.get("octopus", {})
+            price_source = OctopusEnergySource(
+                ha_controller=controller,
+                import_today_entity=octopus_config.get("import_today_entity", ""),
+                import_tomorrow_entity=octopus_config.get("import_tomorrow_entity", ""),
+                export_today_entity=octopus_config.get("export_today_entity", ""),
+                export_tomorrow_entity=octopus_config.get("export_tomorrow_entity", ""),
+            )
+            logger.info("Using Octopus Energy Agile tariff price source")
+            return price_source
+
+        if price_provider == "nordpool_official":
+            config_entry_id = nordpool_config.get("config_entry_id")
+            if config_entry_id:
+                from .official_nordpool_source import OfficialNordpoolSource
+
+                price_source = OfficialNordpoolSource(
+                    controller,
+                    config_entry_id,
+                    vat_multiplier=self.price_settings.vat_multiplier,
+                )
+                logger.info("Using official Home Assistant Nordpool integration")
+                return price_source
+
+        # Also support legacy use_official_integration flag for backward compatibility
+        use_official = nordpool_config.get("use_official_integration", False)
+        config_entry_id = nordpool_config.get("config_entry_id")
+        if use_official and config_entry_id:
+            from .official_nordpool_source import OfficialNordpoolSource
+
+            price_source = OfficialNordpoolSource(
+                controller,
+                config_entry_id,
+                vat_multiplier=self.price_settings.vat_multiplier,
+            )
+            logger.info("Using official Home Assistant Nordpool integration")
+            return price_source
+
+        # Default: legacy sensor-based Nordpool
+        logger.info("Using legacy/custom Nordpool sensor integration")
+        return HomeAssistantSource(
+            controller, vat_multiplier=self.price_settings.vat_multiplier
+        )
 
     def _sync_soc_limits(self) -> None:
         """
@@ -258,7 +299,7 @@ class BatterySystemManager:
             self._handle_special_cases(current_period, prepare_next_day)
 
             # Get price data
-            prices, _ = self._get_price_data(prepare_next_day)
+            prices, price_entries = self._get_price_data(prepare_next_day)
             if not prices:
                 logger.warning("Schedule update aborted: No price data available")
                 return False
@@ -283,11 +324,12 @@ class BatterySystemManager:
 
             optimization_period, optimization_data = optimization_data_result
 
-            # Run optimization using DP algorithm with quarterly resolution
+            # Run optimization using DP algorithm
             optimization_result = self._run_optimization(
                 optimization_period,
                 optimization_data,
                 prices,
+                price_entries,
                 prepare_next_day,
             )
 
@@ -615,16 +657,29 @@ class BatterySystemManager:
 
             prices = [entry["price"] for entry in price_entries]
 
-            # Prices are quarterly (96 periods) - DP algorithm supports variable horizon
-            # Handle DST transitions (quarterly)
-            if len(prices) == 92:
+            # DP algorithm supports variable horizon and period duration
+            # Nordpool: 92-100 quarterly periods (DST), Octopus: 48 half-hourly
+            period_hours = self._price_manager.price_source.period_duration_hours
+            if period_hours == 0.25:
+                # Nordpool quarterly: handle DST transitions
+                if len(prices) == 92:
+                    logger.info(
+                        "Detected DST spring forward transition (92 quarterly periods)"
+                    )
+                elif len(prices) == 100:
+                    logger.info(
+                        "Detected DST fall back transition (100 quarterly periods)"
+                    )
+                elif len(prices) != 96:
+                    logger.warning(
+                        f"Expected 96 quarterly prices but got {len(prices)}"
+                    )
+            else:
+                expected = int(24 / period_hours)
                 logger.info(
-                    "Detected DST spring forward transition (92 quarterly periods)"
+                    f"Got {len(prices)} prices "
+                    f"({period_hours}h periods, expected ~{expected})"
                 )
-            elif len(prices) == 100:
-                logger.info("Detected DST fall back transition (100 quarterly periods)")
-            elif len(prices) != 96:
-                logger.warning(f"Expected 96 quarterly prices but got {len(prices)}")
 
             return prices, price_entries
 
@@ -917,6 +972,7 @@ class BatterySystemManager:
         optimization_period: int,
         optimization_data: dict[str, list[float]],
         prices: list[float],
+        price_entries: list[dict[str, Any]],
         prepare_next_day: bool,
     ) -> OptimizationResult | None:
         """Run optimization - now returns OptimizationResult directly."""
@@ -959,11 +1015,11 @@ class BatterySystemManager:
                 f"Running optimization for {n_periods} periods from {format_period(optimization_period)}"
             )
 
-            # Calculate buy and sell prices
-            buy_prices = self._price_manager.get_buy_prices(raw_prices=remaining_prices)
-            sell_prices = self._price_manager.get_sell_prices(
-                raw_prices=remaining_prices
-            )
+            # Get buy and sell prices from pre-calculated price entries
+            # This preserves direct sell prices from sources like Octopus Energy
+            remaining_entries = price_entries[optimization_period:]
+            buy_prices = [entry["buyPrice"] for entry in remaining_entries]
+            sell_prices = [entry["sellPrice"] for entry in remaining_entries]
 
             # Run DP optimization with strategic intent capture - returns OptimizationResult directly
             result = optimize_battery_schedule(
@@ -974,6 +1030,7 @@ class BatterySystemManager:
                 initial_soe=current_soe,
                 battery_settings=self.battery_settings,
                 initial_cost_basis=initial_cost_basis,
+                period_duration_hours=self._price_manager.price_source.period_duration_hours,
             )
 
             # Add timestamps to period data (algorithm is time-agnostic, operates on relative indices)
@@ -1123,9 +1180,9 @@ class BatterySystemManager:
             for i, period_data in enumerate(period_data_list):
                 target_period = optimization_period + i
                 if target_period < len(full_day_strategic_intents):
-                    full_day_strategic_intents[
-                        target_period
-                    ] = period_data.decision.strategic_intent
+                    full_day_strategic_intents[target_period] = (
+                        period_data.decision.strategic_intent
+                    )
 
             # Store initial SOC in OptimizationResult for DailyViewBuilder
             if self._initial_soe is not None:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -643,7 +643,14 @@ class BatterySystemManager:
     def _get_price_data(
         self, prepare_next_day: bool
     ) -> tuple[list[float] | None, list[dict[str, Any]] | None]:
-        """Get price data - preserves original logic."""
+        """Get price data, normalized to 15-minute (quarterly) resolution.
+
+        The entire system (period indices, historical store, Growatt schedule,
+        sensor collection) operates on 15-minute periods (96/day).  Price sources
+        may deliver coarser granularity (e.g. 30-min for Octopus, 60-min for
+        official Nordpool).  This method expands such prices so every downstream
+        consumer always sees one entry per 15-minute slot.
+        """
         try:
             if prepare_next_day:
                 price_entries = self._price_manager.get_tomorrow_prices()
@@ -655,31 +662,32 @@ class BatterySystemManager:
                 logger.warning("No prices available")
                 return None, None
 
+            # Normalize to 15-minute resolution if the source uses coarser periods
+            period_hours = self._price_manager.price_source.period_duration_hours
+            if period_hours > 0.25:
+                repeat_factor = int(period_hours / 0.25)
+                original_count = len(price_entries)
+                price_entries = [
+                    entry for entry in price_entries for _ in range(repeat_factor)
+                ]
+                logger.info(
+                    "Normalized %d prices (%sh periods) to %d quarterly entries",
+                    original_count,
+                    period_hours,
+                    len(price_entries),
+                )
+
             prices = [entry["price"] for entry in price_entries]
 
-            # DP algorithm supports variable horizon and period duration
-            # Nordpool: 92-100 quarterly periods (DST), Octopus: 48 half-hourly
-            period_hours = self._price_manager.price_source.period_duration_hours
-            if period_hours == 0.25:
-                # Nordpool quarterly: handle DST transitions
-                if len(prices) == 92:
-                    logger.info(
-                        "Detected DST spring forward transition (92 quarterly periods)"
-                    )
-                elif len(prices) == 100:
-                    logger.info(
-                        "Detected DST fall back transition (100 quarterly periods)"
-                    )
-                elif len(prices) != 96:
-                    logger.warning(
-                        f"Expected 96 quarterly prices but got {len(prices)}"
-                    )
-            else:
-                expected = int(24 / period_hours)
+            # Validate quarterly period count (handles DST: 92, 96, or 100)
+            if len(prices) == 92:
                 logger.info(
-                    f"Got {len(prices)} prices "
-                    f"({period_hours}h periods, expected ~{expected})"
+                    "Detected DST spring forward transition (92 quarterly periods)"
                 )
+            elif len(prices) == 100:
+                logger.info("Detected DST fall back transition (100 quarterly periods)")
+            elif len(prices) != 96:
+                logger.warning(f"Expected 96 quarterly prices but got {len(prices)}")
 
             return prices, price_entries
 
@@ -1030,7 +1038,7 @@ class BatterySystemManager:
                 initial_soe=current_soe,
                 battery_settings=self.battery_settings,
                 initial_cost_basis=initial_cost_basis,
-                period_duration_hours=self._price_manager.price_source.period_duration_hours,
+                period_duration_hours=0.25,  # Always quarterly after normalization in _get_price_data
             )
 
             # Add timestamps to period data (algorithm is time-agnostic, operates on relative indices)

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1988,6 +1988,13 @@ class BatterySystemManager:
         try:
             if "battery" in settings:
                 self.battery_settings.update(**settings["battery"])
+                # Propagate battery capacity to components that store their own copy
+                new_capacity = self.battery_settings.total_capacity
+                self.sensor_collector.battery_capacity = new_capacity
+                self.sensor_collector.energy_flow_calculator.battery_capacity = (
+                    new_capacity
+                )
+                self.historical_store.total_capacity = new_capacity
 
             if "home" in settings:
                 self.home_settings.update(**settings["home"])
@@ -1996,7 +2003,9 @@ class BatterySystemManager:
                 self.price_settings.update(**settings["price"])
                 self._price_manager.markup_rate = self.price_settings.markup_rate
                 self._price_manager.vat_multiplier = self.price_settings.vat_multiplier
-                self._price_manager.additional_costs = self.price_settings.additional_costs
+                self._price_manager.additional_costs = (
+                    self.price_settings.additional_costs
+                )
                 self._price_manager.tax_reduction = self.price_settings.tax_reduction
                 self._price_manager.area = self.price_settings.area
                 self._price_manager.clear_cache()

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -643,13 +643,10 @@ class BatterySystemManager:
     def _get_price_data(
         self, prepare_next_day: bool
     ) -> tuple[list[float] | None, list[dict[str, Any]] | None]:
-        """Get price data, normalized to 15-minute (quarterly) resolution.
+        """Get price data in 15-minute (quarterly) resolution.
 
-        The entire system (period indices, historical store, Growatt schedule,
-        sensor collection) operates on 15-minute periods (96/day).  Price sources
-        may deliver coarser granularity (e.g. 30-min for Octopus, 60-min for
-        official Nordpool).  This method expands such prices so every downstream
-        consumer always sees one entry per 15-minute slot.
+        All price sources return 96 quarterly periods per day. Sources with
+        coarser raw data (e.g. Octopus 30-min) expand internally.
         """
         try:
             if prepare_next_day:
@@ -661,21 +658,6 @@ class BatterySystemManager:
             if not price_entries:
                 logger.warning("No prices available")
                 return None, None
-
-            # Normalize to 15-minute resolution if the source uses coarser periods
-            period_hours = self._price_manager.price_source.period_duration_hours
-            if period_hours > 0.25:
-                repeat_factor = int(period_hours / 0.25)
-                original_count = len(price_entries)
-                price_entries = [
-                    entry for entry in price_entries for _ in range(repeat_factor)
-                ]
-                logger.info(
-                    "Normalized %d prices (%sh periods) to %d quarterly entries",
-                    original_count,
-                    period_hours,
-                    len(price_entries),
-                )
 
             prices = [entry["price"] for entry in price_entries]
 
@@ -1997,6 +1979,12 @@ class BatterySystemManager:
 
             if "price" in settings:
                 self.price_settings.update(**settings["price"])
+                self._price_manager.markup_rate = self.price_settings.markup_rate
+                self._price_manager.vat_multiplier = self.price_settings.vat_multiplier
+                self._price_manager.additional_costs = self.price_settings.additional_costs
+                self._price_manager.tax_reduction = self.price_settings.tax_reduction
+                self._price_manager.area = self.price_settings.area
+                self._price_manager.clear_cache()
 
             logger.info("Settings updated successfully")
 

--- a/core/bess/historical_data_store.py
+++ b/core/bess/historical_data_store.py
@@ -1,36 +1,47 @@
 """HistoricalDataStore - Stores actual sensor data at quarterly resolution.
 
 Simplified storage using continuous period indices (0 = today 00:00).
-Only stores today's data in memory.
+Only stores today's data in memory. Persists to disk for restart recovery.
 """
 
+import json
 import logging
+from dataclasses import asdict, fields
 from datetime import datetime
+from pathlib import Path
 
-from core.bess.models import PeriodData
+from core.bess.models import DecisionData, EconomicData, EnergyData, PeriodData
 from core.bess.time_utils import TIMEZONE, get_period_count
 
 logger = logging.getLogger(__name__)
+
+PERSIST_PATH = Path("/config/bess_historical_data.json")
 
 
 class HistoricalDataStore:
     """Stores actual sensor data at quarterly resolution.
 
     Uses simple integer indices: 0 = today 00:00, 95 = today 23:45.
-    Only stores today's data in memory.
+    Only stores today's data in memory. Persists to disk for restart recovery.
     """
 
-    def __init__(self, battery_capacity_kwh: float):
+    def __init__(self, battery_capacity_kwh: float, persist_path: Path | None = None):
         """Initialize the historical data store.
 
         Args:
             battery_capacity_kwh: Total battery capacity for SOC calculations
+            persist_path: Optional custom path for persistence file (for testing)
         """
         # Simple storage: period_index → PeriodData
         self._records: dict[int, PeriodData] = {}
 
         # Store battery capacity for SOC calculations
         self.total_capacity = battery_capacity_kwh
+
+        self._persist_path = persist_path or PERSIST_PATH
+
+        # Load persisted data on startup
+        self._load_from_disk()
 
         logger.debug("Initialized HistoricalDataStore")
 
@@ -64,6 +75,8 @@ class HistoricalDataStore:
             period_data.energy.battery_soe_end,
         )
 
+        self._save_to_disk()
+
     def get_period(self, period_index: int) -> PeriodData | None:
         """Get data for a specific period.
 
@@ -94,7 +107,122 @@ class HistoricalDataStore:
         Useful for testing or daily reset.
         """
         self._records.clear()
+
+        if self._persist_path.exists():
+            try:
+                self._persist_path.unlink()
+                logger.debug(f"Deleted persistence file {self._persist_path}")
+            except Exception as e:
+                logger.warning(f"Failed to delete persistence file: {e}")
+
         logger.info("Cleared all historical data")
+
+    def _save_to_disk(self) -> None:
+        """Persist today's historical data to survive restart.
+
+        Stores serialized PeriodData records with today's date for validation.
+        """
+        if not self._records:
+            return
+
+        # Serialize records using dataclasses.asdict()
+        serialized_records: dict[str, dict] = {}
+        for period_index, period_data in self._records.items():
+            record_dict = asdict(period_data)
+            # Convert datetime to ISO format for JSON serialization
+            if record_dict["timestamp"] is not None:
+                record_dict["timestamp"] = record_dict["timestamp"].isoformat()
+            serialized_records[str(period_index)] = record_dict
+
+        data = {
+            "date": datetime.now(tz=TIMEZONE).date().isoformat(),
+            "records": serialized_records,
+        }
+
+        try:
+            self._persist_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._persist_path, "w") as f:
+                json.dump(data, f)
+            logger.debug(
+                f"Persisted {len(serialized_records)} historical records"
+                f" to {self._persist_path}"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to persist historical data: {e}")
+
+    def _load_from_disk(self) -> None:
+        """Load persisted historical data on startup.
+
+        Only loads if the persisted file is from today.
+        Reconstructs PeriodData objects, filtering init=False fields
+        so that __post_init__ recalculates derived values.
+        """
+        if not self._persist_path.exists():
+            logger.debug("No persisted historical data file found")
+            return
+
+        try:
+            with open(self._persist_path) as f:
+                data = json.load(f)
+
+            # Validate date - only use if from today
+            stored_date = data.get("date")
+            today = datetime.now(tz=TIMEZONE).date().isoformat()
+            if stored_date != today:
+                logger.info(
+                    f"Persisted historical data from {stored_date}"
+                    f" (not today {today}), discarding"
+                )
+                return
+
+            # Identify init=True field names for filtered reconstruction
+            energy_init_fields = {f.name for f in fields(EnergyData) if f.init}
+            economic_init_fields = {f.name for f in fields(EconomicData) if f.init}
+
+            records = data.get("records", {})
+            for period_key, record_dict in records.items():
+                period_index = int(period_key)
+
+                # Reconstruct EnergyData (filter init=False fields)
+                energy_dict = record_dict["energy"]
+                energy_kwargs = {
+                    k: v for k, v in energy_dict.items() if k in energy_init_fields
+                }
+                energy = EnergyData(**energy_kwargs)
+
+                # Reconstruct EconomicData (filter init=False fields)
+                economic_dict = record_dict.get("economic", {})
+                economic_kwargs = {
+                    k: v for k, v in economic_dict.items() if k in economic_init_fields
+                }
+                economic = EconomicData(**economic_kwargs)
+
+                # Reconstruct DecisionData (all fields are init=True)
+                decision_dict = record_dict.get("decision", {})
+                decision = DecisionData(**decision_dict)
+
+                # Parse timestamp
+                timestamp = None
+                if record_dict.get("timestamp") is not None:
+                    timestamp = datetime.fromisoformat(record_dict["timestamp"])
+
+                period_data = PeriodData(
+                    period=record_dict["period"],
+                    energy=energy,
+                    timestamp=timestamp,
+                    data_source=record_dict.get("data_source", "predicted"),
+                    economic=economic,
+                    decision=decision,
+                )
+
+                self._records[period_index] = period_data
+
+            logger.info(
+                f"Loaded {len(self._records)} persisted historical records" " from disk"
+            )
+
+        except Exception as e:
+            logger.warning(f"Failed to load persisted historical data: {e}")
 
     def get_stored_count(self) -> int:
         """Get count of stored periods.

--- a/core/bess/influxdb_helper.py
+++ b/core/bess/influxdb_helper.py
@@ -116,14 +116,17 @@ def get_sensor_data(sensors_list, start_time=None, stop_time=None) -> dict:
     start_str = start_time.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
     end_str = stop_time.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    sensor_filter = " or ".join(
-        [f'r["_measurement"] == "sensor.{sensor}"' for sensor in sensors_list]
-    )
+    # Build sensor filter compatible with both InfluxDB 1.x and 2.x:
+    # - InfluxDB 2.x: _measurement contains the entity_id (e.g. "sensor.xyz_...")
+    # - InfluxDB 1.x: _measurement contains the unit (e.g. "%", "W"), entity_id is a tag
+    sensor_conditions = []
+    for sensor in sensors_list:
+        sensor_conditions.append(
+            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "sensor.{sensor}"'
+        )
+    sensor_filter = " or ".join(f"({c})" for c in sensor_conditions)
 
     # Time-bounded query (always uses range since we always have start_time)
-    # Note: The _measurement filter already uniquely identifies the sensors,
-    # so the "domain" tag filter is omitted for compatibility with InfluxDB 1.x
-    # setups where this tag may not be present.
     flux_query = f"""from(bucket: "{bucket}")
                     |> range(start: {start_str}, stop: {end_str})
                     |> filter(fn: (r) => {sensor_filter})
@@ -163,29 +166,75 @@ def get_sensor_data(sensors_list, start_time=None, stop_time=None) -> dict:
         return {"status": "error", "message": f"Unexpected error: {e!s}"}
 
 
+def _build_column_index(data_lines: list[str]) -> dict[str, int] | None:
+    """Find the header row in CSV data lines and return a column name-to-index map.
+
+    The header row is the first non-empty line that contains known InfluxDB column
+    names like '_value' and '_time'. Returns None if no header row is found.
+    """
+    for line in data_lines:
+        parts = [p.strip() for p in line.split(",")]
+        if "_value" in parts and "_time" in parts:
+            return {name: idx for idx, name in enumerate(parts)}
+    return None
+
+
+def _extract_sensor_name(parts: list[str], col_map: dict[str, int]) -> str:
+    """Extract the sensor entity_id from a CSV row, supporting both InfluxDB versions.
+
+    InfluxDB 2.x stores the entity_id in _measurement.
+    InfluxDB 1.x stores it in the entity_id tag column.
+    """
+    entity_id_idx = col_map.get("entity_id")
+    measurement_idx = col_map.get("_measurement")
+
+    # Prefer entity_id tag if it exists and looks like a sensor entity
+    if entity_id_idx is not None and entity_id_idx < len(parts):
+        entity_val = parts[entity_id_idx].strip()
+        if entity_val.startswith("sensor."):
+            return entity_val
+
+    # Fall back to _measurement (InfluxDB 2.x stores entity_id here)
+    if measurement_idx is not None and measurement_idx < len(parts):
+        measurement_val = parts[measurement_idx].strip()
+        if measurement_val.startswith("sensor."):
+            return measurement_val
+
+    return ""
+
+
 def parse_influxdb_response(response_text) -> dict:
-    """Parse InfluxDB response to extract the latest measurement for each sensor."""
+    """Parse InfluxDB response to extract the latest measurement for each sensor.
+
+    Uses header-aware column detection to support both InfluxDB 1.x and 2.x,
+    where columns may appear at different positions depending on the tag set.
+    """
     readings = {}
     lines = response_text.strip().split("\n")
 
     # Skip metadata rows (lines starting with '#')
     data_lines = [line for line in lines if not line.startswith("#")]
 
-    # Process each data line
+    col_map = _build_column_index(data_lines)
+    if col_map is None:
+        _LOGGER.warning("No header row found in InfluxDB response")
+        return readings
+
+    value_idx = col_map["_value"]
+
+    # Process each data line (skip the header row itself)
     for line in data_lines:
         parts = line.split(",")
         try:
-            # Ensure the line has enough parts and the value can be converted to float
-            if len(parts) < 9 or parts[6] == "_value":
+            # Skip header row and short lines
+            if len(parts) <= value_idx or parts[value_idx].strip() == "_value":
                 continue
 
-            # Extract sensor name (_measurement) and value (_value)
-            sensor_name = parts[
-                10
-            ].strip()  # _measurement is the 11th column (index 10)
-            value = float(parts[6].strip())  # _value is the 7th column (index 6)
+            sensor_name = _extract_sensor_name(parts, col_map)
+            if not sensor_name:
+                continue
 
-            # Store the value in the readings dictionary with the sensor name
+            value = float(parts[value_idx].strip())
             readings[sensor_name] = value
         except (IndexError, ValueError) as e:
             _LOGGER.error("Failed to parse line: %s, error: %s", line, e)
@@ -252,15 +301,18 @@ def get_sensor_data_batch(sensors_list, target_date) -> dict:
     )
     end_str = end_datetime.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    sensor_filter = " or ".join(
-        [f'r["_measurement"] == "sensor.{sensor}"' for sensor in sensors_list]
-    )
+    # Build sensor filter compatible with both InfluxDB 1.x and 2.x:
+    # - InfluxDB 2.x: _measurement contains the entity_id (e.g. "sensor.xyz_...")
+    # - InfluxDB 1.x: _measurement contains the unit (e.g. "%", "W"), entity_id is a tag
+    sensor_conditions = []
+    for sensor in sensors_list:
+        sensor_conditions.append(
+            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "sensor.{sensor}"'
+        )
+    sensor_filter = " or ".join(f"({c})" for c in sensor_conditions)
 
     # Batch query: Get ALL data points, then for each period we'll find the last value
     # BEFORE that period's end time (same logic as individual queries for sparse data).
-    # Note: The _measurement filter already uniquely identifies the sensors,
-    # so the "domain" tag filter is omitted for compatibility with InfluxDB 1.x
-    # setups where this tag may not be present.
     flux_query = f"""from(bucket: "{bucket}")
                     |> range(start: {start_str}, stop: {end_str})
                     |> filter(fn: (r) => {sensor_filter})
@@ -301,14 +353,23 @@ def get_sensor_data_batch(sensors_list, target_date) -> dict:
         data_lines = [line for line in response_lines if not line.startswith("#")]
         _LOGGER.info("InfluxDB returned %d data lines (non-header)", len(data_lines))
 
-        # Log unique measurements to see what sensors we got
+        # Log unique sensors found using header-aware column detection
+        col_map = _build_column_index(data_lines)
         measurements = {}
-        for line in data_lines:
-            parts = line.split(",")
-            if len(parts) > 10 and parts[10] != "entity_id" and parts[6] != "_value":
-                sensor = parts[10].strip()
-                measurements[sensor] = measurements.get(sensor, 0) + 1
+        if col_map is not None:
+            value_idx = col_map["_value"]
+            for line in data_lines:
+                parts = line.split(",")
+                if len(parts) <= value_idx or parts[value_idx].strip() == "_value":
+                    continue
+                sensor = _extract_sensor_name(parts, col_map)
+                if sensor:
+                    measurements[sensor] = measurements.get(sensor, 0) + 1
         _LOGGER.info("Sensor counts in response: %s", measurements)
+        if not measurements and data_lines:
+            _LOGGER.warning(
+                "Zero sensors found. First 3 data lines: %s", data_lines[:3]
+            )
 
         # Parse the batch response
         period_data = _parse_batch_response(
@@ -366,18 +427,31 @@ def _parse_batch_response(
     lines = response_text.strip().split("\n")
     data_lines = [line for line in lines if not line.startswith("#")]
 
+    col_map = _build_column_index(data_lines)
+    if col_map is None:
+        _LOGGER.warning("No header row found in batch InfluxDB response")
+        return {}
+
+    value_idx = col_map["_value"]
+    time_idx = col_map["_time"]
+
     # Step 1: Parse all data points grouped by sensor
     sensor_data = {}  # {sensor_name: [(timestamp, value), ...]}
 
     for line in data_lines:
         parts = line.split(",")
         try:
-            if len(parts) < 11 or parts[6] == "_value":
+            if (
+                len(parts) <= max(value_idx, time_idx)
+                or parts[value_idx].strip() == "_value"
+            ):
                 continue
 
-            timestamp_str = parts[5].strip()
-            sensor_name = parts[10].strip()
-            value = float(parts[6].strip())
+            timestamp_str = parts[time_idx].strip()
+            sensor_name = _extract_sensor_name(parts, col_map)
+            if not sensor_name:
+                continue
+            value = float(parts[value_idx].strip())
 
             timestamp = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
             timestamp_local = timestamp.astimezone(local_tz)

--- a/core/bess/influxdb_helper.py
+++ b/core/bess/influxdb_helper.py
@@ -117,12 +117,13 @@ def get_sensor_data(sensors_list, start_time=None, stop_time=None) -> dict:
     end_str = stop_time.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Build sensor filter compatible with both InfluxDB 1.x and 2.x:
-    # - InfluxDB 2.x: _measurement contains the entity_id (e.g. "sensor.xyz_...")
-    # - InfluxDB 1.x: _measurement contains the unit (e.g. "%", "W"), entity_id is a tag
+    # - InfluxDB 2.x: _measurement contains the full entity_id (e.g. "sensor.xyz_...")
+    # - InfluxDB 1.x: _measurement contains the unit (e.g. "%", "W"),
+    #   entity_id tag stores the short name without domain prefix (e.g. "xyz_...")
     sensor_conditions = []
     for sensor in sensors_list:
         sensor_conditions.append(
-            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "sensor.{sensor}"'
+            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "{sensor}"'
         )
     sensor_filter = " or ".join(f"({c})" for c in sensor_conditions)
 
@@ -182,17 +183,26 @@ def _build_column_index(data_lines: list[str]) -> dict[str, int] | None:
 def _extract_sensor_name(parts: list[str], col_map: dict[str, int]) -> str:
     """Extract the sensor entity_id from a CSV row, supporting both InfluxDB versions.
 
-    InfluxDB 2.x stores the entity_id in _measurement.
-    InfluxDB 1.x stores it in the entity_id tag column.
+    InfluxDB 2.x stores the full entity_id (e.g. "sensor.xyz_...") in _measurement.
+    InfluxDB 1.x stores the short name without domain prefix (e.g. "xyz_...") in the
+    entity_id tag column, with the domain ("sensor") in a separate domain tag.
+
+    Returns a normalized name always prefixed with "sensor." so downstream consumers
+    (e.g. _normalize_sensor_readings) can consistently strip the prefix.
     """
     entity_id_idx = col_map.get("entity_id")
     measurement_idx = col_map.get("_measurement")
 
-    # Prefer entity_id tag if it exists and looks like a sensor entity
+    # Prefer entity_id tag if present and non-empty
     if entity_id_idx is not None and entity_id_idx < len(parts):
         entity_val = parts[entity_id_idx].strip()
-        if entity_val.startswith("sensor."):
-            return entity_val
+        if entity_val:
+            # InfluxDB 2.x: already has "sensor." prefix
+            if entity_val.startswith("sensor."):
+                return entity_val
+            # InfluxDB 1.x: short name without prefix — normalize it
+            if entity_val and entity_val != "entity_id":
+                return f"sensor.{entity_val}"
 
     # Fall back to _measurement (InfluxDB 2.x stores entity_id here)
     if measurement_idx is not None and measurement_idx < len(parts):
@@ -302,12 +312,13 @@ def get_sensor_data_batch(sensors_list, target_date) -> dict:
     end_str = end_datetime.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Build sensor filter compatible with both InfluxDB 1.x and 2.x:
-    # - InfluxDB 2.x: _measurement contains the entity_id (e.g. "sensor.xyz_...")
-    # - InfluxDB 1.x: _measurement contains the unit (e.g. "%", "W"), entity_id is a tag
+    # - InfluxDB 2.x: _measurement contains the full entity_id (e.g. "sensor.xyz_...")
+    # - InfluxDB 1.x: _measurement contains the unit (e.g. "%", "W"),
+    #   entity_id tag stores the short name without domain prefix (e.g. "xyz_...")
     sensor_conditions = []
     for sensor in sensors_list:
         sensor_conditions.append(
-            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "sensor.{sensor}"'
+            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "{sensor}"'
         )
     sensor_filter = " or ".join(f"({c})" for c in sensor_conditions)
 

--- a/core/bess/octopus_energy_source.py
+++ b/core/bess/octopus_energy_source.py
@@ -2,7 +2,9 @@
 Octopus Energy Agile tariff price source.
 
 Fetches import and export rates from Octopus Energy HA event entities.
-Prices are VAT-inclusive in GBP/kWh at 30-minute resolution (48 periods/day).
+Prices are VAT-inclusive in GBP/kWh. Raw data arrives at 30-minute resolution
+(48 periods/day) and is expanded to 15-minute quarterly resolution (96 periods/day)
+to match the system-wide period model.
 """
 
 import logging
@@ -13,15 +15,17 @@ from .price_manager import PriceSource
 
 logger = logging.getLogger(__name__)
 
-EXPECTED_PERIODS_PER_DAY = 48
-MIN_PERIODS_PER_DAY = 46
+EXPECTED_RAW_PERIODS = 48  # Octopus provides 48 half-hourly slots
+MIN_RAW_PERIODS = 46  # Allow slightly fewer during incremental publishing
 
 
 class OctopusEnergySource(PriceSource):
     """Price source for Octopus Energy Agile tariff via Home Assistant event entities.
 
+    Raw data arrives at 30-minute resolution (48 half-hourly slots per day) and is
+    expanded to 96 quarterly (15-minute) periods to match the system-wide period model.
+
     Key differences from Nordpool:
-    - 30-minute periods (48/day) instead of 15-minute (96/day)
     - Separate import and export rate entities
     - Prices are already VAT-inclusive final prices in GBP/kWh
     - Data comes from HA event entity attributes (rates list)
@@ -52,8 +56,8 @@ class OctopusEnergySource(PriceSource):
 
     @property
     def period_duration_hours(self) -> float:
-        """Octopus Energy uses 30-minute periods."""
-        return 0.5
+        """Quarterly (15-minute) periods, matching the system-wide resolution."""
+        return 0.25
 
     def get_prices_for_date(self, target_date: date) -> list[float]:
         """Get import rates from Octopus Energy for the specified date.
@@ -62,7 +66,8 @@ class OctopusEnergySource(PriceSource):
             target_date: The date to get import prices for
 
         Returns:
-            List of 48 import rates in GBP/kWh (VAT-inclusive)
+            List of 96 quarterly import rates in GBP/kWh (VAT-inclusive),
+            expanded from 48 half-hourly raw rates
 
         Raises:
             PriceDataUnavailableError: If rates cannot be fetched
@@ -90,7 +95,8 @@ class OctopusEnergySource(PriceSource):
             target_date: The date to get export prices for
 
         Returns:
-            List of 48 export rates in GBP/kWh, or None if no export entity configured
+            List of 96 quarterly export rates in GBP/kWh (expanded from 48 raw),
+            or None if no export entity configured
         """
         if not self.export_today_entity and not self.export_tomorrow_entity:
             return None
@@ -120,13 +126,16 @@ class OctopusEnergySource(PriceSource):
     ) -> list[float]:
         """Fetch rates from a Home Assistant event entity.
 
+        Octopus provides 48 half-hourly rates. Each rate is duplicated to produce
+        96 quarterly (15-minute) periods matching the system-wide resolution.
+
         Args:
             entity_id: HA entity ID to fetch from
             target_date: Date to filter rates for
             rate_type: "import" or "export" (for logging)
 
         Returns:
-            List of 48 rate values (value_inc_vat) sorted chronologically
+            List of 96 quarterly rate values (value_inc_vat) sorted chronologically
 
         Raises:
             PriceDataUnavailableError: If rates cannot be fetched or validated
@@ -159,33 +168,37 @@ class OctopusEnergySource(PriceSource):
         # Filter rates for the target date and sort chronologically
         filtered_rates = self._filter_rates_for_date(rates, target_date)
 
-        if len(filtered_rates) < MIN_PERIODS_PER_DAY:
+        if len(filtered_rates) < MIN_RAW_PERIODS:
             raise PriceDataUnavailableError(
                 date=target_date,
                 message=(
-                    f"Expected at least {MIN_PERIODS_PER_DAY} {rate_type} rates for {target_date}, "
+                    f"Expected at least {MIN_RAW_PERIODS} {rate_type} rates for {target_date}, "
                     f"got {len(filtered_rates)} from {entity_id}"
                 ),
             )
-        if len(filtered_rates) > EXPECTED_PERIODS_PER_DAY:
+        if len(filtered_rates) > EXPECTED_RAW_PERIODS:
             raise PriceDataUnavailableError(
                 date=target_date,
                 message=(
                     f"Too many {rate_type} rates for {target_date}: "
-                    f"expected at most {EXPECTED_PERIODS_PER_DAY}, "
+                    f"expected at most {EXPECTED_RAW_PERIODS}, "
                     f"got {len(filtered_rates)} from {entity_id}"
                 ),
             )
 
-        # Extract value_inc_vat from each rate entry
-        prices = [float(rate["value_inc_vat"]) for rate in filtered_rates]
+        # Extract value_inc_vat from each half-hourly rate entry
+        half_hourly_prices = [float(rate["value_inc_vat"]) for rate in filtered_rates]
+
+        # Expand 48 half-hourly prices → 96 quarterly prices (duplicate each)
+        quarterly_prices = [p for p in half_hourly_prices for _ in range(2)]
 
         logger.info(
-            f"Fetched {len(prices)} Octopus {rate_type} rates for {target_date}: "
-            f"range {min(prices):.4f} - {max(prices):.4f} GBP/kWh"
+            f"Fetched {len(half_hourly_prices)} Octopus {rate_type} rates for {target_date} "
+            f"(expanded to {len(quarterly_prices)} quarterly periods): "
+            f"range {min(half_hourly_prices):.4f} - {max(half_hourly_prices):.4f} GBP/kWh"
         )
 
-        return prices
+        return quarterly_prices
 
     def _filter_rates_for_date(
         self, rates: list[dict], target_date: date

--- a/core/bess/octopus_energy_source.py
+++ b/core/bess/octopus_energy_source.py
@@ -14,6 +14,7 @@ from .price_manager import PriceSource
 logger = logging.getLogger(__name__)
 
 EXPECTED_PERIODS_PER_DAY = 48
+MIN_PERIODS_PER_DAY = 46
 
 
 class OctopusEnergySource(PriceSource):
@@ -158,11 +159,20 @@ class OctopusEnergySource(PriceSource):
         # Filter rates for the target date and sort chronologically
         filtered_rates = self._filter_rates_for_date(rates, target_date)
 
-        if len(filtered_rates) != EXPECTED_PERIODS_PER_DAY:
+        if len(filtered_rates) < MIN_PERIODS_PER_DAY:
             raise PriceDataUnavailableError(
                 date=target_date,
                 message=(
-                    f"Expected {EXPECTED_PERIODS_PER_DAY} {rate_type} rates for {target_date}, "
+                    f"Expected at least {MIN_PERIODS_PER_DAY} {rate_type} rates for {target_date}, "
+                    f"got {len(filtered_rates)} from {entity_id}"
+                ),
+            )
+        if len(filtered_rates) > EXPECTED_PERIODS_PER_DAY:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=(
+                    f"Too many {rate_type} rates for {target_date}: "
+                    f"expected at most {EXPECTED_PERIODS_PER_DAY}, "
                     f"got {len(filtered_rates)} from {entity_id}"
                 ),
             )

--- a/core/bess/octopus_energy_source.py
+++ b/core/bess/octopus_energy_source.py
@@ -1,0 +1,261 @@
+"""
+Octopus Energy Agile tariff price source.
+
+Fetches import and export rates from Octopus Energy HA event entities.
+Prices are VAT-inclusive in GBP/kWh at 30-minute resolution (48 periods/day).
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+
+from .exceptions import PriceDataUnavailableError, SystemConfigurationError
+from .price_manager import PriceSource
+
+logger = logging.getLogger(__name__)
+
+EXPECTED_PERIODS_PER_DAY = 48
+
+
+class OctopusEnergySource(PriceSource):
+    """Price source for Octopus Energy Agile tariff via Home Assistant event entities.
+
+    Key differences from Nordpool:
+    - 30-minute periods (48/day) instead of 15-minute (96/day)
+    - Separate import and export rate entities
+    - Prices are already VAT-inclusive final prices in GBP/kWh
+    - Data comes from HA event entity attributes (rates list)
+    """
+
+    def __init__(
+        self,
+        ha_controller,
+        import_today_entity: str,
+        import_tomorrow_entity: str,
+        export_today_entity: str,
+        export_tomorrow_entity: str,
+    ) -> None:
+        """Initialize with Home Assistant controller and Octopus entity IDs.
+
+        Args:
+            ha_controller: Controller with access to Home Assistant API
+            import_today_entity: Entity ID for today's import rates
+            import_tomorrow_entity: Entity ID for tomorrow's import rates
+            export_today_entity: Entity ID for today's export rates
+            export_tomorrow_entity: Entity ID for tomorrow's export rates
+        """
+        self.ha_controller = ha_controller
+        self.import_today_entity = import_today_entity
+        self.import_tomorrow_entity = import_tomorrow_entity
+        self.export_today_entity = export_today_entity
+        self.export_tomorrow_entity = export_tomorrow_entity
+
+    @property
+    def period_duration_hours(self) -> float:
+        """Octopus Energy uses 30-minute periods."""
+        return 0.5
+
+    def get_prices_for_date(self, target_date: date) -> list[float]:
+        """Get import rates from Octopus Energy for the specified date.
+
+        Args:
+            target_date: The date to get import prices for
+
+        Returns:
+            List of 48 import rates in GBP/kWh (VAT-inclusive)
+
+        Raises:
+            PriceDataUnavailableError: If rates cannot be fetched
+            SystemConfigurationError: If date is not today or tomorrow
+        """
+        current_date = datetime.now().date()
+        tomorrow_date = current_date + timedelta(days=1)
+
+        if target_date not in (current_date, tomorrow_date):
+            raise SystemConfigurationError(
+                message=f"Can only fetch today's or tomorrow's prices, not {target_date}"
+            )
+
+        if target_date == current_date:
+            entity_id = self.import_today_entity
+        else:
+            entity_id = self.import_tomorrow_entity
+
+        return self._fetch_rates(entity_id, target_date, "import")
+
+    def get_sell_prices_for_date(self, target_date: date) -> list[float] | None:
+        """Get export rates from Octopus Energy for the specified date.
+
+        Args:
+            target_date: The date to get export prices for
+
+        Returns:
+            List of 48 export rates in GBP/kWh, or None if no export entity configured
+        """
+        if not self.export_today_entity and not self.export_tomorrow_entity:
+            return None
+
+        current_date = datetime.now().date()
+        tomorrow_date = current_date + timedelta(days=1)
+
+        if target_date not in (current_date, tomorrow_date):
+            return None
+
+        if target_date == current_date:
+            entity_id = self.export_today_entity
+        else:
+            entity_id = self.export_tomorrow_entity
+
+        if not entity_id:
+            return None
+
+        try:
+            return self._fetch_rates(entity_id, target_date, "export")
+        except PriceDataUnavailableError:
+            logger.warning(f"Export rates unavailable for {target_date}")
+            return None
+
+    def _fetch_rates(
+        self, entity_id: str, target_date: date, rate_type: str
+    ) -> list[float]:
+        """Fetch rates from a Home Assistant event entity.
+
+        Args:
+            entity_id: HA entity ID to fetch from
+            target_date: Date to filter rates for
+            rate_type: "import" or "export" (for logging)
+
+        Returns:
+            List of 48 rate values (value_inc_vat) sorted chronologically
+
+        Raises:
+            PriceDataUnavailableError: If rates cannot be fetched or validated
+        """
+        try:
+            response = self.ha_controller._api_request(
+                "get", f"/api/states/{entity_id}"
+            )
+        except Exception as e:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"Failed to fetch {rate_type} rates from {entity_id}: {e}",
+            ) from e
+
+        if not response or "attributes" not in response:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"No attributes in response from {entity_id}",
+            )
+
+        attributes = response["attributes"]
+        rates = attributes.get("rates")
+
+        if not rates or not isinstance(rates, list):
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"No rates list in attributes from {entity_id}",
+            )
+
+        # Filter rates for the target date and sort chronologically
+        filtered_rates = self._filter_rates_for_date(rates, target_date)
+
+        if len(filtered_rates) != EXPECTED_PERIODS_PER_DAY:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=(
+                    f"Expected {EXPECTED_PERIODS_PER_DAY} {rate_type} rates for {target_date}, "
+                    f"got {len(filtered_rates)} from {entity_id}"
+                ),
+            )
+
+        # Extract value_inc_vat from each rate entry
+        prices = [float(rate["value_inc_vat"]) for rate in filtered_rates]
+
+        logger.info(
+            f"Fetched {len(prices)} Octopus {rate_type} rates for {target_date}: "
+            f"range {min(prices):.4f} - {max(prices):.4f} GBP/kWh"
+        )
+
+        return prices
+
+    def _filter_rates_for_date(
+        self, rates: list[dict], target_date: date
+    ) -> list[dict]:
+        """Filter and sort rates for a specific date.
+
+        Args:
+            rates: List of rate entries with 'start' timestamps
+            target_date: Date to filter for
+
+        Returns:
+            Filtered and sorted list of rate entries for the target date
+        """
+        filtered = []
+        for rate in rates:
+            start_str = rate.get("start")
+            if not start_str:
+                continue
+
+            try:
+                start_dt = datetime.fromisoformat(start_str)
+                if start_dt.date() == target_date:
+                    filtered.append(rate)
+            except (ValueError, TypeError):
+                continue
+
+        # Sort by start time
+        filtered.sort(key=lambda r: r["start"])
+
+        return filtered
+
+    def perform_health_check(self) -> dict:
+        """Perform health check on Octopus Energy source.
+
+        Returns:
+            dict: Health check result with status and checks
+        """
+        checks = []
+        overall_status = "OK"
+        today = datetime.now().date()
+
+        # Test import rates
+        import_check = {
+            "component": "OctopusEnergySource (Import)",
+            "status": "OK",
+            "message": "",
+        }
+        try:
+            import_prices = self.get_prices_for_date(today)
+            import_check["message"] = (
+                f"Successfully fetched {len(import_prices)} import rates for today"
+            )
+        except Exception as e:
+            import_check["status"] = "ERROR"
+            import_check["message"] = f"Failed to fetch import rates: {e}"
+            overall_status = "ERROR"
+        checks.append(import_check)
+
+        # Test export rates
+        export_check = {
+            "component": "OctopusEnergySource (Export)",
+            "status": "OK",
+            "message": "",
+        }
+        try:
+            export_prices = self.get_sell_prices_for_date(today)
+            if export_prices is not None:
+                export_check["message"] = (
+                    f"Successfully fetched {len(export_prices)} export rates for today"
+                )
+            else:
+                export_check["message"] = "No export entity configured"
+        except Exception as e:
+            export_check["status"] = "WARNING"
+            export_check["message"] = f"Failed to fetch export rates: {e}"
+            if overall_status == "OK":
+                overall_status = "WARNING"
+        checks.append(export_check)
+
+        return {
+            "status": overall_status,
+            "checks": checks,
+        }

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -22,8 +22,9 @@ class PriceSource:
     def period_duration_hours(self) -> float:
         """Duration of each price period in hours.
 
-        Returns:
-            0.25 for quarterly (Nordpool), 0.5 for half-hourly (Octopus), etc.
+        All sources must return 0.25 (quarterly / 15-minute periods) to match
+        the system-wide period model. Sources with coarser raw data (e.g. Octopus
+        30-min) must expand internally before returning prices.
         """
         return 0.25
 
@@ -390,6 +391,17 @@ class PriceManager:
         self._tomorrow_prices = None
         self._tomorrow_date = None
 
+    def clear_cache(self) -> None:
+        """Clear cached price data.
+
+        Must be called when pricing parameters (markup, VAT, additional costs)
+        change, since cached prices were calculated with the old values.
+        """
+        self._today_prices = None
+        self._today_date = None
+        self._tomorrow_prices = None
+        self._tomorrow_date = None
+
     def _calculate_buy_price(self, base_price: float) -> float:
         """Calculate retail buy price from Nordpool base price.
 
@@ -564,16 +576,13 @@ class PriceManager:
     def get_available_prices(self) -> tuple[list[float], list[float]]:
         """Get all available prices starting at today 00:00.
 
-        Period count depends on the price source resolution:
-        - Nordpool: 96 periods/day (15-min quarterly)
-        - Octopus Energy: 48 periods/day (30-min half-hourly)
-
+        All sources provide 96 quarterly (15-minute) periods per day.
         Automatically tries tomorrow, falls back to today only.
 
         Returns:
             (buy_prices, sell_prices) tuple where:
             - Index 0 = today 00:00
-            - Length: periods_per_day (today only) or 2x (today + tomorrow)
+            - Length: 96 (today only) or 192 (today + tomorrow)
         """
         today = datetime.now().date()
         tomorrow = today + timedelta(days=1)

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -18,6 +18,15 @@ class PriceSource:
     This defines the interface that all price sources must implement.
     """
 
+    @property
+    def period_duration_hours(self) -> float:
+        """Duration of each price period in hours.
+
+        Returns:
+            0.25 for quarterly (Nordpool), 0.5 for half-hourly (Octopus), etc.
+        """
+        return 0.25
+
     def get_prices_for_date(self, target_date: date) -> list:
         """Get prices for a specific date.
 
@@ -25,12 +34,27 @@ class PriceSource:
             target_date: The date to get prices for
 
         Returns:
-            List of hourly prices for the specified date
+            List of prices for the specified date (one per period)
 
         Raises:
             NotImplementedError: If the source doesn't implement this method
         """
         raise NotImplementedError("Price sources must implement get_prices_for_date")
+
+    def get_sell_prices_for_date(self, target_date: date) -> list[float] | None:
+        """Get separate sell/export prices for a specific date.
+
+        Override this method when the price source provides distinct export rates
+        (e.g., Octopus Energy). Returns None by default, meaning sell prices are
+        calculated from buy prices using markup/tax reduction.
+
+        Args:
+            target_date: The date to get sell prices for
+
+        Returns:
+            List of sell prices per period, or None if not applicable
+        """
+        return None
 
     def perform_health_check(self) -> dict:
         """Perform health check on the price source.
@@ -416,17 +440,27 @@ class PriceManager:
             # Get raw prices from the source
             raw_prices = self.price_source.get_prices_for_date(target_date)
 
+            # Check for separate sell/export prices (e.g., Octopus Energy)
+            direct_sell_prices = self.price_source.get_sell_prices_for_date(target_date)
+
             # Format prices with timestamp and calculations
             price_data = []
             base_timestamp = datetime.combine(target_date, datetime.min.time())
+            period_hours = self.price_source.period_duration_hours
 
-            for hour, price in enumerate(raw_prices):
-                timestamp = base_timestamp + timedelta(hours=hour)
+            for index, price in enumerate(raw_prices):
+                timestamp = base_timestamp + timedelta(hours=index * period_hours)
+
+                if direct_sell_prices is not None:
+                    sell_price = direct_sell_prices[index]
+                else:
+                    sell_price = self._calculate_sell_price(price)
+
                 price_entry = {
                     "timestamp": timestamp.strftime("%Y-%m-%d %H:%M"),
                     "price": price,
                     "buyPrice": self._calculate_buy_price(price),
-                    "sellPrice": self._calculate_sell_price(price),
+                    "sellPrice": sell_price,
                 }
                 price_data.append(price_entry)
 
@@ -527,24 +561,19 @@ class PriceManager:
             price_data = self.get_price_data(target_date)
             return [entry["sellPrice"] for entry in price_data]
 
-
     def get_available_prices(self) -> tuple[list[float], list[float]]:
-        """Get all available prices at quarterly resolution starting at today 00:00.
+        """Get all available prices starting at today 00:00.
 
-        Nordpool provides quarterly prices (96 periods/day) directly.
+        Period count depends on the price source resolution:
+        - Nordpool: 96 periods/day (15-min quarterly)
+        - Octopus Energy: 48 periods/day (30-min half-hourly)
+
         Automatically tries tomorrow, falls back to today only.
 
         Returns:
             (buy_prices, sell_prices) tuple where:
             - Index 0 = today 00:00
-            - Index 96 = tomorrow 00:00 (if available)
-            - Length: 96 (today only) or 192 (today + tomorrow)
-
-        Example at 14:00:
-            buy, sell = get_available_prices()
-            # buy[0] = today 00:00
-            # buy[56] = today 14:00 (current period)
-            # Caller slices: buy[56:] for optimization from now
+            - Length: periods_per_day (today only) or 2x (today + tomorrow)
         """
         today = datetime.now().date()
         tomorrow = today + timedelta(days=1)
@@ -607,14 +636,14 @@ class PriceManager:
 
             price_data = f"\n{title}:\n"
             price_data += "-" * 50 + "\n"
-            price_data += "Hour   | Nordpool Price | Retail Price  | Sell Price\n"
+            price_data += "Time   | Base Price     | Buy Price     | Sell Price\n"
             price_data += "-" * 50 + "\n"
 
             for entry in prices:
-                hour = entry["timestamp"].split()[1][:5]
-                price_str = f"{hour}  | {entry['price']:.4f} SEK    | "
-                buy_str = f"{entry['buyPrice']:.4f} SEK  | "
-                sell_str = f"{entry['sellPrice']:.4f} SEK\n"
+                time_str = entry["timestamp"].split()[1][:5]
+                price_str = f"{time_str}  | {entry['price']:.4f}        | "
+                buy_str = f"{entry['buyPrice']:.4f}       | "
+                sell_str = f"{entry['sellPrice']:.4f}\n"
                 price_data += price_str + buy_str + sell_str
 
             self._logger.info(price_data)

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -501,7 +501,7 @@ class PriceManager:
         tomorrow = datetime.now().date() + timedelta(days=1)
         try:
             return self.get_price_data(tomorrow)
-        except ValueError:
+        except (ValueError, PriceDataUnavailableError):
             return []  # Return empty list instead of raising error
 
     def get_prices(self, target_date: date | None = None) -> list:

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -79,10 +79,10 @@ def _make_source(controller):
 class TestOctopusEnergySourceProperties:
     """Test basic properties of OctopusEnergySource."""
 
-    def test_period_duration_hours_is_half_hour(self):
+    def test_period_duration_hours_is_quarterly(self):
         controller = MagicMock()
         source = _make_source(controller)
-        assert source.period_duration_hours == 0.5
+        assert source.period_duration_hours == 0.25
 
     def test_default_price_source_period_duration_is_quarter(self):
         """Verify the base PriceSource default is 0.25 (Nordpool)."""
@@ -101,9 +101,13 @@ class TestImportRateFetching:
 
         prices = source.get_prices_for_date(today)
 
-        assert len(prices) == 48
+        # 48 half-hourly rates expanded to 96 quarterly periods
+        assert len(prices) == 96
+        # Each raw rate is duplicated: indices 0,1 from rate 0; indices 94,95 from rate 47
         assert prices[0] == rates[0]["value_inc_vat"]
-        assert prices[47] == rates[47]["value_inc_vat"]
+        assert prices[1] == rates[0]["value_inc_vat"]
+        assert prices[94] == rates[47]["value_inc_vat"]
+        assert prices[95] == rates[47]["value_inc_vat"]
 
     def test_fetch_tomorrow_import_rates(self):
         tomorrow = datetime.now().date() + timedelta(days=1)
@@ -113,7 +117,7 @@ class TestImportRateFetching:
 
         prices = source.get_prices_for_date(tomorrow)
 
-        assert len(prices) == 48
+        assert len(prices) == 96
 
     def test_rejects_date_beyond_tomorrow(self):
         day_after = datetime.now().date() + timedelta(days=2)
@@ -142,7 +146,8 @@ class TestImportRateFetching:
             source = _make_source(controller)
 
             prices = source.get_prices_for_date(today)
-            assert len(prices) == count
+            # Each raw rate is expanded to 2 quarterly periods
+            assert len(prices) == count * 2
 
     def test_too_many_rates_raises_error(self):
         """More than 48 rates for a single date should fail validation."""
@@ -198,8 +203,10 @@ class TestExportRateFetching:
         sell_prices = source.get_sell_prices_for_date(today)
 
         assert sell_prices is not None
-        assert len(sell_prices) == 48
+        assert len(sell_prices) == 96
+        # Each raw rate is duplicated into two quarterly periods
         assert sell_prices[0] == export_rates[0]["value_inc_vat"]
+        assert sell_prices[1] == export_rates[0]["value_inc_vat"]
 
     def test_no_export_entity_returns_none(self):
         today = datetime.now().date()
@@ -246,7 +253,7 @@ class TestDateFilteringAndSorting:
         source = _make_source(controller)
 
         prices = source.get_prices_for_date(today)
-        assert len(prices) == 48
+        assert len(prices) == 96  # 48 raw rates expanded to 96 quarterly
 
     def test_sorts_rates_chronologically(self):
         """Rates should be sorted by start time regardless of input order."""
@@ -259,9 +266,10 @@ class TestDateFilteringAndSorting:
         source = _make_source(controller)
 
         prices = source.get_prices_for_date(today)
-        assert len(prices) == 48
-        # First price should be the midnight rate (lowest index)
+        assert len(prices) == 96
+        # First price should be the midnight rate (lowest index), duplicated
         assert prices[0] == 0.20  # base_value for index 0
+        assert prices[1] == 0.20  # same rate, second quarterly period
 
 
 class TestHealthCheck:
@@ -314,14 +322,15 @@ class TestPriceManagerIntegration:
 
         price_data = pm.get_price_data(today)
 
-        assert len(price_data) == 48
-        # Sell price should come directly from export rates, not calculated
+        assert len(price_data) == 96
+        # Sell price should come directly from export rates (duplicated for quarterly)
         assert price_data[0]["sellPrice"] == export_rates[0]["value_inc_vat"]
+        assert price_data[1]["sellPrice"] == export_rates[0]["value_inc_vat"]
         # Buy price should still be calculated from import rates
         assert price_data[0]["buyPrice"] == import_rates[0]["value_inc_vat"]
 
-    def test_price_manager_timestamps_use_half_hour_spacing(self):
-        """Timestamps should be 30 minutes apart for Octopus."""
+    def test_price_manager_timestamps_use_quarter_hour_spacing(self):
+        """Timestamps should be 15 minutes apart (quarterly resolution)."""
         today = datetime.now().date()
         rates = _make_rates(today)
         controller = _make_ha_controller(rates)
@@ -338,10 +347,11 @@ class TestPriceManagerIntegration:
 
         price_data = pm.get_price_data(today)
 
-        # First entry at 00:00, second at 00:30
+        # 15-minute spacing: 00:00, 00:15, 00:30, 00:45
         assert price_data[0]["timestamp"].endswith("00:00")
-        assert price_data[1]["timestamp"].endswith("00:30")
-        assert price_data[2]["timestamp"].endswith("01:00")
+        assert price_data[1]["timestamp"].endswith("00:15")
+        assert price_data[2]["timestamp"].endswith("00:30")
+        assert price_data[3]["timestamp"].endswith("00:45")
 
     def test_price_manager_fallback_sell_without_export(self):
         """Without export entity, sell price should use calculated formula."""

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -123,11 +123,42 @@ class TestImportRateFetching:
         with pytest.raises(SystemConfigurationError):
             source.get_prices_for_date(day_after)
 
-    def test_wrong_period_count_raises_error(self):
-        """Rates with fewer than 48 entries should fail validation."""
+    def test_too_few_rates_raises_error(self):
+        """Rates below minimum threshold should fail validation."""
         today = datetime.now().date()
-        rates = _make_rates(today, count=24)  # Only 24 periods
+        rates = _make_rates(today, count=20)  # Well below minimum of 46
         controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_partial_rates_accepted(self):
+        """46-47 rates should be accepted (Octopus publishes incrementally)."""
+        today = datetime.now().date()
+        for count in (46, 47):
+            rates = _make_rates(today, count=count)
+            controller = _make_ha_controller(rates)
+            source = _make_source(controller)
+
+            prices = source.get_prices_for_date(today)
+            assert len(prices) == count
+
+    def test_too_many_rates_raises_error(self):
+        """More than 48 rates for a single date should fail validation."""
+        today = datetime.now().date()
+        rates = _make_rates(today, count=48)
+        # Add duplicate rates that also fall on today to exceed 48
+        extra = _make_rates(today, count=2, base_value=0.50)
+        # Adjust extra start times to be within the same day but unique
+        for i, rate in enumerate(extra):
+            start = datetime.combine(today, datetime.min.time()) + timedelta(
+                minutes=15 * i
+            )
+            rate["start"] = start.isoformat()
+            rate["end"] = (start + timedelta(minutes=15)).isoformat()
+        all_rates = rates + extra
+        controller = _make_ha_controller(all_rates)
         source = _make_source(controller)
 
         with pytest.raises(PriceDataUnavailableError):

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -1,0 +1,343 @@
+"""
+Test the OctopusEnergySource implementation.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.bess.exceptions import PriceDataUnavailableError, SystemConfigurationError
+from core.bess.octopus_energy_source import OctopusEnergySource
+from core.bess.price_manager import MockSource, PriceManager
+
+
+def _make_rates(target_date, count=48, base_value=0.20, export=False):
+    """Create mock Octopus rate entries for a given date.
+
+    Args:
+        target_date: Date to create rates for
+        count: Number of 30-minute periods
+        base_value: Base price value
+        export: If True, use lower values typical of export rates
+
+    Returns:
+        List of rate dicts with start, end, and value_inc_vat
+    """
+    rates = []
+    for i in range(count):
+        start = datetime.combine(target_date, datetime.min.time()) + timedelta(
+            minutes=30 * i
+        )
+        end = start + timedelta(minutes=30)
+        value = (
+            (base_value + i * 0.01) if not export else (base_value * 0.3 + i * 0.005)
+        )
+        rates.append(
+            {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                "value_inc_vat": value,
+            }
+        )
+    return rates
+
+
+def _make_ha_controller(import_rates, export_rates=None):
+    """Create a mock HA controller that returns rates for given entity IDs.
+
+    Args:
+        import_rates: Rates to return for import entities
+        export_rates: Rates to return for export entities (optional)
+    """
+    controller = MagicMock()
+
+    def api_request(method, path):
+        if "import_today" in path or "import_tomorrow" in path:
+            return {"attributes": {"rates": import_rates}}
+        if "export_today" in path or "export_tomorrow" in path:
+            if export_rates is not None:
+                return {"attributes": {"rates": export_rates}}
+            return {"attributes": {}}
+        return {}
+
+    controller._api_request = MagicMock(side_effect=api_request)
+    return controller
+
+
+def _make_source(controller):
+    """Create an OctopusEnergySource with standard test entity IDs."""
+    return OctopusEnergySource(
+        ha_controller=controller,
+        import_today_entity="event.octopus_import_today",
+        import_tomorrow_entity="event.octopus_import_tomorrow",
+        export_today_entity="event.octopus_export_today",
+        export_tomorrow_entity="event.octopus_export_tomorrow",
+    )
+
+
+class TestOctopusEnergySourceProperties:
+    """Test basic properties of OctopusEnergySource."""
+
+    def test_period_duration_hours_is_half_hour(self):
+        controller = MagicMock()
+        source = _make_source(controller)
+        assert source.period_duration_hours == 0.5
+
+    def test_default_price_source_period_duration_is_quarter(self):
+        """Verify the base PriceSource default is 0.25 (Nordpool)."""
+        mock = MockSource([1.0])
+        assert mock.period_duration_hours == 0.25
+
+
+class TestImportRateFetching:
+    """Test fetching import rates from Octopus Energy entities."""
+
+    def test_fetch_today_import_rates(self):
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+
+        assert len(prices) == 48
+        assert prices[0] == rates[0]["value_inc_vat"]
+        assert prices[47] == rates[47]["value_inc_vat"]
+
+    def test_fetch_tomorrow_import_rates(self):
+        tomorrow = datetime.now().date() + timedelta(days=1)
+        rates = _make_rates(tomorrow)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(tomorrow)
+
+        assert len(prices) == 48
+
+    def test_rejects_date_beyond_tomorrow(self):
+        day_after = datetime.now().date() + timedelta(days=2)
+        controller = MagicMock()
+        source = _make_source(controller)
+
+        with pytest.raises(SystemConfigurationError):
+            source.get_prices_for_date(day_after)
+
+    def test_wrong_period_count_raises_error(self):
+        """Rates with fewer than 48 entries should fail validation."""
+        today = datetime.now().date()
+        rates = _make_rates(today, count=24)  # Only 24 periods
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_no_rates_attribute_raises_error(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(
+            return_value={"attributes": {"no_rates_key": []}}
+        )
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_api_failure_raises_error(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+
+class TestExportRateFetching:
+    """Test fetching export/sell rates from Octopus Energy entities."""
+
+    def test_fetch_export_rates(self):
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        sell_prices = source.get_sell_prices_for_date(today)
+
+        assert sell_prices is not None
+        assert len(sell_prices) == 48
+        assert sell_prices[0] == export_rates[0]["value_inc_vat"]
+
+    def test_no_export_entity_returns_none(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        source = OctopusEnergySource(
+            ha_controller=controller,
+            import_today_entity="event.import_today",
+            import_tomorrow_entity="event.import_tomorrow",
+            export_today_entity="",
+            export_tomorrow_entity="",
+        )
+
+        assert source.get_sell_prices_for_date(today) is None
+
+    def test_export_failure_returns_none(self):
+        """Export rate failure should return None, not raise."""
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
+        source = _make_source(controller)
+
+        assert source.get_sell_prices_for_date(today) is None
+
+    def test_default_get_sell_prices_for_date_returns_none(self):
+        """Base PriceSource returns None for sell prices."""
+        mock = MockSource([1.0])
+        assert mock.get_sell_prices_for_date(datetime.now().date()) is None
+
+
+class TestDateFilteringAndSorting:
+    """Test rate filtering by date and chronological sorting."""
+
+    def test_filters_rates_by_date(self):
+        """Only rates matching the target date should be included."""
+        today = datetime.now().date()
+        tomorrow = today + timedelta(days=1)
+
+        # Mix rates from today and tomorrow
+        today_rates = _make_rates(today)
+        tomorrow_rates = _make_rates(tomorrow, count=10)
+        mixed_rates = today_rates + tomorrow_rates
+
+        controller = _make_ha_controller(mixed_rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+        assert len(prices) == 48
+
+    def test_sorts_rates_chronologically(self):
+        """Rates should be sorted by start time regardless of input order."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        # Reverse the order
+        rates.reverse()
+
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+        assert len(prices) == 48
+        # First price should be the midnight rate (lowest index)
+        assert prices[0] == 0.20  # base_value for index 0
+
+
+class TestHealthCheck:
+    """Test health check functionality."""
+
+    def test_healthy_source(self):
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        result = source.perform_health_check()
+
+        assert result["status"] == "OK"
+        assert len(result["checks"]) == 2
+        assert result["checks"][0]["status"] == "OK"
+        assert result["checks"][1]["status"] == "OK"
+
+    def test_unhealthy_import(self):
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("down"))
+        source = _make_source(controller)
+
+        result = source.perform_health_check()
+
+        assert result["status"] == "ERROR"
+        assert result["checks"][0]["status"] == "ERROR"
+
+
+class TestPriceManagerIntegration:
+    """Test OctopusEnergySource integration with PriceManager."""
+
+    def test_price_manager_uses_direct_sell_prices(self):
+        """When source provides sell prices, PriceManager should use them directly."""
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=0.0,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        assert len(price_data) == 48
+        # Sell price should come directly from export rates, not calculated
+        assert price_data[0]["sellPrice"] == export_rates[0]["value_inc_vat"]
+        # Buy price should still be calculated from import rates
+        assert price_data[0]["buyPrice"] == import_rates[0]["value_inc_vat"]
+
+    def test_price_manager_timestamps_use_half_hour_spacing(self):
+        """Timestamps should be 30 minutes apart for Octopus."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=0.0,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        # First entry at 00:00, second at 00:30
+        assert price_data[0]["timestamp"].endswith("00:00")
+        assert price_data[1]["timestamp"].endswith("00:30")
+        assert price_data[2]["timestamp"].endswith("01:00")
+
+    def test_price_manager_fallback_sell_without_export(self):
+        """Without export entity, sell price should use calculated formula."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+
+        source = OctopusEnergySource(
+            ha_controller=controller,
+            import_today_entity="event.octopus_import_today",
+            import_tomorrow_entity="event.octopus_import_tomorrow",
+            export_today_entity="",
+            export_tomorrow_entity="",
+        )
+
+        tax_reduction = 0.05
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=tax_reduction,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        # Sell price should be calculated: base_price + tax_reduction
+        expected_sell = rates[0]["value_inc_vat"] + tax_reduction
+        assert abs(price_data[0]["sellPrice"] - expected_sell) < 1e-6

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -327,17 +327,25 @@ const InverterStatusDashboard: React.FC = () => {
       }
       setError(null);
       
-      const [statusData, scheduleData, batteryData, dashboardDataResult] = await Promise.all([
+      const results = await Promise.allSettled([
         fetchInverterStatus(),
         fetchGrowattSchedule(),
         fetchBatterySettings(),
         fetchDashboardData()
       ]);
-      
-      setInverterStatus(statusData);
-      setGrowattSchedule(scheduleData);
-      setBatterySettings(batteryData);
-      setDashboardData(dashboardDataResult);
+
+      if (results[0].status === 'fulfilled') setInverterStatus(results[0].value);
+      else console.warn('Failed to fetch inverter status:', results[0].reason);
+
+      if (results[1].status === 'fulfilled') setGrowattSchedule(results[1].value);
+      else console.warn('Failed to fetch growatt schedule:', results[1].reason);
+
+      if (results[2].status === 'fulfilled') setBatterySettings(results[2].value);
+      else console.warn('Failed to fetch battery settings:', results[2].reason);
+
+      if (results[3].status === 'fulfilled') setDashboardData(results[3].value);
+      else console.warn('Failed to fetch dashboard data:', results[3].reason);
+
       setLastUpdate(new Date());
       
       if (isInitialLoad) {


### PR DESCRIPTION
## Summary

- Dashboard energy flow chart and Savings page lost all data on restart because `HistoricalDataStore` kept records only in memory
- Added JSON file persistence to `/config/bess_historical_data.json`, following the existing `ScheduleStore` pattern
- Records are saved after each `record_period()` call (every 15 min) and loaded on startup if from today

## Test plan

- [x] All 139 unit tests pass with zero regressions
- [x] Black and Ruff pass clean
- [ ] Verify persistence file is created at `/config/bess_historical_data.json` after a recording cycle
- [ ] Verify chart data survives a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)