### PR TITLE
Use Promise.allSettled for resilient Inverter page data loading

### DIFF
--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -330,19 +330,36 @@ const InverterStatusDashboard: React.FC = () => {
       }
       setError(null);
       
-      const [statusData, scheduleData, batteryData, dashboardDataResult] = await Promise.all([
+      const results = await Promise.allSettled([
         fetchInverterStatus(),
         fetchGrowattSchedule(),
         fetchBatterySettings(),
         fetchDashboardData()
       ]);
-      
-      setInverterStatus(statusData);
-      setGrowattSchedule(scheduleData);
-      setBatterySettings(batteryData);
-      setDashboardData(dashboardDataResult);
+
+      if (results[0].status === 'fulfilled') {
+        setInverterStatus(results[0].value);
+      } else {
+        console.warn('Failed to fetch inverter status:', results[0].reason);
+      }
+      if (results[1].status === 'fulfilled') {
+        setGrowattSchedule(results[1].value);
+      } else {
+        console.warn('Failed to fetch schedule:', results[1].reason);
+      }
+      if (results[2].status === 'fulfilled') {
+        setBatterySettings(results[2].value);
+      } else {
+        console.warn('Failed to fetch battery settings:', results[2].reason);
+      }
+      if (results[3].status === 'fulfilled') {
+        setDashboardData(results[3].value);
+      } else {
+        console.warn('Failed to fetch dashboard data:', results[3].reason);
+      }
+
       setLastUpdate(new Date());
-      
+
       if (isInitialLoad) {
         setIsInitialLoad(false);
       }


### PR DESCRIPTION
## Summary

- Replace `Promise.all` with `Promise.allSettled` in `InverterStatusDashboard.tsx` so that a single failing endpoint no longer blanks the entire Inverter page
- Each API call settles independently — successful responses populate their state while failures are logged as warnings

## Motivation

When I was setting up, certain bits were broken/lacking config, preventing the whole dashboard from showing

When no optimization schedule exists yet, `/api/dashboard` returns HTTP 500. With `Promise.all`, this rejects the entire batch and the Inverter page shows nothing — even though inverter status, schedule, and battery settings are all available.

## Test plan

- [ ] Start with no optimization schedule and verify the Inverter page renders available data
- [ ] Verify all data loads normally when all endpoints succeed
- [ ] Verify console warnings appear for any individual endpoint failure