### PR TITLE
[WIP] Solar clipping awareness for DC-coupled hybrid inverters (v8.1.1)

### DIFF
--- a/.claude/agents/bess-analyst.md
+++ b/.claude/agents/bess-analyst.md
@@ -84,6 +84,21 @@ You are a BESS (Battery Energy Storage System) analyst. Your role is to analyze 
 3. Trace the cost basis tracking through charge/discharge
 4. Verify price data fed to optimizer
 
+### Debugging DC Clipping / Solar Capture
+
+When `battery.inverter_ac_capacity_kw > 0` in config, the system is clipping-aware:
+
+- `split_solar_forecast()` splits raw solar into `ac_solar` (≤ inverter limit) and `dc_excess`
+- DC excess is fed to `optimize_battery_schedule(dc_excess_solar=...)` and `_run_dynamic_programming`
+- In `_calculate_reward`, DC excess is absorbed into battery **before** the AC optimization decision
+- `EnergyData.dc_excess_to_battery` = DC excess captured; `EnergyData.solar_clipped` = DC excess lost
+- `EnergyData.battery_charged` = AC-side charging only (does NOT include DC excess)
+- `EnergyData.solar_production` = AC solar only (capped at inverter limit), NOT raw DC production
+- DC excess has **zero grid cost**, only cycle cost in cost basis
+- The DP naturally keeps battery headroom for clipping hours because DC energy is cheaper than grid
+- Even the idle fallback schedule (`_create_idle_schedule`) absorbs DC excess automatically
+- When disabled (`inverter_ac_capacity_kw = 0`), behavior is identical to pre-clipping code
+
 ### Debugging Schedule Issues
 
 1. Read `growatt_schedule.py` TOU conversion logic

--- a/.claude/agents/bess-analyst.md
+++ b/.claude/agents/bess-analyst.md
@@ -95,9 +95,26 @@ When `battery.inverter_ac_capacity_kw > 0` in config, the system is clipping-awa
 - `EnergyData.battery_charged` = AC-side charging only (does NOT include DC excess)
 - `EnergyData.solar_production` = AC solar only (capped at inverter limit), NOT raw DC production
 - DC excess has **zero grid cost**, only cycle cost in cost basis
+- DC wear cost applies regardless of AC action (idle, charge, or discharge) — it's a physical process
 - The DP naturally keeps battery headroom for clipping hours because DC energy is cheaper than grid
 - Even the idle fallback schedule (`_create_idle_schedule`) absorbs DC excess automatically
 - When disabled (`inverter_ac_capacity_kw = 0`), behavior is identical to pre-clipping code
+- `validate_energy_balance()` checks AC-side only; DC excess is self-balancing by definition (dc_excess_to_battery + solar_clipped = total DC excess)
+
+#### API Visibility
+
+- `/api/dashboard` exposes `dcExcessToBattery` and `solarClipped` as `FormattedValue` fields per period
+- `/api/settings/battery` exposes `inverterAcCapacityKw` and `solarPanelDcCapacityKw`
+- Both fields appear in today's data (actual and predicted) and tomorrow's data
+- Values are zero when clipping is disabled or solar doesn't exceed inverter AC limit
+- Quarter-hourly values are summed when aggregating to hourly resolution
+
+#### Common Clipping Debugging Steps
+
+1. Check `inverterAcCapacityKw` is set > 0 in `/api/settings/battery` response
+2. Check solar forecast — clipping only occurs when per-period solar > `inverter_ac_capacity_kw * period_duration_hours`
+3. If `dcExcessToBattery` is always 0 but clipping should occur, check that `split_solar_forecast` is being called in `battery_system_manager.py._run_optimization`
+4. If `solarClipped` is high, battery may be reaching max SOE before peak clipping hours — check if the optimizer is keeping enough headroom
 
 ### Debugging Schedule Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed "Battery" label and internal title from Battery Mode Timeline for cleaner layout. (thanks [@pookey](https://github.com/pookey))
 - Removed "Actual hours" / "Predicted hours" legend labels from both charts (shading is self-explanatory). (thanks [@pookey](https://github.com/pookey))
 
+## [7.10.0] - 2026-03-14
+
+### Added
+
+- Solar clipping awareness for DC-coupled hybrid inverters. When `battery.inverter_ac_capacity_kw`
+  is set, the optimizer splits the Solcast solar forecast into AC-available solar (capped at the
+  inverter limit) and DC-excess solar (the portion that bypasses AC conversion and flows directly
+  to the battery on the DC bus). The DP algorithm naturally keeps battery headroom open during
+  clipping hours because DC-excess energy has zero grid cost — only cycle cost — making it
+  cheaper to store than grid-charged energy. (thanks [@pookey](https://github.com/pookey))
+- New `EnergyData` fields `dc_excess_to_battery` and `solar_clipped` track captured vs lost DC
+  excess per period for dashboard visibility.
+- New `battery.solar_panel_dc_capacity_kw` config setting (informational, not required).
+- Idle fallback schedule now absorbs DC excess even when AC optimization is rejected by the
+  profitability gate, since DC absorption is a physical process independent of AC decisions.
+
+### Changed
+
+- `EnergyData.solar_production` represents AC solar only (capped at inverter limit) when clipping
+  is enabled; `EnergyData.battery_charged` represents AC-side charging only.
+- Cost basis for DC-excess energy reflects cycle cost only (no grid cost), so the profitability
+  check naturally favours discharging DC-charged energy over grid-charged energy.
+- When `inverter_ac_capacity_kw = 0` (default), behaviour is identical to previous versions.
+
 ## [7.9.5] - 2026-03-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New `battery.solar_panel_dc_capacity_kw` config setting (informational, not required).
 - Idle fallback schedule now absorbs DC excess even when AC optimization is rejected by the
   profitability gate, since DC absorption is a physical process independent of AC decisions.
+- `dcExcessToBattery` and `solarClipped` exposed in `/api/dashboard` per-period response.
+- `inverterAcCapacityKw` and `solarPanelDcCapacityKw` exposed in `/api/settings/battery` response.
 
 ### Changed
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -377,6 +377,16 @@ def _aggregate_quarterly_to_hourly(
             solarSavings=create_formatted_value(
                 sum(p.solarSavings.value for p in quarter_periods), "currency", currency
             ),
+            dcExcessToBattery=create_formatted_value(
+                sum(p.dcExcessToBattery.value for p in quarter_periods),
+                "energy_kwh_only",
+                currency,
+            ),
+            solarClipped=create_formatted_value(
+                sum(p.solarClipped.value for p in quarter_periods),
+                "energy_kwh_only",
+                currency,
+            ),
             # Use dominant strategic intent with tie-breaking (same logic as Growatt schedule)
             strategicIntent=dominant_intent,
             directSolar=sum(p.directSolar for p in quarter_periods),

--- a/backend/api_dataclasses.py
+++ b/backend/api_dataclasses.py
@@ -276,6 +276,10 @@ class APIDashboardHourlyData:
     solarExcess: FormattedValue  # How much solar excess in solar-only scenario
     solarSavings: FormattedValue  # Savings from solar vs grid-only
 
+    # DC-coupled solar clipping fields
+    dcExcessToBattery: FormattedValue
+    solarClipped: FormattedValue
+
     # Raw values for logic only
     strategicIntent: str
     directSolar: float
@@ -398,6 +402,15 @@ class APIDashboardHourlyData:
             solarSavings=safe_format(
                 hourly.economic.solar_savings,
                 "currency",
+            ),
+            # DC-coupled solar clipping
+            dcExcessToBattery=safe_format(
+                getattr(hourly.energy, "dc_excess_to_battery", 0.0),
+                "energy_kwh_only",
+            ),
+            solarClipped=safe_format(
+                getattr(hourly.energy, "solar_clipped", 0.0),
+                "energy_kwh_only",
             ),
             # Raw values for logic
             strategicIntent=hourly.decision.strategic_intent,

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -17,6 +17,7 @@ from .dp_battery_algorithm import (
     OptimizationResult,
     optimize_battery_schedule,
     print_optimization_results,
+    split_solar_forecast,
 )
 from .dp_schedule import DPSchedule
 from .exceptions import (
@@ -1367,6 +1368,15 @@ class BatterySystemManager:
                 n_periods
             )
 
+            # Split solar into AC-available and DC-excess when inverter limit is configured
+            dc_excess_solar = None
+            if self.battery_settings.inverter_ac_capacity_kw > 0:
+                remaining_solar, dc_excess_solar = split_solar_forecast(
+                    solar_production=remaining_solar,
+                    inverter_ac_capacity_kw=self.battery_settings.inverter_ac_capacity_kw,
+                    period_duration_hours=0.25,
+                )
+
             # Run DP optimization with strategic intent capture - returns OptimizationResult directly
             result = optimize_battery_schedule(
                 buy_price=buy_prices,
@@ -1380,6 +1390,7 @@ class BatterySystemManager:
                 terminal_value_per_kwh=terminal_value,
                 currency=self.home_settings.currency,
                 max_charge_power_per_period=max_charge_power_per_period,
+                dc_excess_solar=dc_excess_solar,
             )
 
             # Add timestamps to period data (algorithm is time-agnostic, operates on relative indices)

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -74,6 +74,7 @@ The algorithm returns comprehensive results including:
 __all__ = [
     "optimize_battery_schedule",
     "print_optimization_results",
+    "split_solar_forecast",
 ]
 
 
@@ -115,6 +116,36 @@ class StrategicIntent(Enum):
     IDLE = "IDLE"  # No significant action (includes natural solar export)
 
 
+def split_solar_forecast(
+    solar_production: list[float],
+    inverter_ac_capacity_kw: float,
+    period_duration_hours: float,
+) -> tuple[list[float], list[float]]:
+    """Split solar forecast into AC-available and DC-excess components.
+
+    When solar DC production exceeds the inverter's AC output capacity, the excess
+    flows directly to the battery on the DC bus (bypassing AC conversion). This
+    function splits the raw solar forecast into:
+
+    - ac_solar: the portion that can be converted to AC (capped at inverter limit)
+    - dc_excess: the portion exceeding the AC limit (can only charge the battery)
+
+    Args:
+        solar_production: Raw solar forecast per period (kWh).
+        inverter_ac_capacity_kw: Inverter AC output limit in kW. Must be > 0.
+            Caller is responsible for skipping the split when the feature is
+            disabled (inverter_ac_capacity_kw == 0).
+        period_duration_hours: Duration of each period in hours.
+
+    Returns:
+        Tuple of (ac_solar, dc_excess) lists, both same length as solar_production.
+    """
+    ac_limit_kwh = inverter_ac_capacity_kw * period_duration_hours
+    ac_solar = [min(s, ac_limit_kwh) for s in solar_production]
+    dc_excess = [max(0.0, s - ac_limit_kwh) for s in solar_production]
+    return ac_solar, dc_excess
+
+
 def _discretize_state_action_space(
     battery_settings: BatterySettings,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -140,7 +171,11 @@ def _discretize_state_action_space(
 
 
 def _state_transition(
-    soe: float, power: float, battery_settings: BatterySettings, dt: float
+    soe: float,
+    power: float,
+    battery_settings: BatterySettings,
+    dt: float,
+    solar_excess_ac: float = 0.0,
 ) -> float:
     """
     Calculate the next state of energy based on current SOE and power action.
@@ -149,6 +184,12 @@ def _state_transition(
     - Charging: power x dt x efficiency = energy actually stored
     - Discharging: power x dt / efficiency = energy removed from storage
     This ensures that efficiency losses are properly accounted for in energy balance.
+
+    IDLE AUTO-CHARGING (load_first mode):
+    When power=0, the Growatt inverter operates in load_first mode where excess solar
+    automatically charges the battery before exporting to grid. solar_excess_ac (kW)
+    models this: any positive value causes the battery to charge up to the available
+    capacity and the inverter's charge power limit.
     """
     if power > 0:  # Charging
         # Energy stored = power throughput x charging efficiency
@@ -162,8 +203,11 @@ def _state_transition(
         actual_discharge = min(discharge_energy, available_energy)
         next_soe = soe - actual_discharge
 
-    else:  # Hold
-        next_soe = soe
+    else:  # IDLE (load_first mode): excess solar auto-charges battery
+        auto_charge_kw = min(solar_excess_ac, battery_settings.max_charge_power_kw)
+        auto_charge_stored = auto_charge_kw * dt * battery_settings.efficiency_charge
+        available_capacity = max(0.0, battery_settings.max_soe_kwh - soe)
+        next_soe = soe + min(auto_charge_stored, available_capacity)
 
     # Ensure SOE stays within physical bounds
     next_soe = min(
@@ -185,43 +229,62 @@ def _compute_reward(
     sell_price: list[float],
     solar_production: float,
     cost_basis: float,
+    dc_excess_solar: float = 0.0,
 ) -> tuple[float, float]:
     """Hot-path reward computation — returns scalars only, no dataclass allocation.
 
     CYCLE COST POLICY:
-    - Applied only to charging operations (not discharging)
     - Applied to energy actually stored (after efficiency losses)
-    - Grid costs applied to energy throughput (what you draw from grid)
-    - Cost basis includes BOTH grid costs AND cycle costs for profitability analysis
+    - For AC charging: cycle cost on energy stored from AC side
+    - For DC excess absorption: cycle cost on DC energy stored (zero grid cost)
+    - DC wear cost is always applied when dc_excess_solar > 0, regardless of AC action
+
+    DC EXCESS FLOW:
+    soe (pre-DC) -> soe_after_dc (absorbs dc_excess_solar) -> next_soe (AC action applied).
+    Caller must compute next_soe with _state_transition(soe_after_dc, power, ...).
 
     PROFITABILITY CHECK:
     - For any discharge, calculate the value of the discharged energy
     - Value = max(avoiding grid purchases, grid export revenue)
-    - Discharge only profitable if this value > cost_basis
+    - Discharge only profitable if this value > cost_basis (DC-blended)
     - Must account for discharge efficiency losses
 
-    Example for stored energy costing 2.61/kWh:
-    - If buy_price = 2.58, sell_price = 1.81
-    - Avoid purchase value: 2.58 x 0.95 = 2.45/kWh stored
-    - Export value: 1.81 x 0.95 = 1.72/kWh stored
-    - Best value: max(2.45, 1.72) = 2.45/kWh stored
-    - 2.45 < 2.61 → UNPROFITABLE (correctly blocked)
-
     Returns:
-        (reward, new_cost_basis) or (float("-inf"), cost_basis) if discharge is unprofitable.
+        (reward, new_cost_basis) or (float("-inf"), cost_basis_after_dc) if discharge unprofitable.
     """
     current_buy_price = buy_price[period]
     current_sell_price = sell_price[period]
 
     # Use same tolerance as main DP loop to handle floating-point imprecision from np.arange
-    # (e.g., intended 0.0 may be -5.33e-14, which must be treated as IDLE, not discharge)
     _power_tolerance = 0.001  # kW
 
-    # Battery flows
+    # ============================================================================
+    # DC EXCESS ABSORPTION (happens before AC decision)
+    # ============================================================================
+    dc_to_battery = min(dc_excess_solar, max(0.0, battery_settings.max_soe_kwh - soe))
+    soe_after_dc = soe + dc_to_battery
+    dc_wear_cost = dc_to_battery * battery_settings.cycle_cost_per_kwh
+
+    # Blend DC energy into cost basis at cycle-cost-only basis
+    if dc_to_battery > 0 and soe_after_dc > battery_settings.min_soe_kwh:
+        cost_basis_after_dc = (soe * cost_basis + dc_wear_cost) / soe_after_dc
+    else:
+        cost_basis_after_dc = cost_basis
+
+    # ============================================================================
+    # AC-SIDE ENERGY FLOWS
+    # ============================================================================
+    # solar_production here is AC solar (already capped at inverter limit by caller).
     battery_charged = max(0, power * dt) if power > _power_tolerance else 0.0
     battery_discharged = max(0, -power * dt) if power < -_power_tolerance else 0.0
 
-    # Grid flows from energy balance
+    # IDLE auto-charging: when power~=0 and next_soe > soe_after_dc, excess AC solar
+    # charged the battery (load_first mode). Derive throughput from SOE delta.
+    if -_power_tolerance <= power <= _power_tolerance and next_soe > soe_after_dc:
+        auto_charge_stored = next_soe - soe_after_dc
+        battery_charged = auto_charge_stored / battery_settings.efficiency_charge
+
+    # Grid flows from energy balance (AC solar only)
     energy_balance = (
         solar_production + battery_discharged - home_consumption - battery_charged
     )
@@ -231,39 +294,55 @@ def _compute_reward(
     # ============================================================================
     # BATTERY CYCLE COST AND COST BASIS CALCULATION
     # ============================================================================
-    new_cost_basis = cost_basis
+    new_cost_basis = cost_basis_after_dc
 
-    if power > _power_tolerance:  # Charging
+    if power > _power_tolerance:  # AC charging
         energy_stored = power * dt * battery_settings.efficiency_charge
-        battery_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
+        ac_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
+        battery_wear_cost = ac_wear_cost + dc_wear_cost
 
         solar_available = max(0, solar_production - home_consumption)
         solar_to_battery = min(solar_available, power * dt)
         grid_to_battery = max(0, (power * dt) - solar_to_battery)
         grid_energy_cost = grid_to_battery * current_buy_price
-        total_new_cost = grid_energy_cost + battery_wear_cost
+        total_new_cost = grid_energy_cost + ac_wear_cost
 
         if next_soe > battery_settings.min_soe_kwh:
-            existing_cost = soe * cost_basis
+            existing_cost = soe_after_dc * cost_basis_after_dc
             new_cost_basis = (existing_cost + total_new_cost) / next_soe
         else:
             new_cost_basis = (
-                (total_new_cost / energy_stored) if energy_stored > 0 else cost_basis
+                (total_new_cost / energy_stored)
+                if energy_stored > 0
+                else cost_basis_after_dc
             )
 
     elif power < -_power_tolerance:  # Discharging
-        battery_wear_cost = 0.0
+        battery_wear_cost = dc_wear_cost
 
-        # Profitability check: only discharge if value exceeds cost basis
+        # Profitability check vs DC-blended cost basis
         avoid_purchase_value = current_buy_price * battery_settings.efficiency_discharge
         export_value = current_sell_price * battery_settings.efficiency_discharge
         effective_value_per_kwh_stored = max(avoid_purchase_value, export_value)
 
-        if effective_value_per_kwh_stored <= cost_basis:
-            return float("-inf"), cost_basis
+        if effective_value_per_kwh_stored <= cost_basis_after_dc:
+            return float("-inf"), cost_basis_after_dc
 
-    else:  # Idle
-        battery_wear_cost = 0.0
+    else:  # IDLE
+        if next_soe > soe_after_dc:
+            # IDLE auto-charging from solar excess
+            auto_charge_stored = next_soe - soe_after_dc
+            ac_auto_wear_cost = (
+                auto_charge_stored * battery_settings.cycle_cost_per_kwh
+            )
+            battery_wear_cost = dc_wear_cost + ac_auto_wear_cost
+            if next_soe > battery_settings.min_soe_kwh:
+                existing_cost = soe_after_dc * cost_basis_after_dc
+                new_cost_basis = (existing_cost + ac_auto_wear_cost) / next_soe
+            else:
+                new_cost_basis = cost_basis_after_dc
+        else:
+            battery_wear_cost = dc_wear_cost
 
     # ============================================================================
     # REWARD CALCULATION
@@ -289,6 +368,7 @@ def _build_period_data(
     solar_production: float,
     new_cost_basis: float,
     currency: str,
+    dc_excess_solar: float = 0.0,
 ) -> PeriodData:
     """Build full PeriodData for the winning action of a DP cell.
 
@@ -298,8 +378,21 @@ def _build_period_data(
     current_buy_price = buy_price[period]
     current_sell_price = sell_price[period]
 
-    battery_charged = max(0, power * dt) if power > 0 else 0.0
-    battery_discharged = max(0, -power * dt) if power < 0 else 0.0
+    _power_tolerance = 0.001
+
+    # DC absorption (before AC action)
+    dc_to_battery = min(dc_excess_solar, max(0.0, battery_settings.max_soe_kwh - soe))
+    soe_after_dc = soe + dc_to_battery
+    dc_clipped = dc_excess_solar - dc_to_battery
+    dc_wear_cost = dc_to_battery * battery_settings.cycle_cost_per_kwh
+
+    battery_charged = max(0, power * dt) if power > _power_tolerance else 0.0
+    battery_discharged = max(0, -power * dt) if power < -_power_tolerance else 0.0
+
+    # IDLE auto-charging surfaces as AC-side battery_charged
+    if -_power_tolerance <= power <= _power_tolerance and next_soe > soe_after_dc:
+        auto_charge_stored = next_soe - soe_after_dc
+        battery_charged = auto_charge_stored / battery_settings.efficiency_charge
 
     energy_balance = (
         solar_production + battery_discharged - home_consumption - battery_charged
@@ -316,20 +409,28 @@ def _build_period_data(
         grid_exported=grid_exported,
         battery_soe_start=soe,
         battery_soe_end=next_soe,
+        dc_excess_to_battery=dc_to_battery,
+        solar_clipped=dc_clipped,
     )
 
-    if power > 0:  # Charging
+    if power > _power_tolerance:  # Charging
         energy_stored = power * dt * battery_settings.efficiency_charge
-        battery_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
+        ac_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
+        battery_wear_cost = ac_wear_cost + dc_wear_cost
 
-        expected_stored = next_soe - soe
+        expected_stored = next_soe - soe_after_dc
         if abs(energy_stored - expected_stored) > 0.01:
             logger.warning(
                 f"Energy stored mismatch: calculated={energy_stored:.3f}, "
                 f"SOE delta={expected_stored:.3f}"
             )
+    elif -_power_tolerance <= power <= _power_tolerance and next_soe > soe_after_dc:
+        auto_charge_stored = next_soe - soe_after_dc
+        battery_wear_cost = (
+            dc_wear_cost + auto_charge_stored * battery_settings.cycle_cost_per_kwh
+        )
     else:
-        battery_wear_cost = 0.0
+        battery_wear_cost = dc_wear_cost
 
     import_cost = grid_imported * current_buy_price
     export_revenue = grid_exported * current_sell_price
@@ -510,6 +611,7 @@ def _run_dynamic_programming(
     terminal_value_per_kwh: float = 0.0,
     currency: str = "SEK",
     max_charge_power_per_period: list[float] | None = None,
+    dc_excess_solar: list[float] | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
     """
     Enhanced DP that stores the PeriodData objects calculated during optimization.
@@ -557,6 +659,23 @@ def _run_dynamic_programming(
                 else None
             )
 
+            # DC excess absorption for this period (happens before AC decision)
+            dc_excess = dc_excess_solar[t] if dc_excess_solar is not None else 0.0
+            dc_to_battery = min(
+                dc_excess, max(0.0, battery_settings.max_soe_kwh - soe)
+            )
+            soe_after_dc = soe + dc_to_battery
+
+            # Solar excess for IDLE auto-charging (load_first mode).
+            # Excess AC solar auto-charges the battery before exporting to grid.
+            effective_max_charge = (
+                period_max_charge
+                if period_max_charge is not None
+                else battery_settings.max_charge_power_kw
+            )
+            solar_excess_kwh = max(0.0, solar_production[t] - home_consumption[t])
+            solar_excess_ac_kw = min(solar_excess_kwh / dt, effective_max_charge)
+
             # Try all possible actions
             for power in power_levels:
                 # Skip physically impossible actions (same as before)
@@ -564,7 +683,8 @@ def _run_dynamic_programming(
                 # (e.g., "0.0" might be 2.2e-16 which would incorrectly match "power > 0")
                 power_tolerance = 0.001  # kW
                 if power < -power_tolerance:  # Discharging
-                    available_energy = soe - battery_settings.min_soe_kwh
+                    # Available energy is from soe_after_dc (DC fills battery first)
+                    available_energy = soe_after_dc - battery_settings.min_soe_kwh
                     max_discharge_power = (
                         available_energy / dt * battery_settings.efficiency_discharge
                     )
@@ -575,7 +695,8 @@ def _run_dynamic_programming(
                     if period_max_charge is not None and power > period_max_charge:
                         continue
 
-                    available_capacity = battery_settings.max_soe_kwh - soe
+                    # Available capacity accounts for DC already absorbed
+                    available_capacity = battery_settings.max_soe_kwh - soe_after_dc
                     max_charge_power = (
                         available_capacity / dt / battery_settings.efficiency_charge
                     )
@@ -583,8 +704,10 @@ def _run_dynamic_programming(
                         continue
                 # else: IDLE (near-zero power) - no physical constraints to check
 
-                # Calculate next state
-                next_soe = _state_transition(soe, power, battery_settings, dt)
+                # Calculate next state from soe_after_dc (DC absorbed, then AC action)
+                next_soe = _state_transition(
+                    soe_after_dc, power, battery_settings, dt, solar_excess_ac_kw
+                )
                 if (
                     next_soe < battery_settings.min_soe_kwh
                     or next_soe > battery_settings.max_soe_kwh
@@ -604,6 +727,7 @@ def _run_dynamic_programming(
                     buy_price=buy_price,
                     sell_price=sell_price,
                     cost_basis=C[t, i],
+                    dc_excess_solar=dc_excess,
                 )
 
                 # Skip if unprofitable
@@ -643,6 +767,7 @@ def _run_dynamic_programming(
                     sell_price=sell_price,
                     new_cost_basis=best_new_cost_basis,
                     currency=currency,
+                    dc_excess_solar=dc_excess,
                 )
             else:
                 # No valid action found - create a default IDLE PeriodData
@@ -651,24 +776,43 @@ def _run_dynamic_programming(
                     f"No valid action found for period {t}, state {i} (SOE={soe:.1f}). "
                     f"Creating default IDLE state."
                 )
-                # Calculate IDLE scenario: no battery action, just grid covering consumption
+                # IDLE: no AC charging action, but DC excess + solar auto-charging
+                dc_clipped_idle = dc_excess - dc_to_battery
+                idle_auto_soe = _state_transition(
+                    soe_after_dc, 0.0, battery_settings, dt, solar_excess_ac_kw
+                )
+                idle_auto_stored = idle_auto_soe - soe_after_dc
+                idle_battery_charged = (
+                    idle_auto_stored / battery_settings.efficiency_charge
+                    if idle_auto_stored > 0
+                    else 0.0
+                )
                 idle_grid_imported = max(0, home_consumption[t] - solar_production[t])
-                idle_grid_exported = max(0, solar_production[t] - home_consumption[t])
+                idle_grid_exported = max(
+                    0,
+                    solar_production[t] - home_consumption[t] - idle_battery_charged,
+                )
                 idle_energy = EnergyData(
                     solar_production=solar_production[t],
                     home_consumption=home_consumption[t],
-                    battery_charged=0.0,
+                    battery_charged=idle_battery_charged,
                     battery_discharged=0.0,
                     grid_imported=idle_grid_imported,
                     grid_exported=idle_grid_exported,
                     battery_soe_start=soe,
-                    battery_soe_end=soe,
+                    battery_soe_end=idle_auto_soe,
+                    dc_excess_to_battery=dc_to_battery,
+                    solar_clipped=dc_clipped_idle,
+                )
+                dc_wear_idle = dc_to_battery * battery_settings.cycle_cost_per_kwh
+                ac_auto_wear_idle = (
+                    idle_auto_stored * battery_settings.cycle_cost_per_kwh
                 )
                 idle_economic = EconomicData.from_energy_data(
                     energy_data=idle_energy,
                     buy_price=buy_price[t],
                     sell_price=sell_price[t],
-                    battery_cycle_cost=0.0,
+                    battery_cycle_cost=dc_wear_idle + ac_auto_wear_idle,
                 )
                 idle_decision = DecisionData(
                     strategic_intent="IDLE",
@@ -692,12 +836,17 @@ def _run_dynamic_programming(
                     -(
                         idle_grid_imported * buy_price[t]
                         - idle_grid_exported * sell_price[t]
+                        + dc_wear_idle
+                        + ac_auto_wear_idle
                     )
                     + V[t + 1, i]
                 )
 
-            # Update cost basis for next time step
-            if best_action != 0 and t + 1 < horizon:
+            # Update cost basis for next time step — also propagate when DC excess
+            # or IDLE auto-charge changed the SOE without an explicit action.
+            if t + 1 < horizon and (
+                best_action != 0 or dc_to_battery > 0 or best_next_soe > soe
+            ):
                 next_i = round(
                     (best_next_soe - battery_settings.min_soe_kwh) / SOE_STEP_KWH
                 )
@@ -731,9 +880,15 @@ def _create_idle_schedule(
     solar_production: list[float],
     initial_soe: float,
     battery_settings: BatterySettings,
+    dt: float = 0.25,
+    dc_excess_solar: list[float] | None = None,
 ) -> OptimizationResult:
     """
-    Create an all-IDLE schedule where battery does nothing.
+    Create an all-IDLE schedule where battery does no explicit AC charging/discharging.
+
+    DC excess solar is still absorbed into the battery (a physical process that
+    happens automatically, independent of optimization decisions). In load_first
+    (IDLE) mode, excess AC solar also auto-charges the battery before exporting.
 
     Used as fallback when optimization doesn't meet minimum profit threshold.
     """
@@ -741,23 +896,52 @@ def _create_idle_schedule(
     current_soe = initial_soe
 
     for t in range(horizon):
-        # No battery action - pure grid consumption
+        # DC excess absorption (automatic, even in idle schedule)
+        dc_excess = dc_excess_solar[t] if dc_excess_solar is not None else 0.0
+        dc_to_battery = min(
+            dc_excess, max(0.0, battery_settings.max_soe_kwh - current_soe)
+        )
+        dc_clipped = dc_excess - dc_to_battery
+        soe_after_dc = current_soe + dc_to_battery
+        dc_wear_cost = dc_to_battery * battery_settings.cycle_cost_per_kwh
+
+        # Auto-charging from AC solar excess (load_first mode)
+        solar_excess_kwh = max(0.0, solar_production[t] - home_consumption[t])
+        auto_charge_kw = min(
+            solar_excess_kwh / dt, battery_settings.max_charge_power_kw
+        )
+        auto_charge_stored = min(
+            auto_charge_kw * dt * battery_settings.efficiency_charge,
+            max(0.0, battery_settings.max_soe_kwh - soe_after_dc),
+        )
+        auto_battery_charged = (
+            auto_charge_stored / battery_settings.efficiency_charge
+            if auto_charge_stored > 0
+            else 0.0
+        )
+        soe_end = soe_after_dc + auto_charge_stored
+        ac_auto_wear_cost = auto_charge_stored * battery_settings.cycle_cost_per_kwh
+
         energy_data = EnergyData(
             solar_production=solar_production[t],
             home_consumption=home_consumption[t],
-            battery_charged=0.0,
+            battery_charged=auto_battery_charged,
             battery_discharged=0.0,
             grid_imported=max(0, home_consumption[t] - solar_production[t]),
-            grid_exported=max(0, solar_production[t] - home_consumption[t]),
+            grid_exported=max(
+                0, solar_production[t] - home_consumption[t] - auto_battery_charged
+            ),
             battery_soe_start=current_soe,
-            battery_soe_end=current_soe,
+            battery_soe_end=soe_end,
+            dc_excess_to_battery=dc_to_battery,
+            solar_clipped=dc_clipped,
         )
 
         economic_data = EconomicData.from_energy_data(
             energy_data=energy_data,
             buy_price=buy_price[t],
             sell_price=sell_price[t],
-            battery_cycle_cost=0.0,
+            battery_cycle_cost=dc_wear_cost + ac_auto_wear_cost,
         )
 
         decision_data = DecisionData(
@@ -776,6 +960,7 @@ def _create_idle_schedule(
         )
 
         period_data_list.append(period_data)
+        current_soe = soe_end
 
     # Calculate economic summary for idle schedule
     total_base_cost = sum(home_consumption[i] * buy_price[i] for i in range(horizon))
@@ -820,6 +1005,7 @@ def optimize_battery_schedule(
     terminal_value_per_kwh: float = 0.0,
     currency: str = "SEK",
     max_charge_power_per_period: list[float] | None = None,
+    dc_excess_solar: list[float] | None = None,
 ) -> OptimizationResult:
     """
     Battery optimization that eliminates dual cost calculation by using
@@ -891,6 +1077,7 @@ def optimize_battery_schedule(
         terminal_value_per_kwh=terminal_value_per_kwh,
         currency=currency,
         max_charge_power_per_period=max_charge_power_per_period,
+        dc_excess_solar=dc_excess_solar,
     )
 
     # Step 2: Extract optimal path results directly from stored DP data
@@ -980,6 +1167,8 @@ def optimize_battery_schedule(
             solar_production=solar_production,
             initial_soe=initial_soe,
             battery_settings=battery_settings,
+            dt=dt,
+            dc_excess_solar=dc_excess_solar,
         )
 
     return OptimizationResult(

--- a/core/bess/models.py
+++ b/core/bess/models.py
@@ -75,6 +75,10 @@ class EnergyData:
     battery_soe_start: float  # kWh (changed from battery_soc_start)
     battery_soe_end: float  # kWh (changed from battery_soc_end)
 
+    # DC clipping flows (set by caller when inverter AC capacity limit is configured)
+    dc_excess_to_battery: float = 0.0  # DC excess absorbed directly by battery (kWh)
+    solar_clipped: float = 0.0  # DC excess lost because battery was full (kWh)
+
     # Detailed flows (calculated automatically in __post_init__)
     solar_to_home: float = field(default=0.0, init=False)
     solar_to_battery: float = field(default=0.0, init=False)
@@ -180,9 +184,7 @@ class EconomicData:
         0.0  # cost with solar only (no battery - algorithm baseline)
     )
     hourly_savings: float = 0.0  # savings vs baseline scenario
-    solar_savings: float = field(
-        default=0.0, init=False
-    )  # calculated automatically
+    solar_savings: float = field(default=0.0, init=False)  # calculated automatically
 
     def __post_init__(self):
         """Calculate derived economic fields."""
@@ -261,9 +263,7 @@ class EconomicSummary:
     solar_only_cost: float
     battery_solar_cost: float
     grid_to_solar_savings: float  # savings from solar vs grid-only
-    grid_to_battery_solar_savings: (
-        float  # savings from battery+solar vs grid-only
-    )
+    grid_to_battery_solar_savings: float  # savings from battery+solar vs grid-only
     solar_to_battery_solar_savings: float
     grid_to_battery_solar_savings_pct: float  # % - percentage savings vs grid-only
     total_charged: float

--- a/core/bess/models.py
+++ b/core/bess/models.py
@@ -152,7 +152,17 @@ class EnergyData:
         return self.battery_soe_end - self.battery_soe_start
 
     def validate_energy_balance(self, tolerance: float = 0.2) -> tuple[bool, str]:
-        """Validate energy balance - always warn and continue, never fail."""
+        """Validate energy balance - always warn and continue, never fail.
+
+        This checks AC-side energy conservation only. DC excess solar
+        (dc_excess_to_battery, solar_clipped) bypasses the AC bus entirely
+        and is balanced by definition (dc_excess_to_battery + solar_clipped
+        = total DC excess). The SOE change includes DC absorption but that
+        does not affect AC-side energy accounting.
+
+        Note: battery_charged is AC-side charging only; solar_production is
+        AC solar only (capped at inverter limit) when clipping is enabled.
+        """
         energy_in = self.solar_production + self.grid_imported + self.battery_discharged
         energy_out = self.home_consumption + self.grid_exported + self.battery_charged
         balance_error = abs(energy_in - energy_out)

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -121,6 +121,8 @@ class BatterySettings:
     )
     efficiency_charge: float = BATTERY_EFFICIENCY_CHARGE
     efficiency_discharge: float = BATTERY_EFFICIENCY_DISCHARGE
+    inverter_ac_capacity_kw: float = 0.0
+    solar_panel_dc_capacity_kw: float = 0.0
     reserved_capacity: float = field(init=False)
     min_soe_kwh: float = field(init=False)
     max_soe_kwh: float = field(init=False)
@@ -160,6 +162,12 @@ class BatterySettings:
             )
             self.min_action_profit_threshold = battery_config.get(
                 "min_action_profit_threshold", BATTERY_MIN_ACTION_PROFIT_THRESHOLD
+            )
+            self.inverter_ac_capacity_kw = battery_config.get(
+                "inverter_ac_capacity_kw", 0.0
+            )
+            self.solar_panel_dc_capacity_kw = battery_config.get(
+                "solar_panel_dc_capacity_kw", 0.0
             )
             self.__post_init__()
         return self

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -7,7 +7,12 @@ core functions produce outputs with the expected structure and reasonable values
 but don't test specific optimization results.
 """
 
-from core.bess.dp_battery_algorithm import optimize_battery_schedule
+import pytest  # type: ignore
+
+from core.bess.dp_battery_algorithm import (
+    optimize_battery_schedule,
+    split_solar_forecast,
+)
 from core.bess.models import EconomicSummary, PeriodData
 from core.bess.settings import BatterySettings
 
@@ -417,3 +422,200 @@ def test_strategy_data_structure():
         assert hour_data.decision.strategic_intent is not None
         assert hour_data.decision.battery_action is not None
         assert hour_data.decision.cost_basis >= 0
+
+
+# =============================================================================
+# Solar Clipping Tests
+# =============================================================================
+
+
+def test_split_solar_forecast_math():
+    """split_solar_forecast correctly separates AC and DC-excess components."""
+    # 96 periods of 15min each (0.25h), inverter limited to 5kW → 1.25 kWh/period
+    raw_solar = [0.0] * 32 + [0.5] * 16 + [1.5] * 16 + [2.0] * 16 + [0.0] * 16
+    ac_solar, dc_excess = split_solar_forecast(
+        solar_production=raw_solar,
+        inverter_ac_capacity_kw=5.0,
+        period_duration_hours=0.25,
+    )
+    ac_limit = 5.0 * 0.25  # 1.25 kWh per period
+
+    assert len(ac_solar) == len(raw_solar)
+    assert len(dc_excess) == len(raw_solar)
+
+    for raw, ac, dc in zip(raw_solar, ac_solar, dc_excess, strict=True):
+        assert ac == min(raw, ac_limit)
+        assert dc == max(0.0, raw - ac_limit)
+        assert abs(ac + dc - raw) < 1e-9
+
+    # Periods below the limit have no DC excess
+    for i in range(48):  # first 48 periods: 0.0 or 0.5 kWh (both < 1.25 kWh)
+        assert dc_excess[i] == 0.0
+
+    # Periods above the limit have DC excess
+    for i in range(64, 80):  # 2.0 kWh/period > 1.25 kWh limit
+        assert dc_excess[i] == pytest.approx(0.75)
+
+
+def test_split_solar_forecast_zero_inverter_limit():
+    """split_solar_forecast with 0.0 inverter limit returns all solar as AC (disabled)."""
+    raw_solar = [1.0, 2.0, 3.0]
+    ac_solar, dc_excess = split_solar_forecast(
+        solar_production=raw_solar,
+        inverter_ac_capacity_kw=0.0,
+        period_duration_hours=0.25,
+    )
+    # AC limit = 0 kWh → all solar is capped at 0, all is DC excess
+    assert ac_solar == [0.0, 0.0, 0.0]
+    assert dc_excess == [1.0, 2.0, 3.0]
+
+
+def test_no_clipping_when_disabled():
+    """Optimizer behavior is identical when inverter_ac_capacity_kw is 0 (disabled)."""
+    buy_price = [0.3] * 8 + [1.5] * 8 + [0.3] * 8
+    sell_price = [0.2] * 24
+    home_consumption = [0.5] * 24
+    solar = [0.0] * 8 + [3.0] * 8 + [0.0] * 8
+
+    settings = BatterySettings(
+        total_capacity=10.0,
+        min_soc=10.0,
+        max_soc=100.0,
+        max_charge_power_kw=5.0,
+        max_discharge_power_kw=5.0,
+        cycle_cost_per_kwh=0.10,
+        min_action_profit_threshold=0.0,
+    )
+
+    # Without DC excess (no clipping)
+    result_no_clip = optimize_battery_schedule(
+        buy_price=buy_price,
+        sell_price=sell_price,
+        home_consumption=home_consumption,
+        solar_production=solar,
+        initial_soe=settings.min_soe_kwh,
+        battery_settings=settings,
+        dc_excess_solar=None,
+    )
+
+    # With dc_excess_solar of all zeros (equivalent to disabled)
+    result_zeros = optimize_battery_schedule(
+        buy_price=buy_price,
+        sell_price=sell_price,
+        home_consumption=home_consumption,
+        solar_production=solar,
+        initial_soe=settings.min_soe_kwh,
+        battery_settings=settings,
+        dc_excess_solar=[0.0] * 24,
+    )
+
+    # Both results should have identical economic outcomes
+    assert result_no_clip.economic_summary is not None
+    assert result_zeros.economic_summary is not None
+    assert (
+        result_no_clip.economic_summary.grid_to_battery_solar_savings
+        == pytest.approx(
+            result_zeros.economic_summary.grid_to_battery_solar_savings, abs=0.01
+        )
+    )
+    assert result_no_clip.economic_summary.battery_solar_cost == pytest.approx(
+        result_zeros.economic_summary.battery_solar_cost, abs=0.01
+    )
+
+
+def test_dc_excess_has_zero_grid_cost():
+    """DC excess stored in battery has cost basis reflecting only cycle cost (no grid cost).
+
+    Even when the profitability gate rejects AC optimization (falls back to idle schedule),
+    DC excess is still physically absorbed into the battery — it is tracked in the result.
+    """
+    settings = BatterySettings(
+        total_capacity=10.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=5.0,
+        max_discharge_power_kw=5.0,
+        cycle_cost_per_kwh=0.40,
+        min_action_profit_threshold=0.0,
+    )
+
+    # 4 periods: DC excess midday, high-price consumption in the evening.
+    # Period 0-1: DC excess available, battery absorbs it (free solar, cycle cost only)
+    # Period 2-3: expensive grid, discharge stored DC energy for home consumption
+    buy_price = [0.3, 0.3, 2.0, 2.0]
+    sell_price = [0.1, 0.1, 0.1, 0.1]
+    home_consumption = [0.0, 0.0, 1.5, 1.5]
+    ac_solar = [0.0, 0.0, 0.0, 0.0]
+    dc_excess = [2.0, 2.0, 0.0, 0.0]
+
+    result = optimize_battery_schedule(
+        buy_price=buy_price,
+        sell_price=sell_price,
+        home_consumption=home_consumption,
+        solar_production=ac_solar,
+        initial_soe=0.0,
+        battery_settings=settings,
+        dc_excess_solar=dc_excess,
+    )
+
+    assert len(result.period_data) == 4
+
+    # DC excess periods should show absorption with no grid import
+    dc_periods = [p for p in result.period_data if p.energy.dc_excess_to_battery > 0]
+    assert len(dc_periods) > 0, "Expected at least one period with DC excess absorption"
+
+    for period in dc_periods:
+        # DC excess is absorbed without any grid import (it's free solar on DC bus)
+        assert period.energy.grid_imported == pytest.approx(
+            0.0, abs=0.01
+        ), "DC excess absorption should not require grid import"
+        # DC excess tracked separately (not as AC solar)
+        assert period.energy.solar_production == pytest.approx(0.0, abs=0.01)
+
+
+def test_clipping_capture_preferred_over_grid_charge():
+    """Optimizer keeps battery headroom for free clipped solar rather than grid-charging early."""
+    settings = BatterySettings(
+        total_capacity=10.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=5.0,
+        max_discharge_power_kw=5.0,
+        cycle_cost_per_kwh=0.10,
+        min_action_profit_threshold=0.0,
+    )
+
+    # Scenario: cheap grid at night (periods 0-7), DC clipping midday (periods 8-15),
+    # expensive grid evening (periods 16-23).
+    # A clipping-unaware optimizer would grid-charge at night, filling battery before clipping.
+    # A clipping-aware optimizer should leave headroom for free clipped solar.
+    buy_price = [0.2] * 8 + [1.0] * 8 + [2.0] * 8
+    sell_price = [0.1] * 24
+    home_consumption = [0.2] * 24
+    ac_solar = [0.0] * 8 + [1.0] * 8 + [0.0] * 8  # AC solar (capped at inverter limit)
+    dc_excess = [0.0] * 8 + [1.5] * 8 + [0.0] * 8  # DC excess above inverter limit
+
+    result_with_clipping = optimize_battery_schedule(
+        buy_price=buy_price,
+        sell_price=sell_price,
+        home_consumption=home_consumption,
+        solar_production=ac_solar,
+        initial_soe=0.0,
+        battery_settings=settings,
+        dc_excess_solar=dc_excess,
+    )
+
+    # Calculate total solar clipped in the clipping-aware result
+    total_clipped = sum(
+        p.energy.solar_clipped for p in result_with_clipping.period_data
+    )
+
+    # The optimizer should capture most of the available DC excess (not clip it due to full battery)
+    total_dc_available = sum(dc_excess)
+    capture_rate = (
+        1.0 - (total_clipped / total_dc_available) if total_dc_available > 0 else 1.0
+    )
+    assert capture_rate > 0.5, (
+        f"Expected optimizer to capture >50% of DC excess, got {capture_rate:.1%} "
+        f"(clipped={total_clipped:.2f} of {total_dc_available:.2f} kWh)"
+    )

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -10,6 +10,7 @@ but don't test specific optimization results.
 import pytest  # type: ignore
 
 from core.bess.dp_battery_algorithm import (
+    _state_transition,
     optimize_battery_schedule,
     split_solar_forecast,
 )
@@ -617,4 +618,135 @@ def test_clipping_capture_preferred_over_grid_charge():
     assert capture_rate > 0.5, (
         f"Expected optimizer to capture >50% of DC excess, got {capture_rate:.1%} "
         f"(clipped={total_clipped:.2f} of {total_dc_available:.2f} kWh)"
+    )
+
+
+def test_idle_models_solar_auto_charging():
+    """In IDLE (load_first) mode, excess solar auto-charges the battery.
+
+    When power=0, _state_transition must increase SOE when solar exceeds consumption.
+    """
+    settings = BatterySettings(
+        total_capacity=10.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=5.0,
+        efficiency_charge=0.95,
+        cycle_cost_per_kwh=0.10,
+    )
+    soe_start = 2.0
+    dt = 0.25  # 15-minute period
+    solar_excess_kw = 3.0  # 3 kW excess solar after meeting home load
+
+    next_soe = _state_transition(
+        soe_start, 0.0, settings, dt, solar_excess_ac=solar_excess_kw
+    )
+
+    # Battery should have charged from solar excess
+    assert next_soe > soe_start, "IDLE with solar excess must increase battery SOE"
+    expected_stored = (
+        min(solar_excess_kw, settings.max_charge_power_kw)
+        * dt
+        * settings.efficiency_charge
+    )
+    assert next_soe == pytest.approx(soe_start + expected_stored, abs=0.001)
+
+
+def test_idle_auto_charge_capped_at_capacity():
+    """Auto-charging in IDLE mode stops at max_soe — cannot overflow the battery."""
+    settings = BatterySettings(
+        total_capacity=10.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=5.0,
+        efficiency_charge=0.95,
+        cycle_cost_per_kwh=0.10,
+    )
+    # Start near full — only 0.1 kWh of headroom
+    soe_start = 9.9
+    dt = 0.25
+    solar_excess_kw = 5.0  # More solar than capacity allows
+
+    next_soe = _state_transition(
+        soe_start, 0.0, settings, dt, solar_excess_ac=solar_excess_kw
+    )
+
+    assert next_soe <= settings.max_soe_kwh, "SOE must not exceed max_soe"
+    assert next_soe == pytest.approx(settings.max_soe_kwh, abs=0.001)
+
+
+def test_idle_no_auto_charge_without_solar_excess():
+    """Without solar excess, IDLE holds battery flat (original behavior preserved)."""
+    settings = BatterySettings(
+        total_capacity=10.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=5.0,
+        cycle_cost_per_kwh=0.10,
+    )
+    soe_start = 5.0
+    dt = 0.25
+
+    next_soe = _state_transition(soe_start, 0.0, settings, dt, solar_excess_ac=0.0)
+
+    assert next_soe == pytest.approx(
+        soe_start, abs=0.001
+    ), "No excess solar → SOE unchanged"
+
+
+def test_dp_keeps_headroom_for_dc_excess_over_morning_solar():
+    """With DC clipping enabled, DP should prefer keeping battery headroom for free DC excess
+    over filling the battery from morning AC solar auto-charging.
+
+    Setup: morning solar excess in IDLE → fills battery without fix.
+    Afternoon DC excess clipped if battery is full.
+    Fix: DP models morning auto-charging, sees headroom lost → schedules discharge or EXPORT_ARBITRAGE.
+    """
+    settings = BatterySettings(
+        total_capacity=10.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=5.0,
+        max_discharge_power_kw=5.0,
+        cycle_cost_per_kwh=0.10,
+        min_action_profit_threshold=0.0,
+    )
+
+    # 8 periods (2h at 15-min resolution):
+    # Periods 0-3: morning — solar > consumption (auto-charges battery in IDLE)
+    # Periods 4-7: afternoon — DC excess available (free solar, but only fits if battery not full)
+    buy_price = [0.5] * 4 + [0.5] * 4
+    sell_price = [0.1] * 8
+    # Morning: 2 kWh solar, 0.5 kWh consumption → 1.5 kWh excess per period
+    home_consumption = [0.5] * 4 + [0.5] * 4
+    ac_solar = [2.0] * 4 + [0.0] * 4
+    # Afternoon: 1.5 kWh DC excess per period (8 periods = 6 kWh total)
+    dc_excess = [0.0] * 4 + [1.5] * 4
+
+    # Battery starts empty — morning solar would fill it to ~5.7 kWh in IDLE (4x1.5x0.95)
+    result = optimize_battery_schedule(
+        buy_price=buy_price,
+        sell_price=sell_price,
+        home_consumption=home_consumption,
+        solar_production=ac_solar,
+        initial_soe=0.0,
+        battery_settings=settings,
+        dc_excess_solar=dc_excess,
+        period_duration_hours=0.25,
+    )
+
+    # Total DC excess available
+    total_dc_available = sum(dc_excess)
+
+    # Total DC excess absorbed (not clipped)
+    total_dc_absorbed = sum(p.energy.dc_excess_to_battery for p in result.period_data)
+    total_clipped = sum(p.energy.solar_clipped for p in result.period_data)
+
+    # The optimizer should capture most of the DC excess by managing morning SOE
+    capture_rate = (
+        total_dc_absorbed / total_dc_available if total_dc_available > 0 else 1.0
+    )
+    assert capture_rate > 0.5, (
+        f"Expected DP to capture >50% of DC excess by managing morning battery SOE, "
+        f"got {capture_rate:.1%} (absorbed={total_dc_absorbed:.2f}, clipped={total_clipped:.2f})"
     )

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -457,17 +457,16 @@ def test_split_solar_forecast_math():
         assert dc_excess[i] == pytest.approx(0.75)
 
 
-def test_split_solar_forecast_zero_inverter_limit():
-    """split_solar_forecast with 0.0 inverter limit returns all solar as AC (disabled)."""
-    raw_solar = [1.0, 2.0, 3.0]
+def test_split_solar_forecast_preserves_total():
+    """AC + DC excess always equals the raw solar input for every period."""
+    raw_solar = [0.0, 0.5, 1.25, 2.0, 3.5]
     ac_solar, dc_excess = split_solar_forecast(
         solar_production=raw_solar,
-        inverter_ac_capacity_kw=0.0,
+        inverter_ac_capacity_kw=5.0,
         period_duration_hours=0.25,
     )
-    # AC limit = 0 kWh → all solar is capped at 0, all is DC excess
-    assert ac_solar == [0.0, 0.0, 0.0]
-    assert dc_excess == [1.0, 2.0, 3.0]
+    for raw, ac, dc in zip(raw_solar, ac_solar, dc_excess, strict=True):
+        assert ac + dc == pytest.approx(raw)
 
 
 def test_no_clipping_when_disabled():


### PR DESCRIPTION
> **⚠️ WIP / casual work-in-progress.** I'm still tinkering with this feature casually on my own hardware. This PR is raised purely so anyone else who's interested can follow along, comment, or contribute — no expectation of merge, and no urgency. Happy to keep it as a draft indefinitely.

Re-opens #58 against v8.1.1 after the upstream DP refactor. The original PR was closed pending a rebase onto the refactored algorithm.

## Summary

When the DC panel capacity exceeds the inverter's AC output limit, the battery would previously fill before peak solar hours, permanently wasting DC-excess energy the inverter cannot convert to AC. This PR teaches the DP optimizer about the clipping boundary so it preserves battery headroom for the peak.

- `split_solar_forecast()` divides the Solcast forecast into AC solar (≤ inverter limit) and DC-excess solar.
- The DP absorbs DC excess before its AC-side charge/discharge decision.
- DC-excess energy has zero grid cost (only cycle cost), so backward induction naturally defers grid-charging to after the clipping window — no heuristics.
- Backward compatible: `inverter_ac_capacity_kw = 0` (default) matches previous behaviour.

## Changes since #58

This is a clean port onto v8.1.1 plus fixes for all reviewer feedback from the original PR:

- **Rebased onto the `_compute_reward` / `_build_period_data` split** introduced by the DP refactor (commit `1fa811d`).
- **Code review items from the original PR** ([original comment](https://github.com/johanzander/bess-manager/pull/58#issuecomment-4061431654), addressed in commit `91b8676`):
  - ~~`config.yaml` schema `float` → `float?`~~ — obsolete under v8's unified settings API (these fields are no longer gated by the HA add-on schema).
  - Fixed `split_solar_forecast` docstring/test: `inverter_ac_capacity_kw = 0` is guarded by the caller; removed the misleading "0 = no limit" wording.
  - Documented that DC excess bypasses the AC bus in `validate_energy_balance` — the AC-side balance holds by construction since grid flows are derived from it.
  - Updated `_calculate_reward` cycle-cost docstring to reflect that DC wear cost applies regardless of AC action.
- **DP IDLE auto-charging fix** ([original comment](https://github.com/johanzander/bess-manager/pull/58#issuecomment-4081801261), commit `3d67ece`): on Growatt `load_first`, excess solar auto-charges during IDLE periods. The DP previously modelled IDLE as a flat hold, underestimating morning SOE buildup and leaving insufficient afternoon headroom. Now modelled in `_state_transition`, `_calculate_reward`, `_run_dynamic_programming`, and `_create_idle_schedule`. Discovered on real hardware (2026-03-18: periods 30–39 planned IDLE but battery gained 5.8 kWh, reaching 76% by 10:00 with only 2.1 kWh headroom despite >5 kW afternoon forecast).

## Test plan

- [x] `pytest core/bess/tests/unit/` passes
- [x] `black` / `ruff` clean
- [x] Clipping fields exposed in `/api/dashboard` and `/api/settings/battery`
- [ ] Real-hardware verification on UK 6.7 kWp DC / 5 kW AC setup (awaiting a sunny day — limited opportunities in the UK ;) )

## References

- Supersedes #58