### PR TITLE
Fix terminal value using last known price instead of daily average

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.1] - 2026-03-05
+
+### Fixed
+
+- Terminal value calculation now uses the last known non-zero price in the remaining horizon rather than the average of all remaining prices. Using the average inflated the terminal value when evening peak prices were included, causing the optimizer to incorrectly prefer holding battery charge over discharging during high-price periods. The last known price (typically an overnight off-peak rate) is a more accurate proxy for the expected cost of recharging tomorrow.
+
 ## [7.3.0] - 2026-03-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Terminal value calculation now uses the last known non-zero price in the remaining horizon rather than the average of all remaining prices. Using the average inflated the terminal value when evening peak prices were included, causing the optimizer to incorrectly prefer holding battery charge over discharging during high-price periods. The last known price (typically an overnight off-peak rate) is a more accurate proxy for the expected cost of recharging tomorrow.
+- Terminal value calculation now uses the median of remaining buy prices instead of the average. The average inflated the terminal value when evening peak prices were included, causing the optimizer to incorrectly prefer holding battery charge over discharging during high-price periods. The median is outlier-resistant (peaks cannot inflate it), works correctly across all price providers (Nordpool, Octopus Agile), and properly handles negative prices which are valid in both markets.
 
 ## [7.3.0] - 2026-03-04
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "7.3.0"
+version: "7.3.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -4,6 +4,7 @@ Complete replacement for battery_system.py that preserves ALL functionality.
 """
 
 import logging
+import statistics
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -1018,13 +1019,14 @@ class BatterySystemManager:
 
         When the horizon already extends past today (i.e. tomorrow's prices are
         included), return 0.0 since the DP has explicit future data. Otherwise,
-        estimate value from the last known buy price adjusted for efficiency
+        estimate value from the median buy price adjusted for efficiency
         and cycle cost.
 
-        Using the last known price (rather than an average) avoids inflating the
-        terminal value with peak prices that appear earlier in the horizon. The
-        last price in the day is typically an overnight off-peak price, which is
-        the best proxy for what overnight recharging would cost tomorrow.
+        Using the median of remaining buy prices avoids inflating the terminal
+        value with peak prices. The median is outlier-resistant, so evening
+        peaks cannot pull up the estimate regardless of price provider
+        (Nordpool, Octopus Agile, etc.). It also correctly handles negative
+        prices, which are valid in both markets.
 
         Args:
             buy_prices: Full buy price array (from optimization_period onwards)
@@ -1046,26 +1048,23 @@ class BatterySystemManager:
             )
             return 0.0
 
-        # Estimate terminal value from the last known non-zero buy price.
-        # This represents the expected overnight recharge cost: the last price
-        # before midnight is typically an off-peak rate, which is a far better
-        # proxy than an average that includes evening peaks.
+        # Estimate terminal value from the median buy price. The median is
+        # resistant to outliers (peaks), works across all price providers,
+        # and correctly handles negative prices.
         if not buy_prices:
             return 0.0
 
-        last_known_price = next(
-            (p for p in reversed(buy_prices) if p > 0), buy_prices[0]
-        )
+        median_price = statistics.median(buy_prices)
         terminal_value = (
-            last_known_price * self.battery_settings.efficiency_discharge
+            median_price * self.battery_settings.efficiency_discharge
             - self.battery_settings.cycle_cost_per_kwh
         )
         terminal_value = max(0.0, terminal_value)
 
         logger.info(
-            "Terminal value: %.3f/kWh (last_known_price=%.3f, efficiency=%.2f, cycle_cost=%.3f)",
+            "Terminal value: %.3f/kWh (median_price=%.3f, efficiency=%.2f, cycle_cost=%.3f)",
             terminal_value,
-            last_known_price,
+            median_price,
             self.battery_settings.efficiency_discharge,
             self.battery_settings.cycle_cost_per_kwh,
         )

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1018,8 +1018,13 @@ class BatterySystemManager:
 
         When the horizon already extends past today (i.e. tomorrow's prices are
         included), return 0.0 since the DP has explicit future data. Otherwise,
-        estimate value from today's average buy price adjusted for efficiency
+        estimate value from the last known buy price adjusted for efficiency
         and cycle cost.
+
+        Using the last known price (rather than an average) avoids inflating the
+        terminal value with peak prices that appear earlier in the horizon. The
+        last price in the day is typically an overnight off-peak price, which is
+        the best proxy for what overnight recharging would cost tomorrow.
 
         Args:
             buy_prices: Full buy price array (from optimization_period onwards)
@@ -1041,21 +1046,26 @@ class BatterySystemManager:
             )
             return 0.0
 
-        # Estimate terminal value from today's buy prices
+        # Estimate terminal value from the last known non-zero buy price.
+        # This represents the expected overnight recharge cost: the last price
+        # before midnight is typically an off-peak rate, which is a far better
+        # proxy than an average that includes evening peaks.
         if not buy_prices:
             return 0.0
 
-        avg_buy_price = sum(buy_prices) / len(buy_prices)
+        last_known_price = next(
+            (p for p in reversed(buy_prices) if p > 0), buy_prices[0]
+        )
         terminal_value = (
-            avg_buy_price * self.battery_settings.efficiency_discharge
+            last_known_price * self.battery_settings.efficiency_discharge
             - self.battery_settings.cycle_cost_per_kwh
         )
         terminal_value = max(0.0, terminal_value)
 
         logger.info(
-            "Terminal value: %.3f SEK/kWh (avg_buy=%.3f, efficiency=%.2f, cycle_cost=%.3f)",
+            "Terminal value: %.3f/kWh (last_known_price=%.3f, efficiency=%.2f, cycle_cost=%.3f)",
             terminal_value,
-            avg_buy_price,
+            last_known_price,
             self.battery_settings.efficiency_discharge,
             self.battery_settings.cycle_cost_per_kwh,
         )


### PR DESCRIPTION
## Summary

- When tomorrow's prices aren't yet published (Octopus Agile doesn't publish the next day's import rates until around 16:00), the optimizer falls back to a terminal value to prevent dumping battery charge at end of day.
- Previously the terminal value was calculated as the average of all remaining buy prices for the day. This included tonight's expensive peak periods, inflating the terminal value and causing the optimizer to refuse to discharge during those same peaks — a circular, self-defeating calculation.
- Now uses the last known non-zero price in the horizon (typically the 22:30 off-peak rate, since Octopus hasn't yet published 23:00+). This is a far more accurate proxy for what overnight recharging would cost tomorrow, and allows the optimizer to correctly schedule evening discharge during peak-price periods.

## Test plan

- [ ] Verify that with tomorrow's import prices unavailable (before ~16:00), the battery correctly schedules discharge during evening peak periods
- [ ] Verify that when tomorrow's prices are available, terminal value remains 0.0 (unchanged behaviour — the last-known-price path is not reached)
- [ ] Verify that a full-day run from midnight still behaves correctly