### PR TITLE
Refactor: pass BatterySettings reference instead of bare float capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.1] - 2026-03-02
+
+### Fixed
+
+- Battery SOC no longer shows impossible values (e.g. 168%) when battery capacity differs from the 30 kWh default. `SensorCollector`, `EnergyFlowCalculator`, and `HistoricalDataStore` were initialised with the default capacity and only received the configured value via manual propagation in `update_settings()`. They now hold a shared `BatterySettings` reference so the configured capacity is always used for SOC-to-SOE conversion.
+
 ## [7.1.0] - 2026-03-01
 
 Thanks to [@pookey](https://github.com/pookey) for contributing this fix (PR #20).

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "7.1.0"
+version: "7.1.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -65,16 +65,12 @@ class BatterySystemManager:
         self._controller = controller
 
         # Initialize core data stores with proper component separation
-        self.historical_store = HistoricalDataStore(
-            self.battery_settings.total_capacity
-        )
+        self.historical_store = HistoricalDataStore(self.battery_settings)
         self.schedule_store = ScheduleStore()
         self.prediction_snapshot_store = PredictionSnapshotStore()
 
         # Initialize specialized components
-        self.sensor_collector = SensorCollector(
-            controller, self.battery_settings.total_capacity
-        )
+        self.sensor_collector = SensorCollector(controller, self.battery_settings)
 
         # Initialize view builder
         self.daily_view_builder = DailyViewBuilder(

--- a/core/bess/energy_flow_calculator.py
+++ b/core/bess/energy_flow_calculator.py
@@ -7,20 +7,22 @@ while separating it from sensor collection and predictions.
 
 import logging
 
+from .settings import BatterySettings
+
 logger = logging.getLogger(__name__)
 
 
 class EnergyFlowCalculator:
     """Calculates all energy flows in the systemand validates energy balance."""
 
-    def __init__(self, battery_capacity_kwh: float, ha_controller):
+    def __init__(self, battery_settings: BatterySettings, ha_controller):
         """Initialize energy flow calculator.
 
         Args:
-            battery_capacity_kwh: Total battery capacity for SOC calculations
+            battery_settings: Battery settings reference (shared, always up-to-date)
             ha_controller: HA controller for sensor resolution (required)
         """
-        self.battery_capacity = battery_capacity_kwh
+        self.battery_settings = battery_settings
         self.ha_controller = ha_controller
         self.sensor_to_flow_map = self._build_sensor_flow_mapping()
 

--- a/core/bess/historical_data_store.py
+++ b/core/bess/historical_data_store.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 
 from core.bess.models import PeriodData
+from core.bess.settings import BatterySettings
 from core.bess.time_utils import TIMEZONE, get_period_count
 
 logger = logging.getLogger(__name__)
@@ -20,17 +21,17 @@ class HistoricalDataStore:
     Only stores today's data in memory.
     """
 
-    def __init__(self, battery_capacity_kwh: float):
+    def __init__(self, battery_settings: BatterySettings):
         """Initialize the historical data store.
 
         Args:
-            battery_capacity_kwh: Total battery capacity for SOC calculations
+            battery_settings: Battery settings reference (shared, always up-to-date)
         """
         # Simple storage: period_index → PeriodData
         self._records: dict[int, PeriodData] = {}
 
-        # Store battery capacity for SOC calculations
-        self.total_capacity = battery_capacity_kwh
+        # Store battery settings reference for SOC calculations
+        self.battery_settings = battery_settings
 
         logger.debug("Initialized HistoricalDataStore")
 

--- a/core/bess/sensor_collector.py
+++ b/core/bess/sensor_collector.py
@@ -9,6 +9,7 @@ from .energy_flow_calculator import EnergyFlowCalculator
 from .health_check import perform_health_check
 from .influxdb_helper import get_sensor_data_batch
 from .models import EnergyData
+from .settings import BatterySettings
 
 logger = logging.getLogger(__name__)
 
@@ -16,17 +17,17 @@ logger = logging.getLogger(__name__)
 class SensorCollector:
     """Collects sensor data from InfluxDB and calculates energy flows with strategic intent reconstruction."""
 
-    def __init__(self, ha_controller, battery_capacity_kwh: float):
+    def __init__(self, ha_controller, battery_settings: BatterySettings):
         """Initialize sensor collector.
 
         Args:
             ha_controller: Home Assistant API controller
-            battery_capacity_kwh: Battery capacity in kWh
+            battery_settings: Battery settings reference (shared, always up-to-date)
         """
         self.ha_controller = ha_controller
-        self.battery_capacity = battery_capacity_kwh
+        self.battery_settings = battery_settings
         self.energy_flow_calculator = EnergyFlowCalculator(
-            battery_capacity_kwh, ha_controller
+            battery_settings, ha_controller
         )
 
         # Batch mode: fetch all periods in 1-2 queries instead of 176 (98% faster)
@@ -253,8 +254,8 @@ class SensorCollector:
             )
 
         # Convert SOC to SOE
-        soe_start = (battery_soc_start / 100.0) * self.battery_capacity
-        soe_end = (battery_soc_end / 100.0) * self.battery_capacity
+        soe_start = (battery_soc_start / 100.0) * self.battery_settings.total_capacity
+        soe_end = (battery_soc_end / 100.0) * self.battery_settings.total_capacity
 
         # Create EnergyData directly - detailed flows calculated automatically in __post_init__
         energy_data = EnergyData(

--- a/core/bess/tests/integration/test_daily_view_builder.py
+++ b/core/bess/tests/integration/test_daily_view_builder.py
@@ -38,7 +38,7 @@ def battery_settings():
 @pytest.fixture
 def historical_store(battery_settings):
     """Historical store with some actual data."""
-    store = HistoricalDataStore(battery_capacity_kwh=battery_settings.total_capacity)
+    store = HistoricalDataStore(battery_settings=battery_settings)
     return store
 
 
@@ -112,9 +112,7 @@ def test_midday_mix_actual_and_predicted(
     """Midday (period 56): past = actual, future = predicted."""
     # Add actual data for periods 0-55 (past)
     for i in range(56):
-        historical_store.record_period(
-            i, create_period_data(i, "actual", savings=5.0)
-        )
+        historical_store.record_period(i, create_period_data(i, "actual", savings=5.0))
 
     # Create predicted data for all 96 periods
     periods = [create_period_data(i, "predicted", savings=10.0) for i in range(96)]
@@ -149,9 +147,7 @@ def test_end_of_day_mostly_actual(view_builder, historical_store, schedule_store
     """Late evening (period 92): most data is actual."""
     # Add actual data for periods 0-91
     for i in range(92):
-        historical_store.record_period(
-            i, create_period_data(i, "actual", savings=7.0)
-        )
+        historical_store.record_period(i, create_period_data(i, "actual", savings=7.0))
 
     # Create predicted data
     periods = [create_period_data(i, "predicted", savings=10.0) for i in range(96)]
@@ -229,9 +225,7 @@ def test_different_periods_throughout_day(
     """Test actual/predicted split at different times of day."""
     # Add actual data for all past periods
     for i in range(96):
-        historical_store.record_period(
-            i, create_period_data(i, "actual", savings=5.0)
-        )
+        historical_store.record_period(i, create_period_data(i, "actual", savings=5.0))
 
     # Create predicted data
     periods = [create_period_data(i, "predicted", savings=10.0) for i in range(96)]

--- a/core/bess/tests/unit/test_historical_data_store.py
+++ b/core/bess/tests/unit/test_historical_data_store.py
@@ -7,6 +7,7 @@ import pytest
 
 from core.bess.historical_data_store import HistoricalDataStore
 from core.bess.models import DecisionData, EnergyData, PeriodData
+from core.bess.settings import BatterySettings
 
 TIMEZONE = ZoneInfo("Europe/Stockholm")
 
@@ -14,7 +15,7 @@ TIMEZONE = ZoneInfo("Europe/Stockholm")
 @pytest.fixture
 def store():
     """Create a fresh HistoricalDataStore for testing."""
-    return HistoricalDataStore(battery_capacity_kwh=30.0)
+    return HistoricalDataStore(battery_settings=BatterySettings(total_capacity=30.0))
 
 
 @pytest.fixture
@@ -123,11 +124,11 @@ def test_get_stored_count(store, sample_period_data):
 
 
 def test_total_capacity_stored(store):
-    """Should store battery capacity."""
-    assert store.total_capacity == 30.0
+    """Should store battery capacity via settings reference."""
+    assert store.battery_settings.total_capacity == 30.0
 
 
 def test_custom_battery_capacity():
-    """Should accept custom battery capacity."""
-    store = HistoricalDataStore(battery_capacity_kwh=50.0)
-    assert store.total_capacity == 50.0
+    """Should accept custom battery capacity via settings."""
+    store = HistoricalDataStore(battery_settings=BatterySettings(total_capacity=50.0))
+    assert store.battery_settings.total_capacity == 50.0


### PR DESCRIPTION
## Summary

- `SensorCollector`, `EnergyFlowCalculator`, and `HistoricalDataStore` now accept a shared `BatterySettings` reference instead of a bare `float` capacity
- Components always read the live value from the shared settings object, eliminating manual capacity propagation in `update_settings()`
- Matches the pattern already used by `DailyViewBuilder` and `GrowattScheduleManager`
- Bumps version to 7.1.1

## Context

Addresses the review feedback on the original SOC >100% fix — instead of manually propagating a float to three components, pass the `BatterySettings` reference so components always read the live value.

## Test plan

- [x] `pytest core/bess/tests/unit/ core/bess/tests/integration/` — 190 passed, 2 skipped
- [x] `black` and `ruff check` clean
- [ ] Deploy to HA install — verify SOC values stay 0-100%