### PR TITLE
Add configurable single/three-phase electricity support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.8.0] - 2026-03-09
+
+### Added
+
+- Configurable single/three-phase electricity support via `home.phase_count` setting (1 or 3, default 3). Single-phase systems (common in the UK) no longer incorrectly divide battery power by 3, which was underestimating phase load and reducing fuse protection effectiveness. (thanks [@pookey](https://github.com/pookey))
+- Pass through `max_fuse_current`, `voltage`, and `safety_margin_factor` from config.yaml to the settings system — these were previously defined in config but stayed at defaults.
+
+### Changed
+
+- Power monitor health check adapts to phase count: single-phase systems only require L1 current sensor, not L2/L3.
+- Power monitor logging adapts to show one or three phases depending on configuration.
+
 ## [7.7.0] - 2026-03-09
 
 ### Added

--- a/backend/app.py
+++ b/backend/app.py
@@ -358,6 +358,10 @@ class BESSController:
                 "home": {
                     "defaultHourly": home_config["consumption"],
                     "currency": home_config["currency"],
+                    "maxFuseCurrent": home_config.get("max_fuse_current", 25),
+                    "voltage": home_config.get("voltage", 230),
+                    "safetyMargin": home_config.get("safety_margin_factor", 1.0),
+                    "phaseCount": home_config.get("phase_count", 3),
                 },
                 "price": {
                     "area": electricity_price_config["area"],

--- a/backend/app.py
+++ b/backend/app.py
@@ -336,7 +336,14 @@ class BESSController:
                     )
 
             # Required home settings
-            required_home_keys = ["consumption", "currency"]
+            required_home_keys = [
+                "consumption",
+                "currency",
+                "max_fuse_current",
+                "voltage",
+                "safety_margin_factor",
+                "phase_count",
+            ]
             for key in required_home_keys:
                 if key not in home_config:
                     raise ValueError(
@@ -358,10 +365,10 @@ class BESSController:
                 "home": {
                     "defaultHourly": home_config["consumption"],
                     "currency": home_config["currency"],
-                    "maxFuseCurrent": home_config.get("max_fuse_current", 25),
-                    "voltage": home_config.get("voltage", 230),
-                    "safetyMargin": home_config.get("safety_margin_factor", 1.0),
-                    "phaseCount": home_config.get("phase_count", 3),
+                    "maxFuseCurrent": home_config["max_fuse_current"],
+                    "voltage": home_config["voltage"],
+                    "safetyMargin": home_config["safety_margin_factor"],
+                    "phaseCount": home_config["phase_count"],
                 },
                 "price": {
                     "area": electricity_price_config["area"],

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "7.7.0"
+version: "7.8.0"
 slug: "bess_manager"
 init: false
 arch:
@@ -33,6 +33,7 @@ options:
     max_fuse_current: 25            # Maximum fuse current in amperes
     voltage: 230                    # Line voltage in volts
     safety_margin_factor: 1.0       # Safety margin for power calculations (100% - safe with 5min monitoring)
+    phase_count: 3                  # Number of electrical phases (1 for single-phase, 3 for three-phase)
   battery:
     total_capacity: 30.0             # kWh
     min_soc: 15                      # Minimum state of charge (%) - synced to inverter on startup
@@ -120,6 +121,7 @@ schema:
     max_fuse_current: int
     voltage: int
     safety_margin_factor: float
+    phase_count: int
   battery:
     total_capacity: float
     min_soc: float

--- a/core/bess/power_monitor.py
+++ b/core/bess/power_monitor.py
@@ -3,7 +3,7 @@
 It does this by:
 
 1. Power Monitoring:
-   - Continuously monitors current draw on all three phases
+   - Continuously monitors current draw on electrical phases (single or three-phase)
    - Calculates total power consumption per phase
    - Considers house fuse limits (e.g., 25A per phase)
    - Maintains a safety margin to prevent tripping fuses
@@ -82,12 +82,19 @@ class HomePowerMonitor:
     def check_health(self) -> list:
         """Check the health of the Power Monitor component."""
         # Define what controller methods this component uses
-        power_methods = [
-            "get_l1_current",
-            "get_l2_current",
-            "get_l3_current",
-            "get_charging_power_rate",
-        ]
+        # Single-phase systems only need L1; three-phase needs all three
+        if self.home_settings.phase_count == 1:
+            power_methods = [
+                "get_l1_current",
+                "get_charging_power_rate",
+            ]
+        else:
+            power_methods = [
+                "get_l1_current",
+                "get_l2_current",
+                "get_l3_current",
+                "get_charging_power_rate",
+            ]
 
         # For power monitoring, since the component itself is optional, all methods are optional
         # System can operate without power monitoring - it's an enhancement feature
@@ -104,37 +111,43 @@ class HomePowerMonitor:
 
         return [health_check]
 
-    def get_current_phase_loads_w(self) -> tuple[float, float, float]:
-        """Get current load on each phase in watts."""
+    def get_current_phase_loads_w(self) -> tuple[float, ...]:
+        """Get current load on each phase in watts.
+
+        Returns a tuple with one element per phase (1 for single-phase, 3 for three-phase).
+        """
+        voltage = self.home_settings.voltage
+
+        if self.home_settings.phase_count == 1:
+            l1_current = self.controller.get_l1_current()
+            return (l1_current * voltage,)
+
         l1_current = self.controller.get_l1_current()
         l2_current = self.controller.get_l2_current()
         l3_current = self.controller.get_l3_current()
 
         return (
-            l1_current * self.home_settings.voltage,
-            l2_current * self.home_settings.voltage,
-            l3_current * self.home_settings.voltage,
+            l1_current * voltage,
+            l2_current * voltage,
+            l3_current * voltage,
         )
 
     def calculate_available_charging_power(self) -> float:
         """Calculate safe battery charging power based on most loaded phase and target power."""
-        # Get current loads in watts
-        l1, l2, l3 = self.get_current_phase_loads_w()
+        phase_count = self.home_settings.phase_count
 
-        # Calculate current usage as percentage of max safe current (for logging)
-        l1_pct = (l1 / self.max_power_per_phase) * 100
-        l2_pct = (l2 / self.max_power_per_phase) * 100
-        l3_pct = (l3 / self.max_power_per_phase) * 100
+        # Get current loads in watts (variable-length tuple matching phase count)
+        phase_loads = self.get_current_phase_loads_w()
 
         # Find most loaded phase in watts
-        max_load_w = max(l1, l2, l3)
+        max_load_w = max(phase_loads)
         max_load_pct = (max_load_w / self.max_power_per_phase) * 100
 
         # Calculate available power on most loaded phase
         available_power_w = self.max_power_per_phase - max_load_w
 
-        # Max battery power per phase (assuming equal distribution across 3 phases)
-        max_battery_power_per_phase_w = self.max_charge_power_w / 3
+        # Max battery power per phase (distributed across phases)
+        max_battery_power_per_phase_w = self.max_charge_power_w / phase_count
 
         # Calculate available charging power as percentage of battery's max power
         # This is the correct calculation: available power relative to what the battery needs
@@ -146,10 +159,19 @@ class HomePowerMonitor:
         # Limit by target charging power
         charging_power_pct = min(available_pct, self.target_charging_power_pct)
 
+        # Log phase loads
+        if phase_count == 1:
+            pct = (phase_loads[0] / self.max_power_per_phase) * 100
+            phase_log = f"Phase load: {phase_loads[0]:.0f}W ({pct:.1f}%)"
+        else:
+            phase_parts = []
+            for i, load in enumerate(phase_loads):
+                pct = (load / self.max_power_per_phase) * 100
+                phase_parts.append(f"#{i + 1}: {load:.0f}W ({pct:.1f}%)")
+            phase_log = "Phase loads: " + ", ".join(phase_parts)
+
         log_message = (
-            "Phase loads: #1: %.0fW (%.1f%%), "
-            "#2: %.0fW (%.1f%%), "
-            "#3: %.0fW (%.1f%%)\n"
+            "%s\n"
             "Most loaded phase: %.1f%%\n"
             "Available power: %.0fW (%.1f%% of battery max per phase)\n"
             "Target charging: %.1f%%\n"
@@ -157,12 +179,7 @@ class HomePowerMonitor:
         )
         logger.info(
             log_message,
-            l1,
-            l1_pct,
-            l2,
-            l2_pct,
-            l3,
-            l3_pct,
+            phase_log,
             max_load_pct,
             available_power_w,
             available_pct,

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -54,7 +54,10 @@ BATTERY_EFFICIENCY_DISCHARGE = 0.95  # DC-AC conversion losses
 # Default LFP temperature derating curve: (temp_celsius, charge_rate_percent)
 # Based on LFP battery characteristics (Battery University, manufacturer data)
 DEFAULT_TEMPERATURE_DERATING_CURVE: list[tuple[float, float]] = [
-    (-1.0, 20.0),  # Below 0°C: heavily limited (battery heaters may allow some charging)
+    (
+        -1.0,
+        20.0,
+    ),  # Below 0°C: heavily limited (battery heaters may allow some charging)
     (0.0, 20.0),  # At 0°C: heavily limited
     (5.0, 50.0),  # At 5°C: significant derating
     (10.0, 80.0),  # At 10°C: mild derating
@@ -169,9 +172,16 @@ class HomeSettings:
     max_fuse_current: int = HOUSE_MAX_FUSE_CURRENT_A
     voltage: int = HOUSE_VOLTAGE_V
     safety_margin: float = SAFETY_MARGIN_FACTOR
+    phase_count: int = 3
     default_hourly: float = HOME_HOURLY_CONSUMPTION_KWH
     min_valid: float = MIN_CONSUMPTION
     currency: str = DEFAULT_CURRENCY
+
+    def __post_init__(self):
+        assert self.phase_count in (
+            1,
+            3,
+        ), f"phase_count must be 1 or 3, got {self.phase_count}"
 
     def update(self, **kwargs: Any) -> None:
         """Update settings from dict."""
@@ -183,6 +193,7 @@ class HomeSettings:
                     f"HomeSettings has no attribute '{snake_key}' (from key '{key}')"
                 )
             setattr(self, snake_key, value)
+        self.__post_init__()
 
     def from_ha_config(self, config: dict) -> "HomeSettings":
         """Create instance from Home Assistant add-on config."""
@@ -195,10 +206,12 @@ class HomeSettings:
             self.safety_margin = home_config.get(
                 "safety_margin_factor", SAFETY_MARGIN_FACTOR
             )
+            self.phase_count = home_config.get("phase_count", 3)
             self.default_hourly = config["home"].get(
                 "consumption", HOME_HOURLY_CONSUMPTION_KWH
             )
             self.currency = config["home"].get("currency", DEFAULT_CURRENCY)
+            self.__post_init__()
         return self
 
 

--- a/core/bess/tests/unit/test_power_monitor_calculation.py
+++ b/core/bess/tests/unit/test_power_monitor_calculation.py
@@ -55,11 +55,12 @@ class MockController:
 
 @pytest.fixture
 def standard_settings():
-    """Standard settings matching user's configuration."""
+    """Standard settings matching user's configuration (three-phase)."""
     home = HomeSettings(
         max_fuse_current=25,  # 25A fuse
         voltage=230,  # 230V
         safety_margin=0.95,  # 95% safety margin
+        phase_count=3,  # Three-phase system
     )
     battery = BatterySettings(
         max_charge_power_kw=15.0,  # 15kW max charge power
@@ -311,3 +312,137 @@ def test_different_safety_margins():
     assert (
         available_pct_98 > available_pct_90
     ), "Higher safety margin should allow more charging"
+
+
+# === Single-phase tests ===
+
+
+@pytest.fixture
+def single_phase_settings():
+    """Standard settings for a single-phase system (e.g., UK)."""
+    home = HomeSettings(
+        max_fuse_current=25,
+        voltage=230,
+        safety_margin=0.95,
+        phase_count=1,
+    )
+    battery = BatterySettings(
+        max_charge_power_kw=15.0,
+        charging_power_rate=98,
+    )
+    return home, battery
+
+
+def test_single_phase_no_division(single_phase_settings):
+    """Verify battery power is NOT divided by 3 on single-phase systems.
+
+    On single-phase, the full battery charge power flows through one phase,
+    so available power should be calculated against the full battery power.
+    """
+    home, battery = single_phase_settings
+
+    # Light load: 1840W on the single phase
+    controller = MockController(l1_current=1840 / 230)
+
+    monitor = HomePowerMonitor(controller, home, battery)
+    available_pct = monitor.calculate_available_charging_power()
+
+    # Max power per phase: 230 * 25 * 0.95 = 5,462.5W
+    # Available: 5,462.5 - 1,840 = 3,622.5W
+    # Battery max per phase (single): 15,000W / 1 = 15,000W
+    # Available %: (3,622.5 / 15,000) * 100 = 24.15%
+    expected_pct = 24.15
+    assert (
+        abs(available_pct - expected_pct) < 0.1
+    ), f"Expected ~{expected_pct}%, got {available_pct:.2f}%"
+
+
+def test_single_phase_only_reads_l1(single_phase_settings):
+    """Verify L2/L3 are not called on single-phase systems."""
+    home, battery = single_phase_settings
+
+    controller = MockController(l1_current=5.0)
+
+    # Track which methods are called
+    calls = []
+    original_l2 = controller.get_l2_current
+    original_l3 = controller.get_l3_current
+
+    def tracking_l2():
+        calls.append("l2")
+        return original_l2()
+
+    def tracking_l3():
+        calls.append("l3")
+        return original_l3()
+
+    controller.get_l2_current = tracking_l2
+    controller.get_l3_current = tracking_l3
+
+    monitor = HomePowerMonitor(controller, home, battery)
+    monitor.get_current_phase_loads_w()
+
+    assert "l2" not in calls, "L2 should not be read on single-phase"
+    assert "l3" not in calls, "L3 should not be read on single-phase"
+
+
+def test_single_phase_fuse_protection(single_phase_settings):
+    """Verify correct available power calculation on single-phase."""
+    home, battery = single_phase_settings
+
+    # Zero load — full fuse capacity available
+    controller = MockController(l1_current=0.0)
+
+    monitor = HomePowerMonitor(controller, home, battery)
+    available_pct = monitor.calculate_available_charging_power()
+
+    # Available power: 5,462.5W
+    # Battery max (single phase): 15,000W
+    # Available %: (5,462.5 / 15,000) * 100 = 36.42%
+    # Limited by this (less than target 98%)
+    expected_pct = 36.42
+    assert (
+        abs(available_pct - expected_pct) < 0.1
+    ), f"Expected ~{expected_pct}%, got {available_pct:.2f}%"
+
+
+def test_single_phase_high_load(single_phase_settings):
+    """Verify throttling at fuse limit on single-phase."""
+    home, battery = single_phase_settings
+
+    # Load near fuse limit: 5,200W
+    controller = MockController(l1_current=5200 / 230)
+
+    monitor = HomePowerMonitor(controller, home, battery)
+    available_pct = monitor.calculate_available_charging_power()
+
+    # Available power: 5,462.5 - 5,200 = 262.5W
+    # Battery max (single phase): 15,000W
+    # Available %: (262.5 / 15,000) * 100 = 1.75%
+    expected_pct = 1.75
+    assert (
+        abs(available_pct - expected_pct) < 0.1
+    ), f"Expected ~{expected_pct}%, got {available_pct:.2f}%"
+
+
+def test_single_phase_returns_single_element_tuple(single_phase_settings):
+    """Verify get_current_phase_loads_w returns a single-element tuple."""
+    home, battery = single_phase_settings
+
+    controller = MockController(l1_current=10.0)
+    monitor = HomePowerMonitor(controller, home, battery)
+
+    loads = monitor.get_current_phase_loads_w()
+    assert len(loads) == 1, f"Expected 1-element tuple, got {len(loads)}"
+    assert loads[0] == 10.0 * 230, f"Expected {10.0 * 230}W, got {loads[0]}W"
+
+
+def test_three_phase_returns_three_element_tuple(standard_settings):
+    """Verify get_current_phase_loads_w returns a three-element tuple."""
+    home, battery = standard_settings
+
+    controller = MockController(l1_current=5.0, l2_current=6.0, l3_current=7.0)
+    monitor = HomePowerMonitor(controller, home, battery)
+
+    loads = monitor.get_current_phase_loads_w()
+    assert len(loads) == 3, f"Expected 3-element tuple, got {len(loads)}"

--- a/core/bess/tests/unit/test_settings.py
+++ b/core/bess/tests/unit/test_settings.py
@@ -1,7 +1,10 @@
 """Test the new BatterySettings dataclass implementation."""
 
+import pytest
+
 from core.bess.settings import (
     BatterySettings,
+    HomeSettings,
     TemperatureDeratingSettings,
     apply_temperature_derating,
     interpolate_derating,
@@ -264,3 +267,74 @@ def test_apply_temperature_derating():
     assert result[3] == 3.75  # 15°C -> 75% -> 3.75kW
     assert result[4] == 5.0  # 20°C -> 100% -> 5kW
     assert result[5] == 5.0  # 25°C -> 100% -> 5kW
+
+
+# === HomeSettings phase_count tests ===
+
+
+def test_home_settings_phase_count_default():
+    """Test phase_count defaults to 3."""
+    settings = HomeSettings()
+    assert settings.phase_count == 3
+
+
+def test_home_settings_phase_count_single():
+    """Test phase_count can be set to 1."""
+    settings = HomeSettings(phase_count=1)
+    assert settings.phase_count == 1
+
+
+def test_home_settings_phase_count_invalid():
+    """Test phase_count rejects invalid values."""
+    with pytest.raises(AssertionError, match="phase_count must be 1 or 3"):
+        HomeSettings(phase_count=2)
+
+    with pytest.raises(AssertionError, match="phase_count must be 1 or 3"):
+        HomeSettings(phase_count=0)
+
+
+def test_home_settings_update_phase_count():
+    """Test update() with phaseCount (camelCase conversion)."""
+    settings = HomeSettings()
+    assert settings.phase_count == 3
+
+    settings.update(phaseCount=1)
+    assert settings.phase_count == 1
+
+
+def test_home_settings_update_phase_count_invalid():
+    """Test update() rejects invalid phase_count."""
+    settings = HomeSettings()
+
+    with pytest.raises(AssertionError, match="phase_count must be 1 or 3"):
+        settings.update(phaseCount=2)
+
+
+def test_home_settings_from_ha_config_phase_count():
+    """Test from_ha_config reads phase_count."""
+    settings = HomeSettings()
+    config = {
+        "home": {
+            "max_fuse_current": 25,
+            "voltage": 230,
+            "safety_margin_factor": 1.0,
+            "phase_count": 1,
+            "consumption": 3.5,
+            "currency": "GBP",
+        }
+    }
+    settings.from_ha_config(config)
+    assert settings.phase_count == 1
+
+
+def test_home_settings_from_ha_config_phase_count_default():
+    """Test from_ha_config defaults phase_count to 3."""
+    settings = HomeSettings()
+    config = {
+        "home": {
+            "consumption": 3.5,
+            "currency": "SEK",
+        }
+    }
+    settings.from_ha_config(config)
+    assert settings.phase_count == 3


### PR DESCRIPTION
## Summary

- Add `home.phase_count` config option (1 or 3, default 3) so the power monitor correctly handles both single-phase and three-phase electrical systems
- Fix `max_fuse_current`, `voltage`, and `safety_margin_factor` not being passed from config.yaml through `_apply_settings()` — they were defined in config but stayed at defaults
- Power monitor health check and logging adapt to phase count (single-phase only needs L1 sensor)

## Context

The power monitor divided battery charge power by 3 to estimate per-phase load. For single-phase systems (common in the UK), the full battery power flows through one phase, so this division underestimated the actual load and reduced fuse protection effectiveness.

## Test plan

- [x] Existing three-phase tests pass unchanged (8 tests)
- [x] New single-phase tests verify correct power calculation without /3 division (6 tests)
- [x] New settings tests verify phase_count default, validation, and config loading (7 tests)
- [x] All 37 tests pass, black and ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)