### PR TITLE
Add Octopus Energy Agile tariff support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.0] - 2026-03-01
+
+### Added
+
+- Octopus Energy Agile tariff support as a new price source alongside Nordpool. Fetches import and export rates from Home Assistant event entities at 30-minute resolution with VAT-inclusive GBP/kWh prices.
+- Separate import and export rate entities for Octopus Energy, allowing direct sell price data instead of calculated fallback.
+- `get_sell_prices_for_date()` on `PriceSource` for sources that provide direct export/sell rates.
+- Documentation for Octopus Energy setup in README, Installation Guide, and User Guide.
+
+### Changed
+
+- **Breaking:** Unified energy provider configuration into a single `energy_provider:` section. The previous `nordpool:` top-level section and `nordpool_kwh_today`/`nordpool_kwh_tomorrow` sensor entries have been replaced. See [UPGRADE.md](UPGRADE.md) for migration instructions.
+- Price logging now uses currency-neutral column headers instead of hardcoded "SEK".
+
+### Removed
+
+- `use_official_integration` boolean from config (replaced by `energy_provider.provider` field).
+- `nordpool_kwh_today`/`nordpool_kwh_tomorrow` from `sensors:` section (moved to `energy_provider.nordpool`).
+- Dead code: `LegacyNordpoolSource` class and unused Nordpool price methods from `ha_api_controller.py`.
+
 ## [6.0.6] - 2026-02-26
 
 ### Fixed

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,7 +6,7 @@ Complete guide for installing and configuring BESS Battery Manager for Home Assi
 
 - Home Assistant OS, Container, or Supervised
 - Growatt battery system with Home Assistant integration
-- Nordpool integration configured
+- Electricity price integration: **Nordpool** (Nordic markets) or **Octopus Energy** (UK market)
 
 ## Step 1: Install the Add-on
 
@@ -106,11 +106,25 @@ home:
   safety_margin_factor: 0.95        # Safety margin (95%)
 
 electricity_price:
-  area: "SE4"                       # Nordpool area
+  area: "SE4"                       # Nordpool area (or "UK" for Octopus)
   markup_rate: 0.08                 # Markup (per kWh, in your currency)
   vat_multiplier: 1.25              # VAT (1.25 = 25%)
   additional_costs: 1.03            # Additional costs (per kWh)
   tax_reduction: 0.6518             # Tax reduction for sold energy (per kWh)
+
+# Energy provider configuration
+energy_provider:
+  provider: "nordpool"              # "nordpool", "nordpool_official", or "octopus"
+  nordpool:
+    today_entity: "sensor.nordpool_kwh_your_area"
+    tomorrow_entity: "sensor.nordpool_kwh_your_area"
+  nordpool_official:
+    config_entry_id: ""             # Required when provider is "nordpool_official"
+  octopus:                          # Only needed when provider is "octopus"
+    import_today_entity: ""         # See "Octopus Energy Setup" section below
+    import_tomorrow_entity: ""
+    export_today_entity: ""
+    export_tomorrow_entity: ""
 
 sensors:
   # Battery sensors (required)
@@ -132,10 +146,6 @@ sensors:
   # Consumption forecast (required)
   48h_avg_grid_import: "sensor.48h_average_grid_import_power"  # From Step 2
 
-  # Price sensors (required)
-  nordpool_kwh_today: "sensor.nordpool_kwh_your_area"
-  nordpool_kwh_tomorrow: "sensor.nordpool_kwh_your_area"
-
   # Solar forecast (required)
   solar_forecast_today: "sensor.solcast_pv_forecast_forecast_today"
 
@@ -156,6 +166,36 @@ sensors:
   # lifetime_export_to_grid: "sensor.your_lifetime_export_to_grid"
   # ev_energy_meter: "sensor.your_ev_energy_meter"
 ```
+
+### Octopus Energy Setup
+
+If you're using Octopus Energy (UK), set `provider: "octopus"` under `energy_provider:` and configure the entity IDs.
+
+**1. Find your entity IDs** in Developer Tools > States, search for `octopus_energy_electricity`:
+
+```yaml
+octopus:
+  import_today_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_current_day_rates"
+  import_tomorrow_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_next_day_rates"
+  export_today_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_export_current_day_rates"
+  export_tomorrow_entity: "event.octopus_energy_electricity_<MPAN>_<SERIAL>_export_next_day_rates"
+```
+
+**2. Adjust electricity_price settings** - Octopus prices are already VAT-inclusive in GBP/kWh:
+
+```yaml
+home:
+  currency: "GBP"
+
+electricity_price:
+  area: "UK"
+  markup_rate: 0.0
+  vat_multiplier: 1.0
+  additional_costs: 0.0
+  tax_reduction: 0.0           # Adjust if you receive SEG payments
+```
+
+**3. Set cycle_cost and min_action_profit_threshold in GBP** (see notes below).
 
 ### ⚠️ Important Configuration Notes
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Intelligent Battery Energy Storage System (BESS) management and optimization for
 
 ## Overview
 
-The BESS Battery Manager is a sophisticated Home Assistant add-on that automatically optimizes Growatt inverter battery storage systems using dynamic programming algorithms and Nordic electricity market pricing. It continuously analyzes published electricity prices, solar production forecasts, and consumption predictions to determine optimal charge/discharge schedules that minimize your electricity costs.
+The BESS Battery Manager is a sophisticated Home Assistant add-on that automatically optimizes Growatt inverter battery storage systems using dynamic programming algorithms and electricity market pricing. It continuously analyzes published electricity prices, solar production forecasts, and consumption predictions to determine optimal charge/discharge schedules that minimize your electricity costs.
 
-The system requires the Growatt, Nordpool, and solar forecast (e.g., Solcast) Home Assistant integrations to function, and optionally uses InfluxDB for historical data storage. Unlike simple timer-based systems, BESS Manager makes intelligent decisions by weighing multiple factors: current battery state, published hourly electricity prices, solar weather forecasts, consumption estimates, and battery degradation costs. The system updates its optimization strategy every hour as new sensor data becomes available, ensuring your battery always operates in the most economically beneficial way while respecting technical constraints like charge rates and depth-of-discharge limits.
+The system requires the Growatt, a price source (Nordpool or Octopus Energy), and solar forecast (e.g., Solcast) Home Assistant integrations to function, and optionally uses InfluxDB for historical data storage. Unlike simple timer-based systems, BESS Manager makes intelligent decisions by weighing multiple factors: current battery state, published electricity prices, solar weather forecasts, consumption estimates, and battery degradation costs. The system updates its optimization strategy every hour as new sensor data becomes available, ensuring your battery always operates in the most economically beneficial way while respecting technical constraints like charge rates and depth-of-discharge limits.
 
 ## Key Capabilities
 
 **Dynamic Programming Optimization**: Solves 24-hour battery scheduling as an optimization problem, considering electricity prices, solar forecasts, consumption patterns, and battery constraints to find the globally optimal charge/discharge schedule.
 
-**Nordpool Market Integration**: Automatically retrieves electricity prices from Nordic power markets to be used by optimization algorithm.
+**Electricity Market Integration**: Supports Nordpool (Nordic markets, 15-min resolution) and Octopus Energy Agile tariff (UK market, 30-min resolution with separate import/export rates).
 
 **Battery Wear Economics**: Incorporates battery degradation costs (cycle cost) into optimization calculations to balance immediate savings against long-term battery life.
 
@@ -48,7 +48,7 @@ Tested with MIN/TLX inverters
 
 ### Required Integrations
 
-- 📊 **Nordpool** integration for electricity prices
+- 📊 **Nordpool** or **Octopus Energy** integration for electricity prices
 - 🏠 **Growatt** integration for battery control and energy monitoring
 - ☀️ **Solar forecast** integration (e.g., Solcast) for production predictions
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,79 @@
+# Upgrade Guide
+
+## Upgrading to 6.2.0
+
+Version 6.2.0 introduces Octopus Energy support and unifies the energy provider
+configuration. **Existing users must update their `config.yaml`** as described below.
+
+### Config changes required
+
+#### 1. Replace `nordpool:` section with `energy_provider:`
+
+**Before (6.0.x):**
+
+```yaml
+nordpool:
+  use_official_integration: true
+  config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888"
+```
+
+**After (6.2.0) - for `nordpool_official` users:**
+
+```yaml
+energy_provider:
+  provider: "nordpool_official"
+  nordpool:
+    today_entity: ""              # Not needed for nordpool_official
+    tomorrow_entity: ""
+  nordpool_official:
+    config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888"
+  octopus:
+    import_today_entity: ""
+    import_tomorrow_entity: ""
+    export_today_entity: ""
+    export_tomorrow_entity: ""
+```
+
+**After (6.2.0) - for legacy `nordpool` sensor users:**
+
+```yaml
+energy_provider:
+  provider: "nordpool"
+  nordpool:
+    today_entity: "sensor.nordpool_kwh_se4_sek_2_10_025"
+    tomorrow_entity: "sensor.nordpool_kwh_se4_sek_2_10_025"
+  nordpool_official:
+    config_entry_id: ""
+  octopus:
+    import_today_entity: ""
+    import_tomorrow_entity: ""
+    export_today_entity: ""
+    export_tomorrow_entity: ""
+```
+
+#### 2. Remove Nordpool price sensors from `sensors:`
+
+The `nordpool_kwh_today` and `nordpool_kwh_tomorrow` entries have moved into
+`energy_provider.nordpool`. Remove them from your `sensors:` section:
+
+```yaml
+sensors:
+  # REMOVE these two lines:
+  # nordpool_kwh_today: "sensor.nordpool_kwh_se4_sek_2_10_025"
+  # nordpool_kwh_tomorrow: "sensor.nordpool_kwh_se4_sek_2_10_025"
+```
+
+#### 3. (Optional) New Octopus Energy setup
+
+If you are a UK user with Octopus Energy, see the
+[Octopus Energy Setup](INSTALLATION.md#octopus-energy-setup) section in the
+Installation Guide.
+
+### Summary of config key changes
+
+| Old key | New key |
+|---------|---------|
+| `nordpool.use_official_integration` | `energy_provider.provider` (`"nordpool"`, `"nordpool_official"`, or `"octopus"`) |
+| `nordpool.config_entry_id` | `energy_provider.nordpool_official.config_entry_id` |
+| `sensors.nordpool_kwh_today` | `energy_provider.nordpool.today_entity` |
+| `sensors.nordpool_kwh_tomorrow` | `energy_provider.nordpool.tomorrow_entity` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -174,8 +174,8 @@ The logs show:
 
 **Solutions**:
 
-- Check electricity price sensor is working
-- Verify price spread is significant (>0.50 SEK/kWh difference)
+- Check electricity price integration is working (Nordpool or Octopus Energy)
+- Verify price spread is significant enough to justify battery wear
 - Wait for price volatility periods
 
 ### "Savings are negative"
@@ -235,8 +235,8 @@ The logs show:
 
 ### Price Settings
 
-- **Area**: Must match your actual Nordpool pricing area
-- **Additional Costs**: Include all taxes, fees, and markup for accurate calculations
+- **Area**: Must match your pricing area (Nordpool area code, or "UK" for Octopus)
+- **Additional Costs**: Include all taxes, fees, and markup for accurate calculations (set to 0 for Octopus as prices are VAT-inclusive)
 
 ### Consumption Prediction
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -128,15 +128,15 @@ class BESSController:
             logger.info("Enabling test mode - hardware writes will be simulated")
         self.ha_controller.set_test_mode(test_mode)
 
-        # Extract nordpool configuration
-        nordpool_config = options.get("nordpool", {})
+        # Extract energy provider configuration
+        energy_provider_config = options.get("energy_provider", {})
 
-        # Create Battery System Manager with nordpool configuration
+        # Create Battery System Manager with price provider configuration
         # Let the system manager choose the appropriate price source
         self.system = BatterySystemManager(
             self.ha_controller,
             price_source=None,  # Let system manager auto-select based on config
-            nordpool_config=nordpool_config,
+            energy_provider_config=energy_provider_config,
         )
 
         # Create scheduler with increased misfire grace time to avoid unnecessary warnings

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "6.0.6"
+version: "6.2.0"
 slug: "bess_manager"
 init: false
 arch:
@@ -46,9 +46,18 @@ options:
     vat_multiplier: 1.25             # 25% VAT
     additional_costs: 1.03           # Additional costs per kWh in your currency (e.g. SE: 28.90 öre överföringsavgift + 53.50 öre energiskatt + moms)
     tax_reduction: 0.6518            # Tax reduction for sold energy in your currency (e.g. SE: 60 öre skattereduktion + 5.18 öre förlustersättning)
-  nordpool:
-    use_official_integration: true  # Set to true to use official HA Nord Pool integration
-    config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888"  # Required when use_official_integration is true
+  energy_provider:
+    provider: "nordpool_official"  # "nordpool" (legacy sensor), "nordpool_official", or "octopus"
+    nordpool:
+      today_entity: "sensor.nordpool_kwh_se4_sek_2_10_025"
+      tomorrow_entity: "sensor.nordpool_kwh_se4_sek_2_10_025"
+    nordpool_official:
+      config_entry_id: "01K3Y99FD3MDZYVFX2XSWR4888"
+    octopus:
+      import_today_entity: ""       # HA entity for today's Octopus import rates
+      import_tomorrow_entity: ""    # HA entity for tomorrow's Octopus import rates
+      export_today_entity: ""       # HA entity for today's Octopus export rates
+      export_tomorrow_entity: ""    # HA entity for tomorrow's Octopus export rates
   growatt:
     device_id: "fbafceb07a1cc74c351ef4310fa430a0"  # Growatt device ID for TOU segment operations
   sensors:
@@ -84,9 +93,6 @@ options:
     lifetime_battery_discharged: "sensor.rkm0d7n04x_lifetime_total_all_batteries_discharged"
     lifetime_system_production: "sensor.rkm0d7n04x_lifetime_system_production"
     ev_energy_meter: "sensor.zap263668_energy_meter"                 # EV charging energy (lifetime)
-    # === Electricity Pricing ===
-    nordpool_kwh_today: "sensor.nordpool_kwh_se4_sek_2_10_025"       # Today's NordPool prices
-    nordpool_kwh_tomorrow: "sensor.nordpool_kwh_se4_sek_2_10_025"    # Tomorrow's NordPool prices
     # === Solar & Consumption Forecasting ===
     48h_avg_grid_import: "sensor.48h_average_grid_import_power"       # 48h average consumption
     solar_forecast_today: "sensor.solcast_pv_forecast_forecast_today" # Today's solar forecast
@@ -115,9 +121,18 @@ schema:
     vat_multiplier: float
     additional_costs: float
     tax_reduction: float
-  nordpool:
-    use_official_integration: bool
-    config_entry_id: str
+  energy_provider:
+    provider: str
+    nordpool:
+      today_entity: str
+      tomorrow_entity: str
+    nordpool_official:
+      config_entry_id: str
+    octopus:
+      import_today_entity: str
+      import_tomorrow_entity: str
+      export_today_entity: str
+      export_tomorrow_entity: str
   growatt:
     device_id: str
   sensors:
@@ -141,8 +156,6 @@ schema:
     lifetime_system_production: str
     lifetime_self_consumption: str
     ev_energy_meter: str
-    nordpool_kwh_today: str
-    nordpool_kwh_tomorrow: str
     48h_avg_grid_import: str
     solar_forecast_today: str
     pv_power: str

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -22,6 +22,7 @@ from .ha_api_controller import HomeAssistantAPIController
 from .health_check import run_system_health_checks
 from .historical_data_store import HistoricalDataStore
 from .models import DecisionData, EconomicData, PeriodData, infer_intent_from_flows
+from .octopus_energy_source import OctopusEnergySource
 from .power_monitor import HomePowerMonitor
 from .prediction_snapshot import PredictionSnapshotStore
 from .price_manager import HomeAssistantSource, PriceManager, PriceSource
@@ -50,7 +51,7 @@ class BatterySystemManager:
         self,
         controller: HomeAssistantAPIController | None = None,
         price_source: PriceSource | None = None,
-        nordpool_config: dict | None = None,
+        energy_provider_config: dict | None = None,
     ):
         """Initialize with same interface as original BatterySystemManager."""
 
@@ -58,7 +59,7 @@ class BatterySystemManager:
         self.battery_settings = BatterySettings()
         self.home_settings = HomeSettings()
         self.price_settings = PriceSettings()
-        self._nordpool_config = nordpool_config or {}
+        self._energy_provider_config = energy_provider_config or {}
 
         # Store controller reference
         self._controller = controller
@@ -89,29 +90,7 @@ class BatterySystemManager:
 
         # Initialize price manager
         if not price_source:
-            # Check if official Nordpool integration should be used
-            nordpool_config = getattr(self, "_nordpool_config", None)
-            if nordpool_config is None:
-                nordpool_config = {}
-            use_official = nordpool_config.get("use_official_integration", False)
-            config_entry_id = nordpool_config.get("config_entry_id")
-
-            if use_official and config_entry_id:
-                # Use official Home Assistant Nordpool integration
-                from .official_nordpool_source import OfficialNordpoolSource
-
-                price_source = OfficialNordpoolSource(
-                    controller,
-                    config_entry_id,
-                    vat_multiplier=self.price_settings.vat_multiplier,
-                )
-                logger.info("Using official Home Assistant Nordpool integration")
-            else:
-                # Use legacy sensor-based approach (current custom component)
-                price_source = HomeAssistantSource(
-                    controller, vat_multiplier=self.price_settings.vat_multiplier
-                )
-                logger.info("Using legacy/custom Nordpool sensor integration")
+            price_source = self._create_price_source(controller)
 
         self._price_manager = PriceManager(
             price_source=price_source,
@@ -146,6 +125,62 @@ class BatterySystemManager:
         if self._controller is None:
             raise RuntimeError("Controller not initialized - system not started")
         return self._controller
+
+    def _create_price_source(self, controller) -> PriceSource:
+        """Create the appropriate price source based on energy_provider config.
+
+        Supports three price providers:
+        - "nordpool": Legacy custom Nordpool sensor component
+        - "nordpool_official": Official HA Nordpool integration via service calls
+        - "octopus": Octopus Energy Agile tariff via HA event entities
+
+        Args:
+            controller: HomeAssistantAPIController instance
+
+        Returns:
+            Configured PriceSource instance
+        """
+        config = self._energy_provider_config
+        provider = config.get("provider", "nordpool")
+
+        if provider == "octopus":
+            octopus_config = config.get("octopus", {})
+            price_source = OctopusEnergySource(
+                ha_controller=controller,
+                import_today_entity=octopus_config["import_today_entity"],
+                import_tomorrow_entity=octopus_config["import_tomorrow_entity"],
+                export_today_entity=octopus_config["export_today_entity"],
+                export_tomorrow_entity=octopus_config["export_tomorrow_entity"],
+            )
+            logger.info("Using Octopus Energy Agile tariff price source")
+            return price_source
+
+        if provider == "nordpool_official":
+            nordpool_official_config = config.get("nordpool_official", {})
+            config_entry_id = nordpool_official_config["config_entry_id"]
+            from .official_nordpool_source import OfficialNordpoolSource
+
+            price_source = OfficialNordpoolSource(
+                controller,
+                config_entry_id,
+                vat_multiplier=self.price_settings.vat_multiplier,
+            )
+            logger.info("Using official Home Assistant Nordpool integration")
+            return price_source
+
+        if provider == "nordpool":
+            nordpool_config = config.get("nordpool", {})
+            logger.info("Using legacy/custom Nordpool sensor integration")
+            return HomeAssistantSource(
+                controller,
+                vat_multiplier=self.price_settings.vat_multiplier,
+                today_entity=nordpool_config["today_entity"],
+                tomorrow_entity=nordpool_config["tomorrow_entity"],
+            )
+
+        raise SystemConfigurationError(
+            message=f"Unknown energy provider: {provider!r}. Must be 'nordpool', 'nordpool_official', or 'octopus'."
+        )
 
     def _sync_soc_limits(self) -> None:
         """
@@ -258,7 +293,7 @@ class BatterySystemManager:
             self._handle_special_cases(current_period, prepare_next_day)
 
             # Get price data
-            prices, _ = self._get_price_data(prepare_next_day)
+            prices, price_entries = self._get_price_data(prepare_next_day)
             if not prices:
                 logger.warning("Schedule update aborted: No price data available")
                 return False
@@ -283,11 +318,12 @@ class BatterySystemManager:
 
             optimization_period, optimization_data = optimization_data_result
 
-            # Run optimization using DP algorithm with quarterly resolution
+            # Run optimization using DP algorithm
             optimization_result = self._run_optimization(
                 optimization_period,
                 optimization_data,
                 prices,
+                price_entries,
                 prepare_next_day,
             )
 
@@ -601,7 +637,11 @@ class BatterySystemManager:
     def _get_price_data(
         self, prepare_next_day: bool
     ) -> tuple[list[float] | None, list[dict[str, Any]] | None]:
-        """Get price data - preserves original logic."""
+        """Get price data in 15-minute (quarterly) resolution.
+
+        All price sources return 96 quarterly periods per day. Sources with
+        coarser raw data (e.g. Octopus 30-min) expand internally.
+        """
         try:
             if prepare_next_day:
                 price_entries = self._price_manager.get_tomorrow_prices()
@@ -615,8 +655,7 @@ class BatterySystemManager:
 
             prices = [entry["price"] for entry in price_entries]
 
-            # Prices are quarterly (96 periods) - DP algorithm supports variable horizon
-            # Handle DST transitions (quarterly)
+            # Validate quarterly period count (handles DST: 92, 96, or 100)
             if len(prices) == 92:
                 logger.info(
                     "Detected DST spring forward transition (92 quarterly periods)"
@@ -917,6 +956,7 @@ class BatterySystemManager:
         optimization_period: int,
         optimization_data: dict[str, list[float]],
         prices: list[float],
+        price_entries: list[dict[str, Any]],
         prepare_next_day: bool,
     ) -> OptimizationResult | None:
         """Run optimization - now returns OptimizationResult directly."""
@@ -959,11 +999,11 @@ class BatterySystemManager:
                 f"Running optimization for {n_periods} periods from {format_period(optimization_period)}"
             )
 
-            # Calculate buy and sell prices
-            buy_prices = self._price_manager.get_buy_prices(raw_prices=remaining_prices)
-            sell_prices = self._price_manager.get_sell_prices(
-                raw_prices=remaining_prices
-            )
+            # Get buy and sell prices from pre-calculated price entries
+            # This preserves direct sell prices from sources like Octopus Energy
+            remaining_entries = price_entries[optimization_period:]
+            buy_prices = [entry["buyPrice"] for entry in remaining_entries]
+            sell_prices = [entry["sellPrice"] for entry in remaining_entries]
 
             # Run DP optimization with strategic intent capture - returns OptimizationResult directly
             result = optimize_battery_schedule(
@@ -974,6 +1014,7 @@ class BatterySystemManager:
                 initial_soe=current_soe,
                 battery_settings=self.battery_settings,
                 initial_cost_basis=initial_cost_basis,
+                period_duration_hours=0.25,  # Always quarterly after normalization in _get_price_data
             )
 
             # Add timestamps to period data (algorithm is time-agnostic, operates on relative indices)
@@ -1123,9 +1164,9 @@ class BatterySystemManager:
             for i, period_data in enumerate(period_data_list):
                 target_period = optimization_period + i
                 if target_period < len(full_day_strategic_intents):
-                    full_day_strategic_intents[
-                        target_period
-                    ] = period_data.decision.strategic_intent
+                    full_day_strategic_intents[target_period] = (
+                        period_data.decision.strategic_intent
+                    )
 
             # Store initial SOC in OptimizationResult for DailyViewBuilder
             if self._initial_soe is not None:
@@ -1932,6 +1973,14 @@ class BatterySystemManager:
 
             if "price" in settings:
                 self.price_settings.update(**settings["price"])
+                self._price_manager.markup_rate = self.price_settings.markup_rate
+                self._price_manager.vat_multiplier = self.price_settings.vat_multiplier
+                self._price_manager.additional_costs = (
+                    self.price_settings.additional_costs
+                )
+                self._price_manager.tax_reduction = self.price_settings.tax_reduction
+                self._price_manager.area = self.price_settings.area
+                self._price_manager.clear_cache()
 
             logger.info("Settings updated successfully")
 

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -276,21 +276,6 @@ class HomeAssistantAPIController:
             "conversion_threshold": None,
         },
         # Energy totals
-        # Price sensors
-        "get_nordpool_prices_today": {
-            "sensor_key": "nordpool_kwh_today",
-            "name": "Nord Pool Prices Today",
-            "unit": "list",
-            "precision": 1,
-            "conversion_threshold": None,
-        },
-        "get_nordpool_prices_tomorrow": {
-            "sensor_key": "nordpool_kwh_tomorrow",
-            "name": "Nord Pool Prices Tomorrow",
-            "unit": "list",
-            "precision": 1,
-            "conversion_threshold": None,
-        },
         # Home consumption forecast
         "get_estimated_consumption": {
             "sensor_key": "48h_avg_grid_import",
@@ -458,7 +443,7 @@ class HomeAssistantAPIController:
                 "get",
                 f"/api/states/{entity_id}",
                 operation=f"Check sensor info for '{method_name}'",
-                category="sensor_read"
+                category="sensor_read",
             )
             if not response:
                 result.update(
@@ -588,7 +573,7 @@ class HomeAssistantAPIController:
                         self.failure_tracker.record_failure(
                             operation=operation_description,
                             category=operation_category,
-                            error=e
+                            error=e,
                         )
 
                     raise  # Re-raise the last exception
@@ -647,8 +632,16 @@ class HomeAssistantAPIController:
             "post",
             path,
             operation=f"Call {service_domain}.{service_name}",
-            category="battery_control" if service_domain in ["number", "switch"] else "inverter_control" if service_domain == "growatt_server" else "other",
-            json=json_data
+            category=(
+                "battery_control"
+                if service_domain in ["number", "switch"]
+                else (
+                    "inverter_control"
+                    if service_domain == "growatt_server"
+                    else "other"
+                )
+            ),
+            json=json_data,
         )
 
     def _get_sensor_value(self, sensor_name):
@@ -664,7 +657,7 @@ class HomeAssistantAPIController:
                 "get",
                 f"/api/states/{entity_id}",
                 operation=f"Read sensor '{sensor_name}'",
-                category="sensor_read"
+                category="sensor_read",
             )
 
             if response and "state" in response:
@@ -688,7 +681,7 @@ class HomeAssistantAPIController:
                 self.failure_tracker.record_failure(
                     operation=f"Read sensor '{sensor_name}'",
                     category="sensor_read",
-                    error=e
+                    error=e,
                 )
 
             return 0.0
@@ -806,7 +799,7 @@ class HomeAssistantAPIController:
                 "get",
                 f"/api/states/{entity_id}",
                 operation="Check grid charge switch state",
-                category="sensor_read"
+                category="sensor_read",
             )
             if response and "state" in response:
                 return response["state"] == "on"
@@ -931,7 +924,7 @@ class HomeAssistantAPIController:
             "get",
             f"/api/states/{entity_id}",
             operation="Get solar forecast data",
-            category="sensor_read"
+            category="sensor_read",
         )
 
         if not response or "attributes" not in response:
@@ -973,103 +966,6 @@ class HomeAssistantAPIController:
 
         return quarterly_values
 
-    def _get_nordpool_prices(self, is_tomorrow=False):
-        """Get Nordpool prices from Home Assistant sensor - simplified to just fetch raw data.
-
-        The HA controller is now a thin data layer that just fetches sensor data.
-        All complex logic (DST handling, timestamp validation, etc.) is handled
-        by the PriceManager layer.
-
-        Args:
-            is_tomorrow: If True, get tomorrow's prices, otherwise today's
-
-        Returns:
-            list: List of hourly prices (may be 23, 24, or 25 hours for DST)
-
-        Raises:
-            ValueError: If prices are not available for the date
-        """
-        time_label = "tomorrow" if is_tomorrow else "today"
-        try:
-            # Determine which sensor to use
-            sensor_key = (
-                "nordpool_kwh_tomorrow" if is_tomorrow else "nordpool_kwh_today"
-            )
-            entity_id = self.sensors.get(sensor_key)
-            if not entity_id:
-                logger.warning(f"No entity ID configured for {sensor_key}")
-                raise ValueError(f"Missing entity ID configuration for {sensor_key}")
-
-            logger.debug(f"Fetching Nordpool prices for {time_label} from {entity_id}")
-
-            # Get entity state
-            entity_response = self._api_request(
-                "get",
-                f"/api/states/{entity_id}",
-                operation=f"Get Nordpool prices for {time_label}",
-                category="sensor_read"
-            )
-
-            if not entity_response:
-                logger.error(
-                    f"Could not retrieve Nordpool sensor state for {time_label}"
-                )
-                raise ValueError(f"Nordpool prices for {time_label} are unavailable")
-
-            # Access attributes from the response
-            attributes = entity_response.get("attributes", {})
-
-            # Try to get raw data from attributes first
-            raw_data_key = "raw_tomorrow" if is_tomorrow else "raw_today"
-            raw_data = attributes.get(raw_data_key)
-
-            if raw_data:
-                # Extract raw prices - let PriceManager handle DST and validation
-                try:
-                    processed_prices = [hour_data["value"] for hour_data in raw_data]
-                    logger.debug(
-                        f"Successfully extracted {len(processed_prices)} hourly prices from {raw_data_key}"
-                    )
-                    return processed_prices
-                except (KeyError, TypeError) as e:
-                    logger.warning(f"Invalid raw data format in {raw_data_key}: {e}")
-
-            # Fallback to the regular array if raw data isn't available
-            regular_data_key = "tomorrow" if is_tomorrow else "today"
-            regular_prices = attributes.get(regular_data_key)
-
-            if regular_prices and isinstance(regular_prices, list):
-                logger.info(
-                    f"Using '{regular_data_key}' attribute with {len(regular_prices)} hourly prices"
-                )
-                return regular_prices
-
-            # Check if tomorrow's prices are valid (for tomorrow only)
-            if is_tomorrow and attributes.get("tomorrow_valid") is False:
-                logger.error(
-                    "Tomorrow's prices are not yet available (tomorrow_valid=false)"
-                )
-                raise ValueError("Tomorrow's Nordpool prices are not yet available")
-
-            # If we get here, no price data was found
-            logger.error(
-                f"Could not find price data for {time_label} in Nordpool sensor attributes"
-            )
-            logger.debug(f"Available attributes: {list(attributes.keys())}")
-            raise ValueError(f"Nordpool prices for {time_label} are unavailable")
-
-        except Exception as e:
-            logger.error(f"Error fetching Nordpool prices for {time_label}: {e!s}")
-            raise
-
-    def get_nordpool_prices_today(self):
-        """Get today's Nordpool prices from Home Assistant sensor."""
-        return self._get_nordpool_prices(is_tomorrow=False)
-
-    def get_nordpool_prices_tomorrow(self):
-        """Get tomorrow's Nordpool prices from Home Assistant sensor."""
-        return self._get_nordpool_prices(is_tomorrow=True)
-
     def get_sensor_data(self, sensors_list):
         """Get current sensor data via Home Assistant REST API.
 
@@ -1096,7 +992,7 @@ class HomeAssistantAPIController:
                     "get",
                     f"/api/states/{entity_id}",
                     operation=f"Get sensor data for '{sensor}'",
-                    category="sensor_read"
+                    category="sensor_read",
                 )
                 if response and "state" in response:
                     try:

--- a/core/bess/octopus_energy_source.py
+++ b/core/bess/octopus_energy_source.py
@@ -1,0 +1,284 @@
+"""
+Octopus Energy Agile tariff price source.
+
+Fetches import and export rates from Octopus Energy HA event entities.
+Prices are VAT-inclusive in GBP/kWh. Raw data arrives at 30-minute resolution
+(48 periods/day) and is expanded to 15-minute quarterly resolution (96 periods/day)
+to match the system-wide period model.
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+
+from .exceptions import PriceDataUnavailableError, SystemConfigurationError
+from .price_manager import PriceSource
+
+logger = logging.getLogger(__name__)
+
+EXPECTED_RAW_PERIODS = 48  # Octopus provides 48 half-hourly slots
+MIN_RAW_PERIODS = 46  # Allow slightly fewer during incremental publishing
+
+
+class OctopusEnergySource(PriceSource):
+    """Price source for Octopus Energy Agile tariff via Home Assistant event entities.
+
+    Raw data arrives at 30-minute resolution (48 half-hourly slots per day) and is
+    expanded to 96 quarterly (15-minute) periods to match the system-wide period model.
+
+    Key differences from Nordpool:
+    - Separate import and export rate entities
+    - Prices are already VAT-inclusive final prices in GBP/kWh
+    - Data comes from HA event entity attributes (rates list)
+    """
+
+    def __init__(
+        self,
+        ha_controller,
+        import_today_entity: str,
+        import_tomorrow_entity: str,
+        export_today_entity: str,
+        export_tomorrow_entity: str,
+    ) -> None:
+        """Initialize with Home Assistant controller and Octopus entity IDs.
+
+        Args:
+            ha_controller: Controller with access to Home Assistant API
+            import_today_entity: Entity ID for today's import rates
+            import_tomorrow_entity: Entity ID for tomorrow's import rates
+            export_today_entity: Entity ID for today's export rates
+            export_tomorrow_entity: Entity ID for tomorrow's export rates
+        """
+        self.ha_controller = ha_controller
+        self.import_today_entity = import_today_entity
+        self.import_tomorrow_entity = import_tomorrow_entity
+        self.export_today_entity = export_today_entity
+        self.export_tomorrow_entity = export_tomorrow_entity
+
+    @property
+    def period_duration_hours(self) -> float:
+        """Quarterly (15-minute) periods, matching the system-wide resolution."""
+        return 0.25
+
+    def get_prices_for_date(self, target_date: date) -> list[float]:
+        """Get import rates from Octopus Energy for the specified date.
+
+        Args:
+            target_date: The date to get import prices for
+
+        Returns:
+            List of 96 quarterly import rates in GBP/kWh (VAT-inclusive),
+            expanded from 48 half-hourly raw rates
+
+        Raises:
+            PriceDataUnavailableError: If rates cannot be fetched
+            SystemConfigurationError: If date is not today or tomorrow
+        """
+        current_date = datetime.now().date()
+        tomorrow_date = current_date + timedelta(days=1)
+
+        if target_date not in (current_date, tomorrow_date):
+            raise SystemConfigurationError(
+                message=f"Can only fetch today's or tomorrow's prices, not {target_date}"
+            )
+
+        if target_date == current_date:
+            entity_id = self.import_today_entity
+        else:
+            entity_id = self.import_tomorrow_entity
+
+        return self._fetch_rates(entity_id, target_date, "import")
+
+    def get_sell_prices_for_date(self, target_date: date) -> list[float] | None:
+        """Get export rates from Octopus Energy for the specified date.
+
+        Args:
+            target_date: The date to get export prices for
+
+        Returns:
+            List of 96 quarterly export rates in GBP/kWh (expanded from 48 raw),
+            or None if no export entity configured
+        """
+        if not self.export_today_entity and not self.export_tomorrow_entity:
+            return None
+
+        current_date = datetime.now().date()
+        tomorrow_date = current_date + timedelta(days=1)
+
+        if target_date not in (current_date, tomorrow_date):
+            return None
+
+        if target_date == current_date:
+            entity_id = self.export_today_entity
+        else:
+            entity_id = self.export_tomorrow_entity
+
+        if not entity_id:
+            return None
+
+        try:
+            return self._fetch_rates(entity_id, target_date, "export")
+        except PriceDataUnavailableError:
+            logger.warning(f"Export rates unavailable for {target_date}")
+            return None
+
+    def _fetch_rates(
+        self, entity_id: str, target_date: date, rate_type: str
+    ) -> list[float]:
+        """Fetch rates from a Home Assistant event entity.
+
+        Octopus provides 48 half-hourly rates. Each rate is duplicated to produce
+        96 quarterly (15-minute) periods matching the system-wide resolution.
+
+        Args:
+            entity_id: HA entity ID to fetch from
+            target_date: Date to filter rates for
+            rate_type: "import" or "export" (for logging)
+
+        Returns:
+            List of 96 quarterly rate values (value_inc_vat) sorted chronologically
+
+        Raises:
+            PriceDataUnavailableError: If rates cannot be fetched or validated
+        """
+        try:
+            response = self.ha_controller._api_request(
+                "get", f"/api/states/{entity_id}"
+            )
+        except Exception as e:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"Failed to fetch {rate_type} rates from {entity_id}: {e}",
+            ) from e
+
+        if not response or "attributes" not in response:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"No attributes in response from {entity_id}",
+            )
+
+        attributes = response["attributes"]
+        rates = attributes.get("rates")
+
+        if not rates or not isinstance(rates, list):
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=f"No rates list in attributes from {entity_id}",
+            )
+
+        # Filter rates for the target date and sort chronologically
+        filtered_rates = self._filter_rates_for_date(rates, target_date)
+
+        if len(filtered_rates) < MIN_RAW_PERIODS:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=(
+                    f"Expected at least {MIN_RAW_PERIODS} {rate_type} rates for {target_date}, "
+                    f"got {len(filtered_rates)} from {entity_id}"
+                ),
+            )
+        if len(filtered_rates) > EXPECTED_RAW_PERIODS:
+            raise PriceDataUnavailableError(
+                date=target_date,
+                message=(
+                    f"Too many {rate_type} rates for {target_date}: "
+                    f"expected at most {EXPECTED_RAW_PERIODS}, "
+                    f"got {len(filtered_rates)} from {entity_id}"
+                ),
+            )
+
+        # Extract value_inc_vat from each half-hourly rate entry
+        half_hourly_prices = [float(rate["value_inc_vat"]) for rate in filtered_rates]
+
+        # Expand 48 half-hourly prices → 96 quarterly prices (duplicate each)
+        quarterly_prices = [p for p in half_hourly_prices for _ in range(2)]
+
+        logger.info(
+            f"Fetched {len(half_hourly_prices)} Octopus {rate_type} rates for {target_date} "
+            f"(expanded to {len(quarterly_prices)} quarterly periods): "
+            f"range {min(half_hourly_prices):.4f} - {max(half_hourly_prices):.4f} GBP/kWh"
+        )
+
+        return quarterly_prices
+
+    def _filter_rates_for_date(
+        self, rates: list[dict], target_date: date
+    ) -> list[dict]:
+        """Filter and sort rates for a specific date.
+
+        Args:
+            rates: List of rate entries with 'start' timestamps
+            target_date: Date to filter for
+
+        Returns:
+            Filtered and sorted list of rate entries for the target date
+        """
+        filtered = []
+        for rate in rates:
+            start_str = rate.get("start")
+            if not start_str:
+                continue
+
+            try:
+                start_dt = datetime.fromisoformat(start_str)
+                if start_dt.date() == target_date:
+                    filtered.append(rate)
+            except (ValueError, TypeError):
+                continue
+
+        # Sort by start time
+        filtered.sort(key=lambda r: r["start"])
+
+        return filtered
+
+    def perform_health_check(self) -> dict:
+        """Perform health check on Octopus Energy source.
+
+        Returns:
+            dict: Health check result with status and checks
+        """
+        checks = []
+        overall_status = "OK"
+        today = datetime.now().date()
+
+        # Test import rates
+        import_check = {
+            "component": "OctopusEnergySource (Import)",
+            "status": "OK",
+            "message": "",
+        }
+        try:
+            import_prices = self.get_prices_for_date(today)
+            import_check["message"] = (
+                f"Successfully fetched {len(import_prices)} import rates for today"
+            )
+        except Exception as e:
+            import_check["status"] = "ERROR"
+            import_check["message"] = f"Failed to fetch import rates: {e}"
+            overall_status = "ERROR"
+        checks.append(import_check)
+
+        # Test export rates
+        export_check = {
+            "component": "OctopusEnergySource (Export)",
+            "status": "OK",
+            "message": "",
+        }
+        try:
+            export_prices = self.get_sell_prices_for_date(today)
+            if export_prices is not None:
+                export_check["message"] = (
+                    f"Successfully fetched {len(export_prices)} export rates for today"
+                )
+            else:
+                export_check["message"] = "No export entity configured"
+        except Exception as e:
+            export_check["status"] = "WARNING"
+            export_check["message"] = f"Failed to fetch export rates: {e}"
+            if overall_status == "OK":
+                overall_status = "WARNING"
+        checks.append(export_check)
+
+        return {
+            "status": overall_status,
+            "checks": checks,
+        }

--- a/core/bess/official_nordpool_source.py
+++ b/core/bess/official_nordpool_source.py
@@ -187,32 +187,3 @@ class OfficialNordpoolSource(PriceSource):
 
         health_check["checks"] = [service_check, config_check]
         return health_check
-
-
-class LegacyNordpoolSource(PriceSource):
-    """Price source for legacy/custom Nordpool integrations using sensor attributes.
-
-    This maintains compatibility with custom Nordpool components that provide
-    'today', 'tomorrow', 'raw_today', 'raw_tomorrow' attributes.
-    """
-
-    def __init__(self, ha_controller, vat_multiplier: float) -> None:
-        """Initialize with Home Assistant controller.
-
-        Args:
-            ha_controller: Controller with access to Home Assistant
-            vat_multiplier: VAT multiplier for price conversion
-        """
-        self.ha_controller = ha_controller
-        self.vat_multiplier = vat_multiplier
-
-    def get_prices_for_date(self, target_date: date) -> list[float]:
-        """Get prices from legacy Nordpool sensor attributes.
-
-        This is the existing logic that expects sensor attributes.
-        """
-        from .price_manager import HomeAssistantSource
-
-        # Use the existing HomeAssistantSource logic
-        legacy_source = HomeAssistantSource(self.ha_controller, self.vat_multiplier)
-        return legacy_source.get_prices_for_date(target_date)

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -18,6 +18,16 @@ class PriceSource:
     This defines the interface that all price sources must implement.
     """
 
+    @property
+    def period_duration_hours(self) -> float:
+        """Duration of each price period in hours.
+
+        All sources must return 0.25 (quarterly / 15-minute periods) to match
+        the system-wide period model. Sources with coarser raw data (e.g. Octopus
+        30-min) must expand internally before returning prices.
+        """
+        return 0.25
+
     def get_prices_for_date(self, target_date: date) -> list:
         """Get prices for a specific date.
 
@@ -25,12 +35,27 @@ class PriceSource:
             target_date: The date to get prices for
 
         Returns:
-            List of hourly prices for the specified date
+            List of prices for the specified date (one per period)
 
         Raises:
             NotImplementedError: If the source doesn't implement this method
         """
         raise NotImplementedError("Price sources must implement get_prices_for_date")
+
+    def get_sell_prices_for_date(self, target_date: date) -> list[float] | None:
+        """Get separate sell/export prices for a specific date.
+
+        Override this method when the price source provides distinct export rates
+        (e.g., Octopus Energy). Returns None by default, meaning sell prices are
+        calculated from buy prices using markup/tax reduction.
+
+        Args:
+            target_date: The date to get sell prices for
+
+        Returns:
+            List of sell prices per period, or None if not applicable
+        """
+        return None
 
     def perform_health_check(self) -> dict:
         """Perform health check on the price source.
@@ -92,16 +117,26 @@ class HomeAssistantSource(PriceSource):
     consistently return VAT-exclusive prices.
     """
 
-    def __init__(self, ha_controller, vat_multiplier: float) -> None:
-        """Initialize with Home Assistant controller.
+    def __init__(
+        self,
+        ha_controller,
+        vat_multiplier: float,
+        today_entity: str,
+        tomorrow_entity: str,
+    ) -> None:
+        """Initialize with Home Assistant controller and entity IDs.
 
         Args:
             ha_controller: Controller with access to Home Assistant
             vat_multiplier: VAT multiplier used to convert VAT-inclusive prices to VAT-exclusive
                             (must be provided from config.yaml)
+            today_entity: HA entity ID for today's Nordpool prices
+            tomorrow_entity: HA entity ID for tomorrow's Nordpool prices
         """
         self.ha_controller = ha_controller
         self.vat_multiplier = vat_multiplier
+        self.today_entity = today_entity
+        self.tomorrow_entity = tomorrow_entity
 
     def get_prices_for_date(self, target_date: date) -> list:
         """Get prices from Home Assistant for the specified date.
@@ -120,9 +155,9 @@ class HomeAssistantSource(PriceSource):
             )
 
         try:
-            # Fetch sensor data from both sensors
-            today_data = self._fetch_sensor_attributes("nordpool_kwh_today")
-            tomorrow_data = self._fetch_sensor_attributes("nordpool_kwh_tomorrow")
+            # Fetch sensor data from both sensors using configured entity IDs
+            today_data = self._fetch_sensor_attributes(self.today_entity)
+            tomorrow_data = self._fetch_sensor_attributes(self.tomorrow_entity)
 
             # Try both sensors - use whichever has valid data for our target date
             for sensor_data, sensor_name in [
@@ -150,15 +185,17 @@ class HomeAssistantSource(PriceSource):
                 message=f"Failed to get price data for {target_date}: {e}",
             ) from e
 
-    def _fetch_sensor_attributes(self, sensor_key):
-        """Fetch attributes from the configured Nordpool sensor via HA controller's sensor mapping."""
+    def _fetch_sensor_attributes(self, entity_id: str):
+        """Fetch attributes from the specified Nordpool sensor entity.
+
+        Args:
+            entity_id: HA entity ID to fetch attributes from
+        """
         try:
-            # Use HA controller's sensor mapping to get the actual entity ID
-            entity_id = self.ha_controller.sensors.get(sensor_key)
             if not entity_id:
                 return None
 
-            # Fetch sensor state with attributes using the mapped entity ID
+            # Fetch sensor state with attributes using the entity ID directly
             response = self.ha_controller._api_request(
                 "get", f"/api/states/{entity_id}"
             )
@@ -366,6 +403,17 @@ class PriceManager:
         self._tomorrow_prices = None
         self._tomorrow_date = None
 
+    def clear_cache(self) -> None:
+        """Clear cached price data.
+
+        Must be called when pricing parameters (markup, VAT, additional costs)
+        change, since cached prices were calculated with the old values.
+        """
+        self._today_prices = None
+        self._today_date = None
+        self._tomorrow_prices = None
+        self._tomorrow_date = None
+
     def _calculate_buy_price(self, base_price: float) -> float:
         """Calculate retail buy price from Nordpool base price.
 
@@ -416,17 +464,27 @@ class PriceManager:
             # Get raw prices from the source
             raw_prices = self.price_source.get_prices_for_date(target_date)
 
+            # Check for separate sell/export prices (e.g., Octopus Energy)
+            direct_sell_prices = self.price_source.get_sell_prices_for_date(target_date)
+
             # Format prices with timestamp and calculations
             price_data = []
             base_timestamp = datetime.combine(target_date, datetime.min.time())
+            period_hours = self.price_source.period_duration_hours
 
-            for hour, price in enumerate(raw_prices):
-                timestamp = base_timestamp + timedelta(hours=hour)
+            for index, price in enumerate(raw_prices):
+                timestamp = base_timestamp + timedelta(hours=index * period_hours)
+
+                if direct_sell_prices is not None:
+                    sell_price = direct_sell_prices[index]
+                else:
+                    sell_price = self._calculate_sell_price(price)
+
                 price_entry = {
                     "timestamp": timestamp.strftime("%Y-%m-%d %H:%M"),
                     "price": price,
                     "buyPrice": self._calculate_buy_price(price),
-                    "sellPrice": self._calculate_sell_price(price),
+                    "sellPrice": sell_price,
                 }
                 price_data.append(price_entry)
 
@@ -467,7 +525,7 @@ class PriceManager:
         tomorrow = datetime.now().date() + timedelta(days=1)
         try:
             return self.get_price_data(tomorrow)
-        except ValueError:
+        except (ValueError, PriceDataUnavailableError):
             return []  # Return empty list instead of raising error
 
     def get_prices(self, target_date: date | None = None) -> list:
@@ -527,24 +585,16 @@ class PriceManager:
             price_data = self.get_price_data(target_date)
             return [entry["sellPrice"] for entry in price_data]
 
-
     def get_available_prices(self) -> tuple[list[float], list[float]]:
-        """Get all available prices at quarterly resolution starting at today 00:00.
+        """Get all available prices starting at today 00:00.
 
-        Nordpool provides quarterly prices (96 periods/day) directly.
+        All sources provide 96 quarterly (15-minute) periods per day.
         Automatically tries tomorrow, falls back to today only.
 
         Returns:
             (buy_prices, sell_prices) tuple where:
             - Index 0 = today 00:00
-            - Index 96 = tomorrow 00:00 (if available)
             - Length: 96 (today only) or 192 (today + tomorrow)
-
-        Example at 14:00:
-            buy, sell = get_available_prices()
-            # buy[0] = today 00:00
-            # buy[56] = today 14:00 (current period)
-            # Caller slices: buy[56:] for optimization from now
         """
         today = datetime.now().date()
         tomorrow = today + timedelta(days=1)
@@ -607,14 +657,14 @@ class PriceManager:
 
             price_data = f"\n{title}:\n"
             price_data += "-" * 50 + "\n"
-            price_data += "Hour   | Nordpool Price | Retail Price  | Sell Price\n"
+            price_data += "Time   | Base Price     | Buy Price     | Sell Price\n"
             price_data += "-" * 50 + "\n"
 
             for entry in prices:
-                hour = entry["timestamp"].split()[1][:5]
-                price_str = f"{hour}  | {entry['price']:.4f} SEK    | "
-                buy_str = f"{entry['buyPrice']:.4f} SEK  | "
-                sell_str = f"{entry['sellPrice']:.4f} SEK\n"
+                time_str = entry["timestamp"].split()[1][:5]
+                price_str = f"{time_str}  | {entry['price']:.4f}        | "
+                buy_str = f"{entry['buyPrice']:.4f}       | "
+                sell_str = f"{entry['sellPrice']:.4f}\n"
                 price_data += price_str + buy_str + sell_str
 
             self._logger.info(price_data)

--- a/core/bess/tests/conftest.py
+++ b/core/bess/tests/conftest.py
@@ -150,10 +150,6 @@ class MockHomeAssistantController(HomeAssistantAPIController):
         """Get TOU settings."""
         return self.settings["tou_settings"]
 
-    def get_nordpool_prices_today(self) -> list[float]:
-        """Get the current Nordpool prices for today."""
-        return [1.0] * 24
-
     # Additional methods for integration tests
     def set_charging_power_rate(self, rate):
         """Set battery charge power rate."""
@@ -433,7 +429,11 @@ def sample_solar_data():
 @pytest.fixture
 def base_system(mock_controller):
     """Provide a clean system instance with mock controller."""
-    return BatterySystemManager(controller=mock_controller)
+    from core.bess.price_manager import MockSource
+
+    return BatterySystemManager(
+        controller=mock_controller, price_source=MockSource([1.0] * 96)
+    )
 
 
 @pytest.fixture

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -1,0 +1,384 @@
+"""
+Test the OctopusEnergySource implementation.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.bess.exceptions import PriceDataUnavailableError, SystemConfigurationError
+from core.bess.octopus_energy_source import OctopusEnergySource
+from core.bess.price_manager import MockSource, PriceManager
+
+
+def _make_rates(target_date, count=48, base_value=0.20, export=False):
+    """Create mock Octopus rate entries for a given date.
+
+    Args:
+        target_date: Date to create rates for
+        count: Number of 30-minute periods
+        base_value: Base price value
+        export: If True, use lower values typical of export rates
+
+    Returns:
+        List of rate dicts with start, end, and value_inc_vat
+    """
+    rates = []
+    for i in range(count):
+        start = datetime.combine(target_date, datetime.min.time()) + timedelta(
+            minutes=30 * i
+        )
+        end = start + timedelta(minutes=30)
+        value = (
+            (base_value + i * 0.01) if not export else (base_value * 0.3 + i * 0.005)
+        )
+        rates.append(
+            {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                "value_inc_vat": value,
+            }
+        )
+    return rates
+
+
+def _make_ha_controller(import_rates, export_rates=None):
+    """Create a mock HA controller that returns rates for given entity IDs.
+
+    Args:
+        import_rates: Rates to return for import entities
+        export_rates: Rates to return for export entities (optional)
+    """
+    controller = MagicMock()
+
+    def api_request(method, path):
+        if "import_today" in path or "import_tomorrow" in path:
+            return {"attributes": {"rates": import_rates}}
+        if "export_today" in path or "export_tomorrow" in path:
+            if export_rates is not None:
+                return {"attributes": {"rates": export_rates}}
+            return {"attributes": {}}
+        return {}
+
+    controller._api_request = MagicMock(side_effect=api_request)
+    return controller
+
+
+def _make_source(controller):
+    """Create an OctopusEnergySource with standard test entity IDs."""
+    return OctopusEnergySource(
+        ha_controller=controller,
+        import_today_entity="event.octopus_import_today",
+        import_tomorrow_entity="event.octopus_import_tomorrow",
+        export_today_entity="event.octopus_export_today",
+        export_tomorrow_entity="event.octopus_export_tomorrow",
+    )
+
+
+class TestOctopusEnergySourceProperties:
+    """Test basic properties of OctopusEnergySource."""
+
+    def test_period_duration_hours_is_quarterly(self):
+        controller = MagicMock()
+        source = _make_source(controller)
+        assert source.period_duration_hours == 0.25
+
+    def test_default_price_source_period_duration_is_quarter(self):
+        """Verify the base PriceSource default is 0.25 (Nordpool)."""
+        mock = MockSource([1.0])
+        assert mock.period_duration_hours == 0.25
+
+
+class TestImportRateFetching:
+    """Test fetching import rates from Octopus Energy entities."""
+
+    def test_fetch_today_import_rates(self):
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+
+        # 48 half-hourly rates expanded to 96 quarterly periods
+        assert len(prices) == 96
+        # Each raw rate is duplicated: indices 0,1 from rate 0; indices 94,95 from rate 47
+        assert prices[0] == rates[0]["value_inc_vat"]
+        assert prices[1] == rates[0]["value_inc_vat"]
+        assert prices[94] == rates[47]["value_inc_vat"]
+        assert prices[95] == rates[47]["value_inc_vat"]
+
+    def test_fetch_tomorrow_import_rates(self):
+        tomorrow = datetime.now().date() + timedelta(days=1)
+        rates = _make_rates(tomorrow)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(tomorrow)
+
+        assert len(prices) == 96
+
+    def test_rejects_date_beyond_tomorrow(self):
+        day_after = datetime.now().date() + timedelta(days=2)
+        controller = MagicMock()
+        source = _make_source(controller)
+
+        with pytest.raises(SystemConfigurationError):
+            source.get_prices_for_date(day_after)
+
+    def test_too_few_rates_raises_error(self):
+        """Rates below minimum threshold should fail validation."""
+        today = datetime.now().date()
+        rates = _make_rates(today, count=20)  # Well below minimum of 46
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_partial_rates_accepted(self):
+        """46-47 rates should be accepted (Octopus publishes incrementally)."""
+        today = datetime.now().date()
+        for count in (46, 47):
+            rates = _make_rates(today, count=count)
+            controller = _make_ha_controller(rates)
+            source = _make_source(controller)
+
+            prices = source.get_prices_for_date(today)
+            # Each raw rate is expanded to 2 quarterly periods
+            assert len(prices) == count * 2
+
+    def test_too_many_rates_raises_error(self):
+        """More than 48 rates for a single date should fail validation."""
+        today = datetime.now().date()
+        rates = _make_rates(today, count=48)
+        # Add duplicate rates that also fall on today to exceed 48
+        extra = _make_rates(today, count=2, base_value=0.50)
+        # Adjust extra start times to be within the same day but unique
+        for i, rate in enumerate(extra):
+            start = datetime.combine(today, datetime.min.time()) + timedelta(
+                minutes=15 * i
+            )
+            rate["start"] = start.isoformat()
+            rate["end"] = (start + timedelta(minutes=15)).isoformat()
+        all_rates = rates + extra
+        controller = _make_ha_controller(all_rates)
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_no_rates_attribute_raises_error(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(
+            return_value={"attributes": {"no_rates_key": []}}
+        )
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+    def test_api_failure_raises_error(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
+        source = _make_source(controller)
+
+        with pytest.raises(PriceDataUnavailableError):
+            source.get_prices_for_date(today)
+
+
+class TestExportRateFetching:
+    """Test fetching export/sell rates from Octopus Energy entities."""
+
+    def test_fetch_export_rates(self):
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        sell_prices = source.get_sell_prices_for_date(today)
+
+        assert sell_prices is not None
+        assert len(sell_prices) == 96
+        # Each raw rate is duplicated into two quarterly periods
+        assert sell_prices[0] == export_rates[0]["value_inc_vat"]
+        assert sell_prices[1] == export_rates[0]["value_inc_vat"]
+
+    def test_no_export_entity_returns_none(self):
+        today = datetime.now().date()
+        controller = MagicMock()
+        source = OctopusEnergySource(
+            ha_controller=controller,
+            import_today_entity="event.import_today",
+            import_tomorrow_entity="event.import_tomorrow",
+            export_today_entity="",
+            export_tomorrow_entity="",
+        )
+
+        assert source.get_sell_prices_for_date(today) is None
+
+    def test_export_failure_returns_none(self):
+        """Export rate failure should return None, not raise."""
+        today = datetime.now().date()
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
+        source = _make_source(controller)
+
+        assert source.get_sell_prices_for_date(today) is None
+
+    def test_default_get_sell_prices_for_date_returns_none(self):
+        """Base PriceSource returns None for sell prices."""
+        mock = MockSource([1.0])
+        assert mock.get_sell_prices_for_date(datetime.now().date()) is None
+
+
+class TestDateFilteringAndSorting:
+    """Test rate filtering by date and chronological sorting."""
+
+    def test_filters_rates_by_date(self):
+        """Only rates matching the target date should be included."""
+        today = datetime.now().date()
+        tomorrow = today + timedelta(days=1)
+
+        # Mix rates from today and tomorrow
+        today_rates = _make_rates(today)
+        tomorrow_rates = _make_rates(tomorrow, count=10)
+        mixed_rates = today_rates + tomorrow_rates
+
+        controller = _make_ha_controller(mixed_rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+        assert len(prices) == 96  # 48 raw rates expanded to 96 quarterly
+
+    def test_sorts_rates_chronologically(self):
+        """Rates should be sorted by start time regardless of input order."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        # Reverse the order
+        rates.reverse()
+
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        prices = source.get_prices_for_date(today)
+        assert len(prices) == 96
+        # First price should be the midnight rate (lowest index), duplicated
+        assert prices[0] == 0.20  # base_value for index 0
+        assert prices[1] == 0.20  # same rate, second quarterly period
+
+
+class TestHealthCheck:
+    """Test health check functionality."""
+
+    def test_healthy_source(self):
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        result = source.perform_health_check()
+
+        assert result["status"] == "OK"
+        assert len(result["checks"]) == 2
+        assert result["checks"][0]["status"] == "OK"
+        assert result["checks"][1]["status"] == "OK"
+
+    def test_unhealthy_import(self):
+        controller = MagicMock()
+        controller._api_request = MagicMock(side_effect=ConnectionError("down"))
+        source = _make_source(controller)
+
+        result = source.perform_health_check()
+
+        assert result["status"] == "ERROR"
+        assert result["checks"][0]["status"] == "ERROR"
+
+
+class TestPriceManagerIntegration:
+    """Test OctopusEnergySource integration with PriceManager."""
+
+    def test_price_manager_uses_direct_sell_prices(self):
+        """When source provides sell prices, PriceManager should use them directly."""
+        today = datetime.now().date()
+        import_rates = _make_rates(today)
+        export_rates = _make_rates(today, export=True)
+        controller = _make_ha_controller(import_rates, export_rates)
+        source = _make_source(controller)
+
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=0.0,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        assert len(price_data) == 96
+        # Sell price should come directly from export rates (duplicated for quarterly)
+        assert price_data[0]["sellPrice"] == export_rates[0]["value_inc_vat"]
+        assert price_data[1]["sellPrice"] == export_rates[0]["value_inc_vat"]
+        # Buy price should still be calculated from import rates
+        assert price_data[0]["buyPrice"] == import_rates[0]["value_inc_vat"]
+
+    def test_price_manager_timestamps_use_quarter_hour_spacing(self):
+        """Timestamps should be 15 minutes apart (quarterly resolution)."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+        source = _make_source(controller)
+
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=0.0,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        # 15-minute spacing: 00:00, 00:15, 00:30, 00:45
+        assert price_data[0]["timestamp"].endswith("00:00")
+        assert price_data[1]["timestamp"].endswith("00:15")
+        assert price_data[2]["timestamp"].endswith("00:30")
+        assert price_data[3]["timestamp"].endswith("00:45")
+
+    def test_price_manager_fallback_sell_without_export(self):
+        """Without export entity, sell price should use calculated formula."""
+        today = datetime.now().date()
+        rates = _make_rates(today)
+        controller = _make_ha_controller(rates)
+
+        source = OctopusEnergySource(
+            ha_controller=controller,
+            import_today_entity="event.octopus_import_today",
+            import_tomorrow_entity="event.octopus_import_tomorrow",
+            export_today_entity="",
+            export_tomorrow_entity="",
+        )
+
+        tax_reduction = 0.05
+        pm = PriceManager(
+            price_source=source,
+            markup_rate=0.0,
+            vat_multiplier=1.0,
+            additional_costs=0.0,
+            tax_reduction=tax_reduction,
+            area="UK",
+        )
+
+        price_data = pm.get_price_data(today)
+
+        # Sell price should be calculated: base_price + tax_reduction
+        expected_sell = rates[0]["value_inc_vat"] + tax_reduction
+        assert abs(price_data[0]["sellPrice"] - expected_sell) < 1e-6

--- a/core/bess/tests/unit/test_price_manager.py
+++ b/core/bess/tests/unit/test_price_manager.py
@@ -38,10 +38,6 @@ def test_direct_price_initialization():
 def test_controller_price_fetching():
     """Test price fetching from controller."""
     mock_controller = MagicMock()
-    mock_controller.sensors = {
-        "nordpool_kwh_today": "sensor.nordpool_kwh_se4_sek_2_10_025",
-        "nordpool_kwh_tomorrow": "sensor.nordpool_kwh_se4_sek_2_10_025",
-    }
 
     today_date = datetime.now().date()
     tomorrow_date = today_date + timedelta(days=1)
@@ -75,13 +71,14 @@ def test_controller_price_fetching():
             }
         return None
 
-    def mock_get_entity_for_service(sensor_key):
-        return "sensor.nordpool_kwh_se4_sek_2_10_025"
-
     mock_controller._api_request = mock_api_request
-    mock_controller._get_entity_for_service = mock_get_entity_for_service
 
-    ha_source = HomeAssistantSource(mock_controller, vat_multiplier=1.25)
+    ha_source = HomeAssistantSource(
+        mock_controller,
+        vat_multiplier=1.25,
+        today_entity="sensor.nordpool_kwh_se4_sek_2_10_025",
+        tomorrow_entity="sensor.nordpool_kwh_se4_sek_2_10_025",
+    )
     pm = PriceManager(
         price_source=ha_source,
         markup_rate=0.1,
@@ -153,9 +150,6 @@ def test_mock_source():
 def test_home_assistant_source_vat_parameter():
     """Test that the VAT multiplier parameter in HomeAssistantSource works correctly."""
     mock_controller = MagicMock()
-    mock_controller.sensors = {
-        "nordpool_kwh_today": "sensor.nordpool_kwh_se4_sek_2_10_025",
-    }
 
     today_date = datetime.now().date()
 
@@ -175,26 +169,36 @@ def test_home_assistant_source_vat_parameter():
             return {"attributes": {"raw_today": raw_today_data}}
         return None
 
-    def mock_get_entity_for_service(sensor_key):
-        return "sensor.nordpool_kwh_se4_sek_2_10_025"
-
     mock_controller._api_request = mock_api_request
-    mock_controller._get_entity_for_service = mock_get_entity_for_service
+
+    entity = "sensor.nordpool_kwh_se4_sek_2_10_025"
 
     # Test with default VAT multiplier (1.25)
-    ha_source_default = HomeAssistantSource(mock_controller, vat_multiplier=1.25)
+    ha_source_default = HomeAssistantSource(
+        mock_controller,
+        vat_multiplier=1.25,
+        today_entity=entity,
+        tomorrow_entity=entity,
+    )
     prices_default = ha_source_default.get_prices_for_date(today_date)
     assert prices_default[0] == 1.6  # 2.0 / 1.25 = 1.6
 
     # Test with custom VAT multiplier (1.20 for 20% VAT)
-    ha_source_custom = HomeAssistantSource(mock_controller, vat_multiplier=1.20)
+    ha_source_custom = HomeAssistantSource(
+        mock_controller,
+        vat_multiplier=1.20,
+        today_entity=entity,
+        tomorrow_entity=entity,
+    )
     prices_custom = ha_source_custom.get_prices_for_date(today_date)
     assert round(prices_custom[0], 4) == round(2.0 / 1.20, 4)  # ~1.6667
 
 
 def test_get_available_prices_today_only():
     """Should return today's prices at quarterly resolution when tomorrow unavailable."""
-    mock_source = MockSource(test_prices=[0.5] * 96)  # Nordpool provides 96 quarterly prices
+    mock_source = MockSource(
+        test_prices=[0.5] * 96
+    )  # Nordpool provides 96 quarterly prices
     pm = PriceManager(
         price_source=mock_source,
         markup_rate=0.05,
@@ -220,7 +224,9 @@ def test_get_available_prices_today_only():
 
 def test_get_available_prices_today_and_tomorrow():
     """Should return today + tomorrow at quarterly resolution when both available."""
-    mock_source = MockSource(test_prices=[0.5] * 96)  # Nordpool provides 96 quarterly prices
+    mock_source = MockSource(
+        test_prices=[0.5] * 96
+    )  # Nordpool provides 96 quarterly prices
     pm = PriceManager(
         price_source=mock_source,
         markup_rate=0.05,
@@ -286,7 +292,9 @@ def test_get_available_prices_returns_full_arrays_from_midnight():
 
 def test_get_available_prices_returns_tuple():
     """Should return a tuple of (buy_prices, sell_prices)."""
-    mock_source = MockSource(test_prices=[0.5] * 96)  # Nordpool provides 96 quarterly prices
+    mock_source = MockSource(
+        test_prices=[0.5] * 96
+    )  # Nordpool provides 96 quarterly prices
     pm = PriceManager(
         price_source=mock_source,
         markup_rate=0.05,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -125,7 +125,7 @@ export interface ElectricitySettings {
   vatMultiplier: number;
   additionalCosts: number;
   taxReduction: number;
-  area: 'SE1' | 'SE2' | 'SE3' | 'SE4';
+  area: string;
 }
 
 export interface ScheduleData {


### PR DESCRIPTION
## Summary

- Add Octopus Energy Agile tariff as a new price source alongside Nordpool, enabling UK users with battery storage to optimise against half-hourly import/export rates
- Unify energy provider configuration into a single `energy_provider:` section, replacing the previous `nordpool:` top-level key and `nordpool_kwh_today`/`nordpool_kwh_tomorrow` sensor entries
- Add UPGRADE.md with step-by-step migration instructions for the breaking config change

## What's included

**Octopus Energy support:**
- `OctopusEnergySource` fetches 48 half-hourly import/export rates from HA event entities, expanded to 96 quarterly periods to match the system-wide period model
- Separate import and export rate entities allow direct sell price data instead of calculated fallback
- `get_sell_prices_for_date()` added to `PriceSource` interface for sources with distinct export rates
- `PriceManager.clear_cache()` ensures settings changes propagate correctly at runtime
- 21 unit tests covering rate fetching, validation, date filtering, health checks, and PriceManager integration

**Config unification:**
- `energy_provider:` section with `provider`, `nordpool`, `nordpool_official`, and `octopus` sub-keys
- `HomeAssistantSource` takes entity IDs directly via constructor instead of looking them up from the sensor map
- Dead code removed: `LegacyNordpoolSource`, unused `get_nordpool_prices_today/tomorrow` methods
- Price logging uses currency-neutral column headers instead of hardcoded "SEK"

**Documentation:**
- UPGRADE.md with before/after config examples and key mapping table
- Updated README, Installation Guide, and User Guide for multi-provider support
- Octopus Energy setup section in Installation Guide with entity ID discovery instructions

## Breaking changes

Existing users must update their `config.yaml` — see [UPGRADE.md](https://github.com/pookey/bess-manager/blob/octopus-energy-upstream/UPGRADE.md) for details.

## Test plan

- [x] All 139 unit tests pass
- [x] Octopus Energy source tests: rate fetching, partial rates (46-47), date filtering, chronological sorting, health checks
- [x] PriceManager integration tests: direct sell prices, quarterly timestamps, fallback sell calculation
- [x] Existing Nordpool and scenario tests unaffected