### PR TITLE
Add configurable consumption forecast strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Configurable consumption forecast strategy via `home.consumption_strategy` setting. Supports `sensor` (default, HA 48h average), `fixed` (flat rate from config), and `influxdb_7d_avg` (7-day rolling average from InfluxDB power sensor data at 15-minute resolution).
+
 ## [7.8.1] - 2026-03-12
 
 ### Fixed

--- a/backend/api.py
+++ b/backend/api.py
@@ -33,10 +33,11 @@ async def get_battery_settings():
         settings = bess_controller.system.get_settings()
         battery_settings = settings["battery"]
         estimated_consumption = settings["home"].default_hourly
+        consumption_strategy = settings["home"].consumption_strategy
 
         # Create APIBatterySettings using existing method
         api_settings = APIBatterySettings.from_internal(
-            battery_settings, estimated_consumption
+            battery_settings, estimated_consumption, consumption_strategy
         )
         return api_settings.__dict__
 

--- a/backend/api_dataclasses.py
+++ b/backend/api_dataclasses.py
@@ -97,9 +97,12 @@ class APIBatterySettings:
     efficiencyCharge: float  # % - charging efficiency
     efficiencyDischarge: float  # % - discharge efficiency
     estimatedConsumption: float  # kWh - estimated daily consumption
+    consumptionStrategy: str  # consumption forecast strategy
 
     @classmethod
-    def from_internal(cls, battery, estimated_consumption: float) -> APIBatterySettings:
+    def from_internal(
+        cls, battery, estimated_consumption: float, consumption_strategy: str = "sensor"
+    ) -> APIBatterySettings:
         """Convert from internal snake_case to canonical camelCase."""
         return cls(
             totalCapacity=battery.total_capacity,
@@ -115,6 +118,7 @@ class APIBatterySettings:
             efficiencyCharge=battery.efficiency_charge,
             efficiencyDischarge=battery.efficiency_discharge,
             estimatedConsumption=estimated_consumption,
+            consumptionStrategy=consumption_strategy,
         )
 
     def to_internal_update(self) -> dict:

--- a/backend/app.py
+++ b/backend/app.py
@@ -343,6 +343,7 @@ class BESSController:
                 "voltage",
                 "safety_margin_factor",
                 "phase_count",
+                "consumption_strategy",
             ]
             for key in required_home_keys:
                 if key not in home_config:
@@ -369,6 +370,7 @@ class BESSController:
                     "voltage": home_config["voltage"],
                     "safetyMargin": home_config["safety_margin_factor"],
                     "phaseCount": home_config["phase_count"],
+                    "consumptionStrategy": home_config["consumption_strategy"],
                 },
                 "price": {
                     "area": electricity_price_config["area"],

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,7 @@ options:
   home:
     consumption: 3.5                # default hourly consumption in kWh
     currency: "SEK"                 # currency for price display and calculations
+    consumption_strategy: "sensor"  # "sensor" (HA 48h avg), "fixed", or "influxdb_7d_avg"
     max_fuse_current: 25            # Maximum fuse current in amperes
     voltage: 230                    # Line voltage in volts
     safety_margin_factor: 1.0       # Safety margin for power calculations (100% - safe with 5min monitoring)
@@ -118,6 +119,7 @@ schema:
   home:
     consumption: float
     currency: str
+    consumption_strategy: str
     max_fuse_current: int
     voltage: int
     safety_margin_factor: float

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -129,6 +129,10 @@ class BatterySystemManager:
         self._current_schedule = None
         self._initial_soe = None
 
+        # Prediction caches (populated by _fetch_predictions)
+        self._consumption_predictions: list[float] | None = None
+        self._solar_predictions: list[float] | None = None
+
         # Critical sensor failure tracking for graceful degradation
         self._critical_sensor_failures = []
 
@@ -604,7 +608,7 @@ class BatterySystemManager:
                 logger.warning("Cannot fetch predictions: controller is not available")
                 return
 
-            consumption_predictions = self._controller.get_estimated_consumption()
+            consumption_predictions = self._get_consumption_forecast()
             solar_predictions = self._controller.get_solar_forecast()
 
             # Store the predictions (this was missing!)
@@ -630,6 +634,98 @@ class BatterySystemManager:
 
         except Exception as e:
             logger.warning(f"Failed to fetch predictions: {e}")
+
+    def _get_consumption_forecast(self) -> list[float]:
+        """Get consumption forecast based on the configured strategy.
+
+        Dispatches to the appropriate data source based on
+        home_settings.consumption_strategy.
+
+        Returns:
+            List of 96 float values (kWh per 15-minute period).
+        """
+        strategy = self.home_settings.consumption_strategy
+
+        if strategy == "sensor":
+            return self.controller.get_estimated_consumption()
+
+        if strategy == "fixed":
+            quarterly = self.home_settings.default_hourly / 4.0
+            return [quarterly] * 96
+
+        if strategy == "influxdb_7d_avg":
+            return self._get_influxdb_7d_avg_forecast()
+
+        raise ValueError(f"Unknown consumption_strategy: '{strategy}'")
+
+    def _get_influxdb_7d_avg_forecast(self) -> list[float]:
+        """Get consumption forecast from InfluxDB 7-day average profile.
+
+        Queries InfluxDB for the past 7 days of the local_load_power sensor
+        and returns the 96-value weekly average profile (kWh per 15-min period).
+        """
+        from .influxdb_helper import get_power_sensor_data_batch
+
+        sensors_config = self._addon_options.get("sensors", {})
+        target_sensor = sensors_config.get("local_load_power", "")
+        if not target_sensor:
+            raise ValueError(
+                "influxdb_7d_avg strategy requires 'local_load_power' sensor configured"
+            )
+
+        # Strip 'sensor.' prefix if present — get_power_sensor_data_batch adds it
+        if target_sensor.startswith("sensor."):
+            target_sensor = target_sensor[len("sensor.") :]
+
+        today = date.today()
+        day_profiles: list[list[float]] = []
+
+        for days_back in range(1, 8):
+            target_date = today - timedelta(days=days_back)
+            result = get_power_sensor_data_batch([target_sensor], target_date)
+
+            if result["status"] != "success":
+                logger.warning(
+                    "Failed to fetch power data for %s: %s",
+                    target_date,
+                    result.get("message", "unknown error"),
+                )
+                continue
+
+            period_data = result["data"]
+            sensor_key = f"sensor.{target_sensor}"
+            profile = [0.0] * 96
+            periods_found = 0
+            for period in range(96):
+                if period in period_data and sensor_key in period_data[period]:
+                    profile[period] = period_data[period][sensor_key]
+                    periods_found += 1
+
+            if periods_found >= 48:  # At least half a day of data
+                day_profiles.append(profile)
+                logger.debug("Got %d periods for %s", periods_found, target_date)
+
+        if not day_profiles:
+            logger.warning(
+                "No valid historical data for influxdb_7d_avg strategy, "
+                "falling back to fixed consumption"
+            )
+            quarterly = self.home_settings.default_hourly / 4.0
+            return [quarterly] * 96
+
+        # Average across all valid days
+        avg_profile = [
+            sum(p[i] for p in day_profiles) / len(day_profiles) for i in range(96)
+        ]
+
+        total_kwh = sum(avg_profile)
+        logger.info(
+            "InfluxDB 7-day average profile: %.1f kWh/day from %d days of data",
+            total_kwh,
+            len(day_profiles),
+        )
+
+        return avg_profile
 
     def _handle_special_cases(self, period: int, prepare_next_day: bool) -> None:
         """Handle special cases like midnight transition."""
@@ -907,7 +1003,7 @@ class BatterySystemManager:
 
         if prepare_next_day:
             # For next day, use predictions only
-            consumption_predictions = self.controller.get_estimated_consumption()
+            consumption_predictions = self._get_consumption_forecast()
             solar_predictions = self.controller.get_solar_forecast()
 
             consumption_data = consumption_predictions
@@ -925,7 +1021,7 @@ class BatterySystemManager:
             completed_periods = [
                 i for i, p in enumerate(today_periods) if p is not None
             ]
-            predictions_consumption = self.controller.get_estimated_consumption()
+            predictions_consumption = self._get_consumption_forecast()
             predictions_solar = self.controller.get_solar_forecast()
 
             # Extend predictions for tomorrow when horizon exceeds today
@@ -2240,8 +2336,10 @@ class BatterySystemManager:
     def _log_battery_system_config(self) -> None:
         """Log the current battery configuration - reproduces original functionality."""
         try:
-            # Get energy data for consumption info (like original)
-            predictions_consumption = self.controller.get_estimated_consumption()
+            # Use already-fetched predictions — avoids triggering a heavy pipeline
+            # (InfluxDB query or ML inference) just for a log message
+            assert self._consumption_predictions is not None
+            predictions_consumption = self._consumption_predictions
 
             # Get current SOC
             if self._controller:

--- a/core/bess/influxdb_helper.py
+++ b/core/bess/influxdb_helper.py
@@ -203,7 +203,7 @@ def _extract_sensor_name(parts: list[str], col_map: dict[str, int]) -> str:
             if entity_val.startswith("sensor."):
                 return entity_val
             # InfluxDB 1.x: short name without prefix — normalize it
-            if entity_val != "entity_id":
+            if entity_val and entity_val != "entity_id":
                 return f"sensor.{entity_val}"
 
     # Fall back to _measurement (InfluxDB 2.x stores entity_id here)
@@ -541,6 +541,7 @@ def _parse_batch_response(
                         target_date,
                     )
                     # Add this as a data point just before the day started
+                    # Use prefixed name to match sensor_data keys from _extract_sensor_name
                     prefixed_name = f"sensor.{sensor_name}"
                     initial_datapoint = (day_start - timedelta(seconds=1), sensor_value)
                     if prefixed_name in sensor_data:
@@ -579,6 +580,209 @@ def _parse_batch_response(
 
     _LOGGER.debug(
         "Parsed %d sensors with data for %d periods", len(sensor_data), len(period_data)
+    )
+
+    return period_data
+
+
+def get_power_sensor_data_batch(power_sensors: list[str], target_date) -> dict:
+    """Fetch average power (W) per period and convert to energy (kWh).
+
+    Power sensors report instantaneous wattage every ~5 minutes. By averaging
+    all readings within each 15-minute period and converting W -> kWh, we get
+    much higher resolution than cumulative energy sensors (which only increment
+    in 0.1 kWh steps).
+
+    Args:
+        power_sensors: List of power sensor entity IDs (without 'sensor.' prefix)
+        target_date: Date to fetch data for (datetime.date or datetime)
+
+    Returns:
+        dict: {
+            "status": "success" or "error",
+            "message": error message if status is "error",
+            "data": {
+                0: {sensor1: avg_kwh, sensor2: avg_kwh, ...},
+                ...
+                95: {...}
+            }
+        }
+    """
+    local_tz = ZoneInfo("Europe/Stockholm")
+
+    if isinstance(target_date, datetime):
+        target_date = target_date.date()
+
+    start_datetime = datetime.combine(target_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+    end_datetime = datetime.combine(target_date, datetime.max.time()).replace(
+        tzinfo=local_tz
+    )
+
+    influxdb_config = get_influxdb_config()
+    url = influxdb_config["url"]
+    bucket = influxdb_config["bucket"]
+    username = influxdb_config["username"]
+    password = influxdb_config["password"]
+
+    if not url or not username or not password or not bucket:
+        _LOGGER.error("InfluxDB configuration is incomplete")
+        return {"status": "error", "message": "Incomplete InfluxDB configuration"}
+
+    headers = {
+        "Content-type": "application/vnd.flux",
+        "Accept": "application/csv",
+    }
+
+    start_str = start_datetime.astimezone(ZoneInfo("UTC")).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    end_str = end_datetime.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Build sensor filter for power sensors (W measurement)
+    sensor_conditions = []
+    for sensor in power_sensors:
+        sensor_conditions.append(
+            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "{sensor}"'
+        )
+    sensor_filter = " or ".join(f"({c})" for c in sensor_conditions)
+
+    flux_query = f"""from(bucket: "{bucket}")
+                    |> range(start: {start_str}, stop: {end_str})
+                    |> filter(fn: (r) => {sensor_filter})
+                    |> filter(fn: (r) => r["_field"] == "value")
+                    |> sort(columns: ["_time"])
+                    """
+
+    try:
+        _LOGGER.info(
+            "Batch fetching power sensor data for %s (%d sensors)",
+            target_date.strftime("%Y-%m-%d"),
+            len(power_sensors),
+        )
+
+        response = requests.post(
+            url=url,
+            auth=(username, password),
+            headers=headers,
+            data=flux_query,
+            timeout=30,
+        )
+
+        if response.status_code == 204:
+            _LOGGER.warning("No power sensor data found for date %s", target_date)
+            return {"status": "error", "message": "No data found"}
+
+        if response.status_code != 200:
+            _LOGGER.error("Error from InfluxDB: %s", response.status_code)
+            return {
+                "status": "error",
+                "message": f"InfluxDB error: {response.status_code}",
+            }
+
+        period_data = _parse_power_batch_response(response.text, target_date, local_tz)
+
+        _LOGGER.info(
+            "Power sensor batch complete: got data for %d periods", len(period_data)
+        )
+
+        return {"status": "success", "data": period_data}
+
+    except requests.RequestException as e:
+        _LOGGER.error("Error connecting to InfluxDB for power sensors: %s", str(e))
+        return {"status": "error", "message": f"Connection error: {e!s}"}
+    except Exception as e:
+        _LOGGER.error("Unexpected error in power sensor batch fetch: %s", str(e))
+        return {"status": "error", "message": f"Unexpected error: {e!s}"}
+
+
+def _parse_power_batch_response(
+    response_text: str, target_date, local_tz
+) -> dict[int, dict[str, float]]:
+    """Parse power sensor response: compute mean W per period, convert to kWh.
+
+    For each 15-minute period, averages all power readings within that period
+    and converts: kWh = mean_watts * (15/60) / 1000
+
+    Args:
+        response_text: CSV response from InfluxDB
+        target_date: The date being queried
+        local_tz: Local timezone
+
+    Returns:
+        dict: {period_num: {"sensor.entity_id": kwh_value, ...}, ...}
+    """
+    lines = response_text.strip().split("\n")
+    data_lines = [line for line in lines if not line.startswith("#")]
+
+    col_map = _build_column_index(data_lines)
+    if col_map is None:
+        _LOGGER.warning("No header row found in power sensor batch response")
+        return {}
+
+    value_idx = col_map["_value"]
+    time_idx = col_map["_time"]
+
+    day_start = datetime.combine(target_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+
+    # Collect readings per sensor per period: {sensor: {period: [values]}}
+    sensor_period_readings: dict[str, dict[int, list[float]]] = {}
+
+    for line in data_lines:
+        parts = line.split(",")
+        try:
+            if (
+                len(parts) <= max(value_idx, time_idx)
+                or parts[value_idx].strip() == "_value"
+            ):
+                continue
+
+            timestamp_str = parts[time_idx].strip()
+            sensor_name = _extract_sensor_name(parts, col_map)
+            if not sensor_name:
+                continue
+            value = float(parts[value_idx].strip())
+
+            # Skip clearly bogus values (e.g. the output_power 429496663.7 overflow)
+            if abs(value) > 100000:
+                continue
+
+            timestamp = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+            timestamp_local = timestamp.astimezone(local_tz)
+
+            # Calculate which period this reading belongs to
+            seconds_since_start = (timestamp_local - day_start).total_seconds()
+            if seconds_since_start < 0 or seconds_since_start >= 86400:
+                continue
+            period = int(seconds_since_start // 900)  # 900 seconds = 15 minutes
+
+            if sensor_name not in sensor_period_readings:
+                sensor_period_readings[sensor_name] = {}
+            if period not in sensor_period_readings[sensor_name]:
+                sensor_period_readings[sensor_name][period] = []
+            sensor_period_readings[sensor_name][period].append(value)
+
+        except (IndexError, ValueError, TypeError):
+            continue
+
+    # Convert mean W to kWh per period (15 min = 0.25 hours)
+    period_data: dict[int, dict[str, float]] = {}
+    for sensor_name, periods in sensor_period_readings.items():
+        for period, values in periods.items():
+            mean_watts = sum(values) / len(values)
+            kwh = mean_watts * 0.25 / 1000.0  # W * hours / 1000 = kWh
+
+            if period not in period_data:
+                period_data[period] = {}
+            period_data[period][sensor_name] = kwh
+
+    _LOGGER.debug(
+        "Parsed power data: %d sensors across %d periods",
+        len(sensor_period_readings),
+        len(period_data),
     )
 
     return period_data

--- a/core/bess/sensor_collector.py
+++ b/core/bess/sensor_collector.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 from .energy_flow_calculator import EnergyFlowCalculator
 from .health_check import perform_health_check
-from .influxdb_helper import get_sensor_data_batch
+from .influxdb_helper import get_power_sensor_data_batch, get_sensor_data_batch
 from .models import EnergyData
 from .settings import BatterySettings
 
@@ -57,6 +57,20 @@ class SensorCollector:
         # Resolve to actual entity IDs for InfluxDB queries
         self.cumulative_sensors = self._resolve_sensor_entity_ids()
 
+        # Power sensors (W) for high-resolution gap-filling
+        # Maps power sensor keys to the same flow names used by energy_flow_calculator
+        self.power_sensor_flow_map: dict[str, str] = {
+            "pv_power": "solar_production",
+            "local_load_power": "load_consumption",
+            "import_power": "import_from_grid",
+            "export_power": "export_to_grid",
+            "battery_charge_power": "battery_charged",
+            "battery_discharge_power": "battery_discharged",
+        }
+        self.power_sensors = self._resolve_power_sensor_ids()
+        self._power_batch_cache: dict = {}  # {date: {period: {sensor: kwh_value}}}
+        self._power_batch_cache_loaded_on: dict = {}
+
     def _resolve_sensor_entity_ids(self) -> list[str]:
         """Resolve sensor keys to entity IDs using the controller's abstraction layer.
 
@@ -74,6 +88,26 @@ class SensorCollector:
                 continue
         logger.info(
             f"Resolved {len(resolved_ids)} sensor entity IDs for InfluxDB queries"
+        )
+        return resolved_ids
+
+    def _resolve_power_sensor_ids(self) -> list[str]:
+        """Resolve power sensor keys to entity IDs for InfluxDB.
+
+        Returns list of entity IDs (without 'sensor.' prefix).
+        """
+        resolved_ids = []
+        for sensor_key in self.power_sensor_flow_map:
+            entity_id = self.ha_controller.resolve_sensor_for_influxdb(sensor_key)
+            if entity_id:
+                resolved_ids.append(entity_id)
+                logger.debug(
+                    f"Resolved power sensor key '{sensor_key}' to '{entity_id}'"
+                )
+            else:
+                logger.debug(f"Power sensor key '{sensor_key}' not configured")
+        logger.info(
+            f"Resolved {len(resolved_ids)} power sensor entity IDs for gap-filling"
         )
         return resolved_ids
 
@@ -182,6 +216,32 @@ class SensorCollector:
         )
         if not flow_dict:
             raise RuntimeError(f"Energy flow calculation failed for period {period}")
+
+        # Gap-filling: when cumulative sensors show zero energy (due to 0.1 kWh resolution),
+        # use power (W) sensors which report every ~5 minutes for much higher resolution
+        energy_flow_keys = [
+            "solar_production",
+            "load_consumption",
+            "import_from_grid",
+            "export_to_grid",
+            "battery_charged",
+            "battery_discharged",
+        ]
+        all_energy_zero = all(
+            abs(flow_dict.get(key, 0.0)) < 0.001 for key in energy_flow_keys
+        )
+        if all_energy_zero and is_historical_backfill:
+            target_date = datetime.now().date()
+            power_flows = self._get_power_based_flows(period, target_date)
+            if power_flows:
+                for key in energy_flow_keys:
+                    if key in power_flows and power_flows[key] > 0.001:
+                        flow_dict[key] = power_flows[key]
+                logger.info(
+                    "Period %d: Gap-filled from power sensors: %s",
+                    period,
+                    {k: f"{v:.4f}" for k, v in power_flows.items() if v > 0.001},
+                )
 
         # Extract BOTH SOC readings from sensors - NO DEFAULTS
         # Use abstraction layer to resolve battery SOC sensor entity ID (without 'sensor.' prefix)
@@ -364,6 +424,106 @@ class SensorCollector:
             )
             return False
 
+    def _ensure_power_batch_loaded(self, target_date) -> bool:
+        """Load power sensor batch data for a date (lazy, cached like cumulative batch).
+
+        Returns:
+            True if data was loaded successfully, False otherwise
+        """
+        today = datetime.now().date()
+
+        if target_date in self._power_batch_cache:
+            if target_date < today:
+                loaded_on = self._power_batch_cache_loaded_on.get(target_date)
+                if loaded_on != today:
+                    del self._power_batch_cache[target_date]
+                    if target_date in self._power_batch_cache_loaded_on:
+                        del self._power_batch_cache_loaded_on[target_date]
+                else:
+                    return True
+            else:
+                return True
+
+        if not self.power_sensors:
+            logger.debug("No power sensors configured, skipping power batch load")
+            return False
+
+        logger.info(
+            "Loading power sensor batch for %s (%d sensors)",
+            target_date.strftime("%Y-%m-%d"),
+            len(self.power_sensors),
+        )
+
+        result = get_power_sensor_data_batch(self.power_sensors, target_date)
+
+        if result.get("status") == "success":
+            data = result.get("data", {})
+            if not data:
+                logger.warning(
+                    "Power sensor batch for %s returned no periods", target_date
+                )
+                return False
+            self._power_batch_cache[target_date] = data
+            self._power_batch_cache_loaded_on[target_date] = today
+            logger.info(
+                "Power sensor batch loaded: %d periods for %s",
+                len(data),
+                target_date.strftime("%Y-%m-%d"),
+            )
+            return True
+        else:
+            logger.warning(
+                "Failed to load power sensor batch for %s: %s",
+                target_date.strftime("%Y-%m-%d"),
+                result.get("message", "Unknown error"),
+            )
+            return False
+
+    def _build_power_entity_to_flow_map(self) -> dict[str, str]:
+        """Build mapping from power sensor entity IDs (with sensor. prefix) to flow names.
+
+        Returns:
+            Dict mapping "sensor.entity_id" -> flow_name
+        """
+        entity_to_flow = {}
+        for sensor_key, flow_name in self.power_sensor_flow_map.items():
+            entity_id = self.ha_controller.resolve_sensor_for_influxdb(sensor_key)
+            if entity_id:
+                entity_to_flow[f"sensor.{entity_id}"] = flow_name
+        return entity_to_flow
+
+    def _get_power_based_flows(
+        self, period: int, target_date
+    ) -> dict[str, float] | None:
+        """Get energy flows for a period computed from power (W) sensors.
+
+        Returns flow dict compatible with energy_flow_calculator output, or None if unavailable.
+        """
+        if not self._ensure_power_batch_loaded(target_date):
+            return None
+
+        period_data = self._power_batch_cache.get(target_date, {}).get(period)
+        if not period_data:
+            return None
+
+        entity_to_flow = self._build_power_entity_to_flow_map()
+
+        flows = {}
+        for entity_key, kwh_value in period_data.items():
+            flow_name = entity_to_flow.get(entity_key)
+            if flow_name:
+                flows[flow_name] = kwh_value
+
+        if not flows:
+            return None
+
+        logger.debug(
+            "Period %d: Power-based flows: %s",
+            period,
+            {k: f"{v:.4f}" for k, v in flows.items()},
+        )
+        return flows
+
     def _get_period_readings(
         self, period: int, date_offset: int = 0
     ) -> dict[str, float] | None:
@@ -480,15 +640,11 @@ class SensorCollector:
                     readings[key[7:]] = float(value)
             except (ValueError, TypeError):
                 logger.warning(
-                    "Invalid value for sensor %s: %s (type: %s)",
+                    "Skipping sensor %s with invalid value: %s (type: %s)",
                     key,
                     value,
                     type(value).__name__,
                 )
-                # Store as 0.0 for numeric sensors to prevent calculation errors
-                readings[key] = 0.0
-                if key.startswith("sensor."):
-                    readings[key[7:]] = 0.0
 
         # Validate that we have the minimum required sensors
         # Check for required sensors using resolved entity IDs

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -176,6 +176,7 @@ class HomeSettings:
     default_hourly: float = HOME_HOURLY_CONSUMPTION_KWH
     min_valid: float = MIN_CONSUMPTION
     currency: str = DEFAULT_CURRENCY
+    consumption_strategy: str = "sensor"
 
     def __post_init__(self):
         assert self.phase_count in (
@@ -211,6 +212,9 @@ class HomeSettings:
                 "consumption", HOME_HOURLY_CONSUMPTION_KWH
             )
             self.currency = config["home"].get("currency", DEFAULT_CURRENCY)
+            self.consumption_strategy = home_config.get(
+                "consumption_strategy", "sensor"
+            )
             self.__post_init__()
         return self
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,6 +115,7 @@ export interface BatterySettings {
   
   // Consumption estimate
   estimatedConsumption: number; // kWh daily estimate
+  consumptionStrategy: string;  // "sensor", "fixed", or "influxdb_7d_avg"
   
   // Price settings
   useActualPrice?: boolean;     // use actual vs estimated prices


### PR DESCRIPTION
## Summary

- Adds a `home.consumption_strategy` config setting with three options:
  - `sensor` (default): existing 48h average sensor from HA (no behavior change)
  - `fixed`: flat hourly estimate from config
  - `influxdb_7d_avg`: 7-day weighted average from InfluxDB historical data
- The `influxdb_7d_avg` strategy fetches the last 7 days of `local_load_power` readings from InfluxDB, averages them into 96 quarter-hourly buckets, and uses that as the daily consumption forecast for the optimizer
- Backward-compatible price provider config: supports both `energy_provider.provider` (v7.0) and `nordpool.price_provider` key formats

### Supporting infrastructure

- InfluxDB batch power sensor data fetching (`get_power_sensor_data_batch`)
- Historical data store disk persistence for restart recovery
- Power sensor gap-filling in sensor collector when cumulative sensors show zero deltas

### No breaking changes

The default strategy is `sensor`, preserving existing behavior. No new Python dependencies are added. No Docker base image change required.

### Config example

```yaml
home:
  consumption_strategy: "influxdb_7d_avg"
  timezone: "Europe/Stockholm"
```

Requires InfluxDB to be configured in the `influxdb` section and a `local_load_power` sensor.

## Test plan

- [ ] Verify default `sensor` strategy works unchanged
- [ ] Test `fixed` strategy produces flat consumption forecast
- [ ] Test `influxdb_7d_avg` with configured InfluxDB and load sensor
- [ ] Verify fallback to `fixed` when `home.timezone` is missing for `influxdb_7d_avg`
- [ ] Verify backward-compatible price provider config works with both key formats