### PR TITLE
Return None instead of 0.0 for unavailable sensor reads

### DIFF
--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -651,8 +651,13 @@ class HomeAssistantAPIController:
             json=json_data,
         )
 
-    def _get_sensor_value(self, sensor_name):
-        """Get value from any sensor by name using unified entity resolution."""
+    def _get_sensor_value(self, sensor_name) -> float | None:
+        """Get value from any sensor by name using unified entity resolution.
+
+        Returns:
+            float: The sensor value, or None if the sensor is unavailable,
+            unknown, or could not be read.
+        """
         try:
             entity_id, resolution_method = self._resolve_entity_id(sensor_name)
             logger.debug(
@@ -668,18 +673,27 @@ class HomeAssistantAPIController:
             )
 
             if response and "state" in response:
-                return float(response["state"])
+                state = response["state"]
+                if isinstance(state, str) and state in ("unavailable", "unknown"):
+                    logger.warning(
+                        "Sensor %s (entity_id: %s) is %s",
+                        sensor_name,
+                        entity_id,
+                        state,
+                    )
+                    return None
+                return float(state)
             else:
                 logger.warning(
                     "Sensor %s (entity_id: %s) returned invalid response or no state",
                     sensor_name,
                     entity_id,
                 )
-                return 0.0
+                return None
 
         except (ValueError, TypeError):
             logger.warning("Could not get value for %s", sensor_name)
-            return 0.0
+            return None
         except requests.RequestException as e:
             logger.error("Error fetching sensor %s: %s", sensor_name, str(e))
 
@@ -691,7 +705,7 @@ class HomeAssistantAPIController:
                     error=e,
                 )
 
-            return 0.0
+            return None
 
     def get_estimated_consumption(self):
         """Get estimated consumption in quarterly resolution (96 periods).


### PR DESCRIPTION
## Summary

- Return `None` instead of `0.0` from `_get_sensor_value()` when a sensor is unavailable, unknown, or fails to read
- Add explicit detection of HA "unavailable"/"unknown" state strings before attempting `float()` conversion
- Update return type annotation to `float | None`

## Motivation

When a Home Assistant sensor is temporarily offline, the current code returns `0.0`, which silently corrupts downstream calculations. For example:
- Battery SOC reads as 0% — optimization thinks the battery is empty
- Solar production reads as 0W — optimization ignores solar availability
- Grid import reads as 0 kWh — energy balance calculations are wrong

Returning `None` lets callers distinguish "no data available" from "sensor genuinely reports zero". Existing `None` guards in `battery_system_manager.py` (e.g. `if soc is not None and 0 <= soc <= 100`) already handle this correctly.

## Breaking change note

Callers that do arithmetic with sensor values without checking for `None` will get a `TypeError` instead of silently using `0.0`. This is intentional — it surfaces the problem immediately rather than producing incorrect optimization results.

## Test plan

- [ ] Verify sensors returning "unavailable" or "unknown" produce `None` (not `0.0`)
- [ ] Verify normal sensor reads still return float values
- [ ] Verify downstream code handles `None` gracefully (SOC checks, energy balance)
- [ ] Verify failure tracker still records sensor read failures