### PR TITLE
Fix IDLE intent blocking battery discharge for home consumption

### DIFF
--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1960,14 +1960,14 @@ class BatterySystemManager:
 
         elif strategic_intent == "IDLE":
             grid_charge = False
-            discharge_rate = 0
+            discharge_rate = 100
 
         else:
             logger.warning(
                 "Unknown strategic intent: %s, using IDLE defaults", strategic_intent
             )
             grid_charge = False
-            discharge_rate = 0
+            discharge_rate = 100
 
         hour = period // 4
         logger.info(

--- a/core/bess/growatt_schedule.py
+++ b/core/bess/growatt_schedule.py
@@ -118,7 +118,7 @@ class GrowattScheduleManager:
             "charge_rate": 0,
             "discharge_rate": 100,
         },
-        "IDLE": {"grid_charge": False, "charge_rate": 100, "discharge_rate": 0},
+        "IDLE": {"grid_charge": False, "charge_rate": 100, "discharge_rate": 100},
     }
 
     def __init__(self, battery_settings: BatterySettings) -> None:
@@ -319,7 +319,7 @@ class GrowattScheduleManager:
             intent = effective_intents[period]
             mode = self.INTENT_TO_MODE.get(intent, "load_first")
             control = self.INTENT_TO_CONTROL.get(
-                intent, {"grid_charge": False, "charge_rate": 100, "discharge_rate": 0}
+                intent, {"grid_charge": False, "charge_rate": 100, "discharge_rate": 100}
             )
 
             period_settings.append(


### PR DESCRIPTION
IDLE periods had discharge_rate=0, which prevented the battery from discharging to cover home load even while importing from grid. Since IDLE means "no strategic action" (no arbitrage, no forced export), the battery should still naturally discharge in load_first mode.

Set discharge_rate=100 for IDLE so the inverter can draw from the battery to meet home consumption as intended by load_first behavior.