### PR TITLE
Fix schedule crash when >9 TOU segments generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.9.1] - 2026-03-13
+
+### Fixed
+
+- Fix schedule creation crash when optimization produces more than 9 TOU segments. The segment limit enforcement was running after segment ID assignment, causing an assertion error that prevented any schedule from being deployed.
+
 ## [7.9.0] - 2026-03-12
 
 ### Changed

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "7.9.0"
+version: "7.9.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/growatt_schedule.py
+++ b/core/bess/growatt_schedule.py
@@ -867,12 +867,12 @@ class GrowattScheduleManager:
         # Sort by start time to ensure chronological order
         self.tou_intervals.sort(key=lambda x: x["start_time"])
 
-        # Assign stable segment IDs (reuse from previous run when possible)
-        self._assign_stable_segment_ids(self.tou_intervals, previous_tou_intervals)
-
-        # Enforce segment limit if needed
+        # Enforce segment limit BEFORE assigning IDs (max 9 TOU segments)
         if len(self.tou_intervals) > self.max_intervals:
             self.tou_intervals = self._enforce_segment_limit(self.tou_intervals)
+
+        # Assign stable segment IDs (reuse from previous run when possible)
+        self._assign_stable_segment_ids(self.tou_intervals, previous_tou_intervals)
 
         logger.info(
             "TOU conversion complete: %d total intervals (15-min resolution)",


### PR DESCRIPTION
## Summary

- The segment limit enforcement (`_enforce_segment_limit`) was called **after** segment ID assignment (`_assign_stable_segment_ids`), which asserts ≤9 intervals
- When the optimizer produces fragmented intents (17-18 mode groups), the assert fires on every 15-minute cycle, preventing any schedule from being deployed
- Swapped the call order so segments are trimmed to 9 before IDs are assigned

## Root cause

The rolling window TOU feature (v7.9.0) added both `_enforce_segment_limit` and `_assign_stable_segment_ids`, but placed them in the wrong order. Tonight's price pattern caused unusually fragmented optimization (alternating GRID_CHARGING/EXPORT_ARBITRAGE in 15-min chunks), triggering the bug.

## Test plan

- [ ] Unit tests pass
- [ ] Deploy to HA and verify schedule appears on /inverter page