### PR TITLE
Rolling window TOU slot management with stable segment IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.9.0] - 2026-03-12
+
+### Changed
+
+- TOU schedule generation now uses a rolling window: only future periods (from the current optimization period onwards) are converted to TOU segments. Past segments no longer consume hardware slots, making the 9-segment limit much less likely to be hit during mid-day re-optimizations.
+- TOU segment IDs are now stable across re-optimizations: when a segment's time range and mode haven't changed, its ID is reused from the previous run, minimizing unnecessary inverter writes.
+- Removed past-interval copying loop from schedule creation — the rolling window approach makes it unnecessary.
+
 ## [7.8.1] - 2026-03-12
 
 ### Fixed

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "7.8.1"
+version: "7.9.0"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1483,22 +1483,19 @@ class BatterySystemManager:
             )
             temp_growatt.strategic_intents = full_day_strategic_intents
 
-            # Copy existing TOU intervals for past periods if not preparing next day
-            if not prepare_next_day and hasattr(
-                self._schedule_manager, "tou_intervals"
-            ):
-                for segment in self._schedule_manager.tou_intervals:
-                    start_time_parts = segment["start_time"].split(":")
-                    start_period = (
-                        int(start_time_parts[0]) * 4 + int(start_time_parts[1]) // 15
-                    )
-                    if start_period < optimization_period:
-                        temp_growatt.tou_intervals.append(segment.copy())
-
-            # Create schedule with strategic intents
+            # Create schedule with rolling window — only future periods get TOU segments
             effective_period = 0 if prepare_next_day else optimization_period
+            previous_tou = (
+                []
+                if prepare_next_day
+                else self._schedule_manager.tou_intervals.copy()
+            )
             logger.info(f"Creating Growatt schedule for period={effective_period}")
-            temp_growatt.create_schedule(temp_schedule)
+            temp_growatt.create_schedule(
+                temp_schedule,
+                current_period=effective_period,
+                previous_tou_intervals=previous_tou,
+            )
 
             return temp_schedule, temp_growatt
 

--- a/core/bess/growatt_schedule.py
+++ b/core/bess/growatt_schedule.py
@@ -425,7 +425,6 @@ class GrowattScheduleManager:
             List of TOU intervals ready for Growatt
         """
         intervals = []
-        segment_id = 1
 
         for group in groups:
             # Skip load_first - it's the inverter default
@@ -461,7 +460,6 @@ class GrowattScheduleManager:
             )
 
             interval = {
-                "segment_id": segment_id,
                 "batt_mode": group["mode"],
                 "start_time": f"{start_hour:02d}:{start_minute:02d}",
                 "end_time": f"{end_hour:02d}:{end_minute:02d}",
@@ -469,11 +467,9 @@ class GrowattScheduleManager:
                 "strategic_intent": intent_summary,
             }
             intervals.append(interval)
-            segment_id += 1
 
             logger.info(
-                "TOU segment #%d: %s-%s (%s) from %d periods: %s",
-                interval["segment_id"],
+                "TOU segment: %s-%s (%s) from %d periods: %s",
                 interval["start_time"],
                 interval["end_time"],
                 interval["batt_mode"],
@@ -482,6 +478,59 @@ class GrowattScheduleManager:
             )
 
         return intervals
+
+    def _assign_stable_segment_ids(
+        self,
+        intervals: list[dict],
+        previous_intervals: list[dict] | None,
+    ) -> None:
+        """Assign segment IDs, reusing IDs from previous intervals when possible.
+
+        When a new interval matches a previous one (same start_time, end_time,
+        and batt_mode), its segment_id is reused so the inverter does not need
+        to rewrite that segment.  Unmatched intervals receive the lowest free
+        IDs from the range 1-9.
+
+        Args:
+            intervals: New TOU intervals (mutated in-place to add segment_id).
+            previous_intervals: TOU intervals from the previous optimisation
+                run, or None on the first run of the day.
+        """
+        if not previous_intervals:
+            for idx, interval in enumerate(intervals, 1):
+                interval["segment_id"] = idx
+            return
+
+        # Build a lookup from (start, end, mode) -> segment_id for previous run
+        prev_lookup: dict[tuple[str, str, str], int] = {}
+        for prev in previous_intervals:
+            key = (prev["start_time"], prev["end_time"], prev["batt_mode"])
+            prev_lookup[key] = prev["segment_id"]
+
+        used_ids: set[int] = set()
+        matched: list[tuple[int, int]] = []  # (interval index, reused id)
+
+        for idx, interval in enumerate(intervals):
+            key = (interval["start_time"], interval["end_time"], interval["batt_mode"])
+            if key in prev_lookup:
+                reused_id = prev_lookup[key]
+                matched.append((idx, reused_id))
+                used_ids.add(reused_id)
+
+        # Apply matched IDs
+        for idx, seg_id in matched:
+            intervals[idx]["segment_id"] = seg_id
+
+        # Assign lowest free IDs to unmatched intervals
+        free_ids = sorted(set(range(1, 10)) - used_ids)
+        free_iter = iter(free_ids)
+        for idx, interval in enumerate(intervals):
+            if "segment_id" not in interval:
+                next_id = next(free_iter, None)
+                assert next_id is not None, (
+                    f"No free segment IDs available for interval {interval}"
+                )
+                interval["segment_id"] = next_id
 
     def _enforce_segment_limit(self, intervals: list[dict]) -> list[dict]:
         """Enforce the 9 TOU segment limit by dropping shortest segments.
@@ -686,7 +735,12 @@ class GrowattScheduleManager:
                 batt_mode,
             )
 
-    def create_schedule(self, schedule: DPSchedule):
+    def create_schedule(
+        self,
+        schedule: DPSchedule,
+        current_period: int = 0,
+        previous_tou_intervals: list[dict] | None = None,
+    ):
         """Process DPSchedule with strategic intents into Growatt format."""
         logger.info(
             "Creating Growatt schedule using strategic intents from DP algorithm"
@@ -710,7 +764,10 @@ class GrowattScheduleManager:
                 )
 
         self.current_schedule = schedule
-        self._consolidate_and_convert_with_strategic_intents()
+        self._consolidate_and_convert_with_strategic_intents(
+            current_period=current_period,
+            previous_tou_intervals=previous_tou_intervals,
+        )
         self._calculate_hourly_settings_with_strategic_intents()
 
         logger.info(
@@ -718,17 +775,26 @@ class GrowattScheduleManager:
             len(self.tou_intervals),
         )
 
-    def _consolidate_and_convert_with_strategic_intents(self):
-        """Convert strategic intents to TOU intervals using 15-minute resolution.
+    def _consolidate_and_convert_with_strategic_intents(
+        self,
+        current_period: int = 0,
+        previous_tou_intervals: list[dict] | None = None,
+    ):
+        """Convert strategic intents to TOU intervals using a rolling window.
 
-        This method works directly with 15-minute periods instead of aggregating
-        to hourly intervals. This eliminates the "gap problem" where majority
-        voting created holes in charging schedules.
+        Only periods from current_period onwards are converted to TOU segments.
+        Past periods are excluded, freeing up hardware slots that would otherwise
+        be wasted on intervals the inverter has already executed.
+
+        When previous_tou_intervals is provided, segment IDs are kept stable:
+        intervals whose time range and mode match a previous interval reuse its
+        segment_id, minimising unnecessary inverter writes.
 
         Algorithm:
-        1. Group consecutive 15-min periods by their mapped battery mode
+        1. Group consecutive 15-min periods (from current_period) by battery mode
         2. Create TOU intervals for non-default (battery_first, grid_first) groups
-        3. Enforce 9-segment limit if needed
+        3. Assign stable segment IDs based on previous intervals
+        4. Enforce 9-segment limit if needed
         """
         if not self.strategic_intents:
             logger.warning(
@@ -765,11 +831,11 @@ class GrowattScheduleManager:
                 self.corruption_detected = True
                 logger.warning("CORRUPTION FLAG SET - Hardware write will be FORCED")
 
-        # Start fresh - all periods are processed from 0
+        # Start fresh - only periods from current_period onwards get TOU segments
         self.tou_intervals = []
 
-        # Group all periods by mode from start of day
-        period_groups = self._group_periods_by_mode(0)
+        # Group periods by mode from current_period (rolling window)
+        period_groups = self._group_periods_by_mode(current_period)
 
         logger.info(
             "Grouped %d periods into %d mode groups",
@@ -801,9 +867,8 @@ class GrowattScheduleManager:
         # Sort by start time to ensure chronological order
         self.tou_intervals.sort(key=lambda x: x["start_time"])
 
-        # Reassign segment IDs in chronological order
-        for i, interval in enumerate(self.tou_intervals, 1):
-            interval["segment_id"] = i
+        # Assign stable segment IDs (reuse from previous run when possible)
+        self._assign_stable_segment_ids(self.tou_intervals, previous_tou_intervals)
 
         # Enforce segment limit if needed
         if len(self.tou_intervals) > self.max_intervals:

--- a/core/bess/growatt_schedule.py
+++ b/core/bess/growatt_schedule.py
@@ -1208,7 +1208,14 @@ class GrowattScheduleManager:
         return result
 
     def get_all_tou_segments(self):
-        """Get all TOU segments with default intervals filling gaps for complete 24-hour coverage."""
+        """Get all TOU segments with default intervals filling gaps for complete 24-hour coverage.
+
+        Each active interval includes an is_expired flag indicating whether its
+        end_time is before the current time of day.
+        """
+        now = datetime.now()
+        current_minutes = now.hour * 60 + now.minute
+
         if not self.tou_intervals:
             # Return default load_first for entire day if no intervals configured
             return [
@@ -1259,6 +1266,7 @@ class GrowattScheduleManager:
             segment = interval.copy()
             if "segment_id" not in segment:
                 segment["segment_id"] = len(result) + 1
+            segment["is_expired"] = interval_end_minutes < current_minutes
             result.append(segment)
             current_time_minutes = interval_end_minutes + 1
 

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -45,6 +45,7 @@ interface TOUInterval {
   enabled: boolean;
   isEmpty?: boolean;
   isDefault?: boolean;
+  isExpired?: boolean;
 }
 
 interface ScheduleHour {
@@ -857,7 +858,9 @@ const InverterStatusDashboard: React.FC = () => {
             <div className="space-y-2">
               {growattSchedule.touIntervals.map((interval, index) => (
                 <div key={index} className={`flex justify-between items-center p-3 rounded-lg ${
-                  interval.isDefault
+                  interval.isExpired
+                    ? 'bg-gray-50 dark:bg-gray-800/30 border border-gray-200 dark:border-gray-700 opacity-40'
+                    : interval.isDefault
                     ? 'bg-gray-50 dark:bg-gray-800/30 border border-gray-200 dark:border-gray-700 opacity-50'
                     : interval.isEmpty
                     ? 'bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 opacity-60'
@@ -866,21 +869,33 @@ const InverterStatusDashboard: React.FC = () => {
                     : 'bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800'
                 }`}>
                   <div className="flex items-center space-x-4">
-                    <div className="font-medium text-gray-900 dark:text-white">
+                    <div className={`font-medium ${
+                      interval.isExpired
+                        ? 'text-gray-400 dark:text-gray-500'
+                        : 'text-gray-900 dark:text-white'
+                    }`}>
                       {interval.isDefault
                         ? 'Default'
                         : `Segment #${interval.segmentId}`}
                     </div>
-                    <div className="text-sm text-gray-600 dark:text-gray-400">
-                      {interval.isEmpty
+                    <div className={`text-sm ${
+                      interval.isExpired
+                        ? 'text-gray-400 dark:text-gray-500 line-through'
+                        : 'text-gray-600 dark:text-gray-400'
+                    }`}>
+                      {interval.isExpired
+                        ? `${interval.startTime} - ${interval.endTime}`
+                        : interval.isEmpty
                         ? 'Not configured'
                         : `${interval.startTime} - ${interval.endTime}`}
                     </div>
                   </div>
                   <div className="flex items-center space-x-3">
-                    {!interval.isEmpty && getBatteryModeDisplay(interval.battMode)}
+                    {!interval.isExpired && !interval.isEmpty && getBatteryModeDisplay(interval.battMode)}
                     <span className={`px-2 py-1 rounded text-xs font-medium ${
-                      interval.isDefault
+                      interval.isExpired
+                        ? 'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
+                        : interval.isDefault
                         ? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
                         : interval.isEmpty
                         ? 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
@@ -888,7 +903,9 @@ const InverterStatusDashboard: React.FC = () => {
                         ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300'
                         : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300'
                     }`}>
-                      {interval.isDefault
+                      {interval.isExpired
+                        ? 'Expired'
+                        : interval.isDefault
                         ? 'Load First'
                         : interval.isEmpty
                         ? 'Empty'


### PR DESCRIPTION
## Summary

- **Rolling window TOU generation**: Only periods from the current optimization period onwards are converted to TOU segments. Past periods are excluded, freeing up hardware slots that were previously wasted on already-executed intervals. This makes the 9-segment limit much less likely to be hit during mid-day re-optimizations.
- **Stable segment IDs**: When a TOU interval's time range and battery mode match the previous optimization run, its segment ID is reused. Unmatched intervals receive the lowest available free IDs. This minimizes unnecessary inverter writes across re-optimizations.
- **Removed past-interval copying loop**: The old approach in `_create_schedule()` manually copied past TOU intervals into the new schedule manager. The rolling window approach makes this unnecessary since past periods simply don't generate segments.
- **Frontend expired interval display**: Added `isExpired` support to the TOU interval rendering — expired intervals show with reduced opacity, grayed-out text, strikethrough times, and an "Expired" badge.

## Test plan

- [ ] Verify first-of-day optimization (period 0) produces identical output to before (full day of segments)
- [ ] Verify mid-day re-optimization (e.g. period 40 = 10:00) only generates TOU segments from 10:00 onwards
- [ ] Confirm segment count is lower during mid-day runs compared to the old approach
- [ ] Verify stable IDs: run two consecutive optimizations with the same price data and confirm segment IDs don't change for matching intervals
- [ ] Verify `prepare_next_day=True` still generates a full schedule (period 0, empty previous intervals)
- [ ] Test that the 9-segment limit enforcement still works correctly with the rolling window
- [ ] Check frontend rendering of expired intervals shows correct styling
- [ ] Confirm no overlapping intervals in generated TOU schedules