### PR TITLE
Add context and response body to API failure diagnostics

### DIFF
--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -481,7 +481,9 @@ class HomeAssistantAPIController:
         """Validate sensors for multiple methods at once."""
         return [self.get_method_sensor_info(method) for method in method_list]
 
-    def _api_request(self, method, path, operation=None, category=None, **kwargs):
+    def _api_request(
+        self, method, path, operation=None, category=None, context: dict | None = None, **kwargs
+    ):
         """Make an API request to Home Assistant with retry logic.
 
         Args:
@@ -489,6 +491,7 @@ class HomeAssistantAPIController:
             path: API path (without base URL)
             operation: Optional human-readable operation description for failure tracking
             category: Optional operation category for failure tracking
+            context: Optional dict of contextual parameters for failure diagnostics
             **kwargs: Additional arguments for requests
 
         Returns:
@@ -577,20 +580,31 @@ class HomeAssistantAPIController:
                         operation_description = operation or f"{method.upper()} {path}"
                         operation_category = category or "other"
 
+                        # Enrich context with HTTP response body for diagnostics
+                        enriched_context = dict(context) if context else {}
+                        if isinstance(e, requests.HTTPError) and e.response is not None:
+                            response_body = e.response.text[:500]
+                            if response_body:
+                                enriched_context["response_body"] = response_body
+
                         self.failure_tracker.record_failure(
                             operation=operation_description,
                             category=operation_category,
                             error=e,
+                            context=enriched_context if enriched_context else None,
                         )
 
                     raise  # Re-raise the last exception
 
-    def _service_call_with_retry(self, service_domain, service_name, **kwargs):
+    def _service_call_with_retry(
+        self, service_domain, service_name, operation: str | None = None, **kwargs
+    ):
         """Call Home Assistant service with retry logic.
 
         Args:
             service_domain: Service domain (e.g., 'switch', 'number')
             service_name: Service name (e.g., 'turn_on', 'set_value')
+            operation: Optional human-readable operation description for failure tracking
             **kwargs: Service parameters
 
         Returns:
@@ -634,11 +648,16 @@ class HomeAssistantAPIController:
 
             path += "?" + urllib.parse.urlencode(query_params)
 
+        # Build context from service call kwargs for failure tracking
+        context = {
+            k: v for k, v in kwargs.items() if k not in ("return_response", "blocking")
+        }
+
         # Make API call
         return self._api_request(
             "post",
             path,
-            operation=f"Call {service_domain}.{service_name}",
+            operation=operation or f"Call {service_domain}.{service_name}",
             category=(
                 "battery_control"
                 if service_domain in ["number", "switch"]
@@ -648,6 +667,7 @@ class HomeAssistantAPIController:
                     else "other"
                 )
             ),
+            context=context,
             json=json_data,
         )
 
@@ -861,15 +881,19 @@ class HomeAssistantAPIController:
                 "Please add growatt.device_id to config.yaml"
             )
 
+        enabled_str = "enabled" if enabled else "disabled"
         self._service_call_with_retry(
-            "growatt_server", "update_time_segment", **service_params
+            "growatt_server",
+            "update_time_segment",
+            operation=f"Write TOU segment {segment_id}: {batt_mode} {start_time}-{end_time} ({enabled_str})",
+            **service_params,
         )
 
     def read_inverter_time_segments(self):
         """Read all time segments from the inverter with retry logic."""
         try:
             # Prepare service call parameters
-            service_params: dict[str, object] = {"return_response": True}
+            service_params: dict[str, str | bool] = {"return_response": True}
 
             # Add device_id if configured
             if self.growatt_device_id:
@@ -882,7 +906,10 @@ class HomeAssistantAPIController:
 
             # Call the service and get the response
             result = self._service_call_with_retry(
-                "growatt_server", "read_time_segments", **service_params
+                "growatt_server",
+                "read_time_segments",
+                operation=None,
+                **service_params,
             )
 
             # Check if the result contains 'service_response' with 'time_segments'


### PR DESCRIPTION
## Summary

- Add `context` parameter to `_api_request()` for passing diagnostic data to the failure tracker
- Add `operation` parameter to `_service_call_with_retry()` for descriptive failure messages
- Auto-build context dict from service call kwargs (segment_id, batt_mode, etc.)
- Extract HTTP response body (truncated to 500 chars) on failure for server-side error details
- Add descriptive operation strings for TOU segment writes

## Motivation

Current failure alerts show generic messages like "Call growatt_server.update_time_segment failed". With this change, they show:
- **What**: "Write TOU segment 3: battery_first 14:00-16:00 (enabled)"
- **Parameters**: segment_id, batt_mode, start_time, end_time, device_id
- **Server response**: The actual error body from the HTTP response

This makes failure alerts actionable without having to dig through logs.

## Test plan

- [ ] Verify TOU segment write failures include descriptive operation strings
- [ ] Verify HTTP error response body is captured (truncated to 500 chars)
- [ ] Verify context dict includes service call parameters
- [ ] Verify normal (non-failing) operations are unaffected
- [ ] Verify read operations (read_time_segments) work correctly