### PR TITLE
Add ML energy consumption predictor (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configurable consumption forecast strategy via `home.consumption_strategy` setting. Supports `sensor` (default, HA 48h average), `fixed` (flat rate from config), and `influxdb_7d_avg` (7-day rolling average from InfluxDB power sensor data at 15-minute resolution).
 - `home.timezone` setting for timezone-aware schedule calculations.
+- XGBoost ML energy consumption predictor with `ml_prediction` strategy option. Trains on InfluxDB historical data, uses weather forecasts from HA, and generates 96 quarter-hourly predictions. Includes ML Report dashboard page showing model metrics, feature importance, and forecast comparison.
+
+### Changed
+
+- Docker base image switched from Alpine 3.19 to Debian Bookworm to support xgboost and scikit-learn wheel installation.
+
+### Note
+
+The ML predictor is experimental. In testing so far, predictions are roughly on par with or slightly worse than a simple 7-day average (`influxdb_7d_avg`). It adds significant startup time (model retrain on boot) and heavy dependencies (xgboost, scikit-learn). It is included as an optional feature for experimentation — the `influxdb_7d_avg` strategy is recommended for production use.
 
 ## [7.4.2] - 2026-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Configurable consumption forecast strategy via `home.consumption_strategy` setting. Supports `sensor` (default, HA 48h average), `fixed` (flat rate from config), and `influxdb_7d_avg` (7-day rolling average from InfluxDB power sensor data at 15-minute resolution).
+- `home.timezone` setting for timezone-aware schedule calculations.
+
 ## [7.4.2] - 2026-03-07
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,16 @@ LABEL \
     org.label-schema.vcs-url="https://github.com/johanzander/bess-manager"
 
 # Install requirements for add-on
-RUN apk add --no-cache \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
-    py3-pip \
+    python3-pip \
+    python3-venv \
     python3-dev \
     gcc \
-    musl-dev \
     bash \
     nodejs \
-    npm
+    npm \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app
@@ -38,8 +39,9 @@ WORKDIR /app
 # Copy Python application files from backend directory
 COPY backend/app.py backend/api.py backend/api_conversion.py backend/api_dataclasses.py backend/log_config.py backend/requirements.txt ./
 
-# Copy core directory
+# Copy core directory and ML module
 COPY core/ /app/core/
+COPY ml/ /app/ml/
 
 # Build and copy frontend
 WORKDIR /tmp/frontend

--- a/backend/api.py
+++ b/backend/api.py
@@ -33,10 +33,11 @@ async def get_battery_settings():
         settings = bess_controller.system.get_settings()
         battery_settings = settings["battery"]
         estimated_consumption = settings["home"].default_hourly
+        consumption_strategy = settings["home"].consumption_strategy
 
         # Create APIBatterySettings using existing method
         api_settings = APIBatterySettings.from_internal(
-            battery_settings, estimated_consumption
+            battery_settings, estimated_consumption, consumption_strategy
         )
         return api_settings.__dict__
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -2250,3 +2250,68 @@ async def dismiss_all_runtime_failures():
     except Exception as e:
         logger.error(f"Error dismissing all runtime failures: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/api/ml-report")
+async def get_ml_report():
+    """Return ML model report: metrics, feature importance, predictions vs yesterday."""
+    import json
+    from pathlib import Path
+
+    from app import bess_controller
+
+    system = bess_controller.system
+    strategy = system.home_settings.consumption_strategy
+    is_active = strategy in ("ml_prediction", "influxdb_7d_avg")
+
+    try:
+        from ml.config import load_config
+
+        ml_cfg = load_config(app_options=system._addon_options)
+        report_path = Path(ml_cfg["model_path"]).with_suffix(".report.json")
+    except Exception as e:
+        logger.warning("Could not load ML config for report: %s", e)
+        return {"isActive": is_active, "modelAvailable": False}
+
+    if not report_path.exists():
+        return {"isActive": is_active, "modelAvailable": False}
+
+    with open(report_path) as f:
+        report = json.load(f)
+
+    predictions = system._ml_forecast_cache
+
+    forecast_date = (
+        system._ml_forecast_cache_date.isoformat()
+        if system._ml_forecast_cache_date
+        else None
+    )
+
+    yesterday_profile = None
+    week_avg_profile = None
+    try:
+        from ml.data_fetcher import fetch_history_context
+
+        history = fetch_history_context(ml_cfg)
+        yesterday_profile = history["yesterday_profile"]
+        week_avg_profile = history["week_avg_profile"]
+    except Exception as e:
+        logger.warning("Could not fetch history context for ML report: %s", e)
+
+    return {
+        "isActive": is_active,
+        "activeStrategy": strategy,
+        "modelAvailable": True,
+        "lastTrained": report["trained_at"],
+        "trainSize": report["train_size"],
+        "testSize": report["test_size"],
+        "metrics": convert_keys_to_camel_case(report["metrics"]),
+        "baselines": {
+            k: convert_keys_to_camel_case(v) for k, v in report["baselines"].items()
+        },
+        "featureImportance": report["feature_importance"],
+        "forecastDate": forecast_date,
+        "predictions": predictions,
+        "yesterdayProfile": yesterday_profile,
+        "weekAvgProfile": week_avg_profile,
+    }

--- a/backend/api_dataclasses.py
+++ b/backend/api_dataclasses.py
@@ -97,9 +97,12 @@ class APIBatterySettings:
     efficiencyCharge: float  # % - charging efficiency
     efficiencyDischarge: float  # % - discharge efficiency
     estimatedConsumption: float  # kWh - estimated daily consumption
+    consumptionStrategy: str  # consumption forecast strategy
 
     @classmethod
-    def from_internal(cls, battery, estimated_consumption: float) -> APIBatterySettings:
+    def from_internal(
+        cls, battery, estimated_consumption: float, consumption_strategy: str = "sensor"
+    ) -> APIBatterySettings:
         """Convert from internal snake_case to canonical camelCase."""
         return cls(
             totalCapacity=battery.total_capacity,
@@ -115,6 +118,7 @@ class APIBatterySettings:
             efficiencyCharge=battery.efficiency_charge,
             efficiencyDischarge=battery.efficiency_discharge,
             estimatedConsumption=estimated_consumption,
+            consumptionStrategy=consumption_strategy,
         )
 
     def to_internal_update(self) -> dict:

--- a/backend/app.py
+++ b/backend/app.py
@@ -255,6 +255,15 @@ class BESSController:
             misfire_grace_time=30,  # Allow 30 seconds of misfire before warning
         )
 
+        # ML model daily retrain at 23:00 — retrain only, predictions are
+        # generated at 23:55 in _handle_special_cases after cache is cleared
+        if self.system._addon_options.get("ml"):
+            self.scheduler.add_job(
+                self.system._retrain_ml_model,
+                CronTrigger(hour=23, minute=0),
+                misfire_grace_time=120,
+            )
+
         # Charging power adjustment (every 5 minutes)
         self.scheduler.add_job(
             self.system.adjust_charging_power,

--- a/backend/app.py
+++ b/backend/app.py
@@ -137,6 +137,7 @@ class BESSController:
             self.ha_controller,
             price_source=None,  # Let system manager auto-select based on config
             energy_provider_config=energy_provider_config,
+            addon_options=options,
         )
 
         # Create scheduler with increased misfire grace time to avoid unnecessary warnings
@@ -324,7 +325,7 @@ class BESSController:
                     )
 
             # Required home settings
-            required_home_keys = ["consumption", "currency"]
+            required_home_keys = ["consumption", "currency", "consumption_strategy"]
             for key in required_home_keys:
                 if key not in home_config:
                     raise ValueError(
@@ -346,6 +347,8 @@ class BESSController:
                 "home": {
                     "defaultHourly": home_config["consumption"],
                     "currency": home_config["currency"],
+                    "consumptionStrategy": home_config["consumption_strategy"],
+                    "timezone": home_config.get("timezone", "Europe/Stockholm"),
                 },
                 "price": {
                     "area": electricity_price_config["area"],

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ pyyaml
 watchdog
 numpy
 pandas
+scikit-learn
+xgboost
+astral

--- a/build.json
+++ b/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
-    "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
-    "i386": "ghcr.io/home-assistant/i386-base:3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-debian:bookworm",
+    "amd64": "ghcr.io/home-assistant/amd64-base-debian:bookworm",
+    "armhf": "ghcr.io/home-assistant/armhf-base-debian:bookworm",
+    "armv7": "ghcr.io/home-assistant/armv7-base-debian:bookworm",
+    "i386": "ghcr.io/home-assistant/i386-base-debian:bookworm"
   },
   "squash": false,
   "args": {}

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,8 @@ options:
   home:
     consumption: 3.5                # default hourly consumption in kWh
     currency: "SEK"                 # currency for price display and calculations
+    consumption_strategy: "sensor"  # "sensor" (HA 48h avg), "fixed", or "influxdb_7d_avg"
+    timezone: "Europe/Stockholm"    # IANA timezone for schedule calculations
     max_fuse_current: 25            # Maximum fuse current in amperes
     voltage: 230                    # Line voltage in volts
     safety_margin_factor: 1.0       # Safety margin for power calculations (100% - safe with 5min monitoring)
@@ -106,6 +108,8 @@ schema:
   home:
     consumption: float
     currency: str
+    consumption_strategy: str
+    timezone: str
     max_fuse_current: int
     voltage: int
     safety_margin_factor: float

--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,7 @@ options:
   home:
     consumption: 3.5                # default hourly consumption in kWh
     currency: "SEK"                 # currency for price display and calculations
-    consumption_strategy: "sensor"  # "sensor" (HA 48h avg), "fixed", or "influxdb_7d_avg"
+    consumption_strategy: "sensor"  # "sensor" (HA 48h avg), "fixed", "influxdb_7d_avg", or "ml_prediction"
     timezone: "Europe/Stockholm"    # IANA timezone for schedule calculations
     max_fuse_current: 25            # Maximum fuse current in amperes
     voltage: 230                    # Line voltage in volts
@@ -99,6 +99,31 @@ options:
     48h_avg_grid_import: "sensor.48h_average_grid_import_power"       # 48h average consumption
     solar_forecast_today: "sensor.solcast_pv_forecast_forecast_today" # Today's solar forecast
     solar_forecast_tomorrow: "sensor.solcast_pv_forecast_forecast_tomorrow" # Tomorrow's solar forecast
+  ml:
+    location:
+      latitude: 59.3293
+      longitude: 18.0686
+      timezone: "Europe/Stockholm"
+    weather_entity: "weather.forecast_home"
+    feature_sensors:
+      outdoor_temperature: "your_temperature_sensor_id"
+    derived_features:
+      hour_of_day: true
+      day_of_week: false
+      daylight_hours: false
+    history_context:
+      yesterday_same_hour: true
+      yesterday_total: true
+      week_avg_same_hour: true
+      recent_24h_mean: true
+    training:
+      days_of_history: 30
+      test_split: 0.2
+      model_params:
+        n_estimators: 200
+        max_depth: 6
+        learning_rate: 0.1
+        min_child_weight: 3
 schema:
   influxdb:
     url: str
@@ -171,3 +196,28 @@ schema:
     output_power: str
     self_power: str
     system_power: str
+  ml:
+    location:
+      latitude: float
+      longitude: float
+      timezone: str
+    weather_entity: str
+    feature_sensors:
+      outdoor_temperature: str
+    derived_features:
+      hour_of_day: bool
+      day_of_week: bool
+      daylight_hours: bool
+    history_context:
+      yesterday_same_hour: bool
+      yesterday_total: bool
+      week_avg_same_hour: bool
+      recent_24h_mean: bool
+    training:
+      days_of_history: int
+      test_split: float
+      model_params:
+        n_estimators: int
+        max_depth: int
+        learning_rate: float
+        min_child_weight: int

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -64,6 +64,7 @@ class BatterySystemManager:
         controller: HomeAssistantAPIController | None = None,
         price_source: PriceSource | None = None,
         energy_provider_config: dict | None = None,
+        addon_options: dict | None = None,
     ):
         """Initialize with same interface as original BatterySystemManager."""
 
@@ -72,6 +73,7 @@ class BatterySystemManager:
         self.home_settings = HomeSettings()
         self.price_settings = PriceSettings()
         self._energy_provider_config = energy_provider_config or {}
+        self._addon_options = addon_options or {}
 
         # Store controller reference
         self._controller = controller
@@ -115,6 +117,10 @@ class BatterySystemManager:
         # Current schedule tracking
         self._current_schedule = None
         self._initial_soe = None
+
+        # Prediction caches (populated by _fetch_predictions)
+        self._consumption_predictions: list[float] | None = None
+        self._solar_predictions: list[float] | None = None
 
         # Critical sensor failure tracking for graceful degradation
         self._critical_sensor_failures = []
@@ -258,6 +264,16 @@ class BatterySystemManager:
 
                 # Initialize historical data - using improved sensor collector
                 self._fetch_and_initialize_historical_data()
+
+                # Validate consumption strategy configuration
+                strategy = self.home_settings.consumption_strategy
+                if strategy == "influxdb_7d_avg":
+                    if not self.home_settings.timezone:
+                        logger.error(
+                            "consumption_strategy is 'influxdb_7d_avg' but 'home.timezone' "
+                            "is not configured. Falling back to 'fixed' strategy."
+                        )
+                        self.home_settings.consumption_strategy = "fixed"
 
                 # Fetch predictions
                 self._fetch_predictions()
@@ -591,7 +607,7 @@ class BatterySystemManager:
                 logger.warning("Cannot fetch predictions: controller is not available")
                 return
 
-            consumption_predictions = self._controller.get_estimated_consumption()
+            consumption_predictions = self._get_consumption_forecast()
             solar_predictions = self._controller.get_solar_forecast()
 
             # Store the predictions (this was missing!)
@@ -617,6 +633,98 @@ class BatterySystemManager:
 
         except Exception as e:
             logger.warning(f"Failed to fetch predictions: {e}")
+
+    def _get_consumption_forecast(self) -> list[float]:
+        """Get consumption forecast based on the configured strategy.
+
+        Dispatches to the appropriate data source based on
+        home_settings.consumption_strategy.
+
+        Returns:
+            List of 96 float values (kWh per 15-minute period).
+        """
+        strategy = self.home_settings.consumption_strategy
+
+        if strategy == "sensor":
+            return self.controller.get_estimated_consumption()
+
+        if strategy == "fixed":
+            quarterly = self.home_settings.default_hourly / 4.0
+            return [quarterly] * 96
+
+        if strategy == "influxdb_7d_avg":
+            return self._get_influxdb_7d_avg_forecast()
+
+        raise ValueError(f"Unknown consumption_strategy: '{strategy}'")
+
+    def _get_influxdb_7d_avg_forecast(self) -> list[float]:
+        """Get consumption forecast from InfluxDB 7-day average profile.
+
+        Queries InfluxDB for the past 7 days of the local_load_power sensor
+        and returns the 96-value weekly average profile (kWh per 15-min period).
+        """
+        from .influxdb_helper import get_power_sensor_data_batch
+
+        sensors_config = self._addon_options.get("sensors", {})
+        target_sensor = sensors_config.get("local_load_power", "")
+        if not target_sensor:
+            raise ValueError(
+                "influxdb_7d_avg strategy requires 'local_load_power' sensor configured"
+            )
+
+        # Strip 'sensor.' prefix if present — get_power_sensor_data_batch adds it
+        if target_sensor.startswith("sensor."):
+            target_sensor = target_sensor[len("sensor.") :]
+
+        today = date.today()
+        day_profiles: list[list[float]] = []
+
+        for days_back in range(1, 8):
+            target_date = today - timedelta(days=days_back)
+            result = get_power_sensor_data_batch([target_sensor], target_date)
+
+            if result["status"] != "success":
+                logger.warning(
+                    "Failed to fetch power data for %s: %s",
+                    target_date,
+                    result.get("message", "unknown error"),
+                )
+                continue
+
+            period_data = result["data"]
+            sensor_key = f"sensor.{target_sensor}"
+            profile = [0.0] * 96
+            periods_found = 0
+            for period in range(96):
+                if period in period_data and sensor_key in period_data[period]:
+                    profile[period] = period_data[period][sensor_key]
+                    periods_found += 1
+
+            if periods_found >= 48:  # At least half a day of data
+                day_profiles.append(profile)
+                logger.debug("Got %d periods for %s", periods_found, target_date)
+
+        if not day_profiles:
+            logger.warning(
+                "No valid historical data for influxdb_7d_avg strategy, "
+                "falling back to fixed consumption"
+            )
+            quarterly = self.home_settings.default_hourly / 4.0
+            return [quarterly] * 96
+
+        # Average across all valid days
+        avg_profile = [
+            sum(p[i] for p in day_profiles) / len(day_profiles) for i in range(96)
+        ]
+
+        total_kwh = sum(avg_profile)
+        logger.info(
+            "InfluxDB 7-day average profile: %.1f kWh/day from %d days of data",
+            total_kwh,
+            len(day_profiles),
+        )
+
+        return avg_profile
 
     def _handle_special_cases(self, period: int, prepare_next_day: bool) -> None:
         """Handle special cases like midnight transition."""
@@ -892,7 +1000,7 @@ class BatterySystemManager:
 
         if prepare_next_day:
             # For next day, use predictions only
-            consumption_predictions = self.controller.get_estimated_consumption()
+            consumption_predictions = self._get_consumption_forecast()
             solar_predictions = self.controller.get_solar_forecast()
 
             consumption_data = consumption_predictions
@@ -910,7 +1018,7 @@ class BatterySystemManager:
             completed_periods = [
                 i for i, p in enumerate(today_periods) if p is not None
             ]
-            predictions_consumption = self.controller.get_estimated_consumption()
+            predictions_consumption = self._get_consumption_forecast()
             predictions_solar = self.controller.get_solar_forecast()
 
             # Extend predictions for tomorrow when horizon exceeds today
@@ -1273,9 +1381,9 @@ class BatterySystemManager:
             for i, period_data in enumerate(period_data_list):
                 target_period = optimization_period + i
                 if target_period < len(full_day_strategic_intents):
-                    full_day_strategic_intents[
-                        target_period
-                    ] = period_data.decision.strategic_intent
+                    full_day_strategic_intents[target_period] = (
+                        period_data.decision.strategic_intent
+                    )
 
             # Store initial SOC in OptimizationResult for DailyViewBuilder
             if self._initial_soe is not None:
@@ -2152,8 +2260,10 @@ class BatterySystemManager:
     def _log_battery_system_config(self) -> None:
         """Log the current battery configuration - reproduces original functionality."""
         try:
-            # Get energy data for consumption info (like original)
-            predictions_consumption = self.controller.get_estimated_consumption()
+            # Use already-fetched predictions — avoids triggering a heavy pipeline
+            # (InfluxDB query or ML inference) just for a log message
+            assert self._consumption_predictions is not None
+            predictions_consumption = self._consumption_predictions
 
             # Get current SOC
             if self._controller:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -122,6 +122,10 @@ class BatterySystemManager:
         self._consumption_predictions: list[float] | None = None
         self._solar_predictions: list[float] | None = None
 
+        # ML forecast cache (populated by _generate_ml_predictions)
+        self._ml_forecast_cache: list[float] | None = None
+        self._ml_forecast_cache_date: date | None = None
+
         # Critical sensor failure tracking for graceful degradation
         self._critical_sensor_failures = []
 
@@ -267,6 +271,15 @@ class BatterySystemManager:
 
                 # Validate consumption strategy configuration
                 strategy = self.home_settings.consumption_strategy
+                ml_config_present = bool(self._addon_options.get("ml"))
+
+                if strategy == "ml_prediction" and not ml_config_present:
+                    logger.error(
+                        "consumption_strategy is 'ml_prediction' but 'ml' config section "
+                        "is missing. Falling back to 'fixed' strategy."
+                    )
+                    self.home_settings.consumption_strategy = "fixed"
+
                 if strategy == "influxdb_7d_avg":
                     if not self.home_settings.timezone:
                         logger.error(
@@ -274,6 +287,17 @@ class BatterySystemManager:
                             "is not configured. Falling back to 'fixed' strategy."
                         )
                         self.home_settings.consumption_strategy = "fixed"
+
+                # Retrain ML model on boot and generate predictions (for report data)
+                if self._addon_options.get("ml"):
+                    try:
+                        logger.info("Retraining ML model on startup...")
+                        self._retrain_ml_model()
+                        self._generate_ml_predictions()
+                    except Exception as e:
+                        logger.error(
+                            "ML model training/prediction failed on startup: %s", e
+                        )
 
                 # Fetch predictions
                 self._fetch_predictions()
@@ -655,6 +679,9 @@ class BatterySystemManager:
         if strategy == "influxdb_7d_avg":
             return self._get_influxdb_7d_avg_forecast()
 
+        if strategy == "ml_prediction":
+            return self._get_ml_prediction_forecast()
+
         raise ValueError(f"Unknown consumption_strategy: '{strategy}'")
 
     def _get_influxdb_7d_avg_forecast(self) -> list[float]:
@@ -726,6 +753,74 @@ class BatterySystemManager:
 
         return avg_profile
 
+    def _get_ml_prediction_forecast(self) -> list[float]:
+        """Get consumption forecast from the ML prediction model.
+
+        Results are cached for the current calendar day. The cache is
+        invalidated by _retrain_ml_model() and by _handle_special_cases()
+        before the next-day prediction refresh.
+        """
+        today = date.today()
+        if (
+            self._ml_forecast_cache_date == today
+            and self._ml_forecast_cache is not None
+        ):
+            return self._ml_forecast_cache
+
+        # Generate fresh predictions
+        self._generate_ml_predictions()
+        if self._ml_forecast_cache is not None:
+            return self._ml_forecast_cache
+
+        # Fallback if ML prediction fails
+        logger.warning("ML prediction failed, falling back to fixed consumption")
+        quarterly = self.home_settings.default_hourly / 4.0
+        return [quarterly] * 96
+
+    def _retrain_ml_model(self) -> None:
+        """Retrain the ML model using the latest InfluxDB data."""
+        from ml.config import load_config
+        from ml.trainer import train_model
+
+        try:
+            ml_config = load_config(app_options=self._addon_options)
+            train_model(ml_config)
+            logger.info("ML model retrained successfully")
+
+            # Invalidate cache so next forecast uses fresh model
+            self._ml_forecast_cache = None
+            self._ml_forecast_cache_date = None
+
+        except Exception as e:
+            logger.exception("Failed to retrain ML model: %s", e)
+
+    def _generate_ml_predictions(self) -> None:
+        """Generate ML predictions for today and cache them."""
+        from ml.config import load_config
+        from ml.predictor import predict
+
+        try:
+            ml_config = load_config(app_options=self._addon_options)
+            predictions = predict(ml_config)
+
+            if predictions is not None and len(predictions) == 96:
+                self._ml_forecast_cache = list(predictions)
+                self._ml_forecast_cache_date = date.today()
+                total = sum(predictions)
+                logger.info(
+                    "ML predictions generated: %.1f kWh total for %s",
+                    total,
+                    date.today(),
+                )
+            else:
+                logger.warning(
+                    "ML prediction returned invalid result: %s",
+                    type(predictions).__name__,
+                )
+
+        except Exception as e:
+            logger.exception("Failed to generate ML predictions: %s", e)
+
     def _handle_special_cases(self, period: int, prepare_next_day: bool) -> None:
         """Handle special cases like midnight transition."""
         if period == 0 and not prepare_next_day:
@@ -748,7 +843,18 @@ class BatterySystemManager:
             # Clear historical store to prevent yesterday's data from appearing as today's future data
             self.historical_store.clear()
             self.prediction_snapshot_store.clear()
+            # Clear ML cache so predictions are regenerated for the new day
+            self._ml_forecast_cache = None
+            self._ml_forecast_cache_date = None
             self._fetch_predictions()
+            # Generate ML predictions for report page (regardless of active strategy)
+            if self._addon_options.get("ml"):
+                try:
+                    self._generate_ml_predictions()
+                except Exception as e:
+                    logger.warning(
+                        "Failed to generate ML predictions for next day: %s", e
+                    )
 
     def _get_price_data(
         self, prepare_next_day: bool

--- a/core/bess/influxdb_helper.py
+++ b/core/bess/influxdb_helper.py
@@ -201,7 +201,7 @@ def _extract_sensor_name(parts: list[str], col_map: dict[str, int]) -> str:
             if entity_val.startswith("sensor."):
                 return entity_val
             # InfluxDB 1.x: short name without prefix — normalize it
-            if entity_val != "entity_id":
+            if entity_val and entity_val != "entity_id":
                 return f"sensor.{entity_val}"
 
     # Fall back to _measurement (InfluxDB 2.x stores entity_id here)
@@ -539,6 +539,7 @@ def _parse_batch_response(
                         target_date,
                     )
                     # Add this as a data point just before the day started
+                    # Use prefixed name to match sensor_data keys from _extract_sensor_name
                     prefixed_name = f"sensor.{sensor_name}"
                     initial_datapoint = (day_start - timedelta(seconds=1), sensor_value)
                     if prefixed_name in sensor_data:
@@ -577,6 +578,209 @@ def _parse_batch_response(
 
     _LOGGER.debug(
         "Parsed %d sensors with data for %d periods", len(sensor_data), len(period_data)
+    )
+
+    return period_data
+
+
+def get_power_sensor_data_batch(power_sensors: list[str], target_date) -> dict:
+    """Fetch average power (W) per period and convert to energy (kWh).
+
+    Power sensors report instantaneous wattage every ~5 minutes. By averaging
+    all readings within each 15-minute period and converting W -> kWh, we get
+    much higher resolution than cumulative energy sensors (which only increment
+    in 0.1 kWh steps).
+
+    Args:
+        power_sensors: List of power sensor entity IDs (without 'sensor.' prefix)
+        target_date: Date to fetch data for (datetime.date or datetime)
+
+    Returns:
+        dict: {
+            "status": "success" or "error",
+            "message": error message if status is "error",
+            "data": {
+                0: {sensor1: avg_kwh, sensor2: avg_kwh, ...},
+                ...
+                95: {...}
+            }
+        }
+    """
+    local_tz = ZoneInfo("Europe/Stockholm")
+
+    if isinstance(target_date, datetime):
+        target_date = target_date.date()
+
+    start_datetime = datetime.combine(target_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+    end_datetime = datetime.combine(target_date, datetime.max.time()).replace(
+        tzinfo=local_tz
+    )
+
+    influxdb_config = get_influxdb_config()
+    url = influxdb_config["url"]
+    bucket = influxdb_config["bucket"]
+    username = influxdb_config["username"]
+    password = influxdb_config["password"]
+
+    if not url or not username or not password or not bucket:
+        _LOGGER.error("InfluxDB configuration is incomplete")
+        return {"status": "error", "message": "Incomplete InfluxDB configuration"}
+
+    headers = {
+        "Content-type": "application/vnd.flux",
+        "Accept": "application/csv",
+    }
+
+    start_str = start_datetime.astimezone(ZoneInfo("UTC")).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    end_str = end_datetime.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Build sensor filter for power sensors (W measurement)
+    sensor_conditions = []
+    for sensor in power_sensors:
+        sensor_conditions.append(
+            f'r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "{sensor}"'
+        )
+    sensor_filter = " or ".join(f"({c})" for c in sensor_conditions)
+
+    flux_query = f"""from(bucket: "{bucket}")
+                    |> range(start: {start_str}, stop: {end_str})
+                    |> filter(fn: (r) => {sensor_filter})
+                    |> filter(fn: (r) => r["_field"] == "value")
+                    |> sort(columns: ["_time"])
+                    """
+
+    try:
+        _LOGGER.info(
+            "Batch fetching power sensor data for %s (%d sensors)",
+            target_date.strftime("%Y-%m-%d"),
+            len(power_sensors),
+        )
+
+        response = requests.post(
+            url=url,
+            auth=(username, password),
+            headers=headers,
+            data=flux_query,
+            timeout=30,
+        )
+
+        if response.status_code == 204:
+            _LOGGER.warning("No power sensor data found for date %s", target_date)
+            return {"status": "error", "message": "No data found"}
+
+        if response.status_code != 200:
+            _LOGGER.error("Error from InfluxDB: %s", response.status_code)
+            return {
+                "status": "error",
+                "message": f"InfluxDB error: {response.status_code}",
+            }
+
+        period_data = _parse_power_batch_response(response.text, target_date, local_tz)
+
+        _LOGGER.info(
+            "Power sensor batch complete: got data for %d periods", len(period_data)
+        )
+
+        return {"status": "success", "data": period_data}
+
+    except requests.RequestException as e:
+        _LOGGER.error("Error connecting to InfluxDB for power sensors: %s", str(e))
+        return {"status": "error", "message": f"Connection error: {e!s}"}
+    except Exception as e:
+        _LOGGER.error("Unexpected error in power sensor batch fetch: %s", str(e))
+        return {"status": "error", "message": f"Unexpected error: {e!s}"}
+
+
+def _parse_power_batch_response(
+    response_text: str, target_date, local_tz
+) -> dict[int, dict[str, float]]:
+    """Parse power sensor response: compute mean W per period, convert to kWh.
+
+    For each 15-minute period, averages all power readings within that period
+    and converts: kWh = mean_watts * (15/60) / 1000
+
+    Args:
+        response_text: CSV response from InfluxDB
+        target_date: The date being queried
+        local_tz: Local timezone
+
+    Returns:
+        dict: {period_num: {"sensor.entity_id": kwh_value, ...}, ...}
+    """
+    lines = response_text.strip().split("\n")
+    data_lines = [line for line in lines if not line.startswith("#")]
+
+    col_map = _build_column_index(data_lines)
+    if col_map is None:
+        _LOGGER.warning("No header row found in power sensor batch response")
+        return {}
+
+    value_idx = col_map["_value"]
+    time_idx = col_map["_time"]
+
+    day_start = datetime.combine(target_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+
+    # Collect readings per sensor per period: {sensor: {period: [values]}}
+    sensor_period_readings: dict[str, dict[int, list[float]]] = {}
+
+    for line in data_lines:
+        parts = line.split(",")
+        try:
+            if (
+                len(parts) <= max(value_idx, time_idx)
+                or parts[value_idx].strip() == "_value"
+            ):
+                continue
+
+            timestamp_str = parts[time_idx].strip()
+            sensor_name = _extract_sensor_name(parts, col_map)
+            if not sensor_name:
+                continue
+            value = float(parts[value_idx].strip())
+
+            # Skip clearly bogus values (e.g. the output_power 429496663.7 overflow)
+            if abs(value) > 100000:
+                continue
+
+            timestamp = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+            timestamp_local = timestamp.astimezone(local_tz)
+
+            # Calculate which period this reading belongs to
+            seconds_since_start = (timestamp_local - day_start).total_seconds()
+            if seconds_since_start < 0 or seconds_since_start >= 86400:
+                continue
+            period = int(seconds_since_start // 900)  # 900 seconds = 15 minutes
+
+            if sensor_name not in sensor_period_readings:
+                sensor_period_readings[sensor_name] = {}
+            if period not in sensor_period_readings[sensor_name]:
+                sensor_period_readings[sensor_name][period] = []
+            sensor_period_readings[sensor_name][period].append(value)
+
+        except (IndexError, ValueError, TypeError):
+            continue
+
+    # Convert mean W to kWh per period (15 min = 0.25 hours)
+    period_data: dict[int, dict[str, float]] = {}
+    for sensor_name, periods in sensor_period_readings.items():
+        for period, values in periods.items():
+            mean_watts = sum(values) / len(values)
+            kwh = mean_watts * 0.25 / 1000.0  # W * hours / 1000 = kWh
+
+            if period not in period_data:
+                period_data[period] = {}
+            period_data[period][sensor_name] = kwh
+
+    _LOGGER.debug(
+        "Parsed power data: %d sensors across %d periods",
+        len(sensor_period_readings),
+        len(period_data),
     )
 
     return period_data

--- a/core/bess/sensor_collector.py
+++ b/core/bess/sensor_collector.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 from .energy_flow_calculator import EnergyFlowCalculator
 from .health_check import perform_health_check
-from .influxdb_helper import get_sensor_data_batch
+from .influxdb_helper import get_power_sensor_data_batch, get_sensor_data_batch
 from .models import EnergyData
 from .settings import BatterySettings
 
@@ -57,6 +57,20 @@ class SensorCollector:
         # Resolve to actual entity IDs for InfluxDB queries
         self.cumulative_sensors = self._resolve_sensor_entity_ids()
 
+        # Power sensors (W) for high-resolution gap-filling
+        # Maps power sensor keys to the same flow names used by energy_flow_calculator
+        self.power_sensor_flow_map: dict[str, str] = {
+            "pv_power": "solar_production",
+            "local_load_power": "load_consumption",
+            "import_power": "import_from_grid",
+            "export_power": "export_to_grid",
+            "battery_charge_power": "battery_charged",
+            "battery_discharge_power": "battery_discharged",
+        }
+        self.power_sensors = self._resolve_power_sensor_ids()
+        self._power_batch_cache: dict = {}  # {date: {period: {sensor: kwh_value}}}
+        self._power_batch_cache_loaded_on: dict = {}
+
     def _resolve_sensor_entity_ids(self) -> list[str]:
         """Resolve sensor keys to entity IDs using the controller's abstraction layer.
 
@@ -74,6 +88,26 @@ class SensorCollector:
                 continue
         logger.info(
             f"Resolved {len(resolved_ids)} sensor entity IDs for InfluxDB queries"
+        )
+        return resolved_ids
+
+    def _resolve_power_sensor_ids(self) -> list[str]:
+        """Resolve power sensor keys to entity IDs for InfluxDB.
+
+        Returns list of entity IDs (without 'sensor.' prefix).
+        """
+        resolved_ids = []
+        for sensor_key in self.power_sensor_flow_map:
+            entity_id = self.ha_controller.resolve_sensor_for_influxdb(sensor_key)
+            if entity_id:
+                resolved_ids.append(entity_id)
+                logger.debug(
+                    f"Resolved power sensor key '{sensor_key}' to '{entity_id}'"
+                )
+            else:
+                logger.debug(f"Power sensor key '{sensor_key}' not configured")
+        logger.info(
+            f"Resolved {len(resolved_ids)} power sensor entity IDs for gap-filling"
         )
         return resolved_ids
 
@@ -177,6 +211,32 @@ class SensorCollector:
         )
         if not flow_dict:
             raise RuntimeError(f"Energy flow calculation failed for period {period}")
+
+        # Gap-filling: when cumulative sensors show zero energy (due to 0.1 kWh resolution),
+        # use power (W) sensors which report every ~5 minutes for much higher resolution
+        energy_flow_keys = [
+            "solar_production",
+            "load_consumption",
+            "import_from_grid",
+            "export_to_grid",
+            "battery_charged",
+            "battery_discharged",
+        ]
+        all_energy_zero = all(
+            abs(flow_dict.get(key, 0.0)) < 0.001 for key in energy_flow_keys
+        )
+        if all_energy_zero and is_historical_backfill:
+            target_date = datetime.now().date()
+            power_flows = self._get_power_based_flows(period, target_date)
+            if power_flows:
+                for key in energy_flow_keys:
+                    if key in power_flows and power_flows[key] > 0.001:
+                        flow_dict[key] = power_flows[key]
+                logger.info(
+                    "Period %d: Gap-filled from power sensors: %s",
+                    period,
+                    {k: f"{v:.4f}" for k, v in power_flows.items() if v > 0.001},
+                )
 
         # Extract BOTH SOC readings from sensors - NO DEFAULTS
         # Use abstraction layer to resolve battery SOC sensor entity ID (without 'sensor.' prefix)
@@ -359,6 +419,106 @@ class SensorCollector:
             )
             return False
 
+    def _ensure_power_batch_loaded(self, target_date) -> bool:
+        """Load power sensor batch data for a date (lazy, cached like cumulative batch).
+
+        Returns:
+            True if data was loaded successfully, False otherwise
+        """
+        today = datetime.now().date()
+
+        if target_date in self._power_batch_cache:
+            if target_date < today:
+                loaded_on = self._power_batch_cache_loaded_on.get(target_date)
+                if loaded_on != today:
+                    del self._power_batch_cache[target_date]
+                    if target_date in self._power_batch_cache_loaded_on:
+                        del self._power_batch_cache_loaded_on[target_date]
+                else:
+                    return True
+            else:
+                return True
+
+        if not self.power_sensors:
+            logger.debug("No power sensors configured, skipping power batch load")
+            return False
+
+        logger.info(
+            "Loading power sensor batch for %s (%d sensors)",
+            target_date.strftime("%Y-%m-%d"),
+            len(self.power_sensors),
+        )
+
+        result = get_power_sensor_data_batch(self.power_sensors, target_date)
+
+        if result.get("status") == "success":
+            data = result.get("data", {})
+            if not data:
+                logger.warning(
+                    "Power sensor batch for %s returned no periods", target_date
+                )
+                return False
+            self._power_batch_cache[target_date] = data
+            self._power_batch_cache_loaded_on[target_date] = today
+            logger.info(
+                "Power sensor batch loaded: %d periods for %s",
+                len(data),
+                target_date.strftime("%Y-%m-%d"),
+            )
+            return True
+        else:
+            logger.warning(
+                "Failed to load power sensor batch for %s: %s",
+                target_date.strftime("%Y-%m-%d"),
+                result.get("message", "Unknown error"),
+            )
+            return False
+
+    def _build_power_entity_to_flow_map(self) -> dict[str, str]:
+        """Build mapping from power sensor entity IDs (with sensor. prefix) to flow names.
+
+        Returns:
+            Dict mapping "sensor.entity_id" -> flow_name
+        """
+        entity_to_flow = {}
+        for sensor_key, flow_name in self.power_sensor_flow_map.items():
+            entity_id = self.ha_controller.resolve_sensor_for_influxdb(sensor_key)
+            if entity_id:
+                entity_to_flow[f"sensor.{entity_id}"] = flow_name
+        return entity_to_flow
+
+    def _get_power_based_flows(
+        self, period: int, target_date
+    ) -> dict[str, float] | None:
+        """Get energy flows for a period computed from power (W) sensors.
+
+        Returns flow dict compatible with energy_flow_calculator output, or None if unavailable.
+        """
+        if not self._ensure_power_batch_loaded(target_date):
+            return None
+
+        period_data = self._power_batch_cache.get(target_date, {}).get(period)
+        if not period_data:
+            return None
+
+        entity_to_flow = self._build_power_entity_to_flow_map()
+
+        flows = {}
+        for entity_key, kwh_value in period_data.items():
+            flow_name = entity_to_flow.get(entity_key)
+            if flow_name:
+                flows[flow_name] = kwh_value
+
+        if not flows:
+            return None
+
+        logger.debug(
+            "Period %d: Power-based flows: %s",
+            period,
+            {k: f"{v:.4f}" for k, v in flows.items()},
+        )
+        return flows
+
     def _get_period_readings(
         self, period: int, date_offset: int = 0
     ) -> dict[str, float] | None:
@@ -475,15 +635,11 @@ class SensorCollector:
                     readings[key[7:]] = float(value)
             except (ValueError, TypeError):
                 logger.warning(
-                    "Invalid value for sensor %s: %s (type: %s)",
+                    "Skipping sensor %s with invalid value: %s (type: %s)",
                     key,
                     value,
                     type(value).__name__,
                 )
-                # Store as 0.0 for numeric sensors to prevent calculation errors
-                readings[key] = 0.0
-                if key.startswith("sensor."):
-                    readings[key[7:]] = 0.0
 
         # Validate that we have the minimum required sensors
         # Check for required sensors using resolved entity IDs

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -162,6 +162,8 @@ class HomeSettings:
     default_hourly: float = HOME_HOURLY_CONSUMPTION_KWH
     min_valid: float = MIN_CONSUMPTION
     currency: str = DEFAULT_CURRENCY
+    consumption_strategy: str = "sensor"
+    timezone: str = "Europe/Stockholm"
 
     def update(self, **kwargs: Any) -> None:
         """Update settings from dict."""
@@ -189,4 +191,8 @@ class HomeSettings:
                 "consumption", HOME_HOURLY_CONSUMPTION_KWH
             )
             self.currency = config["home"].get("currency", DEFAULT_CURRENCY)
+            self.consumption_strategy = home_config.get(
+                "consumption_strategy", "sensor"
+            )
+            self.timezone = home_config.get("timezone", "Europe/Stockholm")
         return self

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./backend:/app:delegated
       - ./core:/app/core:delegated
+      - ./ml:/app/ml:delegated
       - ./frontend/dist:/app/frontend:delegated
       - ./backend/dev-options.json:/data/options.json:ro
     environment:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,8 +5,9 @@ import SavingsAnalysisPage from './pages/SavingsPage';
 import InverterPage from './pages/InverterPage';
 import InsightsPage from './pages/InsightsPage';
 import SystemHealthPage from './pages/SystemHealthPage';
+import MLReportPage from './pages/MLReportPage';
 import { useSettings } from './hooks/useSettings';
-import { Home, Activity, TrendingUp, Brain, Zap, Sun, Moon } from 'lucide-react';
+import { Home, Activity, TrendingUp, Brain, Zap, Sun, Moon, LineChart } from 'lucide-react';
 
 // An ErrorBoundary component to catch rendering errors
 class ErrorBoundary extends React.Component<
@@ -56,7 +57,7 @@ const Navigation = () => {
     // FIXED: Dashboard should be active for both "/" and when no specific page is selected
     if (path === '/') {
       // Dashboard is active for root path OR if we're not on any of the other specific pages
-      const otherPages = ['/insights', '/savings', '/inverter', '/system-health'];
+      const otherPages = ['/insights', '/savings', '/inverter', '/system-health', '/ml-report'];
       const isOnOtherPage = otherPages.some(page => location.pathname.startsWith(page));
       const isDashboardActive = location.pathname === '/' || !isOnOtherPage;
       
@@ -101,6 +102,14 @@ const Navigation = () => {
       >
         <Brain className="h-5 w-5" />
         <span className="hidden sm:inline">Insights</span>
+      </Link>
+      <Link
+        to="/ml-report"
+        className={`p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded flex items-center space-x-1 ${isActive('/ml-report')}`}
+        title="ML forecast quality & model metrics"
+      >
+        <LineChart className="h-5 w-5" />
+        <span className="hidden sm:inline">ML Report</span>
       </Link>
       <Link
         to="/system-health"
@@ -270,6 +279,7 @@ function App() {
                 <Route path="/savings" element={<SavingsAnalysisPage />} />
                 <Route path="/inverter" element={<InverterPage />} />
                 <Route path="/system-health" element={<SystemHealthPage />} />
+                <Route path="/ml-report" element={<MLReportPage />} />
                 {/* Catch-all route: redirect any unmatched paths to dashboard */}
                 <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>

--- a/frontend/src/pages/MLReportPage.tsx
+++ b/frontend/src/pages/MLReportPage.tsx
@@ -1,0 +1,460 @@
+import React, { useEffect, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { LineChart as LineChartIcon, AlertCircle, Info } from 'lucide-react';
+import api from '../lib/api';
+
+interface MLMetrics {
+  maeKwh: number;
+  rmseKwh: number;
+  rSquared: number;
+  mapePercent: number;
+}
+
+interface MLReportData {
+  isActive: boolean;
+  activeStrategy?: string;
+  modelAvailable: boolean;
+  lastTrained?: string;
+  trainSize?: number;
+  testSize?: number;
+  metrics?: MLMetrics;
+  baselines?: Record<string, MLMetrics>;
+  featureImportance?: Array<{ name: string; importance: number }>;
+  forecastDate?: string;
+  predictions?: number[];
+  yesterdayProfile?: number[];
+  weekAvgProfile?: number[];
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatLabel(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const BASELINE_LABELS: Record<string, string> = {
+  same_as_yesterday: 'Same as Yesterday',
+  hourly_mean: 'Hourly Mean',
+  flat_estimate: 'Flat Estimate',
+};
+
+const MLReportPage: React.FC = () => {
+  const [data, setData] = useState<MLReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .get('/api/ml-report')
+      .then((res) => setData(res.data))
+      .catch((err) => setError(err?.message ?? 'Failed to load ML report'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-6 bg-gray-50 dark:bg-gray-900 min-h-screen flex items-center justify-center">
+        <div className="flex items-center gap-3 text-gray-600 dark:text-gray-400">
+          <div className="animate-spin h-5 w-5 border-2 border-blue-500 rounded-full border-t-transparent" />
+          Loading ML report...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 bg-gray-50 dark:bg-gray-900 min-h-screen">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-red-500 mt-0.5 shrink-0" />
+          <p className="text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const notConfigured = data && !data.isActive;
+  const noModel = data && data.isActive && !data.modelAvailable;
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 dark:bg-gray-900 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-3">
+          <LineChartIcon className="h-7 w-7 text-blue-600 dark:text-blue-400" />
+          ML Report
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300 mt-1">
+          Review ML forecast quality, model accuracy, and feature drivers.
+        </p>
+      </div>
+
+      {notConfigured && (
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 flex items-start gap-3">
+          <Info className="h-5 w-5 text-blue-500 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium text-blue-800 dark:text-blue-200">ML prediction not active</p>
+            <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
+              Set <code className="font-mono bg-blue-100 dark:bg-blue-800 px-1 rounded">consumption_strategy</code> to{' '}
+              <code className="font-mono bg-blue-100 dark:bg-blue-800 px-1 rounded">ml_prediction</code> or{' '}
+              <code className="font-mono bg-blue-100 dark:bg-blue-800 px-1 rounded">influxdb_7d_avg</code> in your configuration to enable the ML forecast engine.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {noModel && (
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-amber-500 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium text-amber-800 dark:text-amber-200">No trained model found</p>
+            <p className="text-sm text-amber-700 dark:text-amber-300 mt-1">
+              Run <code className="font-mono bg-amber-100 dark:bg-amber-800 px-1 rounded">python -m ml train</code> to train the model and generate a report.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {data?.modelAvailable && data.metrics && (
+        <>
+          <SummaryCards data={data} />
+          <ForecastChart
+            predictions={data.predictions}
+            yesterday={data.yesterdayProfile}
+            weekAvg={data.weekAvgProfile}
+            forecastDate={data.forecastDate}
+            activeStrategy={data.activeStrategy}
+          />
+          <MetricsTable metrics={data.metrics} baselines={data.baselines ?? {}} />
+          <FeatureImportanceChart features={data.featureImportance ?? []} />
+        </>
+      )}
+    </div>
+  );
+};
+
+// ── Summary cards ──────────────────────────────────────────────────────────────
+
+interface SummaryCardsProps {
+  data: MLReportData;
+}
+
+const SummaryCards: React.FC<SummaryCardsProps> = ({ data }) => {
+  const total24h =
+    data.predictions ? data.predictions.reduce((s, v) => s + v, 0).toFixed(2) : '—';
+
+  const bestBaselineMae =
+    data.baselines
+      ? Math.min(...Object.values(data.baselines).map((b) => b.maeKwh))
+      : null;
+
+  const improvement =
+    bestBaselineMae !== null && data.metrics
+      ? (((bestBaselineMae - data.metrics.maeKwh) / bestBaselineMae) * 100).toFixed(1)
+      : null;
+
+  const cards = [
+    {
+      label: 'Last Trained',
+      value: data.lastTrained ? formatDateTime(data.lastTrained) : '—',
+      sub: `${data.trainSize?.toLocaleString()} train / ${data.testSize?.toLocaleString()} test samples`,
+    },
+    {
+      label: 'Total Forecast 24h',
+      value: `${total24h} kWh`,
+      sub: data.forecastDate ? `For ${data.forecastDate}` : 'No forecast cached',
+    },
+    {
+      label: 'Model MAE',
+      value: data.metrics ? `${data.metrics.maeKwh} kWh` : '—',
+      sub: `RMSE ${data.metrics?.rmseKwh} kWh · R² ${data.metrics?.rSquared}`,
+    },
+    {
+      label: 'vs Best Baseline',
+      value: improvement !== null ? `${improvement}% better` : '—',
+      sub: `Best baseline MAE: ${bestBaselineMae?.toFixed(4)} kWh`,
+      highlight: improvement !== null && parseFloat(improvement) > 0,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((c) => (
+        <div key={c.label} className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+            {c.label}
+          </p>
+          <p
+            className={`mt-1 text-xl font-semibold ${
+              c.highlight
+                ? 'text-green-600 dark:text-green-400'
+                : 'text-gray-900 dark:text-white'
+            }`}
+          >
+            {c.value}
+          </p>
+          {c.sub && <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{c.sub}</p>}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ── Forecast chart ─────────────────────────────────────────────────────────────
+
+interface ForecastChartProps {
+  predictions?: number[];
+  yesterday?: number[];
+  weekAvg?: number[];
+  forecastDate?: string;
+  activeStrategy?: string;
+}
+
+const TOOLTIP_LABELS: Record<string, string> = {
+  predicted: 'ML Predicted',
+  weekAvg: 'Weekly Average',
+  yesterday: 'Yesterday',
+};
+
+const ForecastChart: React.FC<ForecastChartProps> = ({ predictions, yesterday, weekAvg, forecastDate, activeStrategy }) => {
+  const hasAnyData = predictions?.length || weekAvg?.length;
+  if (!hasAnyData) return null;
+
+  const length = Math.max(predictions?.length ?? 0, weekAvg?.length ?? 0, yesterday?.length ?? 0);
+  const chartData = Array.from({ length }, (_, i) => {
+    const label = i % 4 === 0 ? `${String(Math.floor(i / 4)).padStart(2, '0')}:00` : '';
+    return {
+      period: i,
+      label,
+      predicted: predictions?.[i] !== undefined ? Math.round(predictions[i] * 1000) / 1000 : undefined,
+      weekAvg: weekAvg?.[i] !== undefined ? Math.round(weekAvg[i] * 1000) / 1000 : undefined,
+      yesterday: yesterday?.[i] !== undefined ? Math.round(yesterday[i] * 1000) / 1000 : undefined,
+    };
+  });
+
+  const strategyLabel = activeStrategy === 'influxdb_7d_avg' ? ' (using Weekly Average)' : '';
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+        Consumption Forecast{strategyLabel}
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        96-period forecast{forecastDate ? ` for ${forecastDate}` : ''} vs yesterday's actual (kWh per 15 min)
+      </p>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 11 }}
+            interval={0}
+            tickFormatter={(v) => v}
+          />
+          <YAxis tick={{ fontSize: 11 }} width={50} tickFormatter={(v) => `${v}`} />
+          <Tooltip
+            formatter={(value: number, name: string) => [
+              `${value} kWh`,
+              TOOLTIP_LABELS[name] ?? name,
+            ]}
+            labelFormatter={(_, payload) => {
+              if (!payload?.length) return '';
+              const p = payload[0].payload as { period: number };
+              const h = Math.floor(p.period / 4);
+              const m = (p.period % 4) * 15;
+              return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+            }}
+          />
+          <Legend formatter={(value: string) => TOOLTIP_LABELS[value] ?? value} />
+          {predictions?.length ? (
+            <Line
+              type="monotone"
+              dataKey="predicted"
+              stroke="#3b82f6"
+              dot={false}
+              strokeWidth={2}
+              name="predicted"
+            />
+          ) : null}
+          {weekAvg?.length ? (
+            <Line
+              type="monotone"
+              dataKey="weekAvg"
+              stroke="#10b981"
+              dot={false}
+              strokeWidth={2}
+              strokeDasharray={activeStrategy === 'influxdb_7d_avg' ? undefined : '6 3'}
+              name="weekAvg"
+            />
+          ) : null}
+          {yesterday?.length ? (
+            <Line
+              type="monotone"
+              dataKey="yesterday"
+              stroke="#9ca3af"
+              dot={false}
+              strokeWidth={1.5}
+              strokeDasharray="4 2"
+              name="yesterday"
+            />
+          ) : null}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+// ── Metrics table ──────────────────────────────────────────────────────────────
+
+interface MetricsTableProps {
+  metrics: MLMetrics;
+  baselines: Record<string, MLMetrics>;
+}
+
+const MetricsTable: React.FC<MetricsTableProps> = ({ metrics, baselines }) => {
+  const rows: Array<{ key: string; label: string; metrics: MLMetrics; isModel: boolean }> = [
+    { key: 'model', label: 'XGBoost (model)', metrics, isModel: true },
+    ...Object.entries(baselines).map(([k, v]) => ({
+      key: k,
+      label: BASELINE_LABELS[k] ?? formatLabel(k),
+      metrics: v,
+      isModel: false,
+    })),
+  ];
+
+  const bestMae = Math.min(...rows.map((r) => r.metrics.maeKwh));
+  const bestRmse = Math.min(...rows.map((r) => r.metrics.rmseKwh));
+  const bestR2 = Math.max(...rows.map((r) => r.metrics.rSquared));
+  const bestMape = Math.min(...rows.map((r) => r.metrics.mapePercent));
+
+  const cellClass = (val: number, best: number, lowerIsBetter: boolean) => {
+    const isBest = lowerIsBetter ? val === best : val === best;
+    return isBest
+      ? 'text-green-700 dark:text-green-400 font-semibold'
+      : 'text-gray-700 dark:text-gray-300';
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-4">
+        Model vs Baselines
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="text-left py-2 pr-4 font-medium text-gray-500 dark:text-gray-400">
+                Model
+              </th>
+              <th className="text-right py-2 px-4 font-medium text-gray-500 dark:text-gray-400">
+                MAE (kWh)
+              </th>
+              <th className="text-right py-2 px-4 font-medium text-gray-500 dark:text-gray-400">
+                RMSE (kWh)
+              </th>
+              <th className="text-right py-2 px-4 font-medium text-gray-500 dark:text-gray-400">
+                R²
+              </th>
+              <th className="text-right py-2 pl-4 font-medium text-gray-500 dark:text-gray-400">
+                MAPE (%)
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.key}
+                className={`border-b border-gray-100 dark:border-gray-700/50 ${
+                  row.isModel ? 'bg-blue-50 dark:bg-blue-900/20' : ''
+                }`}
+              >
+                <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
+                  {row.label}
+                </td>
+                <td className={`py-2 px-4 text-right ${cellClass(row.metrics.maeKwh, bestMae, true)}`}>
+                  {row.metrics.maeKwh}
+                </td>
+                <td className={`py-2 px-4 text-right ${cellClass(row.metrics.rmseKwh, bestRmse, true)}`}>
+                  {row.metrics.rmseKwh}
+                </td>
+                <td className={`py-2 px-4 text-right ${cellClass(row.metrics.rSquared, bestR2, false)}`}>
+                  {row.metrics.rSquared}
+                </td>
+                <td className={`py-2 pl-4 text-right ${cellClass(row.metrics.mapePercent, bestMape, true)}`}>
+                  {row.metrics.mapePercent}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+        Green highlights indicate best value per column.
+      </p>
+    </div>
+  );
+};
+
+// ── Feature importance chart ───────────────────────────────────────────────────
+
+interface FeatureImportanceChartProps {
+  features: Array<{ name: string; importance: number }>;
+}
+
+const FeatureImportanceChart: React.FC<FeatureImportanceChartProps> = ({ features }) => {
+  if (!features.length) return null;
+
+  const top10 = features.slice(0, 10);
+  const maxImp = top10[0].importance;
+
+  const chartData = top10
+    .map((f) => ({
+      name: formatLabel(f.name),
+      importance: Math.round((f.importance / maxImp) * 1000) / 1000,
+    }))
+    .reverse();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+        Feature Importance
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Top 10 features, relative to the most important feature.
+      </p>
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart
+          data={chartData}
+          layout="vertical"
+          margin={{ top: 0, right: 24, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" horizontal={false} className="opacity-30" />
+          <XAxis type="number" domain={[0, 1]} tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v * 100).toFixed(0)}%`} />
+          <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={160} />
+          <Tooltip formatter={(v: number) => [`${(v * 100).toFixed(1)}%`, 'Relative importance']} />
+          <Bar dataKey="importance" fill="#3b82f6" radius={[0, 3, 3, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default MLReportPage;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,7 +115,7 @@ export interface BatterySettings {
   
   // Consumption estimate
   estimatedConsumption: number; // kWh daily estimate
-  consumptionStrategy: string;  // "sensor", "fixed", or "influxdb_7d_avg"
+  consumptionStrategy: string;  // "sensor", "fixed", "influxdb_7d_avg", or "ml_prediction"
   
   // Price settings
   useActualPrice?: boolean;     // use actual vs estimated prices

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,6 +115,7 @@ export interface BatterySettings {
   
   // Consumption estimate
   estimatedConsumption: number; // kWh daily estimate
+  consumptionStrategy: string;  // "sensor", "fixed", or "influxdb_7d_avg"
   
   // Price settings
   useActualPrice?: boolean;     // use actual vs estimated prices

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,96 @@
+# ML Energy Consumption Predictor
+
+Standalone CLI tool for training and running ML-based energy consumption
+predictions. Uses XGBoost gradient boosting on historical InfluxDB sensor
+data to produce 96 quarter-hourly consumption forecasts.
+
+## Prerequisites
+
+On macOS, XGBoost requires OpenMP:
+
+```bash
+brew install libomp
+```
+
+## Setup
+
+Always use the dedicated venv for the ML module:
+
+```bash
+# Create venv (one time)
+python3 -m venv ml/.venv
+
+# Install dependencies
+ml/.venv/bin/pip install -r backend/requirements.txt
+
+# Install dev tools
+ml/.venv/bin/pip install black ruff
+```
+
+## Usage
+
+All commands must be run from the project root using the venv Python:
+
+```bash
+# Train a model
+ml/.venv/bin/python -m ml train
+
+# Generate 24h consumption prediction
+ml/.venv/bin/python -m ml predict
+
+# Evaluate model performance
+ml/.venv/bin/python -m ml evaluate
+
+# Show naive baseline metrics (no ML)
+ml/.venv/bin/python -m ml baseline
+
+# Retrain + predict + generate timestamped HTML chart
+ml/.venv/bin/python -m ml report
+
+# Fetch and display raw sensor data (debugging)
+ml/.venv/bin/python -m ml fetch-data
+
+# Verbose mode for any command
+ml/.venv/bin/python -m ml train -v
+```
+
+The `report` command runs the full pipeline (train, predict, fetch weather/history)
+and produces `ml/prediction_chart-YYYY-MM-DD.html` — a self-contained dark-theme
+Chart.js dashboard. Run it periodically to track model evolution as more data
+accumulates.
+
+## Configuration
+
+Edit `ml_config.yaml` in the project root. Environment variables
+(`${HA_DB_URL}`, etc.) are resolved from `.env` or the shell environment.
+
+## Quality Checks
+
+```bash
+ml/.venv/bin/black ml/
+ml/.venv/bin/ruff check --fix ml/
+```
+
+## Integration with BESS Manager
+
+The ML predictor integrates with the main BESS optimization system via the
+`consumption_strategy` setting. To use ML predictions for battery optimization:
+
+```yaml
+home:
+  consumption_strategy: "ml_prediction"
+```
+
+When this strategy is active, the battery system manager calls
+`ml.predictor.predict_next_24h()` to generate the consumption forecast
+used by the optimizer. The `influxdb_7d_avg` strategy also reuses the
+`ml.data_fetcher.fetch_history_context()` function to produce a 7-day
+average profile without requiring a trained model.
+
+See the [Installation Guide](../INSTALLATION.md) for all available
+consumption strategies.
+
+## Output Format
+
+Predictions are 96 float values (kWh per 15-minute period), matching
+the format expected by `battery_system_manager.optimize_battery_schedule()`.

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,0 +1,5 @@
+"""ML Energy Consumption Predictor for BESS optimization.
+
+Standalone CLI tool that trains gradient boosting models on historical
+InfluxDB sensor data to predict 96 quarter-hourly consumption values.
+"""

--- a/ml/__main__.py
+++ b/ml/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as `python -m ml`."""
+
+from ml.cli import main
+
+main()

--- a/ml/cli.py
+++ b/ml/cli.py
@@ -1,0 +1,758 @@
+"""CLI entry point for ML energy consumption predictor.
+
+Usage:
+    python -m ml train          # Fetch data, train model, show metrics + baselines
+    python -m ml predict        # Generate 24h prediction, print table
+    python -m ml evaluate       # Show model performance on test data
+    python -m ml baseline       # Show naive baseline metrics (no ML)
+    python -m ml fetch-data     # Just fetch and display raw data (debugging)
+    python -m ml report         # Retrain + predict + generate timestamped HTML chart
+"""
+
+import argparse
+import json
+import logging
+from datetime import date, datetime
+from pathlib import Path
+
+import pandas as pd
+
+from ml.config import load_config
+
+
+def _setup_logging(verbose: bool) -> None:
+    """Configure logging for CLI output."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def _cmd_train(config: dict, target_date: date | None = None) -> None:
+    """Train model and display results."""
+    from ml.trainer import train_model
+
+    result = train_model(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("TRAINING COMPLETE")
+    print("=" * 60)
+    print(f"  Train samples: {result['train_size']}")
+    print(f"  Test samples:  {result['test_size']}")
+    print(f"  Model saved:   {result['model_path']}")
+
+    print("\nML Model Metrics:")
+    for name, value in result["metrics"].items():
+        print(f"  {name}: {value}")
+
+    print("\nBaseline Comparison:")
+    print(f"  {'Method':25s} {'MAE':>10s} {'RMSE':>10s} {'R²':>10s}")
+    print("  " + "-" * 55)
+
+    # ML model row
+    m = result["metrics"]
+    print(
+        f"  {'XGBoost (ML model)':25s} {m['mae_kwh']:>10.4f} "
+        f"{m['rmse_kwh']:>10.4f} {m['r_squared']:>10.4f}"
+    )
+
+    # Baseline rows
+    for baseline_name, metrics in result["baselines"].items():
+        label = baseline_name.replace("_", " ").title()
+        print(
+            f"  {label:25s} {metrics['mae_kwh']:>10.4f} "
+            f"{metrics['rmse_kwh']:>10.4f} {metrics['r_squared']:>10.4f}"
+        )
+
+    # Improvement summary
+    if "same_as_yesterday" in result["baselines"]:
+        baseline_mae = result["baselines"]["same_as_yesterday"]["mae_kwh"]
+        ml_mae = result["metrics"]["mae_kwh"]
+        if baseline_mae > 0:
+            improvement = (1 - ml_mae / baseline_mae) * 100
+            print(
+                f"\n  ML vs Same-as-Yesterday: "
+                f"{improvement:+.1f}% MAE {'improvement' if improvement > 0 else 'worse'}"
+            )
+
+    print("\nFeature Importance (top 10):")
+    for feature_name, importance in result["feature_importance"][:10]:
+        bar = "#" * int(importance * 50)
+        print(f"  {feature_name:30s} {importance:.4f} {bar}")
+
+
+def _cmd_predict(config: dict) -> None:
+    """Generate and display 24h predictions."""
+    from ml.predictor import predict_with_timestamps
+
+    predictions = predict_with_timestamps(config)
+
+    print("\n" + "=" * 60)
+    print("24-HOUR CONSUMPTION PREDICTION")
+    print("=" * 60)
+    print(f"{'Time':>8s}  {'kWh/15min':>10s}  {'kWh/hour':>10s}  {'Visual':s}")
+    print("-" * 60)
+
+    hourly_kwh = 0.0
+    total_kwh = 0.0
+
+    for i, (ts, kwh) in enumerate(predictions):
+        hourly_kwh += kwh
+        total_kwh += kwh
+
+        # Print hourly summary at end of each hour
+        if (i + 1) % 4 == 0:
+            bar = "#" * int(hourly_kwh * 10)
+            print(
+                f"  {ts.strftime('%H:%M'):>6s}  {kwh:>10.3f}  {hourly_kwh:>10.3f}  {bar}"
+            )
+            hourly_kwh = 0.0
+        else:
+            print(f"  {ts.strftime('%H:%M'):>6s}  {kwh:>10.3f}")
+
+    print("-" * 60)
+    print(f"  Total predicted consumption: {total_kwh:.2f} kWh")
+    print(f"  Average hourly: {total_kwh / 24:.2f} kWh/h")
+    print(f"  Average per 15min: {total_kwh / 96:.3f} kWh")
+
+
+def _cmd_evaluate(config: dict, target_date: date | None = None) -> None:
+    """Evaluate model and display detailed metrics."""
+    from ml.trainer import evaluate_model
+
+    result = evaluate_model(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("MODEL EVALUATION")
+    print("=" * 60)
+    print(f"  Test samples: {result['test_size']}")
+
+    print("\nOverall Metrics:")
+    for name, value in result["metrics"].items():
+        print(f"  {name}: {value}")
+
+    print("\nHourly Error Analysis:")
+    print(f"  {'Hour':>4s}  {'Mean Error':>12s}  {'MAE':>8s}  {'Samples':>8s}")
+    print("  " + "-" * 40)
+    for hour, data in sorted(result["hourly_errors"].items()):
+        print(
+            f"  {hour:>4d}  {data['mean_error']:>12.4f}  "
+            f"{data['mae']:>8.4f}  {data['count']:>8d}"
+        )
+
+
+def _cmd_baseline(config: dict, target_date: date | None = None) -> None:
+    """Compute and display naive baseline metrics."""
+    from ml.trainer import compute_baselines
+
+    result = compute_baselines(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("BASELINE METRICS")
+    print("=" * 60)
+    print(f"  Total samples: {result['total_samples']}")
+    print(f"  Test samples:  {result['test_samples']}")
+
+    print(f"\n  {'Method':25s} {'MAE':>10s} {'RMSE':>10s} {'R²':>10s} {'MAPE%':>10s}")
+    print("  " + "-" * 65)
+
+    for baseline_name, metrics in result["baselines"].items():
+        label = baseline_name.replace("_", " ").title()
+        print(
+            f"  {label:25s} {metrics['mae_kwh']:>10.4f} "
+            f"{metrics['rmse_kwh']:>10.4f} {metrics['r_squared']:>10.4f} "
+            f"{metrics['mape_percent']:>10.2f}"
+        )
+
+    print("\nInterpretation:")
+    print("  These baselines represent the performance floor.")
+    print("  An ML model should beat all of these to justify its complexity.")
+    print("  'Same As Yesterday' is the strongest naive baseline for")
+    print("  habitual consumption patterns (e.g., work-from-home).")
+
+
+def _cmd_fetch_data(config: dict, target_date: date | None = None) -> None:
+    """Fetch and display raw sensor data for debugging."""
+    from ml.data_fetcher import fetch_training_data
+
+    df = fetch_training_data(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("RAW SENSOR DATA")
+    print("=" * 60)
+    print(f"  Rows: {len(df)}")
+    print(f"  Columns: {list(df.columns)}")
+    print(f"  Date range: {df.index.min()} to {df.index.max()}")
+
+    print("\nColumn Statistics:")
+    print(df.describe().round(2).to_string())
+
+    print("\nFirst 10 rows:")
+    print(df.head(10).to_string())
+
+    print("\nLast 10 rows:")
+    print(df.tail(10).to_string())
+
+    # Check for gaps
+    time_diffs = df.index.to_series().diff()
+    expected_diff = "15min"
+    gaps = time_diffs[time_diffs > expected_diff]
+    if not gaps.empty:
+        print(f"\nData gaps found ({len(gaps)} gaps > 15min):")
+        for ts, gap in gaps.head(10).items():
+            print(f"  {ts}: {gap}")
+
+
+def _generate_chart_html(
+    train_result: dict,
+    predictions: list[tuple[datetime, float]],
+    weather_df: pd.DataFrame,
+    history_context: dict,
+) -> str:
+    """Generate self-contained HTML chart from pipeline results."""
+    # Quarter-hourly prediction data
+    quarter_data = [
+        {"time": ts.strftime("%H:%M"), "kwh": round(kwh, 4)} for ts, kwh in predictions
+    ]
+
+    # Yesterday's profile mapped to 15-min slots starting at 00:00
+    yesterday_profile = history_context["yesterday_profile"]
+    yesterday_data = [
+        {"time": f"{i // 4:02d}:{(i % 4) * 15:02d}", "kwh": round(v, 4)}
+        for i, v in enumerate(yesterday_profile)
+    ]
+
+    # Hourly aggregation from predictions
+    hourly_data = []
+    for i in range(0, len(predictions), 4):
+        chunk = predictions[i : i + 4]
+        hour_kwh = sum(kwh for _, kwh in chunk)
+        label = chunk[0][0].strftime("%H:%M")
+        hourly_data.append({"hour": label, "kwh": round(hour_kwh, 4)})
+
+    # Weather data from forecast DataFrame
+    weather_data = [
+        {"time": ts.strftime("%H:%M"), "temp": round(row["temperature"], 1)}
+        for ts, row in weather_df.iterrows()
+    ]
+
+    # Feature importance (cast to Python float for JSON serialization)
+    feature_importance = [
+        [name, round(float(imp), 4)] for name, imp in train_result["feature_importance"]
+    ]
+
+    # Summary card values
+    total_kwh = sum(kwh for _, kwh in predictions)
+    yesterday_total = history_context["yesterday_total"]
+
+    hourly_totals = [d["kwh"] for d in hourly_data]
+    peak_idx = hourly_totals.index(max(hourly_totals))
+    low_idx = hourly_totals.index(min(hourly_totals))
+    peak_hour = hourly_data[peak_idx]["hour"]
+    peak_kwh = hourly_totals[peak_idx]
+    low_hour = hourly_data[low_idx]["hour"]
+    low_kwh = hourly_totals[low_idx]
+
+    temps = [d["temp"] for d in weather_data]
+    temp_min = min(temps) if temps else 0.0
+    temp_max = max(temps) if temps else 0.0
+
+    # Prediction time range
+    pred_start = predictions[0][0].strftime("%Y-%m-%d %H:%M")
+    pred_end = predictions[-1][0].strftime("%Y-%m-%d %H:%M")
+
+    # Training data warning
+    train_size = train_result["train_size"]
+    configured_days = 30
+    actual_days = train_size // 96
+    show_warning = actual_days < configured_days
+
+    # Baseline table rows
+    metrics = train_result["metrics"]
+    baselines = train_result["baselines"]
+
+    baseline_rows_html = ""
+    baseline_rows_html += (
+        f'          <tr class="highlight"><td>XGBoost (ML)</td>'
+        f'<td class="val">{metrics["mae_kwh"]:.4f}</td>'
+        f'<td class="val">{metrics["rmse_kwh"]:.4f}</td>'
+        f'<td class="val">{metrics["r_squared"]:.3f}</td>'
+        f'<td class="val">{metrics["mape_percent"]:.1f}</td></tr>\n'
+    )
+    for name, bm in baselines.items():
+        label = name.replace("_", " ").title()
+        baseline_rows_html += (
+            f"          <tr><td>{label}</td>"
+            f'<td class="val">{bm["mae_kwh"]:.4f}</td>'
+            f'<td class="val">{bm["rmse_kwh"]:.4f}</td>'
+            f'<td class="val">{bm["r_squared"]:.3f}</td>'
+            f'<td class="val">{bm["mape_percent"]:.1f}</td></tr>\n'
+        )
+
+    # Warning HTML
+    warning_html = ""
+    if show_warning:
+        warning_html = f"""
+  <div class="warning">
+    <div class="warning-title">Limited Training Data</div>
+    <div class="warning-text">
+      Model trained on only <strong>{actual_days} days</strong> of data (~{train_size} samples) instead of the configured {configured_days} days.
+      Metrics will improve significantly with more history.
+    </div>
+  </div>
+"""
+
+    # Yesterday start index — align yesterday data to prediction timeline
+    pred_start_quarter = predictions[0][0].hour * 4 + predictions[0][0].minute // 15
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ML Energy Prediction &mdash; BESS Manager</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #0f1117; color: #e1e4e8; padding: 24px; }}
+  .container {{ max-width: 1200px; margin: 0 auto; }}
+  h1 {{ font-size: 1.5rem; font-weight: 600; margin-bottom: 4px; }}
+  .subtitle {{ color: #8b949e; font-size: 0.9rem; margin-bottom: 24px; }}
+  .subtitle span {{ color: #f0883e; }}
+  h2 {{ font-size: 1.1rem; font-weight: 600; margin: 0 0 16px; }}
+  .cards {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }}
+  .card {{ background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; }}
+  .card-label {{ color: #8b949e; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px; }}
+  .card-value {{ font-size: 1.6rem; font-weight: 700; }}
+  .card-sub {{ color: #8b949e; font-size: 0.75rem; margin-top: 4px; }}
+  .card-value.total {{ color: #58a6ff; }}
+  .card-value.peak {{ color: #f0883e; }}
+  .card-value.low {{ color: #3fb950; }}
+  .card-value.temp {{ color: #bc8cff; }}
+  .card-unit {{ color: #8b949e; font-size: 0.8rem; font-weight: 400; }}
+  .chart-panel {{ background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; margin-bottom: 16px; }}
+  .chart-title {{ font-size: 0.95rem; font-weight: 600; margin-bottom: 16px; }}
+  .chart-wrap {{ position: relative; height: 280px; }}
+  .toggle-row {{ display: flex; gap: 8px; margin-bottom: 24px; }}
+  .toggle-btn {{ background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 8px 16px; color: #8b949e; cursor: pointer; font-size: 0.85rem; transition: all 0.15s; }}
+  .toggle-btn.active {{ background: #1f6feb22; border-color: #58a6ff; color: #58a6ff; }}
+  .toggle-btn:hover {{ border-color: #58a6ff88; }}
+  .section {{ margin-top: 32px; margin-bottom: 16px; }}
+  .section-label {{ color: #8b949e; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }}
+  .cols {{ display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 16px; }}
+  .metrics-table {{ width: 100%; border-collapse: collapse; font-size: 0.85rem; }}
+  .metrics-table th {{ text-align: left; color: #8b949e; font-weight: 500; padding: 8px 12px; border-bottom: 1px solid #30363d; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; }}
+  .metrics-table td {{ padding: 8px 12px; border-bottom: 1px solid #21262d; }}
+  .metrics-table tr.highlight td {{ color: #58a6ff; font-weight: 600; }}
+  .metrics-table td.val {{ font-family: 'SF Mono', 'Fira Code', monospace; text-align: right; font-size: 0.8rem; }}
+  .feat-row {{ display: flex; align-items: center; margin-bottom: 6px; }}
+  .feat-name {{ width: 170px; font-size: 0.8rem; color: #8b949e; text-align: right; padding-right: 12px; flex-shrink: 0; }}
+  .feat-bar-wrap {{ flex: 1; height: 18px; background: #21262d; border-radius: 4px; overflow: hidden; }}
+  .feat-bar {{ height: 100%; border-radius: 4px; transition: width 0.4s; }}
+  .feat-pct {{ width: 50px; font-size: 0.75rem; color: #8b949e; text-align: right; padding-left: 8px; font-family: monospace; }}
+  .warning {{ background: #f0883e15; border: 1px solid #f0883e44; border-radius: 8px; padding: 16px; margin-bottom: 24px; }}
+  .warning-title {{ color: #f0883e; font-weight: 600; font-size: 0.9rem; margin-bottom: 6px; }}
+  .warning-text {{ color: #8b949e; font-size: 0.85rem; line-height: 1.5; }}
+  @media (max-width: 768px) {{
+    .cards {{ grid-template-columns: repeat(2, 1fr); }}
+    .cols {{ grid-template-columns: 1fr; }}
+  }}
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>ML Energy Consumption Prediction</h1>
+  <p class="subtitle">Direct prediction with weather forecast &mdash; <span>{pred_start} to {pred_end}</span></p>
+{warning_html}
+  <div class="cards">
+    <div class="card">
+      <div class="card-label">Predicted 24h</div>
+      <div class="card-value total">{total_kwh:.2f} <span class="card-unit">kWh</span></div>
+      <div class="card-sub">Yesterday: {yesterday_total:.2f} kWh</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Peak Hour</div>
+      <div class="card-value peak">{peak_kwh:.2f} <span class="card-unit">kWh/h</span></div>
+      <div class="card-sub">{peak_hour}</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Lowest Hour</div>
+      <div class="card-value low">{low_kwh:.2f} <span class="card-unit">kWh/h</span></div>
+      <div class="card-sub">{low_hour}</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Temperature Range</div>
+      <div class="card-value temp">{temp_min:.1f}&ndash;{temp_max:.1f} <span class="card-unit">&deg;C</span></div>
+    </div>
+  </div>
+
+  <div class="toggle-row">
+    <button class="toggle-btn active" data-view="quarter">15-min intervals</button>
+    <button class="toggle-btn" data-view="hourly">Hourly totals</button>
+  </div>
+
+  <div class="chart-panel">
+    <div class="chart-title">Predicted Consumption vs Yesterday</div>
+    <div class="chart-wrap"><canvas id="mainChart"></canvas></div>
+  </div>
+
+  <div class="cols">
+    <div class="chart-panel">
+      <div class="chart-title">Hourly Breakdown</div>
+      <div class="chart-wrap"><canvas id="barChart"></canvas></div>
+    </div>
+    <div class="chart-panel">
+      <div class="chart-title">Temperature &amp; Consumption Correlation</div>
+      <div class="chart-wrap"><canvas id="tempChart"></canvas></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-label">Model Analysis</div>
+  </div>
+
+  <div class="cols">
+    <div class="chart-panel">
+      <h2>Baseline Comparison</h2>
+      <table class="metrics-table">
+        <thead>
+          <tr><th>Method</th><th class="val">MAE</th><th class="val">RMSE</th><th class="val">R&sup2;</th><th class="val">MAPE%</th></tr>
+        </thead>
+        <tbody>
+{baseline_rows_html}        </tbody>
+      </table>
+    </div>
+
+    <div class="chart-panel">
+      <h2>Feature Importance</h2>
+      <div id="feat-bars"></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-label">Methodology</div>
+  </div>
+
+  <div class="chart-panel">
+    <div style="display:grid; grid-template-columns: 1fr 1fr 1fr; gap: 24px; font-size: 0.85rem; color: #8b949e; line-height: 1.6;">
+      <div>
+        <div style="color: #e1e4e8; font-weight: 600; margin-bottom: 8px;">Direct Prediction</div>
+        Single <code style="color:#58a6ff">model.predict(X)</code> call on a 96-row feature matrix.
+        No iterative loop, no error compounding. Each row contains only
+        features known ahead of time for that future period.
+      </div>
+      <div>
+        <div style="color: #e1e4e8; font-weight: 600; margin-bottom: 8px;">Weather-Driven</div>
+        48-hour forecast from Home Assistant (temperature, cloud cover,
+        wind, precipitation) interpolated to 15-min intervals.
+      </div>
+      <div>
+        <div style="color: #e1e4e8; font-weight: 600; margin-bottom: 8px;">History Context</div>
+        Yesterday's consumption profile, weekly averages, and recent 24h mean
+        provide stable context without feeding predictions back as input.
+        Computed once from InfluxDB before prediction.
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+const quarterData = {json.dumps(quarter_data)};
+const yesterdayData = {json.dumps(yesterday_data)};
+const hourlyData = {json.dumps(hourly_data)};
+const weatherData = {json.dumps(weather_data)};
+const featureImportance = {json.dumps(feature_importance)};
+
+const gridColor = '#21262d';
+const tickColor = '#8b949e';
+const blue = '#58a6ff';
+const orange = '#f0883e';
+const green = '#3fb950';
+const purple = '#bc8cff';
+
+function makeGradient(ctx, r, g, b, h) {{
+  const grad = ctx.createLinearGradient(0, 0, 0, h || 280);
+  grad.addColorStop(0, `rgba(${{r}},${{g}},${{b}},0.3)`);
+  grad.addColorStop(1, `rgba(${{r}},${{g}},${{b}},0.02)`);
+  return grad;
+}}
+
+// Reorder yesterday data to align with prediction start time
+const yesterdayReordered = [];
+const startIdx = {pred_start_quarter};
+for (let i = 0; i < 96; i++) {{
+  yesterdayReordered.push(yesterdayData[(startIdx + i) % 96]);
+}}
+
+// Main chart: prediction vs yesterday
+const mainCtx = document.getElementById('mainChart').getContext('2d');
+const mainChart = new Chart(mainCtx, {{
+  type: 'line',
+  data: {{
+    labels: quarterData.map(d => d.time),
+    datasets: [
+      {{
+        label: 'ML Prediction',
+        data: quarterData.map(d => d.kwh),
+        borderColor: blue,
+        backgroundColor: makeGradient(mainCtx, 88, 166, 255),
+        borderWidth: 2,
+        fill: true,
+        tension: 0.3,
+        pointRadius: 0,
+        pointHitRadius: 8,
+        pointHoverRadius: 4,
+        pointHoverBackgroundColor: blue,
+      }},
+      {{
+        label: 'Yesterday Actual',
+        data: yesterdayReordered.map(d => d.kwh),
+        borderColor: '#484f58',
+        borderWidth: 1.5,
+        borderDash: [4, 4],
+        fill: false,
+        tension: 0.3,
+        pointRadius: 0,
+      }}
+    ]
+  }},
+  options: {{
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {{ mode: 'index', intersect: false }},
+    plugins: {{
+      legend: {{ labels: {{ color: tickColor, boxWidth: 12, padding: 16, font: {{ size: 11 }} }} }},
+      tooltip: {{
+        backgroundColor: '#1c2128', borderColor: '#30363d', borderWidth: 1,
+        titleColor: '#e1e4e8', bodyColor: '#8b949e', padding: 10,
+        callbacks: {{ label: ctx => `${{ctx.dataset.label}}: ${{ctx.parsed.y.toFixed(3)}} kWh` }}
+      }}
+    }},
+    scales: {{
+      x: {{
+        grid: {{ color: gridColor }},
+        ticks: {{ color: tickColor, maxTicksLimit: 24, callback: function(val) {{ const l = this.getLabelForValue(val); return l.endsWith(':00') ? l : ''; }} }}
+      }},
+      y: {{
+        grid: {{ color: gridColor }},
+        ticks: {{ color: tickColor, callback: v => v.toFixed(2) }},
+        title: {{ display: true, text: 'kWh / 15min', color: tickColor }}
+      }}
+    }}
+  }}
+}});
+
+// Bar chart
+const barCtx = document.getElementById('barChart').getContext('2d');
+function barColors(data) {{
+  const max = Math.max(...data);
+  return data.map(v => {{
+    const r = v / max;
+    if (r > 0.8) return orange;
+    if (r > 0.5) return blue;
+    return green;
+  }});
+}}
+const hourlyKwh = hourlyData.map(d => d.kwh);
+new Chart(barCtx, {{
+  type: 'bar',
+  data: {{
+    labels: hourlyData.map(d => d.hour),
+    datasets: [{{ label: 'kWh/hour', data: hourlyKwh, backgroundColor: barColors(hourlyKwh), borderRadius: 4, borderSkipped: false }}]
+  }},
+  options: {{
+    responsive: true, maintainAspectRatio: false,
+    plugins: {{
+      legend: {{ display: false }},
+      tooltip: {{ backgroundColor: '#1c2128', borderColor: '#30363d', borderWidth: 1, titleColor: '#e1e4e8', bodyColor: '#8b949e', padding: 10, callbacks: {{ label: ctx => `${{ctx.parsed.y.toFixed(3)}} kWh` }} }}
+    }},
+    scales: {{
+      x: {{ grid: {{ color: gridColor }}, ticks: {{ color: tickColor, maxTicksLimit: 12 }} }},
+      y: {{ grid: {{ color: gridColor }}, ticks: {{ color: tickColor, callback: v => v.toFixed(1) }}, title: {{ display: true, text: 'kWh/hour', color: tickColor }} }}
+    }}
+  }}
+}});
+
+// Temperature + consumption dual axis chart
+const tempCtx = document.getElementById('tempChart').getContext('2d');
+new Chart(tempCtx, {{
+  type: 'line',
+  data: {{
+    labels: quarterData.map(d => d.time),
+    datasets: [
+      {{
+        label: 'Consumption',
+        data: quarterData.map(d => d.kwh),
+        borderColor: blue,
+        backgroundColor: 'transparent',
+        borderWidth: 1.5,
+        tension: 0.3,
+        pointRadius: 0,
+        yAxisID: 'y',
+      }},
+      {{
+        label: 'Temperature',
+        data: weatherData.map(d => d.temp),
+        borderColor: orange,
+        backgroundColor: makeGradient(tempCtx, 240, 136, 62),
+        borderWidth: 1.5,
+        fill: true,
+        tension: 0.3,
+        pointRadius: 0,
+        yAxisID: 'y1',
+      }}
+    ]
+  }},
+  options: {{
+    responsive: true, maintainAspectRatio: false,
+    interaction: {{ mode: 'index', intersect: false }},
+    plugins: {{
+      legend: {{ labels: {{ color: tickColor, boxWidth: 12, padding: 16, font: {{ size: 11 }} }} }},
+      tooltip: {{
+        backgroundColor: '#1c2128', borderColor: '#30363d', borderWidth: 1, titleColor: '#e1e4e8', bodyColor: '#8b949e', padding: 10,
+        callbacks: {{ label: ctx => ctx.dataset.label === 'Temperature' ? `${{ctx.parsed.y.toFixed(1)}} °C` : `${{ctx.parsed.y.toFixed(3)}} kWh` }}
+      }}
+    }},
+    scales: {{
+      x: {{ grid: {{ color: gridColor }}, ticks: {{ color: tickColor, maxTicksLimit: 12, callback: function(val) {{ const l = this.getLabelForValue(val); return l.endsWith(':00') ? l : ''; }} }} }},
+      y: {{ position: 'left', grid: {{ color: gridColor }}, ticks: {{ color: blue, callback: v => v.toFixed(2) }}, title: {{ display: true, text: 'kWh', color: blue }} }},
+      y1: {{ position: 'right', grid: {{ drawOnChartArea: false }}, ticks: {{ color: orange, callback: v => v + '°' }}, title: {{ display: true, text: '°C', color: orange }} }}
+    }}
+  }}
+}});
+
+// Toggle quarter/hourly
+document.querySelectorAll('.toggle-btn').forEach(btn => {{
+  btn.addEventListener('click', () => {{
+    document.querySelectorAll('.toggle-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    const view = btn.dataset.view;
+    if (view === 'hourly') {{
+      mainChart.data.labels = hourlyData.map(d => d.hour);
+      mainChart.data.datasets[0].data = hourlyKwh;
+      mainChart.data.datasets[0].label = 'ML Prediction (hourly)';
+      const yHourly = [];
+      for (let i = 0; i < 96; i += 4) {{
+        let s = 0;
+        for (let j = 0; j < 4; j++) s += yesterdayReordered[i + j].kwh;
+        yHourly.push(s);
+      }}
+      mainChart.data.datasets[1].data = yHourly;
+      mainChart.options.scales.y.title.text = 'kWh / hour';
+    }} else {{
+      mainChart.data.labels = quarterData.map(d => d.time);
+      mainChart.data.datasets[0].data = quarterData.map(d => d.kwh);
+      mainChart.data.datasets[0].label = 'ML Prediction';
+      mainChart.data.datasets[1].data = yesterdayReordered.map(d => d.kwh);
+      mainChart.options.scales.y.title.text = 'kWh / 15min';
+    }}
+    mainChart.update();
+  }});
+}});
+
+// Feature importance bars
+const featContainer = document.getElementById('feat-bars');
+const maxImp = Math.max(...featureImportance.map(f => f[1]));
+const barColors2 = [blue, blue, orange, green, green, purple, green, '#484f58', '#484f58', '#484f58', '#484f58'];
+featureImportance.forEach(([name, imp], i) => {{
+  const pct = maxImp > 0 ? (imp / maxImp * 100) : 0;
+  const row = document.createElement('div');
+  row.className = 'feat-row';
+  row.innerHTML = `
+    <div class="feat-name">${{name.replace(/_/g, ' ')}}</div>
+    <div class="feat-bar-wrap"><div class="feat-bar" style="width:${{pct}}%; background:${{barColors2[i] || '#484f58'}}"></div></div>
+    <div class="feat-pct">${{(imp * 100).toFixed(1)}}%</div>
+  `;
+  featContainer.appendChild(row);
+}});
+</script>
+</body>
+</html>
+"""
+
+
+def _cmd_report(config: dict) -> None:
+    """Retrain model, generate predictions, and produce timestamped HTML chart."""
+    from ml.data_fetcher import fetch_history_context, fetch_weather_forecast
+    from ml.predictor import predict_with_timestamps
+    from ml.trainer import train_model
+
+    print("Retraining model...")
+    train_result = train_model(config)
+    print(f"  Train samples: {train_result['train_size']}")
+    print(f"  MAE: {train_result['metrics']['mae_kwh']:.4f} kWh")
+
+    print("Generating predictions...")
+    predictions = predict_with_timestamps(config)
+    total_kwh = sum(kwh for _, kwh in predictions)
+    print(f"  Predicted 24h total: {total_kwh:.2f} kWh")
+
+    print("Fetching weather forecast...")
+    weather_df = fetch_weather_forecast(config)
+    print(f"  Weather points: {len(weather_df)}")
+
+    print("Fetching history context...")
+    history_context = fetch_history_context(config)
+    print(f"  Yesterday total: {history_context['yesterday_total']:.2f} kWh")
+
+    print("Generating HTML chart...")
+    html = _generate_chart_html(train_result, predictions, weather_df, history_context)
+
+    output_path = Path("ml") / f"prediction_chart-{date.today().isoformat()}.html"
+    output_path.write_text(html, encoding="utf-8")
+
+    print(f"\nReport saved: {output_path}")
+    print("  Open in browser to view charts with live data")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        prog="ml",
+        description="ML Energy Consumption Predictor for BESS",
+    )
+    parser.add_argument(
+        "command",
+        choices=["train", "predict", "evaluate", "baseline", "fetch-data", "report"],
+        help="Command to execute",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to ml_config.yaml (default: ml_config.yaml in project root)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose/debug logging",
+    )
+    parser.add_argument(
+        "--target-date",
+        default=None,
+        help="End date for data window (YYYY-MM-DD). Defaults to yesterday.",
+    )
+
+    args = parser.parse_args(argv)
+    _setup_logging(args.verbose)
+
+    config = load_config(args.config)
+
+    target_date = None
+    if args.target_date:
+        target_date = date.fromisoformat(args.target_date)
+
+    if args.command == "train":
+        _cmd_train(config, target_date)
+    elif args.command == "predict":
+        _cmd_predict(config)
+    elif args.command == "evaluate":
+        _cmd_evaluate(config, target_date)
+    elif args.command == "baseline":
+        _cmd_baseline(config, target_date)
+    elif args.command == "fetch-data":
+        _cmd_fetch_data(config, target_date)
+    elif args.command == "report":
+        _cmd_report(config)

--- a/ml/config.py
+++ b/ml/config.py
@@ -1,0 +1,167 @@
+"""Configuration loading for ML energy predictor.
+
+Loads ml_config.yaml with environment variable interpolation,
+resolving ${ENV_VAR} syntax from the environment or a .env file.
+"""
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import yaml
+from dotenv import load_dotenv
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+DEFAULT_MODEL_PATH = "ml/trained_model.json"
+
+
+def _resolve_env_vars(value: str) -> str:
+    """Replace ${ENV_VAR} placeholders with environment variable values.
+
+    Raises:
+        KeyError: If an environment variable is not set.
+    """
+
+    def _replacer(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            raise KeyError(
+                f"Environment variable '{var_name}' is not set. "
+                f"Check your .env file or environment."
+            )
+        return env_value
+
+    return _ENV_VAR_PATTERN.sub(_replacer, value)
+
+
+def _resolve_recursive(obj: object) -> object:
+    """Walk a nested dict/list and resolve all string values containing ${...}."""
+    if isinstance(obj, str):
+        return _resolve_env_vars(obj)
+    if isinstance(obj, dict):
+        return {k: _resolve_recursive(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_resolve_recursive(item) for item in obj]
+    return obj
+
+
+def _build_from_app_options(app_options: dict) -> dict:
+    """Build ML config dict from the main app options (/data/options.json).
+
+    InfluxDB credentials are resolved with env-var precedence (for dev) falling
+    back to the 'influxdb' section in app_options (production / HA options.json).
+    HA credentials come from environment variables set by run.sh.
+    ML settings come from the 'ml' section.
+    The target sensor is derived from sensors.local_load_power.
+    """
+    ml = app_options["ml"]
+    sensors = app_options.get("sensors", {})
+
+    local_load = sensors.get("local_load_power", "")
+    if local_load.startswith("sensor."):
+        local_load = local_load[len("sensor.") :]
+
+    raw_feature_sensors = ml.get("feature_sensors", {})
+    feature_sensors = {
+        k: v[len("sensor.") :] if isinstance(v, str) and v.startswith("sensor.") else v
+        for k, v in raw_feature_sensors.items()
+    }
+
+    # InfluxDB: env vars take precedence (dev), fall back to app_options (production)
+    influxdb_opts = app_options.get("influxdb", {})
+    influxdb_config = {
+        "url": os.environ.get("HA_DB_URL") or influxdb_opts.get("url", ""),
+        "bucket": os.environ.get("HA_DB_BUCKET") or influxdb_opts.get("bucket", ""),
+        "username": os.environ.get("HA_DB_USER_NAME")
+        or influxdb_opts.get("username", ""),
+        "password": os.environ.get("HA_DB_PASSWORD")
+        or influxdb_opts.get("password", ""),
+    }
+
+    return {
+        "influxdb": influxdb_config,
+        "ha_api": {
+            "url": (
+                "http://supervisor/core"
+                if os.environ.get("HASSIO_TOKEN")
+                else os.environ.get("HA_URL", "http://supervisor/core")
+            ),
+            "token": os.environ.get("HASSIO_TOKEN") or os.environ.get("HA_TOKEN", ""),
+            "weather_entity": ml["weather_entity"],
+        },
+        "location": ml["location"],
+        "target": {
+            "sensor": local_load,
+            "unit": "W",
+        },
+        "feature_sensors": feature_sensors,
+        "derived_features": ml["derived_features"],
+        "history_context": ml["history_context"],
+        "training": ml["training"],
+        "model_path": DEFAULT_MODEL_PATH,
+    }
+
+
+def load_config(
+    config_path: str | None = None, app_options: dict | None = None
+) -> dict:
+    """Load and resolve the ML configuration.
+
+    When app_options is provided (the main app /data/options.json dict), the
+    config is built directly from it and no YAML file is read. This is the
+    path used by the live system.
+
+    When app_options is None, falls back to loading ml_config.yaml from disk
+    (used by the standalone CLI tools).
+
+    Args:
+        config_path: Path to ml_config.yaml for CLI use. Ignored when
+                     app_options is provided.
+        app_options: Main app options dict. When set, config is derived
+                     from the app config + environment variables.
+
+    Returns:
+        Fully resolved configuration dictionary.
+
+    Raises:
+        FileNotFoundError: If config file does not exist (CLI path only).
+        KeyError: If required environment variables are missing.
+    """
+    # Load .env file for local development (needed for env var resolution)
+    project_root = Path(__file__).resolve().parent.parent
+    dotenv_path = project_root / ".env"
+    if dotenv_path.exists():
+        load_dotenv(dotenv_path)
+        _LOGGER.debug("Loaded .env from %s", dotenv_path)
+
+    if app_options is not None:
+        if "ml" not in app_options:
+            raise KeyError(
+                "ML config section 'ml' is missing from add-on options. "
+                "Add the 'ml' section to config.yaml to use ML features."
+            )
+        _LOGGER.info("ML config built from app options")
+        return _build_from_app_options(app_options)
+
+    if config_path is None:
+        config_path = str(project_root / "ml_config.yaml")
+
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"ML config file not found: {config_path}")
+
+    with open(path) as f:
+        raw_config = yaml.safe_load(f)
+
+    resolved = _resolve_recursive(raw_config)
+    assert isinstance(resolved, dict)
+
+    resolved.setdefault("model_path", DEFAULT_MODEL_PATH)
+
+    _LOGGER.info("ML config loaded from %s", config_path)
+    return resolved

--- a/ml/data_fetcher.py
+++ b/ml/data_fetcher.py
@@ -1,0 +1,594 @@
+"""Bulk historical data fetcher from InfluxDB for ML training.
+
+Queries multiple days of sensor data and returns a pandas DataFrame
+with 15-minute aggregated readings for target and feature sensors.
+Also fetches weather forecasts from Home Assistant and history context
+from InfluxDB for prediction.
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import requests
+
+_LOGGER = logging.getLogger(__name__)
+
+UTC = ZoneInfo("UTC")
+
+QUARTER_HOUR_MINUTES = 15
+PERIODS_PER_DAY = 96
+
+
+def _get_local_tz(config: dict) -> ZoneInfo:
+    """Extract the local timezone from config."""
+    return ZoneInfo(config["location"]["timezone"])
+
+
+def _build_sensor_filter(sensors: list[str]) -> str:
+    """Build Flux sensor filter compatible with InfluxDB 1.x and 2.x."""
+    conditions = []
+    for sensor in sensors:
+        conditions.append(
+            f'(r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "{sensor}")'
+        )
+    return " or ".join(conditions)
+
+
+def _query_influxdb(
+    config: dict,
+    flux_query: str,
+    timeout: int = 60,
+) -> str:
+    """Execute a Flux query against InfluxDB and return raw CSV response.
+
+    Raises:
+        RuntimeError: If the query fails or returns no data.
+    """
+    influx_cfg = config["influxdb"]
+    url = influx_cfg["url"]
+    username = influx_cfg["username"]
+    password = influx_cfg["password"]
+
+    headers = {
+        "Content-type": "application/vnd.flux",
+        "Accept": "application/csv",
+    }
+
+    response = requests.post(
+        url=url,
+        auth=(username, password),
+        headers=headers,
+        data=flux_query,
+        timeout=timeout,
+    )
+
+    if response.status_code == 204:
+        raise RuntimeError("InfluxDB returned no data (HTTP 204)")
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"InfluxDB query failed with HTTP {response.status_code}: "
+            f"{response.text[:500]}"
+        )
+
+    return response.text
+
+
+def _parse_csv_to_dataframe(csv_text: str, local_tz: ZoneInfo) -> pd.DataFrame:
+    """Parse InfluxDB CSV response into a DataFrame with timestamp and sensor columns.
+
+    Returns a DataFrame with columns: timestamp, sensor_name, value
+    """
+    rows: list[dict[str, object]] = []
+
+    lines = csv_text.strip().split("\n")
+    data_lines = [line for line in lines if not line.startswith("#")]
+
+    # Find header row
+    col_map: dict[str, int] | None = None
+    for line in data_lines:
+        parts = [p.strip() for p in line.split(",")]
+        if "_value" in parts and "_time" in parts:
+            col_map = {name: idx for idx, name in enumerate(parts)}
+            break
+
+    if col_map is None:
+        _LOGGER.warning("No header row found in InfluxDB response")
+        return pd.DataFrame(columns=["timestamp", "sensor", "value"])
+
+    value_idx = col_map["_value"]
+    time_idx = col_map["_time"]
+    entity_id_idx = col_map.get("entity_id")
+    measurement_idx = col_map.get("_measurement")
+
+    for line in data_lines:
+        parts = line.split(",")
+        try:
+            if len(parts) <= max(value_idx, time_idx):
+                continue
+            if parts[value_idx].strip() == "_value":
+                continue
+
+            # Extract sensor name (same logic as influxdb_helper)
+            sensor_name = ""
+            if entity_id_idx is not None and entity_id_idx < len(parts):
+                entity_val = parts[entity_id_idx].strip()
+                if entity_val and entity_val != "entity_id":
+                    sensor_name = (
+                        entity_val
+                        if entity_val.startswith("sensor.")
+                        else f"sensor.{entity_val}"
+                    )
+
+            if not sensor_name and measurement_idx is not None:
+                measurement_val = parts[measurement_idx].strip()
+                if measurement_val.startswith("sensor."):
+                    sensor_name = measurement_val
+
+            if not sensor_name:
+                continue
+
+            timestamp_str = parts[time_idx].strip()
+            timestamp = datetime.fromisoformat(
+                timestamp_str.replace("Z", "+00:00")
+            ).astimezone(local_tz)
+            value = float(parts[value_idx].strip())
+
+            rows.append({"timestamp": timestamp, "sensor": sensor_name, "value": value})
+
+        except (IndexError, ValueError):
+            continue
+
+    return pd.DataFrame(rows)
+
+
+def _aggregate_to_quarters(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate raw sensor readings to 15-minute means.
+
+    Takes a long-format DataFrame (timestamp, sensor, value) and returns
+    a wide-format DataFrame indexed by quarter-hour timestamp with one
+    column per sensor.
+    """
+    if df.empty:
+        return pd.DataFrame()
+
+    # Floor timestamps to 15-minute boundaries
+    df = df.copy()
+    df["quarter"] = df["timestamp"].dt.floor(f"{QUARTER_HOUR_MINUTES}min")
+
+    # Pivot: each sensor becomes a column, aggregate by mean per quarter
+    pivoted = df.pivot_table(
+        index="quarter",
+        columns="sensor",
+        values="value",
+        aggfunc="mean",
+    )
+
+    # Sort by time
+    pivoted = pivoted.sort_index()
+
+    return pivoted
+
+
+def fetch_training_data(
+    config: dict,
+    target_date: date | None = None,
+) -> pd.DataFrame:
+    """Fetch historical sensor data for ML training.
+
+    Queries InfluxDB for the configured number of days of history,
+    aggregated to 15-minute intervals.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for the training window. Defaults to yesterday.
+
+    Returns:
+        Wide-format DataFrame indexed by quarter-hour timestamps,
+        with columns for target sensor and each feature sensor.
+        Values are raw sensor readings (W for power, °C for temp, etc.).
+
+    Raises:
+        RuntimeError: If InfluxDB query fails or returns no data.
+    """
+    local_tz = _get_local_tz(config)
+
+    if target_date is None:
+        target_date = (datetime.now(local_tz) - timedelta(days=1)).date()
+
+    days_of_history = config["training"]["days_of_history"]
+    start_date = target_date - timedelta(days=days_of_history)
+
+    # Build list of all sensors to query
+    target_sensor = config["target"]["sensor"]
+    feature_sensors = list(config["feature_sensors"].values())
+    all_sensors = [target_sensor, *feature_sensors]
+
+    _LOGGER.info(
+        "Fetching %d days of data (%s to %s) for %d sensors",
+        days_of_history,
+        start_date,
+        target_date,
+        len(all_sensors),
+    )
+
+    # Build time range
+    start_dt = datetime.combine(start_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+    end_dt = datetime.combine(target_date, datetime.max.time()).replace(tzinfo=local_tz)
+
+    start_str = start_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sensor_filter = _build_sensor_filter(all_sensors)
+    bucket = config["influxdb"]["bucket"]
+
+    # Fetch raw data points; 15-minute aggregation done in Python via _aggregate_to_quarters
+    # (InfluxDB 1.x compat mode does not support aggregateWindow)
+    flux_query = f"""from(bucket: "{bucket}")
+        |> range(start: {start_str}, stop: {end_str})
+        |> filter(fn: (r) => {sensor_filter})
+        |> filter(fn: (r) => r["_field"] == "value")
+        |> sort(columns: ["_time"])
+    """
+
+    _LOGGER.info("Executing InfluxDB query for training data...")
+    csv_text = _query_influxdb(config, flux_query, timeout=120)
+
+    # Parse CSV to DataFrame
+    raw_df = _parse_csv_to_dataframe(csv_text, local_tz)
+    _LOGGER.info(
+        "Parsed %d raw readings across %d sensors",
+        len(raw_df),
+        raw_df["sensor"].nunique() if not raw_df.empty else 0,
+    )
+
+    if raw_df.empty:
+        raise RuntimeError(
+            f"No data returned from InfluxDB for sensors {all_sensors} "
+            f"between {start_date} and {target_date}"
+        )
+
+    # Aggregate to quarter-hourly wide format
+    wide_df = _aggregate_to_quarters(raw_df)
+
+    # Rename columns from sensor.xyz to friendly names
+    column_renames = {f"sensor.{target_sensor}": "target"}
+    for feature_name, sensor_id in config["feature_sensors"].items():
+        column_renames[f"sensor.{sensor_id}"] = feature_name
+
+    wide_df = wide_df.rename(columns=column_renames)
+
+    # Forward-fill missing values (sensors may report at different rates)
+    wide_df = wide_df.ffill()
+
+    # Drop rows where target is still NaN (beginning of series before first reading)
+    wide_df = wide_df.dropna(subset=["target"])
+
+    _LOGGER.info(
+        "Training data ready: %d rows, %d columns, date range %s to %s",
+        len(wide_df),
+        len(wide_df.columns),
+        wide_df.index.min(),
+        wide_df.index.max(),
+    )
+
+    return wide_df
+
+
+def fetch_recent_data(
+    config: dict,
+    days: int = 2,
+) -> pd.DataFrame:
+    """Fetch recent sensor data for prediction context.
+
+    Fetches recent observed data from InfluxDB. Used to compute
+    history context features (yesterday's profile, weekly averages).
+
+    Args:
+        config: Resolved ML config dict.
+        days: Number of days of recent data to fetch.
+
+    Returns:
+        Wide-format DataFrame with the same column structure as fetch_training_data.
+
+    Raises:
+        RuntimeError: If InfluxDB query fails or returns insufficient data.
+    """
+    local_tz = _get_local_tz(config)
+    target_sensor = config["target"]["sensor"]
+    feature_sensors = list(config["feature_sensors"].values())
+    all_sensors = [target_sensor, *feature_sensors]
+
+    end_dt = datetime.now(local_tz)
+    start_dt = end_dt - timedelta(days=days)
+
+    start_str = start_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sensor_filter = _build_sensor_filter(all_sensors)
+    bucket = config["influxdb"]["bucket"]
+
+    flux_query = f"""from(bucket: "{bucket}")
+        |> range(start: {start_str}, stop: {end_str})
+        |> filter(fn: (r) => {sensor_filter})
+        |> filter(fn: (r) => r["_field"] == "value")
+        |> sort(columns: ["_time"])
+    """
+
+    _LOGGER.info("Fetching recent data for prediction (%d days)...", days)
+    csv_text = _query_influxdb(config, flux_query, timeout=60)
+
+    raw_df = _parse_csv_to_dataframe(csv_text, local_tz)
+    if raw_df.empty:
+        raise RuntimeError("No recent data returned from InfluxDB")
+
+    wide_df = _aggregate_to_quarters(raw_df)
+
+    # Rename columns
+    column_renames = {f"sensor.{target_sensor}": "target"}
+    for feature_name, sensor_id in config["feature_sensors"].items():
+        column_renames[f"sensor.{sensor_id}"] = feature_name
+
+    wide_df = wide_df.rename(columns=column_renames)
+    wide_df = wide_df.ffill()
+    wide_df = wide_df.dropna(subset=["target"])
+
+    _LOGGER.info(
+        "Recent data: %d rows, date range %s to %s",
+        len(wide_df),
+        wide_df.index.min(),
+        wide_df.index.max(),
+    )
+
+    return wide_df
+
+
+def fetch_weather_forecast(config: dict) -> pd.DataFrame:
+    """Fetch hourly weather forecast from Home Assistant and interpolate to 15-min.
+
+    Calls the HA REST API to get weather forecasts, then interpolates
+    hourly values to 15-minute periods.
+
+    Args:
+        config: Resolved ML config dict with ha_api section.
+
+    Returns:
+        DataFrame indexed by 15-minute timestamps with columns:
+        temperature, cloud_coverage, wind_speed, precipitation.
+
+    Raises:
+        RuntimeError: If the HA API call fails or returns unexpected data.
+    """
+    ha_cfg = config["ha_api"]
+    base_url = ha_cfg["url"].rstrip("/")
+    token = ha_cfg["token"]
+    weather_entity = ha_cfg["weather_entity"]
+
+    url = f"{base_url}/api/services/weather/get_forecasts?return_response"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "type": "hourly",
+        "entity_id": weather_entity,
+    }
+
+    _LOGGER.info("Fetching weather forecast from HA (%s)...", weather_entity)
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"HA weather forecast API failed with HTTP {response.status_code}: "
+            f"{response.text[:500]}"
+        )
+
+    data = response.json()
+
+    # Response structure: {"service_response": {"weather.entity": {"forecast": [...]}}}
+    service_response = data.get("service_response", data)
+    entity_data = service_response.get(weather_entity)
+    if entity_data is None:
+        raise RuntimeError(
+            f"No forecast data for entity '{weather_entity}' in HA response. "
+            f"Available keys: {list(service_response.keys())}"
+        )
+
+    forecasts = entity_data["forecast"]
+    if not forecasts:
+        raise RuntimeError("HA returned empty forecast list")
+
+    local_tz = _get_local_tz(config)
+    rows: list[dict] = []
+    for entry in forecasts:
+        dt_str = entry["datetime"]
+        dt = datetime.fromisoformat(dt_str).astimezone(local_tz)
+        rows.append(
+            {
+                "datetime": dt,
+                "temperature": float(entry["temperature"]),
+                "cloud_coverage": float(entry.get("cloud_coverage", 0)),
+                "wind_speed": float(entry.get("wind_speed", 0)),
+                "precipitation": float(entry.get("precipitation", 0)),
+            }
+        )
+
+    hourly_df = pd.DataFrame(rows).set_index("datetime").sort_index()
+
+    _LOGGER.info(
+        "Weather forecast: %d hourly entries from %s to %s",
+        len(hourly_df),
+        hourly_df.index.min(),
+        hourly_df.index.max(),
+    )
+
+    # Interpolate to 15-minute periods
+    # Create 15-min index spanning the forecast range
+    freq_15min = pd.Timedelta(minutes=QUARTER_HOUR_MINUTES)
+    new_index = pd.date_range(
+        start=hourly_df.index.min(),
+        end=hourly_df.index.max(),
+        freq=freq_15min,
+    )
+
+    # Reindex and interpolate
+    interpolated = hourly_df.reindex(hourly_df.index.union(new_index))
+
+    # Linear interpolation for continuous values
+    for col in ["temperature", "wind_speed", "precipitation"]:
+        interpolated[col] = interpolated[col].interpolate(method="linear")
+
+    # Forward-fill for cloud_coverage (categorical-like)
+    interpolated["cloud_coverage"] = interpolated["cloud_coverage"].ffill()
+
+    # Keep only the 15-min aligned timestamps
+    interpolated = interpolated.reindex(new_index)
+    interpolated = interpolated.ffill().bfill()
+
+    _LOGGER.info(
+        "Interpolated forecast: %d quarter-hourly entries",
+        len(interpolated),
+    )
+
+    return interpolated
+
+
+def fetch_history_context(
+    config: dict,
+    target_date: date | None = None,
+) -> dict:
+    """Fetch historical consumption context from InfluxDB.
+
+    Queries yesterday's consumption pattern and weekly averages to provide
+    context features for prediction. These are computed once and applied
+    to all 96 prediction periods.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: The date we're predicting for. Defaults to today.
+
+    Returns:
+        Dict with keys:
+        - yesterday_profile: list of 96 floats (kWh per 15min for yesterday)
+        - yesterday_total: float (total kWh yesterday)
+        - week_avg_profile: list of 96 floats (average kWh per 15min over past 7 days)
+        - recent_24h_mean: float (mean kWh per 15min over last 24h)
+
+    Raises:
+        RuntimeError: If InfluxDB query fails.
+    """
+    local_tz = _get_local_tz(config)
+
+    if target_date is None:
+        target_date = datetime.now(local_tz).date()
+
+    target_sensor = config["target"]["sensor"]
+    watts_to_kwh_15min = 1.0 / (4 * 1000)
+
+    # Fetch 8 days of target sensor data (7 full days + buffer)
+    start_date = target_date - timedelta(days=8)
+    start_dt = datetime.combine(start_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+    end_dt = datetime.combine(target_date, datetime.min.time()).replace(tzinfo=local_tz)
+
+    start_str = start_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sensor_filter = _build_sensor_filter([target_sensor])
+    bucket = config["influxdb"]["bucket"]
+
+    flux_query = f"""from(bucket: "{bucket}")
+        |> range(start: {start_str}, stop: {end_str})
+        |> filter(fn: (r) => {sensor_filter})
+        |> filter(fn: (r) => r["_field"] == "value")
+        |> sort(columns: ["_time"])
+    """
+
+    _LOGGER.info("Fetching history context (8 days ending %s)...", target_date)
+    csv_text = _query_influxdb(config, flux_query, timeout=60)
+
+    raw_df = _parse_csv_to_dataframe(csv_text, local_tz)
+    if raw_df.empty:
+        raise RuntimeError("No history context data returned from InfluxDB")
+
+    wide_df = _aggregate_to_quarters(raw_df)
+
+    # Get the target column (may be sensor.xyz format)
+    target_col = f"sensor.{target_sensor}"
+    if target_col not in wide_df.columns:
+        raise RuntimeError(
+            f"Target sensor column '{target_col}' not found in history data. "
+            f"Available columns: {list(wide_df.columns)}"
+        )
+
+    consumption = wide_df[target_col].ffill()
+
+    # Convert W to kWh/15min
+    if config["target"].get("unit") == "W":
+        consumption = consumption * watts_to_kwh_15min
+
+    # Yesterday's profile (96 values)
+    yesterday = target_date - timedelta(days=1)
+    yesterday_mask = consumption.index.date == yesterday
+    yesterday_data = consumption[yesterday_mask]
+
+    yesterday_profile = [0.0] * PERIODS_PER_DAY
+    yesterday_total = 0.0
+    if not yesterday_data.empty:
+        for i, val in enumerate(yesterday_data.values[:PERIODS_PER_DAY]):
+            yesterday_profile[i] = float(val)
+        yesterday_total = sum(yesterday_profile)
+
+    _LOGGER.info(
+        "Yesterday (%s): %d periods, total %.2f kWh",
+        yesterday,
+        sum(1 for v in yesterday_profile if v > 0),
+        yesterday_total,
+    )
+
+    # Weekly average profile (96 values averaged across 7 days)
+    week_start = target_date - timedelta(days=7)
+    week_profiles: list[list[float]] = []
+
+    for days_back in range(1, 8):
+        day = target_date - timedelta(days=days_back)
+        day_mask = consumption.index.date == day
+        day_data = consumption[day_mask]
+        if len(day_data) >= PERIODS_PER_DAY // 2:  # At least half a day
+            profile = [0.0] * PERIODS_PER_DAY
+            for i, val in enumerate(day_data.values[:PERIODS_PER_DAY]):
+                profile[i] = float(val)
+            week_profiles.append(profile)
+
+    if week_profiles:
+        week_avg_profile = [
+            sum(p[i] for p in week_profiles) / len(week_profiles)
+            for i in range(PERIODS_PER_DAY)
+        ]
+    else:
+        week_avg_profile = yesterday_profile.copy()
+
+    _LOGGER.info(
+        "Weekly average: computed from %d days (%s to %s)",
+        len(week_profiles),
+        week_start,
+        target_date - timedelta(days=1),
+    )
+
+    # Recent 24h mean
+    recent_24h = consumption.tail(PERIODS_PER_DAY)
+    recent_24h_mean = float(recent_24h.mean()) if not recent_24h.empty else 0.0
+
+    _LOGGER.info("Recent 24h mean: %.4f kWh/15min", recent_24h_mean)
+
+    return {
+        "yesterday_profile": yesterday_profile,
+        "yesterday_total": yesterday_total,
+        "week_avg_profile": week_avg_profile,
+        "recent_24h_mean": recent_24h_mean,
+    }

--- a/ml/feature_engineer.py
+++ b/ml/feature_engineer.py
@@ -1,0 +1,273 @@
+"""Feature engineering for ML energy consumption prediction.
+
+Creates a feature matrix from raw sensor DataFrames by adding
+temporal features, daylight hours, weather forecast data, and
+historical consumption context.
+"""
+
+import logging
+import math
+from datetime import date
+
+import numpy as np
+import pandas as pd
+from astral import LocationInfo
+from astral.sun import sun
+
+_LOGGER = logging.getLogger(__name__)
+
+WATTS_TO_KWH_15MIN = 1.0 / (4 * 1000)
+
+
+def _add_cyclical_encoding(
+    df: pd.DataFrame,
+    values: pd.Series,
+    name: str,
+    period: float,
+) -> pd.DataFrame:
+    """Add sin/cos cyclical encoding for a periodic feature."""
+    radians = 2 * math.pi * values / period
+    df[f"{name}_sin"] = np.sin(radians)
+    df[f"{name}_cos"] = np.cos(radians)
+    return df
+
+
+def _add_time_features(df: pd.DataFrame, config: dict) -> pd.DataFrame:
+    """Add temporal features derived from the DataFrame index."""
+    derived = config["derived_features"]
+    index = df.index
+
+    if derived.get("hour_of_day", False):
+        # Use fractional hour (0.0-23.75) for quarter-hour granularity
+        fractional_hour = index.hour + index.minute / 60.0
+        df = _add_cyclical_encoding(df, fractional_hour, "hour", 24.0)
+
+    if derived.get("day_of_week", False):
+        df = _add_cyclical_encoding(df, index.dayofweek, "dow", 7.0)
+        df["is_weekend"] = (index.dayofweek >= 5).astype(int)
+
+    return df
+
+
+def _compute_daylight_hours(
+    target_date: date, latitude: float, longitude: float, timezone: str
+) -> float:
+    """Compute daylight hours for a given date and location using astral."""
+    location = LocationInfo(
+        name="location",
+        region="",
+        timezone=timezone,
+        latitude=latitude,
+        longitude=longitude,
+    )
+    try:
+        s = sun(location.observer, date=target_date)
+        daylight_seconds = (s["sunset"] - s["sunrise"]).total_seconds()
+        return daylight_seconds / 3600.0
+    except ValueError:
+        # Polar regions: sun doesn't rise or set
+        # Return 0 for polar night, 24 for midnight sun
+        _LOGGER.warning("Could not compute sunrise/sunset for %s", target_date)
+        return 12.0
+
+
+def _add_daylight_feature(df: pd.DataFrame, config: dict) -> pd.DataFrame:
+    """Add daylight hours feature for each row based on its date."""
+    if not config["derived_features"].get("daylight_hours", False):
+        return df
+
+    latitude = config["location"]["latitude"]
+    longitude = config["location"]["longitude"]
+    timezone = config["location"]["timezone"]
+
+    # Cache daylight hours per unique date
+    unique_dates = df.index.date
+    daylight_cache: dict[date, float] = {}
+
+    daylight_values = []
+    for d in unique_dates:
+        if d not in daylight_cache:
+            daylight_cache[d] = _compute_daylight_hours(d, latitude, longitude, timezone)
+        daylight_values.append(daylight_cache[d])
+
+    df["daylight_hours"] = daylight_values
+    return df
+
+
+def _add_weather_features(
+    df: pd.DataFrame,
+    weather_df: pd.DataFrame | None,
+) -> pd.DataFrame:
+    """Merge weather forecast columns into feature DataFrame by timestamp.
+
+    During training, weather_df is None and observed outdoor_temperature
+    from InfluxDB is used as a proxy for forecast temperature.
+
+    During prediction, weather_df contains actual forecast data with
+    columns: temperature, cloud_coverage, wind_speed, precipitation.
+    """
+    if weather_df is not None:
+        # Prediction mode: merge forecast data by nearest timestamp
+        for col in ["temperature", "cloud_coverage", "wind_speed", "precipitation"]:
+            if col in weather_df.columns:
+                # Align by finding nearest timestamp within 15 min
+                merged = pd.merge_asof(
+                    df[[]]
+                    .reset_index()
+                    .rename(columns={df.index.name or "index": "timestamp"}),
+                    weather_df[[col]]
+                    .reset_index()
+                    .rename(columns={weather_df.index.name or "index": "timestamp"}),
+                    on="timestamp",
+                    direction="nearest",
+                    tolerance=pd.Timedelta(minutes=30),
+                )
+                df[col] = merged[col].values
+
+        _LOGGER.info(
+            "Added weather forecast features: %s",
+            [
+                c
+                for c in [
+                    "temperature",
+                    "cloud_coverage",
+                    "wind_speed",
+                    "precipitation",
+                ]
+                if c in df.columns
+            ],
+        )
+    else:
+        # Training mode: use observed outdoor_temperature as proxy for forecast
+        if "outdoor_temperature" in df.columns:
+            df["temperature"] = df["outdoor_temperature"]
+            _LOGGER.info(
+                "Using observed outdoor_temperature as training proxy for forecast"
+            )
+
+    return df
+
+
+def _add_history_context_features(
+    df: pd.DataFrame,
+    history_context: dict | None,
+) -> pd.DataFrame:
+    """Add historical consumption context features.
+
+    These features represent "what happened recently" and are computed
+    once from InfluxDB before prediction (not iteratively).
+
+    Features added:
+    - yesterday_same_hour: consumption at same quarter yesterday
+    - yesterday_total: total kWh yesterday (scalar, same for all rows)
+    - week_avg_same_hour: average consumption at same quarter over past week
+    - recent_24h_mean: mean kWh/15min over last 24h (scalar, same for all rows)
+    """
+    if history_context is None:
+        return df
+
+    yesterday_profile = history_context["yesterday_profile"]
+    week_avg_profile = history_context["week_avg_profile"]
+
+    # Map each row to its quarter-of-day index (0-95)
+    quarter_indices = df.index.hour * 4 + df.index.minute // 15
+
+    # yesterday_same_hour: what was consumption at this time yesterday
+    df["yesterday_same_hour"] = [
+        yesterday_profile[min(qi, len(yesterday_profile) - 1)] for qi in quarter_indices
+    ]
+
+    # yesterday_total: scalar context
+    df["yesterday_total"] = history_context["yesterday_total"]
+
+    # week_avg_same_hour: average at this time over the past week
+    df["week_avg_same_hour"] = [
+        week_avg_profile[min(qi, len(week_avg_profile) - 1)] for qi in quarter_indices
+    ]
+
+    # recent_24h_mean: scalar context
+    df["recent_24h_mean"] = history_context["recent_24h_mean"]
+
+    _LOGGER.info(
+        "Added history context features: yesterday_total=%.2f kWh, "
+        "recent_24h_mean=%.4f kWh/15min",
+        history_context["yesterday_total"],
+        history_context["recent_24h_mean"],
+    )
+
+    return df
+
+
+def engineer_features(
+    raw_df: pd.DataFrame,
+    config: dict,
+    convert_target_to_kwh: bool = True,
+    weather_df: pd.DataFrame | None = None,
+    history_context: dict | None = None,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Create feature matrix from raw sensor DataFrame.
+
+    Takes a wide-format DataFrame (from data_fetcher) with columns like
+    'target', 'outdoor_temperature' and adds all derived features
+    specified in config.
+
+    Args:
+        raw_df: Wide-format DataFrame indexed by quarter-hour timestamps.
+                Must contain a 'target' column with consumption values.
+        config: Resolved ML config dict.
+        convert_target_to_kwh: If True, convert target from Watts to kWh/15min.
+        weather_df: Optional weather forecast DataFrame for prediction mode.
+                    None during training (uses observed temperature as proxy).
+        history_context: Optional dict from fetch_history_context().
+                         None during training (computed per-day in trainer).
+
+    Returns:
+        Tuple of (feature_df, feature_columns) where:
+        - feature_df has both features and 'target' column
+        - feature_columns lists only the feature column names (not target)
+    """
+    df = raw_df.copy()
+
+    # Convert target from W to kWh per 15-min period if needed
+    if convert_target_to_kwh and config["target"].get("unit") == "W":
+        df["target"] = df["target"] * WATTS_TO_KWH_15MIN
+
+    # Add temporal features
+    df = _add_time_features(df, config)
+
+    # Add daylight hours
+    df = _add_daylight_feature(df, config)
+
+    # Add weather features (forecast in prediction, observed proxy in training)
+    df = _add_weather_features(df, weather_df)
+
+    # Add history context features
+    df = _add_history_context_features(df, history_context)
+
+    # Drop raw sensor columns that shouldn't be features
+    columns_to_drop = ["outdoor_temperature"]
+    for col in columns_to_drop:
+        if col in df.columns and col != "temperature":
+            df = df.drop(columns=[col])
+
+    # Identify feature columns (everything except 'target')
+    feature_columns = [col for col in df.columns if col != "target"]
+
+    # Drop rows where any feature is NaN
+    rows_before = len(df)
+    df = df.dropna(subset=feature_columns)
+    rows_dropped = rows_before - len(df)
+    if rows_dropped > 0:
+        _LOGGER.info(
+            "Dropped %d rows with incomplete features",
+            rows_dropped,
+        )
+
+    _LOGGER.info(
+        "Engineered %d features from %d rows: %s",
+        len(feature_columns),
+        len(df),
+        feature_columns,
+    )
+
+    return df, feature_columns

--- a/ml/predictor.py
+++ b/ml/predictor.py
@@ -1,0 +1,186 @@
+"""Prediction module for ML energy consumption forecasting.
+
+Loads a trained XGBoost model and generates 96 quarter-hourly
+consumption predictions using direct multi-output prediction:
+a single model.predict(X) call on a pre-built 96-row feature matrix.
+
+Each row contains only features known ahead of time:
+- Time features (deterministic)
+- Weather forecast (from Home Assistant)
+- Historical context (from InfluxDB, computed once)
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from xgboost import XGBRegressor
+
+from ml.data_fetcher import (
+    PERIODS_PER_DAY,
+    fetch_history_context,
+    fetch_weather_forecast,
+)
+from ml.feature_engineer import engineer_features
+
+_LOGGER = logging.getLogger(__name__)
+
+QUARTER_MINUTES = 15
+
+
+def _build_future_timestamps(
+    config: dict, periods: int = PERIODS_PER_DAY
+) -> pd.DatetimeIndex:
+    """Generate 96 future 15-minute timestamps starting from the next quarter hour."""
+    from ml.data_fetcher import _get_local_tz
+
+    now = datetime.now(_get_local_tz(config))
+
+    # Round up to next quarter hour
+    minutes = now.minute
+    next_quarter = minutes + (QUARTER_MINUTES - minutes % QUARTER_MINUTES)
+    start = now.replace(minute=0, second=0, microsecond=0) + pd.Timedelta(
+        minutes=next_quarter
+    )
+
+    return pd.date_range(start=start, periods=periods, freq="15min")
+
+
+def _build_prediction_dataframe(
+    future_timestamps: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """Build a raw DataFrame for the 96 future periods.
+
+    Creates a DataFrame indexed by future timestamps with a dummy 'target'
+    column (NaN, since we're predicting it). Weather and history context
+    features are added during feature engineering.
+    """
+    df = pd.DataFrame(index=future_timestamps)
+    df.index.name = None
+
+    # Target is what we're predicting - use NaN placeholder
+    df["target"] = np.nan
+
+    return df
+
+
+def predict_next_24h(config: dict) -> list[float]:
+    """Generate 96 quarter-hourly consumption predictions.
+
+    Uses direct multi-output prediction: builds a 96-row feature matrix
+    with time features, weather forecast, and history context, then makes
+    a single model.predict(X) call.
+
+    Args:
+        config: Resolved ML config dict.
+
+    Returns:
+        List of 96 float values representing predicted consumption
+        in kWh per 15-minute period. This format matches what
+        battery_system_manager.optimize_battery_schedule() expects
+        for the home_consumption parameter.
+
+    Raises:
+        FileNotFoundError: If no trained model exists.
+        RuntimeError: If data fetching fails.
+    """
+    model_path = config["model_path"]
+    if not Path(model_path).exists():
+        raise FileNotFoundError(
+            f"No trained model found at {model_path}. Run 'train' first."
+        )
+
+    # Load feature column names
+    feature_meta_path = str(Path(model_path).with_suffix(".features.txt"))
+    if not Path(feature_meta_path).exists():
+        raise FileNotFoundError(
+            f"Feature metadata not found at {feature_meta_path}. Retrain the model."
+        )
+
+    with open(feature_meta_path) as f:
+        feature_columns = [line.strip() for line in f.readlines() if line.strip()]
+
+    _LOGGER.info("Loading model from %s", model_path)
+    model = XGBRegressor()
+    model.load_model(model_path)
+    _LOGGER.info("Using %d features: %s", len(feature_columns), feature_columns)
+
+    # Step 1: Generate future timestamps
+    future_ts = _build_future_timestamps(config)
+    _LOGGER.info(
+        "Predicting %d periods: %s to %s",
+        len(future_ts),
+        future_ts[0],
+        future_ts[-1],
+    )
+
+    # Step 2: Fetch weather forecast from HA
+    _LOGGER.info("Fetching weather forecast from Home Assistant...")
+    weather_df = fetch_weather_forecast(config)
+
+    # Step 3: Fetch history context from InfluxDB
+    _LOGGER.info("Fetching history context from InfluxDB...")
+    history_context = fetch_history_context(config)
+
+    # Step 4: Build raw DataFrame for future periods
+    raw_df = _build_prediction_dataframe(future_ts)
+
+    # Step 5: Engineer features (weather + history context + time features)
+    feature_df, _ = engineer_features(
+        raw_df,
+        config,
+        convert_target_to_kwh=False,
+        weather_df=weather_df,
+        history_context=history_context,
+    )
+
+    # Ensure feature columns match training order
+    missing_cols = set(feature_columns) - set(feature_df.columns)
+    if missing_cols:
+        raise RuntimeError(
+            f"Feature mismatch: model expects {missing_cols} but they are missing "
+            f"from prediction features. Available: {list(feature_df.columns)}"
+        )
+
+    X = feature_df[feature_columns].values
+
+    # Step 6: Single predict call
+    _LOGGER.info("Running model.predict() on %d-row feature matrix...", len(X))
+    predictions = model.predict(X)
+
+    # Clamp to non-negative (consumption can't be negative)
+    predictions = np.maximum(predictions, 0.0)
+
+    result = predictions.tolist()
+
+    # Log summary statistics
+    total_kwh = sum(result)
+    _LOGGER.info(
+        "Prediction summary: total %.2f kWh, "
+        "min %.3f kWh, max %.3f kWh, mean %.3f kWh per 15min",
+        total_kwh,
+        min(result),
+        max(result),
+        total_kwh / len(result),
+    )
+
+    return result
+
+
+def predict_with_timestamps(config: dict) -> list[tuple[datetime, float]]:
+    """Generate predictions with their associated timestamps.
+
+    Convenience wrapper that pairs each prediction with its timestamp.
+
+    Returns:
+        List of (datetime, kWh) tuples for 96 quarter-hourly periods.
+    """
+    future_ts = _build_future_timestamps(config)
+    predictions = predict_next_24h(config)
+
+    return [
+        (ts.to_pydatetime(), pred)
+        for ts, pred in zip(future_ts, predictions, strict=True)
+    ]

--- a/ml/trainer.py
+++ b/ml/trainer.py
@@ -1,0 +1,460 @@
+"""Model training and evaluation for ML energy consumption prediction.
+
+Orchestrates the full training pipeline: fetch data, engineer features,
+train XGBoost model, evaluate with baseline comparisons, and persist to disk.
+"""
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from xgboost import XGBRegressor
+
+from ml.data_fetcher import PERIODS_PER_DAY, fetch_training_data
+from ml.feature_engineer import WATTS_TO_KWH_15MIN, engineer_features
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _temporal_train_test_split(
+    df: pd.DataFrame,
+    feature_columns: list[str],
+    test_fraction: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Split data by time: last test_fraction of rows become test set.
+
+    This avoids data leakage from future values that random splitting would cause.
+
+    Returns:
+        (X_train, X_test, y_train, y_test) as numpy arrays.
+    """
+    split_idx = int(len(df) * (1 - test_fraction))
+
+    train_df = df.iloc[:split_idx]
+    test_df = df.iloc[split_idx:]
+
+    X_train = train_df[feature_columns].values
+    X_test = test_df[feature_columns].values
+    y_train = train_df["target"].values
+    y_test = test_df["target"].values
+
+    _LOGGER.info(
+        "Temporal split: %d train rows, %d test rows (%.0f%% test)",
+        len(train_df),
+        len(test_df),
+        test_fraction * 100,
+    )
+
+    return X_train, X_test, y_train, y_test
+
+
+def _compute_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> dict[str, float]:
+    """Compute regression metrics for model evaluation."""
+    mae = mean_absolute_error(y_true, y_pred)
+    rmse = float(np.sqrt(mean_squared_error(y_true, y_pred)))
+    r2 = r2_score(y_true, y_pred)
+
+    # MAPE - avoid division by zero
+    nonzero_mask = y_true != 0
+    if nonzero_mask.any():
+        mape = float(
+            np.mean(
+                np.abs(
+                    (y_true[nonzero_mask] - y_pred[nonzero_mask]) / y_true[nonzero_mask]
+                )
+            )
+            * 100
+        )
+    else:
+        mape = float("inf")
+
+    return {
+        "mae_kwh": round(mae, 4),
+        "rmse_kwh": round(rmse, 4),
+        "r_squared": round(r2, 4),
+        "mape_percent": round(mape, 2),
+    }
+
+
+def _get_feature_importance(
+    model: XGBRegressor,
+    feature_columns: list[str],
+) -> list[tuple[str, float]]:
+    """Extract and sort feature importance from trained model."""
+    importances = model.feature_importances_
+    feature_imp = list(zip(feature_columns, importances, strict=True))
+    feature_imp.sort(key=lambda x: x[1], reverse=True)
+    return feature_imp
+
+
+def _compute_per_day_history_context(
+    raw_df: pd.DataFrame,
+    target_date: date,
+    config: dict,
+) -> dict:
+    """Compute history context for a specific day from training data.
+
+    During training, we compute history context relative to each day
+    in the training set, using earlier data as the "history".
+
+    Args:
+        raw_df: Full training DataFrame with 'target' column (in raw units).
+        target_date: The day we need context for.
+        config: ML config dict.
+
+    Returns:
+        History context dict matching fetch_history_context() format.
+    """
+    # Convert target to kWh if needed
+    target_col = raw_df["target"]
+    if config["target"].get("unit") == "W":
+        target_col = target_col * WATTS_TO_KWH_15MIN
+
+    # Yesterday's profile
+    yesterday = target_date - timedelta(days=1)
+    yesterday_mask = target_col.index.date == yesterday
+    yesterday_data = target_col[yesterday_mask]
+
+    yesterday_profile = [0.0] * PERIODS_PER_DAY
+    if not yesterday_data.empty:
+        for i, val in enumerate(yesterday_data.values[:PERIODS_PER_DAY]):
+            yesterday_profile[i] = float(val)
+
+    yesterday_total = sum(yesterday_profile)
+
+    # Weekly average profile
+    week_profiles: list[list[float]] = []
+    for days_back in range(1, 8):
+        day = target_date - timedelta(days=days_back)
+        day_mask = target_col.index.date == day
+        day_data = target_col[day_mask]
+        if len(day_data) >= PERIODS_PER_DAY // 2:
+            profile = [0.0] * PERIODS_PER_DAY
+            for i, val in enumerate(day_data.values[:PERIODS_PER_DAY]):
+                profile[i] = float(val)
+            week_profiles.append(profile)
+
+    if week_profiles:
+        week_avg_profile = [
+            sum(p[i] for p in week_profiles) / len(week_profiles)
+            for i in range(PERIODS_PER_DAY)
+        ]
+    else:
+        week_avg_profile = yesterday_profile.copy()
+
+    # Recent 24h mean (from data up to start of target_date)
+    cutoff = pd.Timestamp(target_date, tz=target_col.index.tz)
+    recent = target_col[target_col.index < cutoff].tail(PERIODS_PER_DAY)
+    recent_24h_mean = float(recent.mean()) if not recent.empty else 0.0
+
+    return {
+        "yesterday_profile": yesterday_profile,
+        "yesterday_total": yesterday_total,
+        "week_avg_profile": week_avg_profile,
+        "recent_24h_mean": recent_24h_mean,
+    }
+
+
+def _add_history_context_to_training_data(
+    raw_df: pd.DataFrame,
+    config: dict,
+) -> pd.DataFrame:
+    """Add per-day history context columns to training data.
+
+    For each unique day in the training data, computes history context
+    from earlier days and adds the context columns.
+
+    Returns:
+        DataFrame with history context columns added.
+    """
+    target_col = raw_df["target"]
+    if config["target"].get("unit") == "W":
+        target_col = target_col * WATTS_TO_KWH_15MIN
+
+    unique_dates = sorted(set(raw_df.index.date))
+
+    # Pre-compute context for each day
+    context_cache: dict[date, dict] = {}
+    for d in unique_dates:
+        context_cache[d] = _compute_per_day_history_context(raw_df, d, config)
+
+    # Build columns
+    yesterday_same_hour = []
+    yesterday_total_vals = []
+    week_avg_same_hour = []
+    recent_24h_mean_vals = []
+
+    for ts in raw_df.index:
+        d = ts.date()
+        qi = ts.hour * 4 + ts.minute // 15
+        ctx = context_cache[d]
+
+        yesterday_same_hour.append(
+            ctx["yesterday_profile"][min(qi, PERIODS_PER_DAY - 1)]
+        )
+        yesterday_total_vals.append(ctx["yesterday_total"])
+        week_avg_same_hour.append(ctx["week_avg_profile"][min(qi, PERIODS_PER_DAY - 1)])
+        recent_24h_mean_vals.append(ctx["recent_24h_mean"])
+
+    result = raw_df.copy()
+    result["yesterday_same_hour"] = yesterday_same_hour
+    result["yesterday_total"] = yesterday_total_vals
+    result["week_avg_same_hour"] = week_avg_same_hour
+    result["recent_24h_mean"] = recent_24h_mean_vals
+
+    _LOGGER.info(
+        "Added history context for %d unique days in training data",
+        len(unique_dates),
+    )
+
+    return result
+
+
+def _compute_baseline_metrics(
+    feature_df: pd.DataFrame,
+    test_fraction: float,
+) -> dict[str, dict[str, float]]:
+    """Compute naive baseline metrics on the test set.
+
+    Baselines:
+    - same_as_yesterday: predict today = yesterday's same quarter
+    - hourly_mean: predict each quarter = historical mean for that quarter-of-day
+    - flat_estimate: predict every quarter = overall mean of training data
+
+    Returns:
+        Dict mapping baseline name to metrics dict.
+    """
+    split_idx = int(len(feature_df) * (1 - test_fraction))
+    train_df = feature_df.iloc[:split_idx]
+    test_df = feature_df.iloc[split_idx:]
+
+    y_test = test_df["target"].values
+    baselines: dict[str, dict[str, float]] = {}
+
+    # Baseline 1: Same as yesterday
+    if "yesterday_same_hour" in test_df.columns:
+        y_yesterday = test_df["yesterday_same_hour"].values
+        baselines["same_as_yesterday"] = _compute_metrics(y_test, y_yesterday)
+
+    # Baseline 2: Hourly mean (average by quarter-of-day from training set)
+    train_quarters = train_df.index.hour * 4 + train_df.index.minute // 15
+    quarter_means = train_df.assign(qi=train_quarters).groupby("qi")["target"].mean()
+
+    test_quarters = test_df.index.hour * 4 + test_df.index.minute // 15
+    y_hourly_mean = np.array(
+        [quarter_means.get(qi, train_df["target"].mean()) for qi in test_quarters]
+    )
+    baselines["hourly_mean"] = _compute_metrics(y_test, y_hourly_mean)
+
+    # Baseline 3: Flat estimate (overall training mean)
+    overall_mean = train_df["target"].mean()
+    y_flat = np.full_like(y_test, overall_mean)
+    baselines["flat_estimate"] = _compute_metrics(y_test, y_flat)
+
+    return baselines
+
+
+def train_model(config: dict, target_date: date | None = None) -> dict:
+    """Full training pipeline: fetch, engineer, train, evaluate, save.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for training window. Defaults to yesterday.
+
+    Returns:
+        Dict with keys: metrics, baselines, feature_importance, model_path,
+        train_size, test_size.
+
+    Raises:
+        RuntimeError: If data fetching or training fails.
+    """
+    # Step 1: Fetch historical data
+    _LOGGER.info("Step 1/5: Fetching training data from InfluxDB...")
+    raw_df = fetch_training_data(config, target_date=target_date)
+
+    # Step 2: Add per-day history context to training data
+    _LOGGER.info("Step 2/5: Computing per-day history context...")
+    raw_with_context = _add_history_context_to_training_data(raw_df, config)
+
+    # Step 3: Engineer features (no weather_df for training - uses observed temp)
+    _LOGGER.info("Step 3/5: Engineering features...")
+    feature_df, feature_columns = engineer_features(
+        raw_with_context, config, history_context=None
+    )
+
+    min_samples = 20
+    if len(feature_df) < min_samples:
+        raise RuntimeError(
+            f"Insufficient training data: {len(feature_df)} samples "
+            f"(minimum {min_samples}). Need more days of InfluxDB history."
+        )
+
+    # Step 4: Train/test split and model training
+    _LOGGER.info("Step 4/5: Training XGBoost model...")
+    test_fraction = config["training"]["test_split"]
+    X_train, X_test, y_train, y_test = _temporal_train_test_split(
+        feature_df, feature_columns, test_fraction
+    )
+
+    model_params = config["training"]["model_params"]
+    model = XGBRegressor(
+        n_estimators=model_params["n_estimators"],
+        max_depth=model_params["max_depth"],
+        learning_rate=model_params["learning_rate"],
+        min_child_weight=model_params["min_child_weight"],
+        random_state=42,
+        objective="reg:squarederror",
+    )
+
+    model.fit(
+        X_train,
+        y_train,
+        verbose=False,
+    )
+
+    # Step 5: Evaluate, compute baselines, and save
+    _LOGGER.info("Step 5/5: Evaluating model and computing baselines...")
+    y_pred = model.predict(X_test)
+    metrics = _compute_metrics(y_test, y_pred)
+    feature_importance = _get_feature_importance(model, feature_columns)
+    baselines = _compute_baseline_metrics(feature_df, test_fraction)
+
+    # Save model
+    model_path = config["model_path"]
+    Path(model_path).parent.mkdir(parents=True, exist_ok=True)
+    model.save_model(model_path)
+
+    # Save feature column names alongside model for prediction
+    feature_meta_path = str(Path(model_path).with_suffix(".features.txt"))
+    with open(feature_meta_path, "w") as f:
+        f.write("\n".join(feature_columns))
+
+    _LOGGER.info("Model saved to %s", model_path)
+    _LOGGER.info("Feature metadata saved to %s", feature_meta_path)
+
+    # Save training report sidecar for the web UI
+    report_data = {
+        "trained_at": datetime.now().isoformat(),
+        "train_size": len(X_train),
+        "test_size": len(X_test),
+        "metrics": metrics,
+        "baselines": baselines,
+        "feature_importance": [
+            {"name": name, "importance": round(float(imp), 6)}
+            for name, imp in feature_importance
+        ],
+    }
+    report_path = str(Path(model_path).with_suffix(".report.json"))
+    with open(report_path, "w") as f:
+        json.dump(report_data, f, indent=2)
+    _LOGGER.info("Training report saved to %s", report_path)
+
+    return {
+        "metrics": metrics,
+        "baselines": baselines,
+        "feature_importance": feature_importance,
+        "model_path": model_path,
+        "train_size": len(X_train),
+        "test_size": len(X_test),
+    }
+
+
+def evaluate_model(config: dict, target_date: date | None = None) -> dict:
+    """Load a trained model and evaluate on recent test data.
+
+    Uses the same training data but only evaluates the test split,
+    useful for checking model performance without retraining.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for evaluation window. Defaults to yesterday.
+
+    Returns:
+        Dict with metrics and per-period analysis.
+
+    Raises:
+        FileNotFoundError: If no trained model exists.
+        RuntimeError: If data fetching fails.
+    """
+    model_path = config["model_path"]
+    if not Path(model_path).exists():
+        raise FileNotFoundError(
+            f"No trained model found at {model_path}. Run 'train' first."
+        )
+
+    # Load model
+    model = XGBRegressor()
+    model.load_model(model_path)
+
+    # Fetch and prepare test data
+    raw_df = fetch_training_data(config, target_date=target_date)
+    raw_with_context = _add_history_context_to_training_data(raw_df, config)
+    feature_df, feature_columns = engineer_features(
+        raw_with_context, config, history_context=None
+    )
+
+    test_fraction = config["training"]["test_split"]
+    _, X_test, _, y_test = _temporal_train_test_split(
+        feature_df, feature_columns, test_fraction
+    )
+
+    y_pred = model.predict(X_test)
+    metrics = _compute_metrics(y_test, y_pred)
+
+    # Per-hour analysis: average error by hour of day
+    split_idx = int(len(feature_df) * (1 - test_fraction))
+    test_df = feature_df.iloc[split_idx:].copy()
+    test_df["predicted"] = y_pred
+    test_df["error"] = test_df["predicted"] - test_df["target"]
+    test_df["abs_error"] = test_df["error"].abs()
+    test_df["hour"] = test_df.index.hour
+
+    hourly_errors = (
+        test_df.groupby("hour")
+        .agg(
+            mean_error=pd.NamedAgg(column="error", aggfunc="mean"),
+            mae=pd.NamedAgg(column="abs_error", aggfunc="mean"),
+            count=pd.NamedAgg(column="error", aggfunc="count"),
+        )
+        .round(4)
+    )
+
+    return {
+        "metrics": metrics,
+        "hourly_errors": hourly_errors.to_dict("index"),
+        "test_size": len(X_test),
+    }
+
+
+def compute_baselines(config: dict, target_date: date | None = None) -> dict:
+    """Compute baseline metrics on the test set without training a model.
+
+    Fetches data, engineers features (to get history context columns),
+    then computes naive baseline metrics.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for data window. Defaults to yesterday.
+
+    Returns:
+        Dict with baseline metrics for each heuristic.
+
+    Raises:
+        RuntimeError: If data fetching fails.
+    """
+    raw_df = fetch_training_data(config, target_date=target_date)
+    raw_with_context = _add_history_context_to_training_data(raw_df, config)
+    feature_df, _ = engineer_features(raw_with_context, config, history_context=None)
+
+    test_fraction = config["training"]["test_split"]
+    baselines = _compute_baseline_metrics(feature_df, test_fraction)
+
+    return {
+        "baselines": baselines,
+        "total_samples": len(feature_df),
+        "test_samples": int(len(feature_df) * test_fraction),
+    }


### PR DESCRIPTION
## Summary

Adds an optional `ml_prediction` consumption strategy using XGBoost to predict 24h energy consumption at 15-minute resolution. **Depends on #33** (configurable consumption strategies).

### What's included

- Complete ML module (`ml/`) with training, prediction, feature engineering, and standalone CLI
- ML Report dashboard page showing model metrics, feature importance, and forecast comparison chart
- Daily model retrain scheduler (23:00)
- `/api/ml-report` endpoint for the dashboard
- Docker base image switch from Alpine 3.19 to Debian Bookworm (required for xgboost/scikit-learn wheels)

### Honest assessment

**This is experimental.** In my testing so far, the ML predictions are roughly on par with or slightly worse than the simpler `influxdb_7d_avg` strategy from #33. The model also:

- Adds significant startup time (retrain on boot ~3-5s, weather forecast fetch ~1s)
- Pulls in heavy dependencies: xgboost (~150MB), scikit-learn (~30MB), astral
- Requires switching from Alpine to Debian base image
- Needs weather entity and InfluxDB configured

That said, it's a fun playground for experimenting with consumption prediction, and the ML Report page gives good visibility into how well (or poorly) the model performs compared to baselines.

**I'd completely understand if this isn't something that belongs in core.** The `influxdb_7d_avg` strategy in #33 is more practical for production use.

### Config example

```yaml
home:
  consumption_strategy: "ml_prediction"
ml:
  location:
    latitude: 59.3293
    longitude: 18.0686
    timezone: "Europe/Stockholm"
  weather_entity: "weather.forecast_home"
  feature_sensors:
    outdoor_temperature: "sensor.outdoor_temperature"
  training:
    days_of_history: 30
```

## Test plan

- [ ] Verify ML model trains on boot when `ml` config is present
- [ ] Verify ML Report page shows metrics, feature importance, and chart
- [ ] Test `ml_prediction` strategy produces 96-period forecast
- [ ] Verify fallback to `fixed` when `ml` config section is missing
- [ ] Test daily retrain scheduler fires at 23:00
- [ ] Verify system starts correctly when `ml` section is absent (no ML features loaded)