### PR TITLE
Fix Battery Mode Schedule tooltip times and current-time marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.6.3] - 2026-03-08
+
+### Fixed
+
+- Battery Mode Schedule tooltip showing incorrect times for sub-hour slot boundaries (e.g. 22:30 displayed as 22:00). The `formatHour` function now extracts minutes from fractional hours.
+- Current-time marker on Battery Mode Schedule positioned at start of hour regardless of minutes elapsed. Now uses fractional hours for accurate placement within the hour.
+
 ## [7.6.2] - 2026-03-07
 
 ### Changed

--- a/frontend/src/components/BatteryModeTimeline.tsx
+++ b/frontend/src/components/BatteryModeTimeline.tsx
@@ -76,7 +76,8 @@ function buildSegments(
 
 function formatHour(hour: number): string {
   const h = Math.floor(hour) % 24;
-  return h.toString().padStart(2, '0') + ':00';
+  const m = Math.round((hour - Math.floor(hour)) * 60);
+  return h.toString().padStart(2, '0') + ':' + m.toString().padStart(2, '0');
 }
 
 export const BatteryModeTimeline: React.FC<BatteryModeTimelineProps> = ({

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -195,7 +195,8 @@ export default function DashboardPage({
   // Check if we have valid dashboard data
   const hasValidData = dashboardData && dashboardData.hourlyData && dashboardData.hourlyData.length > 0;
   const hasPartialData = dashboardData && dashboardData.error === 'incomplete_data';
-  const currentHour = new Date().getHours();
+  const now = new Date();
+  const currentHour = now.getHours() + now.getMinutes() / 60;
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary

- Fix `formatHour` to correctly display sub-hour slot boundaries (e.g. 22:30 was showing as 22:00)
- Fix current-time marker to use fractional hours for accurate placement within the hour (was snapping to start of hour)

## Test plan

- [ ] Hover over a schedule slot that starts/ends at a non-hour boundary (e.g. 22:30) — tooltip should show correct minutes
- [ ] Check the "now" marker line matches the actual current time, not just the start of the hour