### PR TITLE
Fix Octopus price source rejecting rates on DST spring-forward days

### DIFF
--- a/core/bess/octopus_energy_source.py
+++ b/core/bess/octopus_energy_source.py
@@ -10,13 +10,16 @@ to match the system-wide period model.
 import logging
 from datetime import date, datetime, timedelta
 
+from . import time_utils
 from .exceptions import PriceDataUnavailableError, SystemConfigurationError
 from .price_manager import PriceSource
 
 logger = logging.getLogger(__name__)
 
-EXPECTED_RAW_PERIODS = 48  # Octopus provides 48 half-hourly slots
-MIN_RAW_PERIODS = 46  # Allow slightly fewer during incremental publishing
+# Tolerance below the expected half-hourly count for a given day.
+# Accounts for incremental publishing and DST boundary timestamp edge cases
+# where rates at the settlement boundary may have the previous day's date.
+_RAW_PERIOD_TOLERANCE = 2
 
 
 class OctopusEnergySource(PriceSource):
@@ -121,8 +124,9 @@ class OctopusEnergySource(PriceSource):
     ) -> list[float]:
         """Fetch rates from a Home Assistant event entity.
 
-        Octopus provides 48 half-hourly rates. Each rate is duplicated to produce
-        96 quarterly (15-minute) periods matching the system-wide resolution.
+        Octopus provides half-hourly rates (normally 48 per day, fewer on DST
+        spring-forward, more on DST fall-back). Each rate is duplicated to
+        produce quarterly (15-minute) periods matching the system-wide resolution.
 
         Args:
             entity_id: HA entity ID to fetch from
@@ -130,7 +134,7 @@ class OctopusEnergySource(PriceSource):
             rate_type: "import" or "export" (for logging)
 
         Returns:
-            List of 96 quarterly rate values (value_inc_vat) sorted chronologically
+            List of quarterly rate values (value_inc_vat) sorted chronologically
 
         Raises:
             PriceDataUnavailableError: If rates cannot be fetched or validated
@@ -163,20 +167,27 @@ class OctopusEnergySource(PriceSource):
         # Filter rates for the target date and sort chronologically
         filtered_rates = self._filter_rates_for_date(rates, target_date)
 
-        if len(filtered_rates) < MIN_RAW_PERIODS:
+        # Compute expected half-hourly count from the actual day length
+        # (DST-aware via time_utils). Allow a tolerance for settlement-boundary
+        # timestamps that may carry the previous day's date.
+        quarterly_period_count = time_utils.get_period_count(target_date)
+        expected_raw = quarterly_period_count // 2
+        min_raw = expected_raw - _RAW_PERIOD_TOLERANCE
+
+        if len(filtered_rates) < min_raw:
             raise PriceDataUnavailableError(
                 date=target_date,
                 message=(
-                    f"Expected at least {MIN_RAW_PERIODS} {rate_type} rates for {target_date}, "
+                    f"Expected at least {min_raw} {rate_type} rates for {target_date}, "
                     f"got {len(filtered_rates)} from {entity_id}"
                 ),
             )
-        if len(filtered_rates) > EXPECTED_RAW_PERIODS:
+        if len(filtered_rates) > expected_raw:
             raise PriceDataUnavailableError(
                 date=target_date,
                 message=(
                     f"Too many {rate_type} rates for {target_date}: "
-                    f"expected at most {EXPECTED_RAW_PERIODS}, "
+                    f"expected at most {expected_raw}, "
                     f"got {len(filtered_rates)} from {entity_id}"
                 ),
             )
@@ -184,7 +195,7 @@ class OctopusEnergySource(PriceSource):
         # Extract value_inc_vat from each half-hourly rate entry
         half_hourly_prices = [float(rate["value_inc_vat"]) for rate in filtered_rates]
 
-        # Expand 48 half-hourly prices → 96 quarterly prices (duplicate each)
+        # Expand half-hourly prices → quarterly prices (duplicate each)
         quarterly_prices = [p for p in half_hourly_prices for _ in range(2)]
 
         logger.info(

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -1,6 +1,6 @@
 """Tests for extended DP optimization horizon with tomorrow's price data."""
 
-from datetime import date
+from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -9,19 +9,25 @@ from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.exceptions import PriceDataUnavailableError
 from core.bess.price_manager import MockSource
 from core.bess.tests.conftest import MockHomeAssistantController, MockSensorCollector
+from core.bess.time_utils import get_period_count
 
 
 class TodayOnlyMockSource(MockSource):
     """Mock source that only returns prices for today, raises for tomorrow."""
 
     def get_prices_for_date(self, target_date: date) -> list:
-        from datetime import datetime
-
         if target_date > datetime.now().date():
             raise PriceDataUnavailableError(
                 message="Tomorrow's prices not yet available"
             )
-        return self.test_prices
+        return self.test_prices[: get_period_count(target_date)]
+
+
+class DSTAwareMockSource(MockSource):
+    """Mock source that returns the correct period count per date (DST-aware)."""
+
+    def get_prices_for_date(self, target_date: date) -> list:
+        return self.test_prices[: get_period_count(target_date)]
 
 
 def _make_system(
@@ -37,15 +43,19 @@ def _make_system(
 
 @pytest.fixture
 def quarterly_prices_24h():
-    """96 quarterly prices with clear day/evening split."""
+    """Up to 100 quarterly prices with clear day/evening split.
+
+    Sized for the longest possible day (DST fall-back = 100 periods).
+    Tests should use DSTAwareMockSource to trim to the actual day length.
+    """
     # Moderate day prices (0.8), low evening (0.2)
-    return [0.8] * 64 + [0.2] * 32
+    return [0.8] * 68 + [0.2] * 32
 
 
 @pytest.fixture
 def quarterly_prices_tomorrow():
-    """96 quarterly prices for tomorrow - morning peak."""
-    return [0.3] * 32 + [1.5] * 32 + [0.5] * 32
+    """Up to 100 quarterly prices for tomorrow - morning peak."""
+    return [0.3] * 34 + [1.5] * 32 + [0.5] * 34
 
 
 class TestGetPriceDataExtended:
@@ -78,14 +88,16 @@ class TestGetPriceDataExtended:
 
     def test_prepare_next_day_unaffected(self, quarterly_prices_24h):
         """prepare_next_day=True flow is completely unaffected by extended horizon."""
-        source = MockSource(quarterly_prices_24h)
+        source = DSTAwareMockSource(quarterly_prices_24h)
         system = _make_system(source)
 
         prices, _price_entries = system._get_price_data(prepare_next_day=True)
 
+        tomorrow = datetime.now().date() + timedelta(days=1)
+        expected = get_period_count(tomorrow)
         assert prices is not None
         # prepare_next_day fetches only tomorrow's prices, no extension
-        assert len(prices) == 96
+        assert len(prices) == expected
 
     def test_192_period_cap_enforced(self):
         """Even with very long price arrays, cap at 192 periods."""
@@ -240,7 +252,7 @@ class TestScheduleTruncation:
     @patch("core.bess.battery_system_manager.SensorCollector", MockSensorCollector)
     def test_schedule_arrays_truncated_to_today(self, quarterly_prices_24h):
         """DPSchedule arrays should never exceed today's period count."""
-        source = MockSource(quarterly_prices_24h)
+        source = DSTAwareMockSource(quarterly_prices_24h)
         controller = MockHomeAssistantController()
         controller.settings["battery_soc"] = 50
         system = _make_system(source, controller)
@@ -273,9 +285,7 @@ class TestScheduleTruncation:
         dp_schedule, _growatt_manager = schedule_result
 
         # Verify all schedule arrays are bounded to today
-        from datetime import datetime
-
-        from core.bess.time_utils import TIMEZONE, get_period_count
+        from core.bess.time_utils import TIMEZONE
 
         today_count = get_period_count(datetime.now(tz=TIMEZONE).date())
         assert len(dp_schedule.actions) <= today_count

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from core.bess import time_utils
 from core.bess.exceptions import PriceDataUnavailableError, SystemConfigurationError
 from core.bess.octopus_energy_source import OctopusEnergySource
 from core.bess.price_manager import MockSource, PriceManager
@@ -111,13 +112,15 @@ class TestImportRateFetching:
 
     def test_fetch_tomorrow_import_rates(self):
         tomorrow = datetime.now().date() + timedelta(days=1)
-        rates = _make_rates(tomorrow)
+        expected_quarterly = time_utils.get_period_count(tomorrow)
+        expected_raw = expected_quarterly // 2
+        rates = _make_rates(tomorrow, count=expected_raw)
         controller = _make_ha_controller(rates)
         source = _make_source(controller)
 
         prices = source.get_prices_for_date(tomorrow)
 
-        assert len(prices) == 96
+        assert len(prices) == expected_quarterly
 
     def test_rejects_date_beyond_tomorrow(self):
         day_after = datetime.now().date() + timedelta(days=2)

--- a/core/bess/time_utils.py
+++ b/core/bess/time_utils.py
@@ -42,10 +42,14 @@ def get_period_count(target_date: date) -> int:
         Number of quarterly periods in this day
     """
     start = datetime.combine(target_date, time(0, 0), tzinfo=TIMEZONE)
-    next_day = start + timedelta(days=1)
+    next_midnight = datetime.combine(
+        target_date + timedelta(days=1), time(0, 0), tzinfo=TIMEZONE
+    )
 
-    # Calculate actual hours (DST-aware)
-    elapsed_hours = (next_day - start).total_seconds() / 3600
+    # Use epoch timestamps for correct DST-aware elapsed time.
+    # Direct datetime subtraction with ZoneInfo gives wall-clock difference
+    # (always 24h), not actual elapsed time.
+    elapsed_hours = (next_midnight.timestamp() - start.timestamp()) / 3600
 
     return int(elapsed_hours * PERIODS_PER_HOUR)
 


### PR DESCRIPTION
## Summary

- Octopus Energy price source rejects tomorrow's rates on DST spring-forward days. The hardcoded `MIN_RAW_PERIODS = 46` doesn't account for shorter days (23 hours) combined with settlement-boundary timestamps that carry the previous day's date, resulting in only 44 rates passing the date filter.
- Replaced static `MIN_RAW_PERIODS` / `EXPECTED_RAW_PERIODS` constants with DST-aware dynamic calculation using `time_utils.get_period_count()`, so rate count thresholds adjust automatically for spring-forward (44 minimum) and fall-back (48 minimum) transitions.

## Context

Discovered on 2026-03-28 (day before UK DST spring-forward). Every 15-minute optimization cycle logged:

```
Tomorrow prices not available (Expected at least 46 import rates for 2026-03-29, 
got 44 from event.octopus_energy_electricity_...next_day_rates), using today only
```

This prevented generation of tomorrow's optimization plan despite Octopus rates being available.

## Test plan

- [x] All existing Octopus source unit tests pass
- [ ] Deploy and verify tomorrow's plan is generated on next 15-minute update cycle
- [ ] Verify normal (non-DST) days still work correctly