### PR TITLE
Use exponential backoff for HA API retry delays

### DIFF
--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -111,7 +111,7 @@ class HomeAssistantAPIController:
             "Content-Type": "application/json",
         }
         self.max_attempts = 4
-        self.retry_delay = 4  # seconds
+        self.retry_base_delay = 2  # seconds (exponential backoff: 2, 4, 8)
         self.test_mode = False
 
         # Use provided sensor configuration
@@ -553,15 +553,16 @@ class HomeAssistantAPIController:
                     raise  # Fail immediately on 404
 
                 if attempt < self.max_attempts - 1:  # Not the last attempt
+                    delay = self.retry_base_delay * (2**attempt)
                     logger.warning(
                         "API request to %s failed on attempt %d/%d: %s. Retrying in %d seconds...",
                         url,
                         attempt + 1,
                         self.max_attempts,
                         str(e),
-                        self.retry_delay,
+                        delay,
                     )
-                    time.sleep(self.retry_delay)
+                    time.sleep(delay)
                 else:  # Last attempt failed
                     logger.error(
                         "API request to %s failed on final attempt %d/%d: %s",


### PR DESCRIPTION
## Summary

- Replace fixed 4-second retry delay with exponential backoff (2s, 4s, 8s) in `ha_api_controller.py`
- Rename `retry_delay` to `retry_base_delay` to clarify the new behavior

## Motivation

Fixed delays are wasteful for transient failures (waiting 4s when 2s would suffice) and too aggressive for sustained outages (hammering every 4s). Exponential backoff adapts to both scenarios — fast recovery for blips, graceful retreat for real outages.

## Test plan

- [ ] Verify retry logging shows increasing delay values (2, 4, 8)
- [ ] Verify successful requests are unaffected (no retry needed)
- [ ] Verify final attempt still raises the exception