### PR TITLE
Handle missing and zero-value data in dashboard charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.1] - 2026-03-06
+
+### Fixed
+
+- Startup data collection for the last completed period used live sensors instead of InfluxDB, causing it to include energy from the in-progress period. This inflated the last completed period (e.g. ~2x values) and left the next period nearly empty on the chart. Now forces InfluxDB for all periods during startup when no sensor cache exists. (thanks [@pookey](https://github.com/pookey))
+
 ## [7.3.0] - 2026-03-04
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "7.3.0"
+version: "7.3.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/sensor_collector.py
+++ b/core/bess/sensor_collector.py
@@ -103,7 +103,10 @@ class SensorCollector:
         # Determine if we're doing historical backfill or runtime collection
         # Historical: period < current - 1 (collecting old data during startup)
         # Runtime: period == current - 1 (collecting just-completed period)
-        is_historical_backfill = period < current_period - 1
+        # ALSO treat as historical if no cache exists (startup/restart) - using live
+        # sensors for the last completed period would include energy from the
+        # currently in-progress period, inflating the last period's data
+        is_historical_backfill = period < current_period - 1 or self._last_readings is None
 
         if is_historical_backfill:
             # HISTORICAL BACKFILL: Use InfluxDB for both current and previous readings

--- a/frontend/src/components/BatteryLevelChart.tsx
+++ b/frontend/src/components/BatteryLevelChart.tsx
@@ -83,8 +83,12 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
       throw new Error(`MISSING DATA: batteryAction is required but missing at index ${index}`);
     }
     const batteryAction = getValue(hour.batteryAction);
-    const batterySocPercent = getValue(hour.batterySocEnd);
-    const price = getValue(hour.buyPrice);
+    const rawSoc = getValue(hour.batterySocEnd);
+    const isActual = hour.dataSource === 'actual';
+    // Treat zero SOC on predicted periods as missing data
+    const batterySocPercent = (rawSoc === 0 && !isActual) ? null : rawSoc;
+    const rawPrice = getValue(hour.buyPrice);
+    const price = rawPrice || null; // Treat zero/missing price as null
     const periodNum = hour.period ?? index;
     if (hour.dataSource === undefined) {
       throw new Error(`MISSING DATA: dataSource is required but missing at index ${index}`);
@@ -126,8 +130,10 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
         continue;
       }
       const batteryAction = getValue(hour.batteryAction);
-      const batterySocPercent = getValue(hour.batterySocEnd);
-      const price = getValue(hour.buyPrice);
+      const rawSocTmrw = getValue(hour.batterySocEnd);
+      const batterySocPercent = rawSocTmrw === 0 ? null : rawSocTmrw;
+      const rawPriceTmrw = getValue(hour.buyPrice);
+      const price = rawPriceTmrw || null;
       // Normalize period numbers: API may return 96-191 (continuation from today) or 0-95
       const rawPeriodNum = hour.period ?? idx;
       const tomorrowPeriodsPerDay = resolution === 'quarter-hourly' ? 96 : 24;

--- a/frontend/src/components/BatteryLevelChart.tsx
+++ b/frontend/src/components/BatteryLevelChart.tsx
@@ -83,22 +83,20 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
       throw new Error(`MISSING DATA: batteryAction is required but missing at index ${index}`);
     }
     const batteryAction = getValue(hour.batteryAction);
-    const batterySocPercent = getValue(hour.batterySocEnd); // Extract from FormattedValue
-    const price = getValue(hour.buyPrice); // Extract from FormattedValue
+    const batterySocPercent = getValue(hour.batterySocEnd);
+    const price = getValue(hour.buyPrice);
     const periodNum = hour.period ?? index;
     if (hour.dataSource === undefined) {
       throw new Error(`MISSING DATA: dataSource is required but missing at index ${index}`);
     }
     const dataSource = hour.dataSource;
 
-    // Calculate x-axis position (center of period)
+    // Calculate x-axis position (start of period)
     let xPosition: number;
     if (resolution === 'quarter-hourly') {
-      // For quarterly: convert period to hour position (period 4 = hour 1.0)
-      xPosition = periodNum / 4 + 0.125; // Center in 15-min period (0.125 = 1/8 hour)
+      xPosition = periodNum / 4;
     } else {
-      // For hourly: center in hour
-      xPosition = periodNum + 0.5;
+      xPosition = periodNum;
     }
 
     return {
@@ -130,14 +128,17 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
       const batteryAction = getValue(hour.batteryAction);
       const batterySocPercent = getValue(hour.batterySocEnd);
       const price = getValue(hour.buyPrice);
-      const periodNum = hour.period ?? idx;
+      // Normalize period numbers: API may return 96-191 (continuation from today) or 0-95
+      const rawPeriodNum = hour.period ?? idx;
+      const tomorrowPeriodsPerDay = resolution === 'quarter-hourly' ? 96 : 24;
+      const periodNum = rawPeriodNum >= tomorrowPeriodsPerDay ? rawPeriodNum - tomorrowPeriodsPerDay : rawPeriodNum;
       const dataSource = hour.dataSource ?? 'predicted';
 
       let xPosition: number;
       if (resolution === 'quarter-hourly') {
-        xPosition = 24 + periodNum / 4 + 0.125;
+        xPosition = 24 + periodNum / 4;
       } else {
-        xPosition = 24 + periodNum + 0.5;
+        xPosition = 24 + periodNum;
       }
 
       chartData.push({
@@ -158,14 +159,14 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
     }
   }
 
-  // Compute max hour for X-axis
+  // Compute max hour for X-axis (add 1 for stepAfter to render last period)
   const maxHourValue = hasTomorrowData
-    ? Math.ceil(Math.max(...chartData.map(d => d.hour)))
+    ? Math.ceil(Math.max(...chartData.map(d => d.hour))) + 1
     : 24;
   const xAxisTicks = Array.from({ length: maxHourValue + 1 }, (_, i) => i);
 
   const maxAction = Math.max(...chartData.map(d => Math.abs(d.action || 0)), 1);
-  const maxPrice = Math.max(...chartData.map(h => h.price), 1);
+  const maxPrice = Math.max(...chartData.map(h => h.price ?? 0), 1);
 
   return (
     <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
@@ -175,16 +176,13 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
             <CartesianGrid strokeDasharray="5 5" stroke={colors.grid} strokeOpacity={0.3} strokeWidth={0.5} />
             <XAxis
               dataKey="hour"
-              interval="preserveStartEnd"
+              interval={0}
               tick={{ fill: colors.text, fontSize: 12 }}
               axisLine={{ stroke: colors.text }}
               tickLine={{ stroke: colors.text }}
               ticks={xAxisTicks}
               tickFormatter={(value: number) => {
-                if (value >= 24) {
-                  return `+${Math.floor(value - 24).toString().padStart(2, '0')}:00`;
-                }
-                return `${Math.floor(value).toString().padStart(2, '0')}:00`;
+                return `${(Math.floor(value) % 24).toString().padStart(2, '0')}:00`;
               }}
             />
             
@@ -286,18 +284,6 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
               />
             ))}
 
-            {/* Midnight separator when tomorrow data exists */}
-            {hasTomorrowData && (
-              <ReferenceLine
-                x={24}
-                yAxisId="left"
-                stroke={colors.text}
-                strokeDasharray="4 4"
-                strokeWidth={1.5}
-                label={{ value: 'Tomorrow', position: 'top', fill: colors.text, fontSize: 11 }}
-              />
-            )}
-            
             <Area
               yAxisId="left"
               type="monotone"
@@ -311,13 +297,14 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
             
             <Line
               yAxisId="right"
-              type="monotone"
+              type="stepAfter"
               dataKey="price"
               stroke="#9CA3AF"
               strokeWidth={1.5}
               strokeDasharray="3 3"
               name="Electricity Price"
               dot={false}
+              connectNulls={false}
             />
             
             <Bar 

--- a/frontend/src/components/EnergyFlowChart.tsx
+++ b/frontend/src/components/EnergyFlowChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ComposedChart, Area, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
+import { ComposedChart, Area, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine, ReferenceArea } from 'recharts';
 import { HourlyData } from '../types';
 import { periodToTimeRange } from '../utils/timeUtils';
 import { DataResolution } from '../hooks/useUserPreferences';
@@ -8,19 +8,11 @@ import { DataResolution } from '../hooks/useUserPreferences';
 const CustomTooltip = ({ active, payload, label, resolution }: any) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
-    if (label === 0) {
-      // Skip tooltip for the empty starting point
-      return null;
-    }
 
     // Get time range from period number stored in data
     const periodNum = data.periodNum;
     const isTomorrow = data.isTomorrow;
-    // For tomorrow data, use the period number relative to tomorrow
-    // In quarter-hourly mode, periods are offset by 96; in hourly, by 24
-    const tomorrowOffset = resolution === 'quarter-hourly' ? 96 : 24;
-    const displayPeriodNum = isTomorrow ? periodNum - tomorrowOffset : periodNum;
-    const timeRange = periodToTimeRange(displayPeriodNum, resolution);
+    const timeRange = periodToTimeRange(periodNum, resolution);
     const dayLabel = isTomorrow ? 'Tomorrow' : '';
 
     // Map chart dataKeys to their corresponding FormattedValue fields
@@ -153,30 +145,13 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
     return field || 0;
   };
 
-  // Shift timeline - data for hour 0 (00:00-01:00) should appear at position 1
-  // Support both hourly (24 periods) and quarterly (96 periods) data
+  // Map each period to a chart data point positioned at the START of its hour
+  // For stepAfter rendering: data at x=0 shows from 0→1, data at x=1 shows from 1→2, etc.
   const numDataPoints = dailyViewData?.length || 24;
-  const chartData: any[] = Array.from({ length: numDataPoints + 1 }, (_, index) => {
-    if (index === 0) {
-      // Add empty data point at the start (before 00:00)
-      return {
-        hour: 0,
-        periodNum: 0,
-        solar: 0,
-        batteryOut: 0,
-        gridIn: 0,
-        home: 0,
-        batteryIn: 0,
-        gridOut: 0,
-        isActual: true,
-        isTomorrow: false,
-        price: 0,
-      };
-    }
-    const dataIndex = index - 1;
-    const dailyViewHour = dailyViewData?.[dataIndex];
+  const chartData: any[] = Array.from({ length: numDataPoints }, (_, index) => {
+    const dailyViewHour = dailyViewData?.[index];
     const isActual = dailyViewHour?.dataSource === 'actual';
-    const periodNum = dataIndex;
+    const periodNum = index;
 
     // Map unified API data format to chart format
     const solarProduction = getValue(dailyViewHour?.solarProduction);
@@ -186,8 +161,8 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
     const gridImported = getValue(dailyViewHour?.gridImported) || 0;
     const gridExported = getValue(dailyViewHour?.gridExported) || 0;
 
-    // Calculate x-axis position
-    const hourPosition = resolution === 'quarter-hourly' ? (periodNum / 4) + 1 : index;
+    // Calculate x-axis position (start of period)
+    const hourPosition = resolution === 'quarter-hourly' ? (periodNum / 4) : periodNum;
 
     return {
       hour: hourPosition,
@@ -216,10 +191,13 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
   const hasTomorrowData = tomorrowData && tomorrowData.length > 0;
   if (hasTomorrowData) {
     for (const [idx, hourData] of tomorrowData.entries()) {
-      const periodNum = hourData.period ?? idx;
+      const rawPeriodNum = hourData.period ?? idx;
+      // Normalize period numbers: API may return 96-191 (continuation from today) or 0-95
+      const tomorrowPeriodsPerDay = resolution === 'quarter-hourly' ? 96 : 24;
+      const periodNum = rawPeriodNum >= tomorrowPeriodsPerDay ? rawPeriodNum - tomorrowPeriodsPerDay : rawPeriodNum;
       const hourPosition = resolution === 'quarter-hourly'
-        ? 24 + (periodNum / 4) + (1 / 4)
-        : 24 + periodNum + 1;
+        ? 24 + (periodNum / 4)
+        : 24 + periodNum;
 
       const solarProduction = getValue(hourData?.solarProduction);
       const homeConsumption = getValue(hourData?.homeConsumption);
@@ -228,11 +206,9 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
       const gridImported = getValue(hourData?.gridImported) || 0;
       const gridExported = getValue(hourData?.gridExported) || 0;
 
-      // Store period num with offset so tooltip can detect tomorrow
-      const tomorrowPeriodOffset = resolution === 'quarter-hourly' ? 96 : 24;
       chartData.push({
         hour: hourPosition,
-        periodNum: tomorrowPeriodOffset + periodNum,
+        periodNum,
         solar: solarProduction,
         batteryOut: batteryDischarged,
         gridIn: gridImported,
@@ -255,9 +231,19 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
   }
 
   // Compute max hour for X-axis domain
+  // Add 1 to include room for the last stepAfter to render
   const maxHour = hasTomorrowData
-    ? Math.ceil(Math.max(...chartData.map(d => d.hour)))
-    : (resolution === 'quarter-hourly' ? 24.25 : 24);
+    ? Math.ceil(Math.max(...chartData.map(d => d.hour))) + 1
+    : 24;
+
+  // Explicit tick positions at whole hours
+  const xAxisTicks = Array.from({ length: Math.ceil(maxHour) + 1 }, (_, i) => i);
+
+  // Find predicted hours range for shading
+  const firstPredictedIdx = chartData.findIndex(d => !d.isActual && !d.isTomorrow);
+  const lastTodayIdx = chartData.findIndex(d => d.isTomorrow);
+  const firstPredictedHour = firstPredictedIdx > -1 ? chartData[firstPredictedIdx].hour : null;
+  const lastTodayHour = lastTodayIdx > -1 ? chartData[lastTodayIdx - 1]?.hour : maxHour;
 
   return (
     <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
@@ -324,12 +310,15 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
             <CartesianGrid strokeDasharray="5 5" stroke={colors.gridLines} strokeOpacity={0.3} strokeWidth={0.5} />
             <XAxis
               dataKey="hour"
+              type="number"
               stroke={colors.text}
               tick={{ fontSize: 12 }}
               domain={[0, maxHour]}
-              label={{ value: hasTomorrowData ? 'Hour' : 'Hour of Day', position: 'insideBottom', offset: -10 }}
+              ticks={xAxisTicks}
+              interval={0}
+              label={{ value: 'Hour of Day', position: 'insideBottom', offset: -10 }}
               tickFormatter={(hour: number) => {
-                return Math.floor(hour % 24).toString().padStart(2, '0');
+                return (Math.floor(hour) % 24).toString().padStart(2, '0');
               }}
             />
             <YAxis 
@@ -360,17 +349,6 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
             {/* Reference line at zero to separate sources from consumption */}
             <ReferenceLine y={0} stroke={colors.text} strokeWidth={2} />
 
-            {/* Midnight separator when tomorrow data exists */}
-            {hasTomorrowData && (
-              <ReferenceLine
-                x={24}
-                stroke={colors.text}
-                strokeDasharray="4 4"
-                strokeWidth={1.5}
-                label={{ value: 'Tomorrow', position: 'top', fill: colors.text, fontSize: 11 }}
-              />
-            )}
-            
             {/* ENERGY SOURCES - Single series, style by isActual */}
             <Area
               type="monotone"
@@ -445,22 +423,19 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
               dot={false}
               connectNulls
             />
-            {/* Overlay for predicted + tomorrow hours - single unified grey */}
-            {chartData.findIndex(d => !d.isActual) > -1 && (
-              <rect
-                x={((chartData.findIndex(d => !d.isActual) / chartData.length) * 100) + '%'}
-                y={0}
-                width={(((chartData.length - chartData.findIndex(d => !d.isActual)) / chartData.length) * 100) + '%'}
-                height="100%"
+            {/* Overlay for predicted hours (today only) */}
+            {firstPredictedHour !== null && (
+              <ReferenceArea
+                x1={firstPredictedHour}
+                x2={lastTodayHour}
                 fill={isDarkMode ? 'rgba(120,120,120,0.12)' : 'rgba(120,120,120,0.10)'}
-                pointerEvents="none"
-                style={{ position: 'absolute', zIndex: 1 }}
+                ifOverflow="hidden"
               />
             )}
-            
+
             {/* Price line on secondary Y-axis */}
             <Line
-              type="monotone"
+              type="stepAfter"
               dataKey="price"
               yAxisId="price"
               stroke="#9CA3AF"
@@ -468,6 +443,7 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
               dot={false}
               strokeDasharray="3 3"
               name="Electricity Price"
+              connectNulls={false}
             />
           </ComposedChart>
         </ResponsiveContainer>

--- a/frontend/src/components/EnergyFlowChart.tsx
+++ b/frontend/src/components/EnergyFlowChart.tsx
@@ -175,7 +175,7 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
       gridOut: gridExported > 0 ? -gridExported : 0,
       isActual,
       isTomorrow: false,
-      price: getValue(dailyViewHour?.buyPrice),
+      price: getValue(dailyViewHour?.buyPrice) || null,
       // Include FormattedValue objects for tooltip
       solarProductionFormatted: dailyViewHour?.solarProduction,
       homeConsumptionFormatted: dailyViewHour?.homeConsumption,
@@ -217,7 +217,7 @@ const CustomTooltip = ({ active, payload, label, resolution }: any) => {
         gridOut: gridExported > 0 ? -gridExported : 0,
         isActual: false,
         isTomorrow: true,
-        price: getValue(hourData?.buyPrice),
+        price: getValue(hourData?.buyPrice) || null,
         // Include FormattedValue objects for tooltip
         solarProductionFormatted: hourData?.solarProduction,
         homeConsumptionFormatted: hourData?.homeConsumption,


### PR DESCRIPTION
## Summary

Builds on #29 to improve data quality handling in both charts.

- **Treat zero SOC on predicted periods as null**: prevents misleading flat lines at 0% when no prediction data is available for future hours
- **Treat zero/missing electricity prices as null**: the price line now breaks visually rather than dropping to zero, which would misrepresent pricing data
- **Apply same null handling to tomorrow data** sections in both EnergyFlowChart and BatteryLevelChart
- Works with `connectNulls={false}` (from #29) to create visual gaps where data is genuinely unavailable

## Test plan

- [ ] Verify predicted hours with no SOC data show a gap instead of flat 0% line
- [ ] Verify hours with no price data show a gap in the price line instead of dropping to 0
- [ ] Verify actual data with genuine 0 values still renders correctly
- [ ] Verify tomorrow data with missing values shows appropriate gaps
- [ ] Test dashboard with partial data availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)