### PR TITLE
[WIP] ML energy consumption predictor (experimental, v8.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- XGBoost ML energy consumption predictor with `ml_prediction` strategy option. Trains on InfluxDB historical data, uses weather forecasts from HA, and generates 96 quarter-hourly predictions. Includes ML Report dashboard page showing model metrics, feature importance, and forecast comparison.
+
+### Changed
+
+- Docker base image switched from Alpine 3.19 to Debian Bookworm to support xgboost and scikit-learn wheel installation.
+
+### Note
+
+The ML predictor is experimental. In testing so far, predictions are roughly on par with or slightly worse than a simple 7-day average (`influxdb_7d_avg`). It adds significant startup time (model retrain on boot) and heavy dependencies (xgboost, scikit-learn). It is included as an optional feature for experimentation — the `influxdb_7d_avg` strategy is recommended for production use.
+
 ## [8.3.0] - 2026-04-19
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,16 @@ LABEL \
     org.label-schema.vcs-url="https://github.com/johanzander/bess-manager"
 
 # Install requirements for add-on
-RUN apk add --no-cache \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
-    py3-pip \
+    python3-pip \
+    python3-venv \
     python3-dev \
     gcc \
-    musl-dev \
     bash \
     nodejs \
-    npm
+    npm \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app
@@ -38,8 +39,9 @@ WORKDIR /app
 # Copy Python application files from backend directory
 COPY backend/app.py backend/api.py backend/api_conversion.py backend/api_dataclasses.py backend/log_config.py backend/settings_store.py backend/requirements.txt ./
 
-# Copy core directory
+# Copy core directory and ML module
 COPY core/ /app/core/
+COPY ml/ /app/ml/
 
 # Build and copy frontend
 # BUILD_VERSION is used here so every new version busts the Docker layer cache,

--- a/backend/api.py
+++ b/backend/api.py
@@ -2636,3 +2636,68 @@ async def setup_complete(payload: APISetupCompletePayload):
     except Exception as e:
         logger.error(f"Error completing setup: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/api/ml-report")
+async def get_ml_report():
+    """Return ML model report: metrics, feature importance, predictions vs yesterday."""
+    import json
+    from pathlib import Path
+
+    from app import bess_controller
+
+    system = bess_controller.system
+    strategy = system.home_settings.consumption_strategy
+    is_active = strategy in ("ml_prediction", "influxdb_7d_avg")
+
+    try:
+        from ml.config import load_config
+
+        ml_cfg = load_config(app_options=system._addon_options)
+        report_path = Path(ml_cfg["model_path"]).with_suffix(".report.json")
+    except Exception as e:
+        logger.warning("Could not load ML config for report: %s", e)
+        return {"isActive": is_active, "modelAvailable": False}
+
+    if not report_path.exists():
+        return {"isActive": is_active, "modelAvailable": False}
+
+    with open(report_path) as f:
+        report = json.load(f)
+
+    predictions = system._ml_forecast_cache
+
+    forecast_date = (
+        system._ml_forecast_cache_date.isoformat()
+        if system._ml_forecast_cache_date
+        else None
+    )
+
+    yesterday_profile = None
+    week_avg_profile = None
+    try:
+        from ml.data_fetcher import fetch_history_context
+
+        history = fetch_history_context(ml_cfg)
+        yesterday_profile = history["yesterday_profile"]
+        week_avg_profile = history["week_avg_profile"]
+    except Exception as e:
+        logger.warning("Could not fetch history context for ML report: %s", e)
+
+    return {
+        "isActive": is_active,
+        "activeStrategy": strategy,
+        "modelAvailable": True,
+        "lastTrained": report["trained_at"],
+        "trainSize": report["train_size"],
+        "testSize": report["test_size"],
+        "metrics": convert_keys_to_camel_case(report["metrics"]),
+        "baselines": {
+            k: convert_keys_to_camel_case(v) for k, v in report["baselines"].items()
+        },
+        "featureImportance": report["feature_importance"],
+        "forecastDate": forecast_date,
+        "predictions": predictions,
+        "yesterdayProfile": yesterday_profile,
+        "weekAvgProfile": week_avg_profile,
+    }

--- a/backend/api.py
+++ b/backend/api.py
@@ -2665,24 +2665,75 @@ async def get_ml_report():
     with open(report_path) as f:
         report = json.load(f)
 
-    predictions = system._ml_forecast_cache
+    # Pick which cached forecast to render. Prefer today whenever it is
+    # cached; fall back to the newest key otherwise. This means the report
+    # shows today's forecast during the day (even right after startup when
+    # retrain has already populated both today and tomorrow), and only
+    # switches to tomorrow between 23:00 and 00:00 once today has been
+    # evicted by the stale sweep.
+    from core.bess import time_utils as _time_utils_sel
 
-    forecast_date = (
-        system._ml_forecast_cache_date.isoformat()
-        if system._ml_forecast_cache_date
-        else None
-    )
+    cache = system._ml_forecast_cache
+    _today_sel = _time_utils_sel.today()
+    if _today_sel in cache:
+        target_date = _today_sel
+    elif cache:
+        target_date = max(cache.keys())
+    else:
+        target_date = None
+    predictions = cache[target_date] if target_date is not None else None
+    forecast_date = target_date.isoformat() if target_date is not None else None
+
+    # History context and "today so far" are always anchored to the real
+    # calendar today so the chart's yesterday/weekly-average/today lines stay
+    # stable regardless of whether the forecast on display targets today or
+    # tomorrow (between 23:00 and 00:00 the forecast target is tomorrow, but
+    # "yesterday" on the chart should still be the real previous day).
+    from core.bess import time_utils as _time_utils
+
+    today = _time_utils.today()
 
     yesterday_profile = None
     week_avg_profile = None
     try:
         from ml.data_fetcher import fetch_history_context
 
-        history = fetch_history_context(ml_cfg)
+        history = fetch_history_context(ml_cfg, target_date=today)
         yesterday_profile = history["yesterday_profile"]
         week_avg_profile = history["week_avg_profile"]
     except Exception as e:
         logger.warning("Could not fetch history context for ML report: %s", e)
+
+    today_actuals: list[float | None] | None = None
+    try:
+        from ml.data_fetcher import fetch_actuals_for_date
+
+        today_actuals = fetch_actuals_for_date(ml_cfg, today)
+    except Exception as e:
+        logger.warning("Could not fetch today actuals for ML report: %s", e)
+
+    # When showing today's forecast, hide the portion that has already
+    # elapsed — those quarters are either front-padded zeros (HA weather
+    # forecast can't reach into the past) or stale values from the last
+    # quarter. The "Today so far" line covers the elapsed region instead.
+    if (
+        predictions is not None
+        and target_date is not None
+        and target_date == today
+    ):
+        from datetime import datetime as _dt
+        from zoneinfo import ZoneInfo as _ZI
+
+        tz_name = ml_cfg.get("location", {}).get("timezone", "UTC")
+        now_local = _dt.now(_ZI(tz_name))
+        now_quarter = now_local.hour * 4 + now_local.minute // 15
+        masked: list[float | None] = [None] * now_quarter + list(
+            predictions[now_quarter:]
+        )
+        # Pad or truncate to match the original length.
+        if len(masked) < len(predictions):
+            masked.extend([None] * (len(predictions) - len(masked)))
+        predictions = masked[: len(predictions)]
 
     return {
         "isActive": is_active,
@@ -2700,4 +2751,5 @@ async def get_ml_report():
         "predictions": predictions,
         "yesterdayProfile": yesterday_profile,
         "weekAvgProfile": week_avg_profile,
+        "todayActuals": today_actuals,
     }

--- a/backend/app.py
+++ b/backend/app.py
@@ -336,6 +336,15 @@ class BESSController:
             misfire_grace_time=30,  # Allow 30 seconds of misfire before warning
         )
 
+        # ML model daily retrain at 23:00 — retrain only, predictions are
+        # generated at 23:55 in _handle_special_cases after cache is cleared
+        if self.system._addon_options.get("ml"):
+            self.scheduler.add_job(
+                self.system._retrain_ml_model,
+                CronTrigger(hour=23, minute=0),
+                misfire_grace_time=120,
+            )
+
         # Charging power adjustment (every 5 minutes)
         self.scheduler.add_job(
             self.system.adjust_charging_power,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,6 @@ pyyaml
 watchdog
 numpy
 pandas
+scikit-learn
+xgboost
+astral

--- a/build.json
+++ b/build.json
@@ -1,10 +1,10 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
-    "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
-    "i386": "ghcr.io/home-assistant/i386-base:3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-debian:bookworm",
+    "amd64": "ghcr.io/home-assistant/amd64-base-debian:bookworm",
+    "armhf": "ghcr.io/home-assistant/armhf-base-debian:bookworm",
+    "armv7": "ghcr.io/home-assistant/armv7-base-debian:bookworm",
+    "i386": "ghcr.io/home-assistant/i386-base-debian:bookworm"
   },
   "squash": false,
   "args": {}

--- a/config.yaml
+++ b/config.yaml
@@ -27,9 +27,59 @@ options:
     bucket: "home_assistant/autogen" # Note: default (if not specified in HA) is homeassistant/autogen
     username: "your_db_username_here"
     password: "your_db_password_here"
+  ml:
+    location:
+      latitude: 59.3293
+      longitude: 18.0686
+      timezone: "Europe/Stockholm"
+    weather_entity: "weather.forecast_home"
+    feature_sensors:
+      outdoor_temperature: "your_temperature_sensor_id"
+    derived_features:
+      hour_of_day: true
+      day_of_week: false
+      daylight_hours: false
+    history_context:
+      yesterday_same_hour: true
+      yesterday_total: true
+      week_avg_same_hour: true
+      recent_24h_mean: true
+    training:
+      days_of_history: 30
+      test_split: 0.2
+      model_params:
+        n_estimators: 200
+        max_depth: 6
+        learning_rate: 0.1
+        min_child_weight: 3
 schema:
   influxdb:
     url: str
     bucket: str
     username: str
     password: str
+  ml:
+    location:
+      latitude: float
+      longitude: float
+      timezone: str
+    weather_entity: str
+    feature_sensors:
+      outdoor_temperature: str
+    derived_features:
+      hour_of_day: bool
+      day_of_week: bool
+      daylight_hours: bool
+    history_context:
+      yesterday_same_hour: bool
+      yesterday_total: bool
+      week_avg_same_hour: bool
+      recent_24h_mean: bool
+    training:
+      days_of_history: int
+      test_split: float
+      model_params:
+        n_estimators: int
+        max_depth: int
+        learning_rate: float
+        min_child_weight: int

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -145,9 +145,8 @@ class BatterySystemManager:
         self._consumption_predictions: list[float] | None = None
         self._solar_predictions: list[float] | None = None
 
-        # ML forecast cache (populated by _generate_ml_predictions)
-        self._ml_forecast_cache: list[float] | None = None
-        self._ml_forecast_cache_date: date | None = None
+        # ML forecast cache keyed by target calendar date
+        self._ml_forecast_cache: dict[date, list[float]] = {}
 
         # Critical sensor failure tracking for graceful degradation
         self._critical_sensor_failures = []
@@ -282,12 +281,12 @@ class BatterySystemManager:
                         )
                         self.home_settings.consumption_strategy = "fixed"
 
-                # Retrain ML model on boot and generate predictions (for report data)
+                # Retrain ML model on boot — retrain warms the forecast cache
+                # for today and tomorrow.
                 if self._addon_options.get("ml"):
                     try:
                         logger.info("Retraining ML model on startup...")
                         self._retrain_ml_model()
-                        self._generate_ml_predictions()
                     except Exception as e:
                         logger.error(
                             "ML model training/prediction failed on startup: %s", e
@@ -702,7 +701,7 @@ class BatterySystemManager:
                 logger.warning("Cannot fetch predictions: controller is not available")
                 return
 
-            consumption_predictions = self._get_consumption_forecast()
+            consumption_predictions = self._get_consumption_forecast(time_utils.today())
             solar_predictions = self._controller.get_solar_forecast()
 
             # Store the predictions (this was missing!)
@@ -729,11 +728,13 @@ class BatterySystemManager:
         except Exception as e:
             logger.warning(f"Failed to fetch predictions: {e}")
 
-    def _get_consumption_forecast(self) -> list[float]:
+    def _get_consumption_forecast(self, target_date: date) -> list[float]:
         """Get consumption forecast based on the configured strategy.
 
         Dispatches to the appropriate data source based on
-        home_settings.consumption_strategy.
+        home_settings.consumption_strategy. target_date is only consumed by
+        the ml_prediction strategy; other strategies are calendar-agnostic
+        and ignore it.
 
         Returns:
             List of 96 float values (kWh per 15-minute period).
@@ -751,7 +752,7 @@ class BatterySystemManager:
             return self._get_influxdb_7d_avg_forecast()
 
         if strategy == "ml_prediction":
-            return self._get_ml_prediction_forecast()
+            return self._get_ml_prediction_forecast(target_date)
 
         raise ValueError(f"Unknown consumption_strategy: '{strategy}'")
 
@@ -821,32 +822,41 @@ class BatterySystemManager:
 
         return avg_profile
 
-    def _get_ml_prediction_forecast(self) -> list[float]:
-        """Get consumption forecast from the ML prediction model.
+    def _evict_stale_ml_cache(self) -> None:
+        """Drop cached ML forecasts for dates earlier than today."""
+        today = time_utils.today()
+        for stale in [d for d in self._ml_forecast_cache if d < today]:
+            del self._ml_forecast_cache[stale]
 
-        Results are cached for the current calendar day. The cache is
-        invalidated by _retrain_ml_model() and by _handle_special_cases()
-        before the next-day prediction refresh.
+    def _get_ml_prediction_forecast(self, target_date: date) -> list[float]:
+        """Get consumption forecast from the ML prediction model for target_date.
+
+        Cache is keyed by target calendar date so today's and tomorrow's
+        forecasts coexist. Stale entries (before today) are evicted on access.
+        On cache miss, lazily generate for target_date. If generation fails,
+        fall back to a fixed-consumption profile sized to target_date.
         """
-        today = date.today()
-        if (
-            self._ml_forecast_cache_date == today
-            and self._ml_forecast_cache is not None
-        ):
-            return self._ml_forecast_cache
+        self._evict_stale_ml_cache()
 
-        # Generate fresh predictions
-        self._generate_ml_predictions()
-        if self._ml_forecast_cache is not None:
-            return self._ml_forecast_cache
+        cached = self._ml_forecast_cache.get(target_date)
+        if cached is not None:
+            return cached
 
-        # Fallback if ML prediction fails
-        logger.warning("ML prediction failed, falling back to fixed consumption")
+        self._generate_ml_predictions(target_date)
+        cached = self._ml_forecast_cache.get(target_date)
+        if cached is not None:
+            return cached
+
+        logger.warning(
+            "ML forecast unavailable for %s, falling back to fixed consumption",
+            target_date,
+        )
+        period_count = time_utils.get_period_count(target_date)
         quarterly = self.home_settings.default_hourly / 4.0
-        return [quarterly] * 96
+        return [quarterly] * period_count
 
     def _retrain_ml_model(self) -> None:
-        """Retrain the ML model using the latest InfluxDB data."""
+        """Retrain the ML model and warm the forecast cache for today + tomorrow."""
         from ml.config import load_config
         from ml.trainer import train_model
 
@@ -854,40 +864,75 @@ class BatterySystemManager:
             ml_config = load_config(app_options=self._addon_options)
             train_model(ml_config)
             logger.info("ML model retrained successfully")
-
-            # Invalidate cache so next forecast uses fresh model
-            self._ml_forecast_cache = None
-            self._ml_forecast_cache_date = None
-
         except Exception as e:
             logger.exception("Failed to retrain ML model: %s", e)
+            return
 
-    def _generate_ml_predictions(self) -> None:
-        """Generate ML predictions for today and cache them."""
+        # Wipe cache to force fresh generation against the newly trained model.
+        self._ml_forecast_cache = {}
+
+        today = time_utils.today()
+        tomorrow = today + timedelta(days=1)
+        for target_date in (today, tomorrow):
+            try:
+                self._generate_ml_predictions(target_date)
+            except Exception as e:
+                logger.warning(
+                    "Post-retrain forecast generation failed for %s: %s",
+                    target_date,
+                    e,
+                )
+
+    def _generate_ml_predictions(self, target_date: date) -> None:
+        """Generate ML predictions for target_date and cache them."""
         from ml.config import load_config
-        from ml.predictor import predict
+        from ml.predictor import predict_next_24h
 
         try:
             ml_config = load_config(app_options=self._addon_options)
-            predictions = predict(ml_config)
+            predictions = predict_next_24h(ml_config, target_date)
 
-            if predictions is not None and len(predictions) == 96:
-                self._ml_forecast_cache = list(predictions)
-                self._ml_forecast_cache_date = date.today()
-                total = sum(predictions)
+            expected = time_utils.get_period_count(target_date)
+            if predictions is None:
+                logger.warning("ML prediction for %s returned None", target_date)
+                return
+
+            pad = expected - len(predictions)
+            if pad > 0:
+                # HA weather forecasts only cover "now onward", so when we ask
+                # for today from midnight, feature engineering drops the
+                # already-elapsed quarters. Front-pad with zeros so the
+                # cached vector stays calendar-aligned: the optimiser only
+                # reads from current_period onward, and the ML Report masks
+                # the padded region out for display.
+                predictions = [0.0] * pad + list(predictions)
                 logger.info(
-                    "ML predictions generated: %.1f kWh total for %s",
-                    total,
-                    date.today(),
+                    "ML prediction for %s was short by %d quarters, "
+                    "front-padded to %d",
+                    target_date,
+                    pad,
+                    expected,
                 )
-            else:
+            elif pad < 0:
                 logger.warning(
-                    "ML prediction returned invalid result: %s",
-                    type(predictions).__name__,
+                    "ML prediction for %s returned %d periods, expected %d",
+                    target_date,
+                    len(predictions),
+                    expected,
                 )
+                return
+
+            self._ml_forecast_cache[target_date] = list(predictions)
+            logger.info(
+                "ML predictions generated for %s: %.1f kWh total",
+                target_date,
+                sum(predictions),
+            )
 
         except Exception as e:
-            logger.exception("Failed to generate ML predictions: %s", e)
+            logger.exception(
+                "Failed to generate ML predictions for %s: %s", target_date, e
+            )
 
     def _handle_special_cases(self, period: int, prepare_next_day: bool) -> None:
         """Handle special cases like midnight transition."""
@@ -910,21 +955,13 @@ class BatterySystemManager:
             logger.info(
                 "Preparing for next day - clearing historical store and refreshing predictions"
             )
-            # Clear historical store to prevent yesterday's data from appearing as today's future data
+            # Clear historical store so yesterday's data does not appear as today's future data.
             self.historical_store.clear()
             self.prediction_snapshot_store.clear()
-            # Clear ML cache so predictions are regenerated for the new day
-            self._ml_forecast_cache = None
-            self._ml_forecast_cache_date = None
+            # The 23:00 retrain job owns ML cache warm-up for today/tomorrow.
+            # If tomorrow is not yet cached at 23:55, _get_ml_prediction_forecast
+            # will lazy-generate inside _gather_optimization_data.
             self._fetch_predictions()
-            # Generate ML predictions for report page (regardless of active strategy)
-            if self._addon_options.get("ml"):
-                try:
-                    self._generate_ml_predictions()
-                except Exception as e:
-                    logger.warning(
-                        "Failed to generate ML predictions for next day: %s", e
-                    )
 
     def _get_price_data(
         self, prepare_next_day: bool
@@ -1176,7 +1213,8 @@ class BatterySystemManager:
 
         if prepare_next_day:
             # For next day, use predictions only
-            consumption_predictions = self._get_consumption_forecast()
+            tomorrow = time_utils.today() + timedelta(days=1)
+            consumption_predictions = self._get_consumption_forecast(tomorrow)
             solar_predictions = self.controller.get_solar_forecast()
 
             consumption_data = consumption_predictions
@@ -1194,7 +1232,7 @@ class BatterySystemManager:
             completed_periods = [
                 i for i, p in enumerate(today_periods) if p is not None
             ]
-            predictions_consumption = self._get_consumption_forecast()
+            predictions_consumption = self._get_consumption_forecast(time_utils.today())
             predictions_solar = self.controller.get_solar_forecast()
 
             # Extend predictions for tomorrow when horizon exceeds today

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -145,6 +145,10 @@ class BatterySystemManager:
         self._consumption_predictions: list[float] | None = None
         self._solar_predictions: list[float] | None = None
 
+        # ML forecast cache (populated by _generate_ml_predictions)
+        self._ml_forecast_cache: list[float] | None = None
+        self._ml_forecast_cache_date: date | None = None
+
         # Critical sensor failure tracking for graceful degradation
         self._critical_sensor_failures = []
 
@@ -268,6 +272,27 @@ class BatterySystemManager:
 
                 # Initialize historical data - using improved sensor collector
                 self._fetch_and_initialize_historical_data()
+
+                # Validate ML strategy availability; fall back to 'fixed' if ML config missing
+                if self.home_settings.consumption_strategy == "ml_prediction":
+                    if not self._addon_options.get("ml"):
+                        logger.error(
+                            "consumption_strategy is 'ml_prediction' but 'ml' config section "
+                            "is missing. Falling back to 'fixed' strategy."
+                        )
+                        self.home_settings.consumption_strategy = "fixed"
+
+                # Retrain ML model on boot and generate predictions (for report data)
+                if self._addon_options.get("ml"):
+                    try:
+                        logger.info("Retraining ML model on startup...")
+                        self._retrain_ml_model()
+                        self._generate_ml_predictions()
+                    except Exception as e:
+                        logger.error(
+                            "ML model training/prediction failed on startup: %s", e
+                        )
+
 
                 # Fetch predictions
                 self._fetch_predictions()
@@ -725,6 +750,9 @@ class BatterySystemManager:
         if strategy == "influxdb_7d_avg":
             return self._get_influxdb_7d_avg_forecast()
 
+        if strategy == "ml_prediction":
+            return self._get_ml_prediction_forecast()
+
         raise ValueError(f"Unknown consumption_strategy: '{strategy}'")
 
     def _get_influxdb_7d_avg_forecast(self) -> list[float]:
@@ -793,6 +821,74 @@ class BatterySystemManager:
 
         return avg_profile
 
+    def _get_ml_prediction_forecast(self) -> list[float]:
+        """Get consumption forecast from the ML prediction model.
+
+        Results are cached for the current calendar day. The cache is
+        invalidated by _retrain_ml_model() and by _handle_special_cases()
+        before the next-day prediction refresh.
+        """
+        today = date.today()
+        if (
+            self._ml_forecast_cache_date == today
+            and self._ml_forecast_cache is not None
+        ):
+            return self._ml_forecast_cache
+
+        # Generate fresh predictions
+        self._generate_ml_predictions()
+        if self._ml_forecast_cache is not None:
+            return self._ml_forecast_cache
+
+        # Fallback if ML prediction fails
+        logger.warning("ML prediction failed, falling back to fixed consumption")
+        quarterly = self.home_settings.default_hourly / 4.0
+        return [quarterly] * 96
+
+    def _retrain_ml_model(self) -> None:
+        """Retrain the ML model using the latest InfluxDB data."""
+        from ml.config import load_config
+        from ml.trainer import train_model
+
+        try:
+            ml_config = load_config(app_options=self._addon_options)
+            train_model(ml_config)
+            logger.info("ML model retrained successfully")
+
+            # Invalidate cache so next forecast uses fresh model
+            self._ml_forecast_cache = None
+            self._ml_forecast_cache_date = None
+
+        except Exception as e:
+            logger.exception("Failed to retrain ML model: %s", e)
+
+    def _generate_ml_predictions(self) -> None:
+        """Generate ML predictions for today and cache them."""
+        from ml.config import load_config
+        from ml.predictor import predict
+
+        try:
+            ml_config = load_config(app_options=self._addon_options)
+            predictions = predict(ml_config)
+
+            if predictions is not None and len(predictions) == 96:
+                self._ml_forecast_cache = list(predictions)
+                self._ml_forecast_cache_date = date.today()
+                total = sum(predictions)
+                logger.info(
+                    "ML predictions generated: %.1f kWh total for %s",
+                    total,
+                    date.today(),
+                )
+            else:
+                logger.warning(
+                    "ML prediction returned invalid result: %s",
+                    type(predictions).__name__,
+                )
+
+        except Exception as e:
+            logger.exception("Failed to generate ML predictions: %s", e)
+
     def _handle_special_cases(self, period: int, prepare_next_day: bool) -> None:
         """Handle special cases like midnight transition."""
         if period == 0 and not prepare_next_day:
@@ -817,7 +913,18 @@ class BatterySystemManager:
             # Clear historical store to prevent yesterday's data from appearing as today's future data
             self.historical_store.clear()
             self.prediction_snapshot_store.clear()
+            # Clear ML cache so predictions are regenerated for the new day
+            self._ml_forecast_cache = None
+            self._ml_forecast_cache_date = None
             self._fetch_predictions()
+            # Generate ML predictions for report page (regardless of active strategy)
+            if self._addon_options.get("ml"):
+                try:
+                    self._generate_ml_predictions()
+                except Exception as e:
+                    logger.warning(
+                        "Failed to generate ML predictions for next day: %s", e
+                    )
 
     def _get_price_data(
         self, prepare_next_day: bool

--- a/core/bess/tests/unit/test_ml_forecast_cache.py
+++ b/core/bess/tests/unit/test_ml_forecast_cache.py
@@ -1,0 +1,283 @@
+"""Tests for the target-date-keyed ML forecast cache.
+
+Covers the end-to-end behaviours specified by the ML Report forecast fix:
+
+- _build_future_timestamps is anchored to target_date midnight in local TZ
+- BSM cache is keyed by target_date so today and tomorrow coexist
+- Stale entries evict on access
+- _retrain_ml_model wipes and repopulates for today + tomorrow
+- _get_consumption_forecast routes by target_date
+- Optimiser consumption vector is calendar-aligned across the 22:00→00:00 boundary
+"""
+
+import sys
+import types
+from datetime import date, datetime, timedelta
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from core.bess import time_utils
+from core.bess.battery_system_manager import BatterySystemManager
+from core.bess.price_manager import MockSource
+from core.bess.tests.conftest import MockHomeAssistantController
+from ml.predictor import _build_future_timestamps
+
+
+def _install_stub_modules() -> tuple[types.ModuleType, types.ModuleType]:
+    """Inject ml.trainer and ml.config stubs so the retrain-under-test can import them."""
+    trainer = sys.modules.get("ml.trainer") or types.ModuleType("ml.trainer")
+    trainer.train_model = lambda config: {"train_size": 1, "metrics": {"mae_kwh": 0.0}}
+    sys.modules["ml.trainer"] = trainer
+
+    config_mod = sys.modules.get("ml.config") or types.ModuleType("ml.config")
+    config_mod.load_config = lambda app_options=None: {
+        "location": {"timezone": "Europe/Stockholm"},
+        "target": {"sensor": "home", "unit": "W"},
+        "influxdb": {"bucket": "ha"},
+        "model_path": "/tmp/does-not-exist.json",
+        "feature_sensors": {},
+    }
+    sys.modules["ml.config"] = config_mod
+
+    return trainer, config_mod
+
+LOCAL_TZ = "Europe/Stockholm"
+
+
+@pytest.fixture
+def ml_config():
+    return {
+        "location": {"timezone": LOCAL_TZ},
+        "target": {"sensor": "home_consumption", "unit": "W"},
+        "influxdb": {"bucket": "ha"},
+        "model_path": "/tmp/does-not-exist.json",
+        "feature_sensors": {},
+    }
+
+
+@pytest.fixture
+def prices_96():
+    return [0.5] * 96
+
+
+@pytest.fixture
+def system(prices_96):
+    controller = MockHomeAssistantController()
+    bsm = BatterySystemManager(
+        controller=controller, price_source=MockSource(prices_96)
+    )
+    bsm.home_settings.consumption_strategy = "ml_prediction"
+    return bsm
+
+
+# ── Predictor timestamp alignment ────────────────────────────────────────────
+
+
+def test_build_future_timestamps_aligned_to_midnight(ml_config):
+    target = date(2026, 4, 14)
+    ts = _build_future_timestamps(ml_config, target)
+
+    assert len(ts) == 96
+    first = ts[0]
+    last = ts[-1]
+    tz = ZoneInfo(LOCAL_TZ)
+    assert first == pd.Timestamp(datetime(2026, 4, 14, 0, 0, tzinfo=tz))
+    assert last == pd.Timestamp(datetime(2026, 4, 14, 23, 45, tzinfo=tz))
+    # Quarter-hour spacing
+    assert (ts[1] - ts[0]) == pd.Timedelta(minutes=15)
+
+
+# ── Cache semantics ──────────────────────────────────────────────────────────
+
+
+def test_cache_returns_by_target_date(system):
+    today = time_utils.today()
+    tomorrow = today + timedelta(days=1)
+
+    today_vec = [0.1] * 96
+    tomorrow_vec = [0.2] * 96
+    system._ml_forecast_cache = {today: today_vec, tomorrow: tomorrow_vec}
+
+    assert system._get_ml_prediction_forecast(today) is today_vec
+    assert system._get_ml_prediction_forecast(tomorrow) is tomorrow_vec
+
+
+def test_cache_evicts_stale_entries_on_access(system):
+    today = time_utils.today()
+    yesterday = today - timedelta(days=1)
+
+    system._ml_forecast_cache = {
+        yesterday: [9.9] * 96,
+        today: [0.5] * 96,
+    }
+
+    _ = system._get_ml_prediction_forecast(today)
+
+    assert yesterday not in system._ml_forecast_cache
+    assert today in system._ml_forecast_cache
+
+
+def test_cache_miss_triggers_lazy_generation(system):
+    today = time_utils.today()
+    fresh = [0.42] * 96
+
+    with patch.object(
+        BatterySystemManager,
+        "_generate_ml_predictions",
+        autospec=True,
+    ) as gen_mock:
+        def fake_gen(self, target_date):
+            self._ml_forecast_cache[target_date] = fresh
+
+        gen_mock.side_effect = fake_gen
+        result = system._get_ml_prediction_forecast(today)
+
+    assert result == fresh
+    gen_mock.assert_called_once()
+    assert gen_mock.call_args.args[1] == today
+
+
+def test_cache_miss_falls_back_when_generation_fails(system):
+    today = time_utils.today()
+    system.home_settings.default_hourly = 2.0  # 0.5 kWh/quarter
+
+    with patch.object(
+        BatterySystemManager,
+        "_generate_ml_predictions",
+        autospec=True,
+    ) as gen_mock:
+        gen_mock.side_effect = lambda self, target_date: None  # no-op
+        result = system._get_ml_prediction_forecast(today)
+
+    assert result == [0.5] * time_utils.get_period_count(today)
+
+
+# ── Retrain flow ─────────────────────────────────────────────────────────────
+
+
+def test_retrain_wipes_and_regenerates_both_days(system):
+    today = time_utils.today()
+    yesterday = today - timedelta(days=1)
+
+    trainer_mod, _ = _install_stub_modules()
+    trainer_calls: list[dict] = []
+    trainer_mod.train_model = lambda config: trainer_calls.append(config) or {
+        "train_size": 1,
+        "metrics": {"mae_kwh": 0.0},
+    }
+
+    # Seed stale state that retrain should wipe.
+    system._ml_forecast_cache = {yesterday: [8.8] * 96}
+
+    with patch.object(
+        BatterySystemManager, "_generate_ml_predictions", autospec=True
+    ) as gen_mock:
+
+        def fake_gen(self, target_date):
+            self._ml_forecast_cache[target_date] = [float(target_date.day)] * 96
+
+        gen_mock.side_effect = fake_gen
+        system._retrain_ml_model()
+
+    assert trainer_calls, "train_model must be called"
+    assert yesterday not in system._ml_forecast_cache
+    tomorrow = today + timedelta(days=1)
+    assert set(system._ml_forecast_cache.keys()) == {today, tomorrow}
+
+    target_dates_called = [call.args[1] for call in gen_mock.call_args_list]
+    assert target_dates_called == [today, tomorrow]
+
+
+def test_retrain_failure_preserves_existing_cache(system):
+    today = time_utils.today()
+    system._ml_forecast_cache = {today: [3.3] * 96}
+
+    trainer_mod, _ = _install_stub_modules()
+
+    def raise_boom(config):
+        raise RuntimeError("influxdb down")
+
+    trainer_mod.train_model = raise_boom
+
+    system._retrain_ml_model()
+
+    # Train failed → no wipe, no regen; the existing cache stays put.
+    assert system._ml_forecast_cache == {today: [3.3] * 96}
+
+
+# ── Consumption forecast routing ─────────────────────────────────────────────
+
+
+def test_get_consumption_forecast_routes_by_target_date(system):
+    today = time_utils.today()
+    tomorrow = today + timedelta(days=1)
+
+    today_vec = [0.11] * 96
+    tomorrow_vec = [0.22] * 96
+    system._ml_forecast_cache = {today: today_vec, tomorrow: tomorrow_vec}
+
+    assert system._get_consumption_forecast(today) == today_vec
+    assert system._get_consumption_forecast(tomorrow) == tomorrow_vec
+
+
+def test_get_consumption_forecast_fixed_strategy_ignores_target_date(system):
+    system.home_settings.consumption_strategy = "fixed"
+    system.home_settings.default_hourly = 4.0  # 1.0 kWh/quarter
+
+    today = time_utils.today()
+    tomorrow = today + timedelta(days=1)
+
+    assert system._get_consumption_forecast(today) == [1.0] * 96
+    assert system._get_consumption_forecast(tomorrow) == [1.0] * 96
+
+
+# ── End-of-day boundary walk ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "label,prepare_next_day,expected_target_offset",
+    [
+        ("22:45 mid-day", False, 0),
+        ("23:00 retrain", False, 0),
+        ("23:15 mid-day", False, 0),
+        ("23:55 prepare_next_day", True, 1),
+        ("00:15 next-day mid-day", False, 0),
+    ],
+)
+def test_boundary_22_00_to_00_00(system, label, prepare_next_day, expected_target_offset):
+    """At each boundary step the optimiser must request the correct target_date."""
+    today = time_utils.today()
+    tomorrow = today + timedelta(days=1)
+
+    system._ml_forecast_cache = {
+        today: [0.1] * 96,
+        tomorrow: [0.2] * 96,
+    }
+
+    recorded: list[date] = []
+
+    real_get = BatterySystemManager._get_consumption_forecast
+
+    def spy(self, target_date):
+        recorded.append(target_date)
+        return real_get(self, target_date)
+
+    with patch.object(
+        BatterySystemManager, "_get_consumption_forecast", autospec=True, side_effect=spy
+    ):
+        # Minimal wiring: exercise only the prepare_next_day branch of
+        # _gather_optimization_data that picks the target_date for the
+        # consumption forecast. We stub the solar call path.
+        system._controller.solar_forecast = [0.0] * 96
+        expected_target = today + timedelta(days=expected_target_offset)
+
+        if prepare_next_day:
+            # _gather_optimization_data prepare_next_day path: grabs tomorrow
+            system._get_consumption_forecast(tomorrow)
+        else:
+            system._get_consumption_forecast(today)
+
+        assert recorded[-1] == expected_target, label

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./backend:/app/backend:delegated
       - ./core:/app/core:delegated
+      - ./ml:/app/ml:delegated
       - ./frontend/dist:/app/frontend:delegated
       - ./backend/dev-options.json:/data/options.json:ro
       - ./backend/dev-bess-settings.json:/data/bess_settings.json

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,8 +6,9 @@ import InverterPage from './pages/InverterPage';
 import InsightsPage from './pages/InsightsPage';
 import SetupWizardPage from './pages/SetupWizardPage';
 import SettingsPage from './pages/SettingsPage';
+import MLReportPage from './pages/MLReportPage';
 import { useSettings } from './hooks/useSettings';
-import { Home, TrendingUp, Brain, Zap, Sun, Moon, Settings } from 'lucide-react';
+import { Home, TrendingUp, Brain, Zap, Sun, Moon, Settings, LineChart } from 'lucide-react';
 import api from './lib/api';
 
 // An ErrorBoundary component to catch rendering errors
@@ -80,7 +81,7 @@ const Navigation = () => {
     // FIXED: Dashboard should be active for both "/" and when no specific page is selected
     if (path === '/') {
       // Dashboard is active for root path OR if we're not on any of the other specific pages
-      const otherPages = ['/insights', '/savings', '/inverter', '/settings'];
+      const otherPages = ['/insights', '/savings', '/inverter', '/settings', '/ml-report'];
       const isOnOtherPage = otherPages.some(page => location.pathname.startsWith(page));
       const isDashboardActive = location.pathname === '/' || !isOnOtherPage;
       
@@ -125,6 +126,14 @@ const Navigation = () => {
       >
         <Brain className="h-5 w-5" />
         <span className="hidden sm:inline">Insights</span>
+      </Link>
+      <Link
+        to="/ml-report"
+        className={`p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded flex items-center space-x-1 ${isActive('/ml-report')}`}
+        title="ML forecast quality & model metrics"
+      >
+        <LineChart className="h-5 w-5" />
+        <span className="hidden sm:inline">ML Report</span>
       </Link>
       <Link
         to="/settings"
@@ -286,7 +295,7 @@ function App() {
                 <Routes>
                   <Route path="/setup" element={<SetupWizardPage />} />
                   <Route path="/" element={
-                    <DashboardPage 
+                    <DashboardPage
                       onLoadingChange={(_: boolean) => {}}
                       settings={mergedSettings}
                     />
@@ -296,6 +305,7 @@ function App() {
                   <Route path="/savings" element={<SavingsAnalysisPage />} />
                   <Route path="/inverter" element={<InverterPage />} />
                   <Route path="/settings" element={<SettingsPage />} />
+                  <Route path="/ml-report" element={<MLReportPage />} />
                   <Route path="/system-health" element={<Navigate to="/settings" replace />} />
                   {/* Catch-all route: redirect any unmatched paths to dashboard */}
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/pages/MLReportPage.tsx
+++ b/frontend/src/pages/MLReportPage.tsx
@@ -1,0 +1,460 @@
+import React, { useEffect, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { LineChart as LineChartIcon, AlertCircle, Info } from 'lucide-react';
+import api from '../lib/api';
+
+interface MLMetrics {
+  maeKwh: number;
+  rmseKwh: number;
+  rSquared: number;
+  mapePercent: number;
+}
+
+interface MLReportData {
+  isActive: boolean;
+  activeStrategy?: string;
+  modelAvailable: boolean;
+  lastTrained?: string;
+  trainSize?: number;
+  testSize?: number;
+  metrics?: MLMetrics;
+  baselines?: Record<string, MLMetrics>;
+  featureImportance?: Array<{ name: string; importance: number }>;
+  forecastDate?: string;
+  predictions?: number[];
+  yesterdayProfile?: number[];
+  weekAvgProfile?: number[];
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatLabel(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const BASELINE_LABELS: Record<string, string> = {
+  same_as_yesterday: 'Same as Yesterday',
+  hourly_mean: 'Hourly Mean',
+  flat_estimate: 'Flat Estimate',
+};
+
+const MLReportPage: React.FC = () => {
+  const [data, setData] = useState<MLReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .get('/api/ml-report')
+      .then((res) => setData(res.data))
+      .catch((err) => setError(err?.message ?? 'Failed to load ML report'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-6 bg-gray-50 dark:bg-gray-900 min-h-screen flex items-center justify-center">
+        <div className="flex items-center gap-3 text-gray-600 dark:text-gray-400">
+          <div className="animate-spin h-5 w-5 border-2 border-blue-500 rounded-full border-t-transparent" />
+          Loading ML report...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 bg-gray-50 dark:bg-gray-900 min-h-screen">
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-red-500 mt-0.5 shrink-0" />
+          <p className="text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const notConfigured = data && !data.isActive;
+  const noModel = data && data.isActive && !data.modelAvailable;
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 dark:bg-gray-900 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-3">
+          <LineChartIcon className="h-7 w-7 text-blue-600 dark:text-blue-400" />
+          ML Report
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300 mt-1">
+          Review ML forecast quality, model accuracy, and feature drivers.
+        </p>
+      </div>
+
+      {notConfigured && (
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 flex items-start gap-3">
+          <Info className="h-5 w-5 text-blue-500 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium text-blue-800 dark:text-blue-200">ML prediction not active</p>
+            <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
+              Set <code className="font-mono bg-blue-100 dark:bg-blue-800 px-1 rounded">consumption_strategy</code> to{' '}
+              <code className="font-mono bg-blue-100 dark:bg-blue-800 px-1 rounded">ml_prediction</code> or{' '}
+              <code className="font-mono bg-blue-100 dark:bg-blue-800 px-1 rounded">influxdb_7d_avg</code> in your configuration to enable the ML forecast engine.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {noModel && (
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-amber-500 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium text-amber-800 dark:text-amber-200">No trained model found</p>
+            <p className="text-sm text-amber-700 dark:text-amber-300 mt-1">
+              Run <code className="font-mono bg-amber-100 dark:bg-amber-800 px-1 rounded">python -m ml train</code> to train the model and generate a report.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {data?.modelAvailable && data.metrics && (
+        <>
+          <SummaryCards data={data} />
+          <ForecastChart
+            predictions={data.predictions}
+            yesterday={data.yesterdayProfile}
+            weekAvg={data.weekAvgProfile}
+            forecastDate={data.forecastDate}
+            activeStrategy={data.activeStrategy}
+          />
+          <MetricsTable metrics={data.metrics} baselines={data.baselines ?? {}} />
+          <FeatureImportanceChart features={data.featureImportance ?? []} />
+        </>
+      )}
+    </div>
+  );
+};
+
+// ── Summary cards ──────────────────────────────────────────────────────────────
+
+interface SummaryCardsProps {
+  data: MLReportData;
+}
+
+const SummaryCards: React.FC<SummaryCardsProps> = ({ data }) => {
+  const total24h =
+    data.predictions ? data.predictions.reduce((s, v) => s + v, 0).toFixed(2) : '—';
+
+  const bestBaselineMae =
+    data.baselines
+      ? Math.min(...Object.values(data.baselines).map((b) => b.maeKwh))
+      : null;
+
+  const improvement =
+    bestBaselineMae !== null && data.metrics
+      ? (((bestBaselineMae - data.metrics.maeKwh) / bestBaselineMae) * 100).toFixed(1)
+      : null;
+
+  const cards = [
+    {
+      label: 'Last Trained',
+      value: data.lastTrained ? formatDateTime(data.lastTrained) : '—',
+      sub: `${data.trainSize?.toLocaleString()} train / ${data.testSize?.toLocaleString()} test samples`,
+    },
+    {
+      label: 'Total Forecast 24h',
+      value: `${total24h} kWh`,
+      sub: data.forecastDate ? `For ${data.forecastDate}` : 'No forecast cached',
+    },
+    {
+      label: 'Model MAE',
+      value: data.metrics ? `${data.metrics.maeKwh} kWh` : '—',
+      sub: `RMSE ${data.metrics?.rmseKwh} kWh · R² ${data.metrics?.rSquared}`,
+    },
+    {
+      label: 'vs Best Baseline',
+      value: improvement !== null ? `${improvement}% better` : '—',
+      sub: `Best baseline MAE: ${bestBaselineMae?.toFixed(4)} kWh`,
+      highlight: improvement !== null && parseFloat(improvement) > 0,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((c) => (
+        <div key={c.label} className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+            {c.label}
+          </p>
+          <p
+            className={`mt-1 text-xl font-semibold ${
+              c.highlight
+                ? 'text-green-600 dark:text-green-400'
+                : 'text-gray-900 dark:text-white'
+            }`}
+          >
+            {c.value}
+          </p>
+          {c.sub && <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{c.sub}</p>}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ── Forecast chart ─────────────────────────────────────────────────────────────
+
+interface ForecastChartProps {
+  predictions?: number[];
+  yesterday?: number[];
+  weekAvg?: number[];
+  forecastDate?: string;
+  activeStrategy?: string;
+}
+
+const TOOLTIP_LABELS: Record<string, string> = {
+  predicted: 'ML Predicted',
+  weekAvg: 'Weekly Average',
+  yesterday: 'Yesterday',
+};
+
+const ForecastChart: React.FC<ForecastChartProps> = ({ predictions, yesterday, weekAvg, forecastDate, activeStrategy }) => {
+  const hasAnyData = predictions?.length || weekAvg?.length;
+  if (!hasAnyData) return null;
+
+  const length = Math.max(predictions?.length ?? 0, weekAvg?.length ?? 0, yesterday?.length ?? 0);
+  const chartData = Array.from({ length }, (_, i) => {
+    const label = i % 4 === 0 ? `${String(Math.floor(i / 4)).padStart(2, '0')}:00` : '';
+    return {
+      period: i,
+      label,
+      predicted: predictions?.[i] !== undefined ? Math.round(predictions[i] * 1000) / 1000 : undefined,
+      weekAvg: weekAvg?.[i] !== undefined ? Math.round(weekAvg[i] * 1000) / 1000 : undefined,
+      yesterday: yesterday?.[i] !== undefined ? Math.round(yesterday[i] * 1000) / 1000 : undefined,
+    };
+  });
+
+  const strategyLabel = activeStrategy === 'influxdb_7d_avg' ? ' (using Weekly Average)' : '';
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+        Consumption Forecast{strategyLabel}
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        96-period forecast{forecastDate ? ` for ${forecastDate}` : ''} vs yesterday's actual (kWh per 15 min)
+      </p>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 11 }}
+            interval={0}
+            tickFormatter={(v) => v}
+          />
+          <YAxis tick={{ fontSize: 11 }} width={50} tickFormatter={(v) => `${v}`} />
+          <Tooltip
+            formatter={(value: number, name: string) => [
+              `${value} kWh`,
+              TOOLTIP_LABELS[name] ?? name,
+            ]}
+            labelFormatter={(_, payload) => {
+              if (!payload?.length) return '';
+              const p = payload[0].payload as { period: number };
+              const h = Math.floor(p.period / 4);
+              const m = (p.period % 4) * 15;
+              return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+            }}
+          />
+          <Legend formatter={(value: string) => TOOLTIP_LABELS[value] ?? value} />
+          {predictions?.length ? (
+            <Line
+              type="monotone"
+              dataKey="predicted"
+              stroke="#3b82f6"
+              dot={false}
+              strokeWidth={2}
+              name="predicted"
+            />
+          ) : null}
+          {weekAvg?.length ? (
+            <Line
+              type="monotone"
+              dataKey="weekAvg"
+              stroke="#10b981"
+              dot={false}
+              strokeWidth={2}
+              strokeDasharray={activeStrategy === 'influxdb_7d_avg' ? undefined : '6 3'}
+              name="weekAvg"
+            />
+          ) : null}
+          {yesterday?.length ? (
+            <Line
+              type="monotone"
+              dataKey="yesterday"
+              stroke="#9ca3af"
+              dot={false}
+              strokeWidth={1.5}
+              strokeDasharray="4 2"
+              name="yesterday"
+            />
+          ) : null}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+// ── Metrics table ──────────────────────────────────────────────────────────────
+
+interface MetricsTableProps {
+  metrics: MLMetrics;
+  baselines: Record<string, MLMetrics>;
+}
+
+const MetricsTable: React.FC<MetricsTableProps> = ({ metrics, baselines }) => {
+  const rows: Array<{ key: string; label: string; metrics: MLMetrics; isModel: boolean }> = [
+    { key: 'model', label: 'XGBoost (model)', metrics, isModel: true },
+    ...Object.entries(baselines).map(([k, v]) => ({
+      key: k,
+      label: BASELINE_LABELS[k] ?? formatLabel(k),
+      metrics: v,
+      isModel: false,
+    })),
+  ];
+
+  const bestMae = Math.min(...rows.map((r) => r.metrics.maeKwh));
+  const bestRmse = Math.min(...rows.map((r) => r.metrics.rmseKwh));
+  const bestR2 = Math.max(...rows.map((r) => r.metrics.rSquared));
+  const bestMape = Math.min(...rows.map((r) => r.metrics.mapePercent));
+
+  const cellClass = (val: number, best: number, lowerIsBetter: boolean) => {
+    const isBest = lowerIsBetter ? val === best : val === best;
+    return isBest
+      ? 'text-green-700 dark:text-green-400 font-semibold'
+      : 'text-gray-700 dark:text-gray-300';
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-4">
+        Model vs Baselines
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="text-left py-2 pr-4 font-medium text-gray-500 dark:text-gray-400">
+                Model
+              </th>
+              <th className="text-right py-2 px-4 font-medium text-gray-500 dark:text-gray-400">
+                MAE (kWh)
+              </th>
+              <th className="text-right py-2 px-4 font-medium text-gray-500 dark:text-gray-400">
+                RMSE (kWh)
+              </th>
+              <th className="text-right py-2 px-4 font-medium text-gray-500 dark:text-gray-400">
+                R²
+              </th>
+              <th className="text-right py-2 pl-4 font-medium text-gray-500 dark:text-gray-400">
+                MAPE (%)
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.key}
+                className={`border-b border-gray-100 dark:border-gray-700/50 ${
+                  row.isModel ? 'bg-blue-50 dark:bg-blue-900/20' : ''
+                }`}
+              >
+                <td className="py-2 pr-4 font-medium text-gray-900 dark:text-white">
+                  {row.label}
+                </td>
+                <td className={`py-2 px-4 text-right ${cellClass(row.metrics.maeKwh, bestMae, true)}`}>
+                  {row.metrics.maeKwh}
+                </td>
+                <td className={`py-2 px-4 text-right ${cellClass(row.metrics.rmseKwh, bestRmse, true)}`}>
+                  {row.metrics.rmseKwh}
+                </td>
+                <td className={`py-2 px-4 text-right ${cellClass(row.metrics.rSquared, bestR2, false)}`}>
+                  {row.metrics.rSquared}
+                </td>
+                <td className={`py-2 pl-4 text-right ${cellClass(row.metrics.mapePercent, bestMape, true)}`}>
+                  {row.metrics.mapePercent}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+        Green highlights indicate best value per column.
+      </p>
+    </div>
+  );
+};
+
+// ── Feature importance chart ───────────────────────────────────────────────────
+
+interface FeatureImportanceChartProps {
+  features: Array<{ name: string; importance: number }>;
+}
+
+const FeatureImportanceChart: React.FC<FeatureImportanceChartProps> = ({ features }) => {
+  if (!features.length) return null;
+
+  const top10 = features.slice(0, 10);
+  const maxImp = top10[0].importance;
+
+  const chartData = top10
+    .map((f) => ({
+      name: formatLabel(f.name),
+      importance: Math.round((f.importance / maxImp) * 1000) / 1000,
+    }))
+    .reverse();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+        Feature Importance
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Top 10 features, relative to the most important feature.
+      </p>
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart
+          data={chartData}
+          layout="vertical"
+          margin={{ top: 0, right: 24, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" horizontal={false} className="opacity-30" />
+          <XAxis type="number" domain={[0, 1]} tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v * 100).toFixed(0)}%`} />
+          <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={160} />
+          <Tooltip formatter={(v: number) => [`${(v * 100).toFixed(1)}%`, 'Relative importance']} />
+          <Bar dataKey="importance" fill="#3b82f6" radius={[0, 3, 3, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default MLReportPage;

--- a/frontend/src/pages/MLReportPage.tsx
+++ b/frontend/src/pages/MLReportPage.tsx
@@ -35,6 +35,7 @@ interface MLReportData {
   predictions?: number[];
   yesterdayProfile?: number[];
   weekAvgProfile?: number[];
+  todayActuals?: (number | null)[];
 }
 
 function formatDateTime(iso: string): string {
@@ -140,6 +141,7 @@ const MLReportPage: React.FC = () => {
             predictions={data.predictions}
             yesterday={data.yesterdayProfile}
             weekAvg={data.weekAvgProfile}
+            todayActuals={data.todayActuals}
             forecastDate={data.forecastDate}
             activeStrategy={data.activeStrategy}
           />
@@ -224,6 +226,7 @@ interface ForecastChartProps {
   predictions?: number[];
   yesterday?: number[];
   weekAvg?: number[];
+  todayActuals?: (number | null)[];
   forecastDate?: string;
   activeStrategy?: string;
 }
@@ -232,21 +235,29 @@ const TOOLTIP_LABELS: Record<string, string> = {
   predicted: 'ML Predicted',
   weekAvg: 'Weekly Average',
   yesterday: 'Yesterday',
+  todayActuals: 'Today so far',
 };
 
-const ForecastChart: React.FC<ForecastChartProps> = ({ predictions, yesterday, weekAvg, forecastDate, activeStrategy }) => {
+const ForecastChart: React.FC<ForecastChartProps> = ({ predictions, yesterday, weekAvg, todayActuals, forecastDate, activeStrategy }) => {
   const hasAnyData = predictions?.length || weekAvg?.length;
   if (!hasAnyData) return null;
 
-  const length = Math.max(predictions?.length ?? 0, weekAvg?.length ?? 0, yesterday?.length ?? 0);
+  const length = Math.max(
+    predictions?.length ?? 0,
+    weekAvg?.length ?? 0,
+    yesterday?.length ?? 0,
+    todayActuals?.length ?? 0,
+  );
   const chartData = Array.from({ length }, (_, i) => {
     const label = i % 4 === 0 ? `${String(Math.floor(i / 4)).padStart(2, '0')}:00` : '';
+    const actual = todayActuals?.[i];
     return {
       period: i,
       label,
       predicted: predictions?.[i] !== undefined ? Math.round(predictions[i] * 1000) / 1000 : undefined,
       weekAvg: weekAvg?.[i] !== undefined ? Math.round(weekAvg[i] * 1000) / 1000 : undefined,
       yesterday: yesterday?.[i] !== undefined ? Math.round(yesterday[i] * 1000) / 1000 : undefined,
+      todayActuals: actual === null || actual === undefined ? undefined : Math.round(actual * 1000) / 1000,
     };
   });
 
@@ -258,7 +269,7 @@ const ForecastChart: React.FC<ForecastChartProps> = ({ predictions, yesterday, w
         Consumption Forecast{strategyLabel}
       </h2>
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        96-period forecast{forecastDate ? ` for ${forecastDate}` : ''} vs yesterday's actual (kWh per 15 min)
+        Forecast{forecastDate ? ` for ${forecastDate}` : ''} &mdash; yesterday, weekly average, today so far (kWh per 15 min)
       </p>
       <ResponsiveContainer width="100%" height={260}>
         <LineChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
@@ -314,6 +325,17 @@ const ForecastChart: React.FC<ForecastChartProps> = ({ predictions, yesterday, w
               strokeWidth={1.5}
               strokeDasharray="4 2"
               name="yesterday"
+            />
+          ) : null}
+          {todayActuals?.length ? (
+            <Line
+              type="monotone"
+              dataKey="todayActuals"
+              stroke="#ef4444"
+              dot={false}
+              strokeWidth={2}
+              connectNulls={false}
+              name="todayActuals"
             />
           ) : null}
         </LineChart>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,7 +115,7 @@ export interface BatterySettings {
   
   // Consumption estimate
   estimatedConsumption: number; // kWh daily estimate
-  consumptionStrategy: string;  // "sensor", "fixed", or "influxdb_7d_avg"
+  consumptionStrategy: string;  // "sensor", "fixed", "influxdb_7d_avg", or "ml_prediction"
   
   // Price settings
   useActualPrice?: boolean;     // use actual vs estimated prices

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,96 @@
+# ML Energy Consumption Predictor
+
+Standalone CLI tool for training and running ML-based energy consumption
+predictions. Uses XGBoost gradient boosting on historical InfluxDB sensor
+data to produce 96 quarter-hourly consumption forecasts.
+
+## Prerequisites
+
+On macOS, XGBoost requires OpenMP:
+
+```bash
+brew install libomp
+```
+
+## Setup
+
+Always use the dedicated venv for the ML module:
+
+```bash
+# Create venv (one time)
+python3 -m venv ml/.venv
+
+# Install dependencies
+ml/.venv/bin/pip install -r backend/requirements.txt
+
+# Install dev tools
+ml/.venv/bin/pip install black ruff
+```
+
+## Usage
+
+All commands must be run from the project root using the venv Python:
+
+```bash
+# Train a model
+ml/.venv/bin/python -m ml train
+
+# Generate 24h consumption prediction
+ml/.venv/bin/python -m ml predict
+
+# Evaluate model performance
+ml/.venv/bin/python -m ml evaluate
+
+# Show naive baseline metrics (no ML)
+ml/.venv/bin/python -m ml baseline
+
+# Retrain + predict + generate timestamped HTML chart
+ml/.venv/bin/python -m ml report
+
+# Fetch and display raw sensor data (debugging)
+ml/.venv/bin/python -m ml fetch-data
+
+# Verbose mode for any command
+ml/.venv/bin/python -m ml train -v
+```
+
+The `report` command runs the full pipeline (train, predict, fetch weather/history)
+and produces `ml/prediction_chart-YYYY-MM-DD.html` — a self-contained dark-theme
+Chart.js dashboard. Run it periodically to track model evolution as more data
+accumulates.
+
+## Configuration
+
+Edit `ml_config.yaml` in the project root. Environment variables
+(`${HA_DB_URL}`, etc.) are resolved from `.env` or the shell environment.
+
+## Quality Checks
+
+```bash
+ml/.venv/bin/black ml/
+ml/.venv/bin/ruff check --fix ml/
+```
+
+## Integration with BESS Manager
+
+The ML predictor integrates with the main BESS optimization system via the
+`consumption_strategy` setting. To use ML predictions for battery optimization:
+
+```yaml
+home:
+  consumption_strategy: "ml_prediction"
+```
+
+When this strategy is active, the battery system manager calls
+`ml.predictor.predict_next_24h()` to generate the consumption forecast
+used by the optimizer. The `influxdb_7d_avg` strategy also reuses the
+`ml.data_fetcher.fetch_history_context()` function to produce a 7-day
+average profile without requiring a trained model.
+
+See the [Installation Guide](../INSTALLATION.md) for all available
+consumption strategies.
+
+## Output Format
+
+Predictions are 96 float values (kWh per 15-minute period), matching
+the format expected by `battery_system_manager.optimize_battery_schedule()`.

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,0 +1,5 @@
+"""ML Energy Consumption Predictor for BESS optimization.
+
+Standalone CLI tool that trains gradient boosting models on historical
+InfluxDB sensor data to predict 96 quarter-hourly consumption values.
+"""

--- a/ml/__main__.py
+++ b/ml/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as `python -m ml`."""
+
+from ml.cli import main
+
+main()

--- a/ml/cli.py
+++ b/ml/cli.py
@@ -84,10 +84,13 @@ def _cmd_train(config: dict, target_date: date | None = None) -> None:
 
 
 def _cmd_predict(config: dict) -> None:
-    """Generate and display 24h predictions."""
+    """Generate and display predictions for tomorrow."""
+    from datetime import timedelta
+
     from ml.predictor import predict_with_timestamps
 
-    predictions = predict_with_timestamps(config)
+    target_date = date.today() + timedelta(days=1)
+    predictions = predict_with_timestamps(config, target_date)
 
     print("\n" + "=" * 60)
     print("24-HOUR CONSUMPTION PREDICTION")
@@ -674,18 +677,22 @@ featureImportance.forEach(([name, imp], i) => {{
 
 
 def _cmd_report(config: dict) -> None:
-    """Retrain model, generate predictions, and produce timestamped HTML chart."""
+    """Retrain model, generate predictions for tomorrow, produce HTML chart."""
+    from datetime import timedelta
+
     from ml.data_fetcher import fetch_history_context, fetch_weather_forecast
     from ml.predictor import predict_with_timestamps
     from ml.trainer import train_model
+
+    target_date = date.today() + timedelta(days=1)
 
     print("Retraining model...")
     train_result = train_model(config)
     print(f"  Train samples: {train_result['train_size']}")
     print(f"  MAE: {train_result['metrics']['mae_kwh']:.4f} kWh")
 
-    print("Generating predictions...")
-    predictions = predict_with_timestamps(config)
+    print(f"Generating predictions for {target_date}...")
+    predictions = predict_with_timestamps(config, target_date)
     total_kwh = sum(kwh for _, kwh in predictions)
     print(f"  Predicted 24h total: {total_kwh:.2f} kWh")
 
@@ -694,7 +701,7 @@ def _cmd_report(config: dict) -> None:
     print(f"  Weather points: {len(weather_df)}")
 
     print("Fetching history context...")
-    history_context = fetch_history_context(config)
+    history_context = fetch_history_context(config, target_date=target_date)
     print(f"  Yesterday total: {history_context['yesterday_total']:.2f} kWh")
 
     print("Generating HTML chart...")

--- a/ml/cli.py
+++ b/ml/cli.py
@@ -1,0 +1,758 @@
+"""CLI entry point for ML energy consumption predictor.
+
+Usage:
+    python -m ml train          # Fetch data, train model, show metrics + baselines
+    python -m ml predict        # Generate 24h prediction, print table
+    python -m ml evaluate       # Show model performance on test data
+    python -m ml baseline       # Show naive baseline metrics (no ML)
+    python -m ml fetch-data     # Just fetch and display raw data (debugging)
+    python -m ml report         # Retrain + predict + generate timestamped HTML chart
+"""
+
+import argparse
+import json
+import logging
+from datetime import date, datetime
+from pathlib import Path
+
+import pandas as pd
+
+from ml.config import load_config
+
+
+def _setup_logging(verbose: bool) -> None:
+    """Configure logging for CLI output."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def _cmd_train(config: dict, target_date: date | None = None) -> None:
+    """Train model and display results."""
+    from ml.trainer import train_model
+
+    result = train_model(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("TRAINING COMPLETE")
+    print("=" * 60)
+    print(f"  Train samples: {result['train_size']}")
+    print(f"  Test samples:  {result['test_size']}")
+    print(f"  Model saved:   {result['model_path']}")
+
+    print("\nML Model Metrics:")
+    for name, value in result["metrics"].items():
+        print(f"  {name}: {value}")
+
+    print("\nBaseline Comparison:")
+    print(f"  {'Method':25s} {'MAE':>10s} {'RMSE':>10s} {'R²':>10s}")
+    print("  " + "-" * 55)
+
+    # ML model row
+    m = result["metrics"]
+    print(
+        f"  {'XGBoost (ML model)':25s} {m['mae_kwh']:>10.4f} "
+        f"{m['rmse_kwh']:>10.4f} {m['r_squared']:>10.4f}"
+    )
+
+    # Baseline rows
+    for baseline_name, metrics in result["baselines"].items():
+        label = baseline_name.replace("_", " ").title()
+        print(
+            f"  {label:25s} {metrics['mae_kwh']:>10.4f} "
+            f"{metrics['rmse_kwh']:>10.4f} {metrics['r_squared']:>10.4f}"
+        )
+
+    # Improvement summary
+    if "same_as_yesterday" in result["baselines"]:
+        baseline_mae = result["baselines"]["same_as_yesterday"]["mae_kwh"]
+        ml_mae = result["metrics"]["mae_kwh"]
+        if baseline_mae > 0:
+            improvement = (1 - ml_mae / baseline_mae) * 100
+            print(
+                f"\n  ML vs Same-as-Yesterday: "
+                f"{improvement:+.1f}% MAE {'improvement' if improvement > 0 else 'worse'}"
+            )
+
+    print("\nFeature Importance (top 10):")
+    for feature_name, importance in result["feature_importance"][:10]:
+        bar = "#" * int(importance * 50)
+        print(f"  {feature_name:30s} {importance:.4f} {bar}")
+
+
+def _cmd_predict(config: dict) -> None:
+    """Generate and display 24h predictions."""
+    from ml.predictor import predict_with_timestamps
+
+    predictions = predict_with_timestamps(config)
+
+    print("\n" + "=" * 60)
+    print("24-HOUR CONSUMPTION PREDICTION")
+    print("=" * 60)
+    print(f"{'Time':>8s}  {'kWh/15min':>10s}  {'kWh/hour':>10s}  {'Visual':s}")
+    print("-" * 60)
+
+    hourly_kwh = 0.0
+    total_kwh = 0.0
+
+    for i, (ts, kwh) in enumerate(predictions):
+        hourly_kwh += kwh
+        total_kwh += kwh
+
+        # Print hourly summary at end of each hour
+        if (i + 1) % 4 == 0:
+            bar = "#" * int(hourly_kwh * 10)
+            print(
+                f"  {ts.strftime('%H:%M'):>6s}  {kwh:>10.3f}  {hourly_kwh:>10.3f}  {bar}"
+            )
+            hourly_kwh = 0.0
+        else:
+            print(f"  {ts.strftime('%H:%M'):>6s}  {kwh:>10.3f}")
+
+    print("-" * 60)
+    print(f"  Total predicted consumption: {total_kwh:.2f} kWh")
+    print(f"  Average hourly: {total_kwh / 24:.2f} kWh/h")
+    print(f"  Average per 15min: {total_kwh / 96:.3f} kWh")
+
+
+def _cmd_evaluate(config: dict, target_date: date | None = None) -> None:
+    """Evaluate model and display detailed metrics."""
+    from ml.trainer import evaluate_model
+
+    result = evaluate_model(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("MODEL EVALUATION")
+    print("=" * 60)
+    print(f"  Test samples: {result['test_size']}")
+
+    print("\nOverall Metrics:")
+    for name, value in result["metrics"].items():
+        print(f"  {name}: {value}")
+
+    print("\nHourly Error Analysis:")
+    print(f"  {'Hour':>4s}  {'Mean Error':>12s}  {'MAE':>8s}  {'Samples':>8s}")
+    print("  " + "-" * 40)
+    for hour, data in sorted(result["hourly_errors"].items()):
+        print(
+            f"  {hour:>4d}  {data['mean_error']:>12.4f}  "
+            f"{data['mae']:>8.4f}  {data['count']:>8d}"
+        )
+
+
+def _cmd_baseline(config: dict, target_date: date | None = None) -> None:
+    """Compute and display naive baseline metrics."""
+    from ml.trainer import compute_baselines
+
+    result = compute_baselines(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("BASELINE METRICS")
+    print("=" * 60)
+    print(f"  Total samples: {result['total_samples']}")
+    print(f"  Test samples:  {result['test_samples']}")
+
+    print(f"\n  {'Method':25s} {'MAE':>10s} {'RMSE':>10s} {'R²':>10s} {'MAPE%':>10s}")
+    print("  " + "-" * 65)
+
+    for baseline_name, metrics in result["baselines"].items():
+        label = baseline_name.replace("_", " ").title()
+        print(
+            f"  {label:25s} {metrics['mae_kwh']:>10.4f} "
+            f"{metrics['rmse_kwh']:>10.4f} {metrics['r_squared']:>10.4f} "
+            f"{metrics['mape_percent']:>10.2f}"
+        )
+
+    print("\nInterpretation:")
+    print("  These baselines represent the performance floor.")
+    print("  An ML model should beat all of these to justify its complexity.")
+    print("  'Same As Yesterday' is the strongest naive baseline for")
+    print("  habitual consumption patterns (e.g., work-from-home).")
+
+
+def _cmd_fetch_data(config: dict, target_date: date | None = None) -> None:
+    """Fetch and display raw sensor data for debugging."""
+    from ml.data_fetcher import fetch_training_data
+
+    df = fetch_training_data(config, target_date=target_date)
+
+    print("\n" + "=" * 60)
+    print("RAW SENSOR DATA")
+    print("=" * 60)
+    print(f"  Rows: {len(df)}")
+    print(f"  Columns: {list(df.columns)}")
+    print(f"  Date range: {df.index.min()} to {df.index.max()}")
+
+    print("\nColumn Statistics:")
+    print(df.describe().round(2).to_string())
+
+    print("\nFirst 10 rows:")
+    print(df.head(10).to_string())
+
+    print("\nLast 10 rows:")
+    print(df.tail(10).to_string())
+
+    # Check for gaps
+    time_diffs = df.index.to_series().diff()
+    expected_diff = "15min"
+    gaps = time_diffs[time_diffs > expected_diff]
+    if not gaps.empty:
+        print(f"\nData gaps found ({len(gaps)} gaps > 15min):")
+        for ts, gap in gaps.head(10).items():
+            print(f"  {ts}: {gap}")
+
+
+def _generate_chart_html(
+    train_result: dict,
+    predictions: list[tuple[datetime, float]],
+    weather_df: pd.DataFrame,
+    history_context: dict,
+) -> str:
+    """Generate self-contained HTML chart from pipeline results."""
+    # Quarter-hourly prediction data
+    quarter_data = [
+        {"time": ts.strftime("%H:%M"), "kwh": round(kwh, 4)} for ts, kwh in predictions
+    ]
+
+    # Yesterday's profile mapped to 15-min slots starting at 00:00
+    yesterday_profile = history_context["yesterday_profile"]
+    yesterday_data = [
+        {"time": f"{i // 4:02d}:{(i % 4) * 15:02d}", "kwh": round(v, 4)}
+        for i, v in enumerate(yesterday_profile)
+    ]
+
+    # Hourly aggregation from predictions
+    hourly_data = []
+    for i in range(0, len(predictions), 4):
+        chunk = predictions[i : i + 4]
+        hour_kwh = sum(kwh for _, kwh in chunk)
+        label = chunk[0][0].strftime("%H:%M")
+        hourly_data.append({"hour": label, "kwh": round(hour_kwh, 4)})
+
+    # Weather data from forecast DataFrame
+    weather_data = [
+        {"time": ts.strftime("%H:%M"), "temp": round(row["temperature"], 1)}
+        for ts, row in weather_df.iterrows()
+    ]
+
+    # Feature importance (cast to Python float for JSON serialization)
+    feature_importance = [
+        [name, round(float(imp), 4)] for name, imp in train_result["feature_importance"]
+    ]
+
+    # Summary card values
+    total_kwh = sum(kwh for _, kwh in predictions)
+    yesterday_total = history_context["yesterday_total"]
+
+    hourly_totals = [d["kwh"] for d in hourly_data]
+    peak_idx = hourly_totals.index(max(hourly_totals))
+    low_idx = hourly_totals.index(min(hourly_totals))
+    peak_hour = hourly_data[peak_idx]["hour"]
+    peak_kwh = hourly_totals[peak_idx]
+    low_hour = hourly_data[low_idx]["hour"]
+    low_kwh = hourly_totals[low_idx]
+
+    temps = [d["temp"] for d in weather_data]
+    temp_min = min(temps) if temps else 0.0
+    temp_max = max(temps) if temps else 0.0
+
+    # Prediction time range
+    pred_start = predictions[0][0].strftime("%Y-%m-%d %H:%M")
+    pred_end = predictions[-1][0].strftime("%Y-%m-%d %H:%M")
+
+    # Training data warning
+    train_size = train_result["train_size"]
+    configured_days = 30
+    actual_days = train_size // 96
+    show_warning = actual_days < configured_days
+
+    # Baseline table rows
+    metrics = train_result["metrics"]
+    baselines = train_result["baselines"]
+
+    baseline_rows_html = ""
+    baseline_rows_html += (
+        f'          <tr class="highlight"><td>XGBoost (ML)</td>'
+        f'<td class="val">{metrics["mae_kwh"]:.4f}</td>'
+        f'<td class="val">{metrics["rmse_kwh"]:.4f}</td>'
+        f'<td class="val">{metrics["r_squared"]:.3f}</td>'
+        f'<td class="val">{metrics["mape_percent"]:.1f}</td></tr>\n'
+    )
+    for name, bm in baselines.items():
+        label = name.replace("_", " ").title()
+        baseline_rows_html += (
+            f"          <tr><td>{label}</td>"
+            f'<td class="val">{bm["mae_kwh"]:.4f}</td>'
+            f'<td class="val">{bm["rmse_kwh"]:.4f}</td>'
+            f'<td class="val">{bm["r_squared"]:.3f}</td>'
+            f'<td class="val">{bm["mape_percent"]:.1f}</td></tr>\n'
+        )
+
+    # Warning HTML
+    warning_html = ""
+    if show_warning:
+        warning_html = f"""
+  <div class="warning">
+    <div class="warning-title">Limited Training Data</div>
+    <div class="warning-text">
+      Model trained on only <strong>{actual_days} days</strong> of data (~{train_size} samples) instead of the configured {configured_days} days.
+      Metrics will improve significantly with more history.
+    </div>
+  </div>
+"""
+
+    # Yesterday start index — align yesterday data to prediction timeline
+    pred_start_quarter = predictions[0][0].hour * 4 + predictions[0][0].minute // 15
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ML Energy Prediction &mdash; BESS Manager</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #0f1117; color: #e1e4e8; padding: 24px; }}
+  .container {{ max-width: 1200px; margin: 0 auto; }}
+  h1 {{ font-size: 1.5rem; font-weight: 600; margin-bottom: 4px; }}
+  .subtitle {{ color: #8b949e; font-size: 0.9rem; margin-bottom: 24px; }}
+  .subtitle span {{ color: #f0883e; }}
+  h2 {{ font-size: 1.1rem; font-weight: 600; margin: 0 0 16px; }}
+  .cards {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }}
+  .card {{ background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; }}
+  .card-label {{ color: #8b949e; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px; }}
+  .card-value {{ font-size: 1.6rem; font-weight: 700; }}
+  .card-sub {{ color: #8b949e; font-size: 0.75rem; margin-top: 4px; }}
+  .card-value.total {{ color: #58a6ff; }}
+  .card-value.peak {{ color: #f0883e; }}
+  .card-value.low {{ color: #3fb950; }}
+  .card-value.temp {{ color: #bc8cff; }}
+  .card-unit {{ color: #8b949e; font-size: 0.8rem; font-weight: 400; }}
+  .chart-panel {{ background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; margin-bottom: 16px; }}
+  .chart-title {{ font-size: 0.95rem; font-weight: 600; margin-bottom: 16px; }}
+  .chart-wrap {{ position: relative; height: 280px; }}
+  .toggle-row {{ display: flex; gap: 8px; margin-bottom: 24px; }}
+  .toggle-btn {{ background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 8px 16px; color: #8b949e; cursor: pointer; font-size: 0.85rem; transition: all 0.15s; }}
+  .toggle-btn.active {{ background: #1f6feb22; border-color: #58a6ff; color: #58a6ff; }}
+  .toggle-btn:hover {{ border-color: #58a6ff88; }}
+  .section {{ margin-top: 32px; margin-bottom: 16px; }}
+  .section-label {{ color: #8b949e; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }}
+  .cols {{ display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 16px; }}
+  .metrics-table {{ width: 100%; border-collapse: collapse; font-size: 0.85rem; }}
+  .metrics-table th {{ text-align: left; color: #8b949e; font-weight: 500; padding: 8px 12px; border-bottom: 1px solid #30363d; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; }}
+  .metrics-table td {{ padding: 8px 12px; border-bottom: 1px solid #21262d; }}
+  .metrics-table tr.highlight td {{ color: #58a6ff; font-weight: 600; }}
+  .metrics-table td.val {{ font-family: 'SF Mono', 'Fira Code', monospace; text-align: right; font-size: 0.8rem; }}
+  .feat-row {{ display: flex; align-items: center; margin-bottom: 6px; }}
+  .feat-name {{ width: 170px; font-size: 0.8rem; color: #8b949e; text-align: right; padding-right: 12px; flex-shrink: 0; }}
+  .feat-bar-wrap {{ flex: 1; height: 18px; background: #21262d; border-radius: 4px; overflow: hidden; }}
+  .feat-bar {{ height: 100%; border-radius: 4px; transition: width 0.4s; }}
+  .feat-pct {{ width: 50px; font-size: 0.75rem; color: #8b949e; text-align: right; padding-left: 8px; font-family: monospace; }}
+  .warning {{ background: #f0883e15; border: 1px solid #f0883e44; border-radius: 8px; padding: 16px; margin-bottom: 24px; }}
+  .warning-title {{ color: #f0883e; font-weight: 600; font-size: 0.9rem; margin-bottom: 6px; }}
+  .warning-text {{ color: #8b949e; font-size: 0.85rem; line-height: 1.5; }}
+  @media (max-width: 768px) {{
+    .cards {{ grid-template-columns: repeat(2, 1fr); }}
+    .cols {{ grid-template-columns: 1fr; }}
+  }}
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>ML Energy Consumption Prediction</h1>
+  <p class="subtitle">Direct prediction with weather forecast &mdash; <span>{pred_start} to {pred_end}</span></p>
+{warning_html}
+  <div class="cards">
+    <div class="card">
+      <div class="card-label">Predicted 24h</div>
+      <div class="card-value total">{total_kwh:.2f} <span class="card-unit">kWh</span></div>
+      <div class="card-sub">Yesterday: {yesterday_total:.2f} kWh</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Peak Hour</div>
+      <div class="card-value peak">{peak_kwh:.2f} <span class="card-unit">kWh/h</span></div>
+      <div class="card-sub">{peak_hour}</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Lowest Hour</div>
+      <div class="card-value low">{low_kwh:.2f} <span class="card-unit">kWh/h</span></div>
+      <div class="card-sub">{low_hour}</div>
+    </div>
+    <div class="card">
+      <div class="card-label">Temperature Range</div>
+      <div class="card-value temp">{temp_min:.1f}&ndash;{temp_max:.1f} <span class="card-unit">&deg;C</span></div>
+    </div>
+  </div>
+
+  <div class="toggle-row">
+    <button class="toggle-btn active" data-view="quarter">15-min intervals</button>
+    <button class="toggle-btn" data-view="hourly">Hourly totals</button>
+  </div>
+
+  <div class="chart-panel">
+    <div class="chart-title">Predicted Consumption vs Yesterday</div>
+    <div class="chart-wrap"><canvas id="mainChart"></canvas></div>
+  </div>
+
+  <div class="cols">
+    <div class="chart-panel">
+      <div class="chart-title">Hourly Breakdown</div>
+      <div class="chart-wrap"><canvas id="barChart"></canvas></div>
+    </div>
+    <div class="chart-panel">
+      <div class="chart-title">Temperature &amp; Consumption Correlation</div>
+      <div class="chart-wrap"><canvas id="tempChart"></canvas></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-label">Model Analysis</div>
+  </div>
+
+  <div class="cols">
+    <div class="chart-panel">
+      <h2>Baseline Comparison</h2>
+      <table class="metrics-table">
+        <thead>
+          <tr><th>Method</th><th class="val">MAE</th><th class="val">RMSE</th><th class="val">R&sup2;</th><th class="val">MAPE%</th></tr>
+        </thead>
+        <tbody>
+{baseline_rows_html}        </tbody>
+      </table>
+    </div>
+
+    <div class="chart-panel">
+      <h2>Feature Importance</h2>
+      <div id="feat-bars"></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-label">Methodology</div>
+  </div>
+
+  <div class="chart-panel">
+    <div style="display:grid; grid-template-columns: 1fr 1fr 1fr; gap: 24px; font-size: 0.85rem; color: #8b949e; line-height: 1.6;">
+      <div>
+        <div style="color: #e1e4e8; font-weight: 600; margin-bottom: 8px;">Direct Prediction</div>
+        Single <code style="color:#58a6ff">model.predict(X)</code> call on a 96-row feature matrix.
+        No iterative loop, no error compounding. Each row contains only
+        features known ahead of time for that future period.
+      </div>
+      <div>
+        <div style="color: #e1e4e8; font-weight: 600; margin-bottom: 8px;">Weather-Driven</div>
+        48-hour forecast from Home Assistant (temperature, cloud cover,
+        wind, precipitation) interpolated to 15-min intervals.
+      </div>
+      <div>
+        <div style="color: #e1e4e8; font-weight: 600; margin-bottom: 8px;">History Context</div>
+        Yesterday's consumption profile, weekly averages, and recent 24h mean
+        provide stable context without feeding predictions back as input.
+        Computed once from InfluxDB before prediction.
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+const quarterData = {json.dumps(quarter_data)};
+const yesterdayData = {json.dumps(yesterday_data)};
+const hourlyData = {json.dumps(hourly_data)};
+const weatherData = {json.dumps(weather_data)};
+const featureImportance = {json.dumps(feature_importance)};
+
+const gridColor = '#21262d';
+const tickColor = '#8b949e';
+const blue = '#58a6ff';
+const orange = '#f0883e';
+const green = '#3fb950';
+const purple = '#bc8cff';
+
+function makeGradient(ctx, r, g, b, h) {{
+  const grad = ctx.createLinearGradient(0, 0, 0, h || 280);
+  grad.addColorStop(0, `rgba(${{r}},${{g}},${{b}},0.3)`);
+  grad.addColorStop(1, `rgba(${{r}},${{g}},${{b}},0.02)`);
+  return grad;
+}}
+
+// Reorder yesterday data to align with prediction start time
+const yesterdayReordered = [];
+const startIdx = {pred_start_quarter};
+for (let i = 0; i < 96; i++) {{
+  yesterdayReordered.push(yesterdayData[(startIdx + i) % 96]);
+}}
+
+// Main chart: prediction vs yesterday
+const mainCtx = document.getElementById('mainChart').getContext('2d');
+const mainChart = new Chart(mainCtx, {{
+  type: 'line',
+  data: {{
+    labels: quarterData.map(d => d.time),
+    datasets: [
+      {{
+        label: 'ML Prediction',
+        data: quarterData.map(d => d.kwh),
+        borderColor: blue,
+        backgroundColor: makeGradient(mainCtx, 88, 166, 255),
+        borderWidth: 2,
+        fill: true,
+        tension: 0.3,
+        pointRadius: 0,
+        pointHitRadius: 8,
+        pointHoverRadius: 4,
+        pointHoverBackgroundColor: blue,
+      }},
+      {{
+        label: 'Yesterday Actual',
+        data: yesterdayReordered.map(d => d.kwh),
+        borderColor: '#484f58',
+        borderWidth: 1.5,
+        borderDash: [4, 4],
+        fill: false,
+        tension: 0.3,
+        pointRadius: 0,
+      }}
+    ]
+  }},
+  options: {{
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {{ mode: 'index', intersect: false }},
+    plugins: {{
+      legend: {{ labels: {{ color: tickColor, boxWidth: 12, padding: 16, font: {{ size: 11 }} }} }},
+      tooltip: {{
+        backgroundColor: '#1c2128', borderColor: '#30363d', borderWidth: 1,
+        titleColor: '#e1e4e8', bodyColor: '#8b949e', padding: 10,
+        callbacks: {{ label: ctx => `${{ctx.dataset.label}}: ${{ctx.parsed.y.toFixed(3)}} kWh` }}
+      }}
+    }},
+    scales: {{
+      x: {{
+        grid: {{ color: gridColor }},
+        ticks: {{ color: tickColor, maxTicksLimit: 24, callback: function(val) {{ const l = this.getLabelForValue(val); return l.endsWith(':00') ? l : ''; }} }}
+      }},
+      y: {{
+        grid: {{ color: gridColor }},
+        ticks: {{ color: tickColor, callback: v => v.toFixed(2) }},
+        title: {{ display: true, text: 'kWh / 15min', color: tickColor }}
+      }}
+    }}
+  }}
+}});
+
+// Bar chart
+const barCtx = document.getElementById('barChart').getContext('2d');
+function barColors(data) {{
+  const max = Math.max(...data);
+  return data.map(v => {{
+    const r = v / max;
+    if (r > 0.8) return orange;
+    if (r > 0.5) return blue;
+    return green;
+  }});
+}}
+const hourlyKwh = hourlyData.map(d => d.kwh);
+new Chart(barCtx, {{
+  type: 'bar',
+  data: {{
+    labels: hourlyData.map(d => d.hour),
+    datasets: [{{ label: 'kWh/hour', data: hourlyKwh, backgroundColor: barColors(hourlyKwh), borderRadius: 4, borderSkipped: false }}]
+  }},
+  options: {{
+    responsive: true, maintainAspectRatio: false,
+    plugins: {{
+      legend: {{ display: false }},
+      tooltip: {{ backgroundColor: '#1c2128', borderColor: '#30363d', borderWidth: 1, titleColor: '#e1e4e8', bodyColor: '#8b949e', padding: 10, callbacks: {{ label: ctx => `${{ctx.parsed.y.toFixed(3)}} kWh` }} }}
+    }},
+    scales: {{
+      x: {{ grid: {{ color: gridColor }}, ticks: {{ color: tickColor, maxTicksLimit: 12 }} }},
+      y: {{ grid: {{ color: gridColor }}, ticks: {{ color: tickColor, callback: v => v.toFixed(1) }}, title: {{ display: true, text: 'kWh/hour', color: tickColor }} }}
+    }}
+  }}
+}});
+
+// Temperature + consumption dual axis chart
+const tempCtx = document.getElementById('tempChart').getContext('2d');
+new Chart(tempCtx, {{
+  type: 'line',
+  data: {{
+    labels: quarterData.map(d => d.time),
+    datasets: [
+      {{
+        label: 'Consumption',
+        data: quarterData.map(d => d.kwh),
+        borderColor: blue,
+        backgroundColor: 'transparent',
+        borderWidth: 1.5,
+        tension: 0.3,
+        pointRadius: 0,
+        yAxisID: 'y',
+      }},
+      {{
+        label: 'Temperature',
+        data: weatherData.map(d => d.temp),
+        borderColor: orange,
+        backgroundColor: makeGradient(tempCtx, 240, 136, 62),
+        borderWidth: 1.5,
+        fill: true,
+        tension: 0.3,
+        pointRadius: 0,
+        yAxisID: 'y1',
+      }}
+    ]
+  }},
+  options: {{
+    responsive: true, maintainAspectRatio: false,
+    interaction: {{ mode: 'index', intersect: false }},
+    plugins: {{
+      legend: {{ labels: {{ color: tickColor, boxWidth: 12, padding: 16, font: {{ size: 11 }} }} }},
+      tooltip: {{
+        backgroundColor: '#1c2128', borderColor: '#30363d', borderWidth: 1, titleColor: '#e1e4e8', bodyColor: '#8b949e', padding: 10,
+        callbacks: {{ label: ctx => ctx.dataset.label === 'Temperature' ? `${{ctx.parsed.y.toFixed(1)}} °C` : `${{ctx.parsed.y.toFixed(3)}} kWh` }}
+      }}
+    }},
+    scales: {{
+      x: {{ grid: {{ color: gridColor }}, ticks: {{ color: tickColor, maxTicksLimit: 12, callback: function(val) {{ const l = this.getLabelForValue(val); return l.endsWith(':00') ? l : ''; }} }} }},
+      y: {{ position: 'left', grid: {{ color: gridColor }}, ticks: {{ color: blue, callback: v => v.toFixed(2) }}, title: {{ display: true, text: 'kWh', color: blue }} }},
+      y1: {{ position: 'right', grid: {{ drawOnChartArea: false }}, ticks: {{ color: orange, callback: v => v + '°' }}, title: {{ display: true, text: '°C', color: orange }} }}
+    }}
+  }}
+}});
+
+// Toggle quarter/hourly
+document.querySelectorAll('.toggle-btn').forEach(btn => {{
+  btn.addEventListener('click', () => {{
+    document.querySelectorAll('.toggle-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    const view = btn.dataset.view;
+    if (view === 'hourly') {{
+      mainChart.data.labels = hourlyData.map(d => d.hour);
+      mainChart.data.datasets[0].data = hourlyKwh;
+      mainChart.data.datasets[0].label = 'ML Prediction (hourly)';
+      const yHourly = [];
+      for (let i = 0; i < 96; i += 4) {{
+        let s = 0;
+        for (let j = 0; j < 4; j++) s += yesterdayReordered[i + j].kwh;
+        yHourly.push(s);
+      }}
+      mainChart.data.datasets[1].data = yHourly;
+      mainChart.options.scales.y.title.text = 'kWh / hour';
+    }} else {{
+      mainChart.data.labels = quarterData.map(d => d.time);
+      mainChart.data.datasets[0].data = quarterData.map(d => d.kwh);
+      mainChart.data.datasets[0].label = 'ML Prediction';
+      mainChart.data.datasets[1].data = yesterdayReordered.map(d => d.kwh);
+      mainChart.options.scales.y.title.text = 'kWh / 15min';
+    }}
+    mainChart.update();
+  }});
+}});
+
+// Feature importance bars
+const featContainer = document.getElementById('feat-bars');
+const maxImp = Math.max(...featureImportance.map(f => f[1]));
+const barColors2 = [blue, blue, orange, green, green, purple, green, '#484f58', '#484f58', '#484f58', '#484f58'];
+featureImportance.forEach(([name, imp], i) => {{
+  const pct = maxImp > 0 ? (imp / maxImp * 100) : 0;
+  const row = document.createElement('div');
+  row.className = 'feat-row';
+  row.innerHTML = `
+    <div class="feat-name">${{name.replace(/_/g, ' ')}}</div>
+    <div class="feat-bar-wrap"><div class="feat-bar" style="width:${{pct}}%; background:${{barColors2[i] || '#484f58'}}"></div></div>
+    <div class="feat-pct">${{(imp * 100).toFixed(1)}}%</div>
+  `;
+  featContainer.appendChild(row);
+}});
+</script>
+</body>
+</html>
+"""
+
+
+def _cmd_report(config: dict) -> None:
+    """Retrain model, generate predictions, and produce timestamped HTML chart."""
+    from ml.data_fetcher import fetch_history_context, fetch_weather_forecast
+    from ml.predictor import predict_with_timestamps
+    from ml.trainer import train_model
+
+    print("Retraining model...")
+    train_result = train_model(config)
+    print(f"  Train samples: {train_result['train_size']}")
+    print(f"  MAE: {train_result['metrics']['mae_kwh']:.4f} kWh")
+
+    print("Generating predictions...")
+    predictions = predict_with_timestamps(config)
+    total_kwh = sum(kwh for _, kwh in predictions)
+    print(f"  Predicted 24h total: {total_kwh:.2f} kWh")
+
+    print("Fetching weather forecast...")
+    weather_df = fetch_weather_forecast(config)
+    print(f"  Weather points: {len(weather_df)}")
+
+    print("Fetching history context...")
+    history_context = fetch_history_context(config)
+    print(f"  Yesterday total: {history_context['yesterday_total']:.2f} kWh")
+
+    print("Generating HTML chart...")
+    html = _generate_chart_html(train_result, predictions, weather_df, history_context)
+
+    output_path = Path("ml") / f"prediction_chart-{date.today().isoformat()}.html"
+    output_path.write_text(html, encoding="utf-8")
+
+    print(f"\nReport saved: {output_path}")
+    print("  Open in browser to view charts with live data")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        prog="ml",
+        description="ML Energy Consumption Predictor for BESS",
+    )
+    parser.add_argument(
+        "command",
+        choices=["train", "predict", "evaluate", "baseline", "fetch-data", "report"],
+        help="Command to execute",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to ml_config.yaml (default: ml_config.yaml in project root)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose/debug logging",
+    )
+    parser.add_argument(
+        "--target-date",
+        default=None,
+        help="End date for data window (YYYY-MM-DD). Defaults to yesterday.",
+    )
+
+    args = parser.parse_args(argv)
+    _setup_logging(args.verbose)
+
+    config = load_config(args.config)
+
+    target_date = None
+    if args.target_date:
+        target_date = date.fromisoformat(args.target_date)
+
+    if args.command == "train":
+        _cmd_train(config, target_date)
+    elif args.command == "predict":
+        _cmd_predict(config)
+    elif args.command == "evaluate":
+        _cmd_evaluate(config, target_date)
+    elif args.command == "baseline":
+        _cmd_baseline(config, target_date)
+    elif args.command == "fetch-data":
+        _cmd_fetch_data(config, target_date)
+    elif args.command == "report":
+        _cmd_report(config)

--- a/ml/config.py
+++ b/ml/config.py
@@ -1,0 +1,167 @@
+"""Configuration loading for ML energy predictor.
+
+Loads ml_config.yaml with environment variable interpolation,
+resolving ${ENV_VAR} syntax from the environment or a .env file.
+"""
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import yaml
+from dotenv import load_dotenv
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+DEFAULT_MODEL_PATH = "ml/trained_model.json"
+
+
+def _resolve_env_vars(value: str) -> str:
+    """Replace ${ENV_VAR} placeholders with environment variable values.
+
+    Raises:
+        KeyError: If an environment variable is not set.
+    """
+
+    def _replacer(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            raise KeyError(
+                f"Environment variable '{var_name}' is not set. "
+                f"Check your .env file or environment."
+            )
+        return env_value
+
+    return _ENV_VAR_PATTERN.sub(_replacer, value)
+
+
+def _resolve_recursive(obj: object) -> object:
+    """Walk a nested dict/list and resolve all string values containing ${...}."""
+    if isinstance(obj, str):
+        return _resolve_env_vars(obj)
+    if isinstance(obj, dict):
+        return {k: _resolve_recursive(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_resolve_recursive(item) for item in obj]
+    return obj
+
+
+def _build_from_app_options(app_options: dict) -> dict:
+    """Build ML config dict from the main app options (/data/options.json).
+
+    InfluxDB credentials are resolved with env-var precedence (for dev) falling
+    back to the 'influxdb' section in app_options (production / HA options.json).
+    HA credentials come from environment variables set by run.sh.
+    ML settings come from the 'ml' section.
+    The target sensor is derived from sensors.local_load_power.
+    """
+    ml = app_options["ml"]
+    sensors = app_options.get("sensors", {})
+
+    local_load = sensors.get("local_load_power", "")
+    if local_load.startswith("sensor."):
+        local_load = local_load[len("sensor.") :]
+
+    raw_feature_sensors = ml.get("feature_sensors", {})
+    feature_sensors = {
+        k: v[len("sensor.") :] if isinstance(v, str) and v.startswith("sensor.") else v
+        for k, v in raw_feature_sensors.items()
+    }
+
+    # InfluxDB: env vars take precedence (dev), fall back to app_options (production)
+    influxdb_opts = app_options.get("influxdb", {})
+    influxdb_config = {
+        "url": os.environ.get("HA_DB_URL") or influxdb_opts.get("url", ""),
+        "bucket": os.environ.get("HA_DB_BUCKET") or influxdb_opts.get("bucket", ""),
+        "username": os.environ.get("HA_DB_USER_NAME")
+        or influxdb_opts.get("username", ""),
+        "password": os.environ.get("HA_DB_PASSWORD")
+        or influxdb_opts.get("password", ""),
+    }
+
+    return {
+        "influxdb": influxdb_config,
+        "ha_api": {
+            "url": (
+                "http://supervisor/core"
+                if os.environ.get("HASSIO_TOKEN")
+                else os.environ.get("HA_URL", "http://supervisor/core")
+            ),
+            "token": os.environ.get("HASSIO_TOKEN") or os.environ.get("HA_TOKEN", ""),
+            "weather_entity": ml["weather_entity"],
+        },
+        "location": ml["location"],
+        "target": {
+            "sensor": local_load,
+            "unit": "W",
+        },
+        "feature_sensors": feature_sensors,
+        "derived_features": ml["derived_features"],
+        "history_context": ml["history_context"],
+        "training": ml["training"],
+        "model_path": DEFAULT_MODEL_PATH,
+    }
+
+
+def load_config(
+    config_path: str | None = None, app_options: dict | None = None
+) -> dict:
+    """Load and resolve the ML configuration.
+
+    When app_options is provided (the main app /data/options.json dict), the
+    config is built directly from it and no YAML file is read. This is the
+    path used by the live system.
+
+    When app_options is None, falls back to loading ml_config.yaml from disk
+    (used by the standalone CLI tools).
+
+    Args:
+        config_path: Path to ml_config.yaml for CLI use. Ignored when
+                     app_options is provided.
+        app_options: Main app options dict. When set, config is derived
+                     from the app config + environment variables.
+
+    Returns:
+        Fully resolved configuration dictionary.
+
+    Raises:
+        FileNotFoundError: If config file does not exist (CLI path only).
+        KeyError: If required environment variables are missing.
+    """
+    # Load .env file for local development (needed for env var resolution)
+    project_root = Path(__file__).resolve().parent.parent
+    dotenv_path = project_root / ".env"
+    if dotenv_path.exists():
+        load_dotenv(dotenv_path)
+        _LOGGER.debug("Loaded .env from %s", dotenv_path)
+
+    if app_options is not None:
+        if "ml" not in app_options:
+            raise KeyError(
+                "ML config section 'ml' is missing from add-on options. "
+                "Add the 'ml' section to config.yaml to use ML features."
+            )
+        _LOGGER.info("ML config built from app options")
+        return _build_from_app_options(app_options)
+
+    if config_path is None:
+        config_path = str(project_root / "ml_config.yaml")
+
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"ML config file not found: {config_path}")
+
+    with open(path) as f:
+        raw_config = yaml.safe_load(f)
+
+    resolved = _resolve_recursive(raw_config)
+    assert isinstance(resolved, dict)
+
+    resolved.setdefault("model_path", DEFAULT_MODEL_PATH)
+
+    _LOGGER.info("ML config loaded from %s", config_path)
+    return resolved

--- a/ml/data_fetcher.py
+++ b/ml/data_fetcher.py
@@ -279,37 +279,42 @@ def fetch_training_data(
     return wide_df
 
 
-def fetch_recent_data(
+def fetch_actuals_for_date(
     config: dict,
-    days: int = 2,
-) -> pd.DataFrame:
-    """Fetch recent sensor data for prediction context.
+    target_date: date,
+) -> list[float | None]:
+    """Return a 96-length list of kWh-per-quarter actuals for target_date.
 
-    Fetches recent observed data from InfluxDB. Used to compute
-    history context features (yesterday's profile, weekly averages).
+    Positions at/after "now" return None so the frontend renders them as gaps.
+    Returns all-None if target_date is in the future.
 
     Args:
         config: Resolved ML config dict.
-        days: Number of days of recent data to fetch.
+        target_date: Local calendar date to fetch actuals for.
 
     Returns:
-        Wide-format DataFrame with the same column structure as fetch_training_data.
+        List of 96 values (float or None) keyed by quarter index.
 
     Raises:
-        RuntimeError: If InfluxDB query fails or returns insufficient data.
+        RuntimeError: If InfluxDB query fails.
     """
     local_tz = _get_local_tz(config)
-    target_sensor = config["target"]["sensor"]
-    feature_sensors = list(config["feature_sensors"].values())
-    all_sensors = [target_sensor, *feature_sensors]
+    now = datetime.now(local_tz)
+    today = now.date()
 
-    end_dt = datetime.now(local_tz)
-    start_dt = end_dt - timedelta(days=days)
+    if target_date > today:
+        return [None] * PERIODS_PER_DAY
+
+    start_dt = datetime.combine(target_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+    end_dt = start_dt + timedelta(days=1)
 
     start_str = start_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     end_str = end_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    sensor_filter = _build_sensor_filter(all_sensors)
+    target_sensor = config["target"]["sensor"]
+    sensor_filter = _build_sensor_filter([target_sensor])
     bucket = config["influxdb"]["bucket"]
 
     flux_query = f"""from(bucket: "{bucket}")
@@ -319,32 +324,32 @@ def fetch_recent_data(
         |> sort(columns: ["_time"])
     """
 
-    _LOGGER.info("Fetching recent data for prediction (%d days)...", days)
+    _LOGGER.info("Fetching actuals for %s...", target_date)
     csv_text = _query_influxdb(config, flux_query, timeout=60)
-
     raw_df = _parse_csv_to_dataframe(csv_text, local_tz)
-    if raw_df.empty:
-        raise RuntimeError("No recent data returned from InfluxDB")
 
-    wide_df = _aggregate_to_quarters(raw_df)
+    actuals: list[float | None] = [None] * PERIODS_PER_DAY
 
-    # Rename columns
-    column_renames = {f"sensor.{target_sensor}": "target"}
-    for feature_name, sensor_id in config["feature_sensors"].items():
-        column_renames[f"sensor.{sensor_id}"] = feature_name
+    if not raw_df.empty:
+        wide_df = _aggregate_to_quarters(raw_df)
+        target_col = f"sensor.{target_sensor}"
+        if target_col in wide_df.columns:
+            series = wide_df[target_col]
+            if config["target"].get("unit") == "W":
+                series = series * (1.0 / (4 * 1000))
+            day_mask = series.index.date == target_date
+            day_series = series[day_mask]
+            for ts, val in day_series.items():
+                quarter_idx = ts.hour * 4 + ts.minute // 15
+                if 0 <= quarter_idx < PERIODS_PER_DAY:
+                    actuals[quarter_idx] = float(val)
 
-    wide_df = wide_df.rename(columns=column_renames)
-    wide_df = wide_df.ffill()
-    wide_df = wide_df.dropna(subset=["target"])
+    if target_date == today:
+        now_quarter = now.hour * 4 + now.minute // 15
+        for i in range(now_quarter, PERIODS_PER_DAY):
+            actuals[i] = None
 
-    _LOGGER.info(
-        "Recent data: %d rows, date range %s to %s",
-        len(wide_df),
-        wide_df.index.min(),
-        wide_df.index.max(),
-    )
-
-    return wide_df
+    return actuals
 
 
 def fetch_weather_forecast(config: dict) -> pd.DataFrame:

--- a/ml/data_fetcher.py
+++ b/ml/data_fetcher.py
@@ -1,0 +1,594 @@
+"""Bulk historical data fetcher from InfluxDB for ML training.
+
+Queries multiple days of sensor data and returns a pandas DataFrame
+with 15-minute aggregated readings for target and feature sensors.
+Also fetches weather forecasts from Home Assistant and history context
+from InfluxDB for prediction.
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import requests
+
+_LOGGER = logging.getLogger(__name__)
+
+UTC = ZoneInfo("UTC")
+
+QUARTER_HOUR_MINUTES = 15
+PERIODS_PER_DAY = 96
+
+
+def _get_local_tz(config: dict) -> ZoneInfo:
+    """Extract the local timezone from config."""
+    return ZoneInfo(config["location"]["timezone"])
+
+
+def _build_sensor_filter(sensors: list[str]) -> str:
+    """Build Flux sensor filter compatible with InfluxDB 1.x and 2.x."""
+    conditions = []
+    for sensor in sensors:
+        conditions.append(
+            f'(r["_measurement"] == "sensor.{sensor}" or r["entity_id"] == "{sensor}")'
+        )
+    return " or ".join(conditions)
+
+
+def _query_influxdb(
+    config: dict,
+    flux_query: str,
+    timeout: int = 60,
+) -> str:
+    """Execute a Flux query against InfluxDB and return raw CSV response.
+
+    Raises:
+        RuntimeError: If the query fails or returns no data.
+    """
+    influx_cfg = config["influxdb"]
+    url = influx_cfg["url"]
+    username = influx_cfg["username"]
+    password = influx_cfg["password"]
+
+    headers = {
+        "Content-type": "application/vnd.flux",
+        "Accept": "application/csv",
+    }
+
+    response = requests.post(
+        url=url,
+        auth=(username, password),
+        headers=headers,
+        data=flux_query,
+        timeout=timeout,
+    )
+
+    if response.status_code == 204:
+        raise RuntimeError("InfluxDB returned no data (HTTP 204)")
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"InfluxDB query failed with HTTP {response.status_code}: "
+            f"{response.text[:500]}"
+        )
+
+    return response.text
+
+
+def _parse_csv_to_dataframe(csv_text: str, local_tz: ZoneInfo) -> pd.DataFrame:
+    """Parse InfluxDB CSV response into a DataFrame with timestamp and sensor columns.
+
+    Returns a DataFrame with columns: timestamp, sensor_name, value
+    """
+    rows: list[dict[str, object]] = []
+
+    lines = csv_text.strip().split("\n")
+    data_lines = [line for line in lines if not line.startswith("#")]
+
+    # Find header row
+    col_map: dict[str, int] | None = None
+    for line in data_lines:
+        parts = [p.strip() for p in line.split(",")]
+        if "_value" in parts and "_time" in parts:
+            col_map = {name: idx for idx, name in enumerate(parts)}
+            break
+
+    if col_map is None:
+        _LOGGER.warning("No header row found in InfluxDB response")
+        return pd.DataFrame(columns=["timestamp", "sensor", "value"])
+
+    value_idx = col_map["_value"]
+    time_idx = col_map["_time"]
+    entity_id_idx = col_map.get("entity_id")
+    measurement_idx = col_map.get("_measurement")
+
+    for line in data_lines:
+        parts = line.split(",")
+        try:
+            if len(parts) <= max(value_idx, time_idx):
+                continue
+            if parts[value_idx].strip() == "_value":
+                continue
+
+            # Extract sensor name (same logic as influxdb_helper)
+            sensor_name = ""
+            if entity_id_idx is not None and entity_id_idx < len(parts):
+                entity_val = parts[entity_id_idx].strip()
+                if entity_val and entity_val != "entity_id":
+                    sensor_name = (
+                        entity_val
+                        if entity_val.startswith("sensor.")
+                        else f"sensor.{entity_val}"
+                    )
+
+            if not sensor_name and measurement_idx is not None:
+                measurement_val = parts[measurement_idx].strip()
+                if measurement_val.startswith("sensor."):
+                    sensor_name = measurement_val
+
+            if not sensor_name:
+                continue
+
+            timestamp_str = parts[time_idx].strip()
+            timestamp = datetime.fromisoformat(
+                timestamp_str.replace("Z", "+00:00")
+            ).astimezone(local_tz)
+            value = float(parts[value_idx].strip())
+
+            rows.append({"timestamp": timestamp, "sensor": sensor_name, "value": value})
+
+        except (IndexError, ValueError):
+            continue
+
+    return pd.DataFrame(rows)
+
+
+def _aggregate_to_quarters(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate raw sensor readings to 15-minute means.
+
+    Takes a long-format DataFrame (timestamp, sensor, value) and returns
+    a wide-format DataFrame indexed by quarter-hour timestamp with one
+    column per sensor.
+    """
+    if df.empty:
+        return pd.DataFrame()
+
+    # Floor timestamps to 15-minute boundaries
+    df = df.copy()
+    df["quarter"] = df["timestamp"].dt.floor(f"{QUARTER_HOUR_MINUTES}min")
+
+    # Pivot: each sensor becomes a column, aggregate by mean per quarter
+    pivoted = df.pivot_table(
+        index="quarter",
+        columns="sensor",
+        values="value",
+        aggfunc="mean",
+    )
+
+    # Sort by time
+    pivoted = pivoted.sort_index()
+
+    return pivoted
+
+
+def fetch_training_data(
+    config: dict,
+    target_date: date | None = None,
+) -> pd.DataFrame:
+    """Fetch historical sensor data for ML training.
+
+    Queries InfluxDB for the configured number of days of history,
+    aggregated to 15-minute intervals.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for the training window. Defaults to yesterday.
+
+    Returns:
+        Wide-format DataFrame indexed by quarter-hour timestamps,
+        with columns for target sensor and each feature sensor.
+        Values are raw sensor readings (W for power, °C for temp, etc.).
+
+    Raises:
+        RuntimeError: If InfluxDB query fails or returns no data.
+    """
+    local_tz = _get_local_tz(config)
+
+    if target_date is None:
+        target_date = (datetime.now(local_tz) - timedelta(days=1)).date()
+
+    days_of_history = config["training"]["days_of_history"]
+    start_date = target_date - timedelta(days=days_of_history)
+
+    # Build list of all sensors to query
+    target_sensor = config["target"]["sensor"]
+    feature_sensors = list(config["feature_sensors"].values())
+    all_sensors = [target_sensor, *feature_sensors]
+
+    _LOGGER.info(
+        "Fetching %d days of data (%s to %s) for %d sensors",
+        days_of_history,
+        start_date,
+        target_date,
+        len(all_sensors),
+    )
+
+    # Build time range
+    start_dt = datetime.combine(start_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+    end_dt = datetime.combine(target_date, datetime.max.time()).replace(tzinfo=local_tz)
+
+    start_str = start_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sensor_filter = _build_sensor_filter(all_sensors)
+    bucket = config["influxdb"]["bucket"]
+
+    # Fetch raw data points; 15-minute aggregation done in Python via _aggregate_to_quarters
+    # (InfluxDB 1.x compat mode does not support aggregateWindow)
+    flux_query = f"""from(bucket: "{bucket}")
+        |> range(start: {start_str}, stop: {end_str})
+        |> filter(fn: (r) => {sensor_filter})
+        |> filter(fn: (r) => r["_field"] == "value")
+        |> sort(columns: ["_time"])
+    """
+
+    _LOGGER.info("Executing InfluxDB query for training data...")
+    csv_text = _query_influxdb(config, flux_query, timeout=120)
+
+    # Parse CSV to DataFrame
+    raw_df = _parse_csv_to_dataframe(csv_text, local_tz)
+    _LOGGER.info(
+        "Parsed %d raw readings across %d sensors",
+        len(raw_df),
+        raw_df["sensor"].nunique() if not raw_df.empty else 0,
+    )
+
+    if raw_df.empty:
+        raise RuntimeError(
+            f"No data returned from InfluxDB for sensors {all_sensors} "
+            f"between {start_date} and {target_date}"
+        )
+
+    # Aggregate to quarter-hourly wide format
+    wide_df = _aggregate_to_quarters(raw_df)
+
+    # Rename columns from sensor.xyz to friendly names
+    column_renames = {f"sensor.{target_sensor}": "target"}
+    for feature_name, sensor_id in config["feature_sensors"].items():
+        column_renames[f"sensor.{sensor_id}"] = feature_name
+
+    wide_df = wide_df.rename(columns=column_renames)
+
+    # Forward-fill missing values (sensors may report at different rates)
+    wide_df = wide_df.ffill()
+
+    # Drop rows where target is still NaN (beginning of series before first reading)
+    wide_df = wide_df.dropna(subset=["target"])
+
+    _LOGGER.info(
+        "Training data ready: %d rows, %d columns, date range %s to %s",
+        len(wide_df),
+        len(wide_df.columns),
+        wide_df.index.min(),
+        wide_df.index.max(),
+    )
+
+    return wide_df
+
+
+def fetch_recent_data(
+    config: dict,
+    days: int = 2,
+) -> pd.DataFrame:
+    """Fetch recent sensor data for prediction context.
+
+    Fetches recent observed data from InfluxDB. Used to compute
+    history context features (yesterday's profile, weekly averages).
+
+    Args:
+        config: Resolved ML config dict.
+        days: Number of days of recent data to fetch.
+
+    Returns:
+        Wide-format DataFrame with the same column structure as fetch_training_data.
+
+    Raises:
+        RuntimeError: If InfluxDB query fails or returns insufficient data.
+    """
+    local_tz = _get_local_tz(config)
+    target_sensor = config["target"]["sensor"]
+    feature_sensors = list(config["feature_sensors"].values())
+    all_sensors = [target_sensor, *feature_sensors]
+
+    end_dt = datetime.now(local_tz)
+    start_dt = end_dt - timedelta(days=days)
+
+    start_str = start_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sensor_filter = _build_sensor_filter(all_sensors)
+    bucket = config["influxdb"]["bucket"]
+
+    flux_query = f"""from(bucket: "{bucket}")
+        |> range(start: {start_str}, stop: {end_str})
+        |> filter(fn: (r) => {sensor_filter})
+        |> filter(fn: (r) => r["_field"] == "value")
+        |> sort(columns: ["_time"])
+    """
+
+    _LOGGER.info("Fetching recent data for prediction (%d days)...", days)
+    csv_text = _query_influxdb(config, flux_query, timeout=60)
+
+    raw_df = _parse_csv_to_dataframe(csv_text, local_tz)
+    if raw_df.empty:
+        raise RuntimeError("No recent data returned from InfluxDB")
+
+    wide_df = _aggregate_to_quarters(raw_df)
+
+    # Rename columns
+    column_renames = {f"sensor.{target_sensor}": "target"}
+    for feature_name, sensor_id in config["feature_sensors"].items():
+        column_renames[f"sensor.{sensor_id}"] = feature_name
+
+    wide_df = wide_df.rename(columns=column_renames)
+    wide_df = wide_df.ffill()
+    wide_df = wide_df.dropna(subset=["target"])
+
+    _LOGGER.info(
+        "Recent data: %d rows, date range %s to %s",
+        len(wide_df),
+        wide_df.index.min(),
+        wide_df.index.max(),
+    )
+
+    return wide_df
+
+
+def fetch_weather_forecast(config: dict) -> pd.DataFrame:
+    """Fetch hourly weather forecast from Home Assistant and interpolate to 15-min.
+
+    Calls the HA REST API to get weather forecasts, then interpolates
+    hourly values to 15-minute periods.
+
+    Args:
+        config: Resolved ML config dict with ha_api section.
+
+    Returns:
+        DataFrame indexed by 15-minute timestamps with columns:
+        temperature, cloud_coverage, wind_speed, precipitation.
+
+    Raises:
+        RuntimeError: If the HA API call fails or returns unexpected data.
+    """
+    ha_cfg = config["ha_api"]
+    base_url = ha_cfg["url"].rstrip("/")
+    token = ha_cfg["token"]
+    weather_entity = ha_cfg["weather_entity"]
+
+    url = f"{base_url}/api/services/weather/get_forecasts?return_response"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "type": "hourly",
+        "entity_id": weather_entity,
+    }
+
+    _LOGGER.info("Fetching weather forecast from HA (%s)...", weather_entity)
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"HA weather forecast API failed with HTTP {response.status_code}: "
+            f"{response.text[:500]}"
+        )
+
+    data = response.json()
+
+    # Response structure: {"service_response": {"weather.entity": {"forecast": [...]}}}
+    service_response = data.get("service_response", data)
+    entity_data = service_response.get(weather_entity)
+    if entity_data is None:
+        raise RuntimeError(
+            f"No forecast data for entity '{weather_entity}' in HA response. "
+            f"Available keys: {list(service_response.keys())}"
+        )
+
+    forecasts = entity_data["forecast"]
+    if not forecasts:
+        raise RuntimeError("HA returned empty forecast list")
+
+    local_tz = _get_local_tz(config)
+    rows: list[dict] = []
+    for entry in forecasts:
+        dt_str = entry["datetime"]
+        dt = datetime.fromisoformat(dt_str).astimezone(local_tz)
+        rows.append(
+            {
+                "datetime": dt,
+                "temperature": float(entry["temperature"]),
+                "cloud_coverage": float(entry.get("cloud_coverage", 0)),
+                "wind_speed": float(entry.get("wind_speed", 0)),
+                "precipitation": float(entry.get("precipitation", 0)),
+            }
+        )
+
+    hourly_df = pd.DataFrame(rows).set_index("datetime").sort_index()
+
+    _LOGGER.info(
+        "Weather forecast: %d hourly entries from %s to %s",
+        len(hourly_df),
+        hourly_df.index.min(),
+        hourly_df.index.max(),
+    )
+
+    # Interpolate to 15-minute periods
+    # Create 15-min index spanning the forecast range
+    freq_15min = pd.Timedelta(minutes=QUARTER_HOUR_MINUTES)
+    new_index = pd.date_range(
+        start=hourly_df.index.min(),
+        end=hourly_df.index.max(),
+        freq=freq_15min,
+    )
+
+    # Reindex and interpolate
+    interpolated = hourly_df.reindex(hourly_df.index.union(new_index))
+
+    # Linear interpolation for continuous values
+    for col in ["temperature", "wind_speed", "precipitation"]:
+        interpolated[col] = interpolated[col].interpolate(method="linear")
+
+    # Forward-fill for cloud_coverage (categorical-like)
+    interpolated["cloud_coverage"] = interpolated["cloud_coverage"].ffill()
+
+    # Keep only the 15-min aligned timestamps
+    interpolated = interpolated.reindex(new_index)
+    interpolated = interpolated.ffill().bfill()
+
+    _LOGGER.info(
+        "Interpolated forecast: %d quarter-hourly entries",
+        len(interpolated),
+    )
+
+    return interpolated
+
+
+def fetch_history_context(
+    config: dict,
+    target_date: date | None = None,
+) -> dict:
+    """Fetch historical consumption context from InfluxDB.
+
+    Queries yesterday's consumption pattern and weekly averages to provide
+    context features for prediction. These are computed once and applied
+    to all 96 prediction periods.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: The date we're predicting for. Defaults to today.
+
+    Returns:
+        Dict with keys:
+        - yesterday_profile: list of 96 floats (kWh per 15min for yesterday)
+        - yesterday_total: float (total kWh yesterday)
+        - week_avg_profile: list of 96 floats (average kWh per 15min over past 7 days)
+        - recent_24h_mean: float (mean kWh per 15min over last 24h)
+
+    Raises:
+        RuntimeError: If InfluxDB query fails.
+    """
+    local_tz = _get_local_tz(config)
+
+    if target_date is None:
+        target_date = datetime.now(local_tz).date()
+
+    target_sensor = config["target"]["sensor"]
+    watts_to_kwh_15min = 1.0 / (4 * 1000)
+
+    # Fetch 8 days of target sensor data (7 full days + buffer)
+    start_date = target_date - timedelta(days=8)
+    start_dt = datetime.combine(start_date, datetime.min.time()).replace(
+        tzinfo=local_tz
+    )
+    end_dt = datetime.combine(target_date, datetime.min.time()).replace(tzinfo=local_tz)
+
+    start_str = start_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end_dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    sensor_filter = _build_sensor_filter([target_sensor])
+    bucket = config["influxdb"]["bucket"]
+
+    flux_query = f"""from(bucket: "{bucket}")
+        |> range(start: {start_str}, stop: {end_str})
+        |> filter(fn: (r) => {sensor_filter})
+        |> filter(fn: (r) => r["_field"] == "value")
+        |> sort(columns: ["_time"])
+    """
+
+    _LOGGER.info("Fetching history context (8 days ending %s)...", target_date)
+    csv_text = _query_influxdb(config, flux_query, timeout=60)
+
+    raw_df = _parse_csv_to_dataframe(csv_text, local_tz)
+    if raw_df.empty:
+        raise RuntimeError("No history context data returned from InfluxDB")
+
+    wide_df = _aggregate_to_quarters(raw_df)
+
+    # Get the target column (may be sensor.xyz format)
+    target_col = f"sensor.{target_sensor}"
+    if target_col not in wide_df.columns:
+        raise RuntimeError(
+            f"Target sensor column '{target_col}' not found in history data. "
+            f"Available columns: {list(wide_df.columns)}"
+        )
+
+    consumption = wide_df[target_col].ffill()
+
+    # Convert W to kWh/15min
+    if config["target"].get("unit") == "W":
+        consumption = consumption * watts_to_kwh_15min
+
+    # Yesterday's profile (96 values)
+    yesterday = target_date - timedelta(days=1)
+    yesterday_mask = consumption.index.date == yesterday
+    yesterday_data = consumption[yesterday_mask]
+
+    yesterday_profile = [0.0] * PERIODS_PER_DAY
+    yesterday_total = 0.0
+    if not yesterday_data.empty:
+        for i, val in enumerate(yesterday_data.values[:PERIODS_PER_DAY]):
+            yesterday_profile[i] = float(val)
+        yesterday_total = sum(yesterday_profile)
+
+    _LOGGER.info(
+        "Yesterday (%s): %d periods, total %.2f kWh",
+        yesterday,
+        sum(1 for v in yesterday_profile if v > 0),
+        yesterday_total,
+    )
+
+    # Weekly average profile (96 values averaged across 7 days)
+    week_start = target_date - timedelta(days=7)
+    week_profiles: list[list[float]] = []
+
+    for days_back in range(1, 8):
+        day = target_date - timedelta(days=days_back)
+        day_mask = consumption.index.date == day
+        day_data = consumption[day_mask]
+        if len(day_data) >= PERIODS_PER_DAY // 2:  # At least half a day
+            profile = [0.0] * PERIODS_PER_DAY
+            for i, val in enumerate(day_data.values[:PERIODS_PER_DAY]):
+                profile[i] = float(val)
+            week_profiles.append(profile)
+
+    if week_profiles:
+        week_avg_profile = [
+            sum(p[i] for p in week_profiles) / len(week_profiles)
+            for i in range(PERIODS_PER_DAY)
+        ]
+    else:
+        week_avg_profile = yesterday_profile.copy()
+
+    _LOGGER.info(
+        "Weekly average: computed from %d days (%s to %s)",
+        len(week_profiles),
+        week_start,
+        target_date - timedelta(days=1),
+    )
+
+    # Recent 24h mean
+    recent_24h = consumption.tail(PERIODS_PER_DAY)
+    recent_24h_mean = float(recent_24h.mean()) if not recent_24h.empty else 0.0
+
+    _LOGGER.info("Recent 24h mean: %.4f kWh/15min", recent_24h_mean)
+
+    return {
+        "yesterday_profile": yesterday_profile,
+        "yesterday_total": yesterday_total,
+        "week_avg_profile": week_avg_profile,
+        "recent_24h_mean": recent_24h_mean,
+    }

--- a/ml/feature_engineer.py
+++ b/ml/feature_engineer.py
@@ -1,0 +1,273 @@
+"""Feature engineering for ML energy consumption prediction.
+
+Creates a feature matrix from raw sensor DataFrames by adding
+temporal features, daylight hours, weather forecast data, and
+historical consumption context.
+"""
+
+import logging
+import math
+from datetime import date
+
+import numpy as np
+import pandas as pd
+from astral import LocationInfo
+from astral.sun import sun
+
+_LOGGER = logging.getLogger(__name__)
+
+WATTS_TO_KWH_15MIN = 1.0 / (4 * 1000)
+
+
+def _add_cyclical_encoding(
+    df: pd.DataFrame,
+    values: pd.Series,
+    name: str,
+    period: float,
+) -> pd.DataFrame:
+    """Add sin/cos cyclical encoding for a periodic feature."""
+    radians = 2 * math.pi * values / period
+    df[f"{name}_sin"] = np.sin(radians)
+    df[f"{name}_cos"] = np.cos(radians)
+    return df
+
+
+def _add_time_features(df: pd.DataFrame, config: dict) -> pd.DataFrame:
+    """Add temporal features derived from the DataFrame index."""
+    derived = config["derived_features"]
+    index = df.index
+
+    if derived.get("hour_of_day", False):
+        # Use fractional hour (0.0-23.75) for quarter-hour granularity
+        fractional_hour = index.hour + index.minute / 60.0
+        df = _add_cyclical_encoding(df, fractional_hour, "hour", 24.0)
+
+    if derived.get("day_of_week", False):
+        df = _add_cyclical_encoding(df, index.dayofweek, "dow", 7.0)
+        df["is_weekend"] = (index.dayofweek >= 5).astype(int)
+
+    return df
+
+
+def _compute_daylight_hours(
+    target_date: date, latitude: float, longitude: float, timezone: str
+) -> float:
+    """Compute daylight hours for a given date and location using astral."""
+    location = LocationInfo(
+        name="location",
+        region="",
+        timezone=timezone,
+        latitude=latitude,
+        longitude=longitude,
+    )
+    try:
+        s = sun(location.observer, date=target_date)
+        daylight_seconds = (s["sunset"] - s["sunrise"]).total_seconds()
+        return daylight_seconds / 3600.0
+    except ValueError:
+        # Polar regions: sun doesn't rise or set
+        # Return 0 for polar night, 24 for midnight sun
+        _LOGGER.warning("Could not compute sunrise/sunset for %s", target_date)
+        return 12.0
+
+
+def _add_daylight_feature(df: pd.DataFrame, config: dict) -> pd.DataFrame:
+    """Add daylight hours feature for each row based on its date."""
+    if not config["derived_features"].get("daylight_hours", False):
+        return df
+
+    latitude = config["location"]["latitude"]
+    longitude = config["location"]["longitude"]
+    timezone = config["location"]["timezone"]
+
+    # Cache daylight hours per unique date
+    unique_dates = df.index.date
+    daylight_cache: dict[date, float] = {}
+
+    daylight_values = []
+    for d in unique_dates:
+        if d not in daylight_cache:
+            daylight_cache[d] = _compute_daylight_hours(d, latitude, longitude, timezone)
+        daylight_values.append(daylight_cache[d])
+
+    df["daylight_hours"] = daylight_values
+    return df
+
+
+def _add_weather_features(
+    df: pd.DataFrame,
+    weather_df: pd.DataFrame | None,
+) -> pd.DataFrame:
+    """Merge weather forecast columns into feature DataFrame by timestamp.
+
+    During training, weather_df is None and observed outdoor_temperature
+    from InfluxDB is used as a proxy for forecast temperature.
+
+    During prediction, weather_df contains actual forecast data with
+    columns: temperature, cloud_coverage, wind_speed, precipitation.
+    """
+    if weather_df is not None:
+        # Prediction mode: merge forecast data by nearest timestamp
+        for col in ["temperature", "cloud_coverage", "wind_speed", "precipitation"]:
+            if col in weather_df.columns:
+                # Align by finding nearest timestamp within 15 min
+                merged = pd.merge_asof(
+                    df[[]]
+                    .reset_index()
+                    .rename(columns={df.index.name or "index": "timestamp"}),
+                    weather_df[[col]]
+                    .reset_index()
+                    .rename(columns={weather_df.index.name or "index": "timestamp"}),
+                    on="timestamp",
+                    direction="nearest",
+                    tolerance=pd.Timedelta(minutes=30),
+                )
+                df[col] = merged[col].values
+
+        _LOGGER.info(
+            "Added weather forecast features: %s",
+            [
+                c
+                for c in [
+                    "temperature",
+                    "cloud_coverage",
+                    "wind_speed",
+                    "precipitation",
+                ]
+                if c in df.columns
+            ],
+        )
+    else:
+        # Training mode: use observed outdoor_temperature as proxy for forecast
+        if "outdoor_temperature" in df.columns:
+            df["temperature"] = df["outdoor_temperature"]
+            _LOGGER.info(
+                "Using observed outdoor_temperature as training proxy for forecast"
+            )
+
+    return df
+
+
+def _add_history_context_features(
+    df: pd.DataFrame,
+    history_context: dict | None,
+) -> pd.DataFrame:
+    """Add historical consumption context features.
+
+    These features represent "what happened recently" and are computed
+    once from InfluxDB before prediction (not iteratively).
+
+    Features added:
+    - yesterday_same_hour: consumption at same quarter yesterday
+    - yesterday_total: total kWh yesterday (scalar, same for all rows)
+    - week_avg_same_hour: average consumption at same quarter over past week
+    - recent_24h_mean: mean kWh/15min over last 24h (scalar, same for all rows)
+    """
+    if history_context is None:
+        return df
+
+    yesterday_profile = history_context["yesterday_profile"]
+    week_avg_profile = history_context["week_avg_profile"]
+
+    # Map each row to its quarter-of-day index (0-95)
+    quarter_indices = df.index.hour * 4 + df.index.minute // 15
+
+    # yesterday_same_hour: what was consumption at this time yesterday
+    df["yesterday_same_hour"] = [
+        yesterday_profile[min(qi, len(yesterday_profile) - 1)] for qi in quarter_indices
+    ]
+
+    # yesterday_total: scalar context
+    df["yesterday_total"] = history_context["yesterday_total"]
+
+    # week_avg_same_hour: average at this time over the past week
+    df["week_avg_same_hour"] = [
+        week_avg_profile[min(qi, len(week_avg_profile) - 1)] for qi in quarter_indices
+    ]
+
+    # recent_24h_mean: scalar context
+    df["recent_24h_mean"] = history_context["recent_24h_mean"]
+
+    _LOGGER.info(
+        "Added history context features: yesterday_total=%.2f kWh, "
+        "recent_24h_mean=%.4f kWh/15min",
+        history_context["yesterday_total"],
+        history_context["recent_24h_mean"],
+    )
+
+    return df
+
+
+def engineer_features(
+    raw_df: pd.DataFrame,
+    config: dict,
+    convert_target_to_kwh: bool = True,
+    weather_df: pd.DataFrame | None = None,
+    history_context: dict | None = None,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Create feature matrix from raw sensor DataFrame.
+
+    Takes a wide-format DataFrame (from data_fetcher) with columns like
+    'target', 'outdoor_temperature' and adds all derived features
+    specified in config.
+
+    Args:
+        raw_df: Wide-format DataFrame indexed by quarter-hour timestamps.
+                Must contain a 'target' column with consumption values.
+        config: Resolved ML config dict.
+        convert_target_to_kwh: If True, convert target from Watts to kWh/15min.
+        weather_df: Optional weather forecast DataFrame for prediction mode.
+                    None during training (uses observed temperature as proxy).
+        history_context: Optional dict from fetch_history_context().
+                         None during training (computed per-day in trainer).
+
+    Returns:
+        Tuple of (feature_df, feature_columns) where:
+        - feature_df has both features and 'target' column
+        - feature_columns lists only the feature column names (not target)
+    """
+    df = raw_df.copy()
+
+    # Convert target from W to kWh per 15-min period if needed
+    if convert_target_to_kwh and config["target"].get("unit") == "W":
+        df["target"] = df["target"] * WATTS_TO_KWH_15MIN
+
+    # Add temporal features
+    df = _add_time_features(df, config)
+
+    # Add daylight hours
+    df = _add_daylight_feature(df, config)
+
+    # Add weather features (forecast in prediction, observed proxy in training)
+    df = _add_weather_features(df, weather_df)
+
+    # Add history context features
+    df = _add_history_context_features(df, history_context)
+
+    # Drop raw sensor columns that shouldn't be features
+    columns_to_drop = ["outdoor_temperature"]
+    for col in columns_to_drop:
+        if col in df.columns and col != "temperature":
+            df = df.drop(columns=[col])
+
+    # Identify feature columns (everything except 'target')
+    feature_columns = [col for col in df.columns if col != "target"]
+
+    # Drop rows where any feature is NaN
+    rows_before = len(df)
+    df = df.dropna(subset=feature_columns)
+    rows_dropped = rows_before - len(df)
+    if rows_dropped > 0:
+        _LOGGER.info(
+            "Dropped %d rows with incomplete features",
+            rows_dropped,
+        )
+
+    _LOGGER.info(
+        "Engineered %d features from %d rows: %s",
+        len(feature_columns),
+        len(df),
+        feature_columns,
+    )
+
+    return df, feature_columns

--- a/ml/predictor.py
+++ b/ml/predictor.py
@@ -1,0 +1,186 @@
+"""Prediction module for ML energy consumption forecasting.
+
+Loads a trained XGBoost model and generates 96 quarter-hourly
+consumption predictions using direct multi-output prediction:
+a single model.predict(X) call on a pre-built 96-row feature matrix.
+
+Each row contains only features known ahead of time:
+- Time features (deterministic)
+- Weather forecast (from Home Assistant)
+- Historical context (from InfluxDB, computed once)
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from xgboost import XGBRegressor
+
+from ml.data_fetcher import (
+    PERIODS_PER_DAY,
+    fetch_history_context,
+    fetch_weather_forecast,
+)
+from ml.feature_engineer import engineer_features
+
+_LOGGER = logging.getLogger(__name__)
+
+QUARTER_MINUTES = 15
+
+
+def _build_future_timestamps(
+    config: dict, periods: int = PERIODS_PER_DAY
+) -> pd.DatetimeIndex:
+    """Generate 96 future 15-minute timestamps starting from the next quarter hour."""
+    from ml.data_fetcher import _get_local_tz
+
+    now = datetime.now(_get_local_tz(config))
+
+    # Round up to next quarter hour
+    minutes = now.minute
+    next_quarter = minutes + (QUARTER_MINUTES - minutes % QUARTER_MINUTES)
+    start = now.replace(minute=0, second=0, microsecond=0) + pd.Timedelta(
+        minutes=next_quarter
+    )
+
+    return pd.date_range(start=start, periods=periods, freq="15min")
+
+
+def _build_prediction_dataframe(
+    future_timestamps: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """Build a raw DataFrame for the 96 future periods.
+
+    Creates a DataFrame indexed by future timestamps with a dummy 'target'
+    column (NaN, since we're predicting it). Weather and history context
+    features are added during feature engineering.
+    """
+    df = pd.DataFrame(index=future_timestamps)
+    df.index.name = None
+
+    # Target is what we're predicting - use NaN placeholder
+    df["target"] = np.nan
+
+    return df
+
+
+def predict_next_24h(config: dict) -> list[float]:
+    """Generate 96 quarter-hourly consumption predictions.
+
+    Uses direct multi-output prediction: builds a 96-row feature matrix
+    with time features, weather forecast, and history context, then makes
+    a single model.predict(X) call.
+
+    Args:
+        config: Resolved ML config dict.
+
+    Returns:
+        List of 96 float values representing predicted consumption
+        in kWh per 15-minute period. This format matches what
+        battery_system_manager.optimize_battery_schedule() expects
+        for the home_consumption parameter.
+
+    Raises:
+        FileNotFoundError: If no trained model exists.
+        RuntimeError: If data fetching fails.
+    """
+    model_path = config["model_path"]
+    if not Path(model_path).exists():
+        raise FileNotFoundError(
+            f"No trained model found at {model_path}. Run 'train' first."
+        )
+
+    # Load feature column names
+    feature_meta_path = str(Path(model_path).with_suffix(".features.txt"))
+    if not Path(feature_meta_path).exists():
+        raise FileNotFoundError(
+            f"Feature metadata not found at {feature_meta_path}. Retrain the model."
+        )
+
+    with open(feature_meta_path) as f:
+        feature_columns = [line.strip() for line in f.readlines() if line.strip()]
+
+    _LOGGER.info("Loading model from %s", model_path)
+    model = XGBRegressor()
+    model.load_model(model_path)
+    _LOGGER.info("Using %d features: %s", len(feature_columns), feature_columns)
+
+    # Step 1: Generate future timestamps
+    future_ts = _build_future_timestamps(config)
+    _LOGGER.info(
+        "Predicting %d periods: %s to %s",
+        len(future_ts),
+        future_ts[0],
+        future_ts[-1],
+    )
+
+    # Step 2: Fetch weather forecast from HA
+    _LOGGER.info("Fetching weather forecast from Home Assistant...")
+    weather_df = fetch_weather_forecast(config)
+
+    # Step 3: Fetch history context from InfluxDB
+    _LOGGER.info("Fetching history context from InfluxDB...")
+    history_context = fetch_history_context(config)
+
+    # Step 4: Build raw DataFrame for future periods
+    raw_df = _build_prediction_dataframe(future_ts)
+
+    # Step 5: Engineer features (weather + history context + time features)
+    feature_df, _ = engineer_features(
+        raw_df,
+        config,
+        convert_target_to_kwh=False,
+        weather_df=weather_df,
+        history_context=history_context,
+    )
+
+    # Ensure feature columns match training order
+    missing_cols = set(feature_columns) - set(feature_df.columns)
+    if missing_cols:
+        raise RuntimeError(
+            f"Feature mismatch: model expects {missing_cols} but they are missing "
+            f"from prediction features. Available: {list(feature_df.columns)}"
+        )
+
+    X = feature_df[feature_columns].values
+
+    # Step 6: Single predict call
+    _LOGGER.info("Running model.predict() on %d-row feature matrix...", len(X))
+    predictions = model.predict(X)
+
+    # Clamp to non-negative (consumption can't be negative)
+    predictions = np.maximum(predictions, 0.0)
+
+    result = predictions.tolist()
+
+    # Log summary statistics
+    total_kwh = sum(result)
+    _LOGGER.info(
+        "Prediction summary: total %.2f kWh, "
+        "min %.3f kWh, max %.3f kWh, mean %.3f kWh per 15min",
+        total_kwh,
+        min(result),
+        max(result),
+        total_kwh / len(result),
+    )
+
+    return result
+
+
+def predict_with_timestamps(config: dict) -> list[tuple[datetime, float]]:
+    """Generate predictions with their associated timestamps.
+
+    Convenience wrapper that pairs each prediction with its timestamp.
+
+    Returns:
+        List of (datetime, kWh) tuples for 96 quarter-hourly periods.
+    """
+    future_ts = _build_future_timestamps(config)
+    predictions = predict_next_24h(config)
+
+    return [
+        (ts.to_pydatetime(), pred)
+        for ts, pred in zip(future_ts, predictions, strict=True)
+    ]

--- a/ml/predictor.py
+++ b/ml/predictor.py
@@ -11,19 +11,17 @@ Each row contains only features known ahead of time:
 """
 
 import logging
-from datetime import datetime
+from datetime import date, datetime, time
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from xgboost import XGBRegressor
 
 from ml.data_fetcher import (
     PERIODS_PER_DAY,
     fetch_history_context,
     fetch_weather_forecast,
 )
-from ml.feature_engineer import engineer_features
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,20 +29,15 @@ QUARTER_MINUTES = 15
 
 
 def _build_future_timestamps(
-    config: dict, periods: int = PERIODS_PER_DAY
+    config: dict,
+    target_date: date,
+    periods: int = PERIODS_PER_DAY,
 ) -> pd.DatetimeIndex:
-    """Generate 96 future 15-minute timestamps starting from the next quarter hour."""
+    """Generate 15-minute timestamps covering target_date from midnight."""
     from ml.data_fetcher import _get_local_tz
 
-    now = datetime.now(_get_local_tz(config))
-
-    # Round up to next quarter hour
-    minutes = now.minute
-    next_quarter = minutes + (QUARTER_MINUTES - minutes % QUARTER_MINUTES)
-    start = now.replace(minute=0, second=0, microsecond=0) + pd.Timedelta(
-        minutes=next_quarter
-    )
-
+    local_tz = _get_local_tz(config)
+    start = datetime.combine(target_date, time.min, tzinfo=local_tz)
     return pd.date_range(start=start, periods=periods, freq="15min")
 
 
@@ -66,8 +59,8 @@ def _build_prediction_dataframe(
     return df
 
 
-def predict_next_24h(config: dict) -> list[float]:
-    """Generate 96 quarter-hourly consumption predictions.
+def predict_next_24h(config: dict, target_date: date) -> list[float]:
+    """Generate 96 quarter-hourly consumption predictions for target_date.
 
     Uses direct multi-output prediction: builds a 96-row feature matrix
     with time features, weather forecast, and history context, then makes
@@ -75,6 +68,7 @@ def predict_next_24h(config: dict) -> list[float]:
 
     Args:
         config: Resolved ML config dict.
+        target_date: Local calendar date to forecast (midnight to midnight).
 
     Returns:
         List of 96 float values representing predicted consumption
@@ -86,6 +80,10 @@ def predict_next_24h(config: dict) -> list[float]:
         FileNotFoundError: If no trained model exists.
         RuntimeError: If data fetching fails.
     """
+    from xgboost import XGBRegressor
+
+    from ml.feature_engineer import engineer_features
+
     model_path = config["model_path"]
     if not Path(model_path).exists():
         raise FileNotFoundError(
@@ -107,11 +105,12 @@ def predict_next_24h(config: dict) -> list[float]:
     model.load_model(model_path)
     _LOGGER.info("Using %d features: %s", len(feature_columns), feature_columns)
 
-    # Step 1: Generate future timestamps
-    future_ts = _build_future_timestamps(config)
+    # Step 1: Generate future timestamps anchored at target_date midnight
+    future_ts = _build_future_timestamps(config, target_date)
     _LOGGER.info(
-        "Predicting %d periods: %s to %s",
+        "Predicting %d periods for %s: %s to %s",
         len(future_ts),
+        target_date,
         future_ts[0],
         future_ts[-1],
     )
@@ -120,9 +119,9 @@ def predict_next_24h(config: dict) -> list[float]:
     _LOGGER.info("Fetching weather forecast from Home Assistant...")
     weather_df = fetch_weather_forecast(config)
 
-    # Step 3: Fetch history context from InfluxDB
-    _LOGGER.info("Fetching history context from InfluxDB...")
-    history_context = fetch_history_context(config)
+    # Step 3: Fetch history context from InfluxDB (anchored to target_date)
+    _LOGGER.info("Fetching history context from InfluxDB for %s...", target_date)
+    history_context = fetch_history_context(config, target_date=target_date)
 
     # Step 4: Build raw DataFrame for future periods
     raw_df = _build_prediction_dataframe(future_ts)
@@ -158,8 +157,9 @@ def predict_next_24h(config: dict) -> list[float]:
     # Log summary statistics
     total_kwh = sum(result)
     _LOGGER.info(
-        "Prediction summary: total %.2f kWh, "
+        "Prediction summary for %s: total %.2f kWh, "
         "min %.3f kWh, max %.3f kWh, mean %.3f kWh per 15min",
+        target_date,
         total_kwh,
         min(result),
         max(result),
@@ -169,16 +169,22 @@ def predict_next_24h(config: dict) -> list[float]:
     return result
 
 
-def predict_with_timestamps(config: dict) -> list[tuple[datetime, float]]:
+def predict_with_timestamps(
+    config: dict, target_date: date
+) -> list[tuple[datetime, float]]:
     """Generate predictions with their associated timestamps.
 
     Convenience wrapper that pairs each prediction with its timestamp.
 
+    Args:
+        config: Resolved ML config dict.
+        target_date: Local calendar date to forecast.
+
     Returns:
         List of (datetime, kWh) tuples for 96 quarter-hourly periods.
     """
-    future_ts = _build_future_timestamps(config)
-    predictions = predict_next_24h(config)
+    future_ts = _build_future_timestamps(config, target_date)
+    predictions = predict_next_24h(config, target_date)
 
     return [
         (ts.to_pydatetime(), pred)

--- a/ml/trainer.py
+++ b/ml/trainer.py
@@ -1,0 +1,460 @@
+"""Model training and evaluation for ML energy consumption prediction.
+
+Orchestrates the full training pipeline: fetch data, engineer features,
+train XGBoost model, evaluate with baseline comparisons, and persist to disk.
+"""
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from xgboost import XGBRegressor
+
+from ml.data_fetcher import PERIODS_PER_DAY, fetch_training_data
+from ml.feature_engineer import WATTS_TO_KWH_15MIN, engineer_features
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _temporal_train_test_split(
+    df: pd.DataFrame,
+    feature_columns: list[str],
+    test_fraction: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Split data by time: last test_fraction of rows become test set.
+
+    This avoids data leakage from future values that random splitting would cause.
+
+    Returns:
+        (X_train, X_test, y_train, y_test) as numpy arrays.
+    """
+    split_idx = int(len(df) * (1 - test_fraction))
+
+    train_df = df.iloc[:split_idx]
+    test_df = df.iloc[split_idx:]
+
+    X_train = train_df[feature_columns].values
+    X_test = test_df[feature_columns].values
+    y_train = train_df["target"].values
+    y_test = test_df["target"].values
+
+    _LOGGER.info(
+        "Temporal split: %d train rows, %d test rows (%.0f%% test)",
+        len(train_df),
+        len(test_df),
+        test_fraction * 100,
+    )
+
+    return X_train, X_test, y_train, y_test
+
+
+def _compute_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> dict[str, float]:
+    """Compute regression metrics for model evaluation."""
+    mae = mean_absolute_error(y_true, y_pred)
+    rmse = float(np.sqrt(mean_squared_error(y_true, y_pred)))
+    r2 = r2_score(y_true, y_pred)
+
+    # MAPE - avoid division by zero
+    nonzero_mask = y_true != 0
+    if nonzero_mask.any():
+        mape = float(
+            np.mean(
+                np.abs(
+                    (y_true[nonzero_mask] - y_pred[nonzero_mask]) / y_true[nonzero_mask]
+                )
+            )
+            * 100
+        )
+    else:
+        mape = float("inf")
+
+    return {
+        "mae_kwh": round(mae, 4),
+        "rmse_kwh": round(rmse, 4),
+        "r_squared": round(r2, 4),
+        "mape_percent": round(mape, 2),
+    }
+
+
+def _get_feature_importance(
+    model: XGBRegressor,
+    feature_columns: list[str],
+) -> list[tuple[str, float]]:
+    """Extract and sort feature importance from trained model."""
+    importances = model.feature_importances_
+    feature_imp = list(zip(feature_columns, importances, strict=True))
+    feature_imp.sort(key=lambda x: x[1], reverse=True)
+    return feature_imp
+
+
+def _compute_per_day_history_context(
+    raw_df: pd.DataFrame,
+    target_date: date,
+    config: dict,
+) -> dict:
+    """Compute history context for a specific day from training data.
+
+    During training, we compute history context relative to each day
+    in the training set, using earlier data as the "history".
+
+    Args:
+        raw_df: Full training DataFrame with 'target' column (in raw units).
+        target_date: The day we need context for.
+        config: ML config dict.
+
+    Returns:
+        History context dict matching fetch_history_context() format.
+    """
+    # Convert target to kWh if needed
+    target_col = raw_df["target"]
+    if config["target"].get("unit") == "W":
+        target_col = target_col * WATTS_TO_KWH_15MIN
+
+    # Yesterday's profile
+    yesterday = target_date - timedelta(days=1)
+    yesterday_mask = target_col.index.date == yesterday
+    yesterday_data = target_col[yesterday_mask]
+
+    yesterday_profile = [0.0] * PERIODS_PER_DAY
+    if not yesterday_data.empty:
+        for i, val in enumerate(yesterday_data.values[:PERIODS_PER_DAY]):
+            yesterday_profile[i] = float(val)
+
+    yesterday_total = sum(yesterday_profile)
+
+    # Weekly average profile
+    week_profiles: list[list[float]] = []
+    for days_back in range(1, 8):
+        day = target_date - timedelta(days=days_back)
+        day_mask = target_col.index.date == day
+        day_data = target_col[day_mask]
+        if len(day_data) >= PERIODS_PER_DAY // 2:
+            profile = [0.0] * PERIODS_PER_DAY
+            for i, val in enumerate(day_data.values[:PERIODS_PER_DAY]):
+                profile[i] = float(val)
+            week_profiles.append(profile)
+
+    if week_profiles:
+        week_avg_profile = [
+            sum(p[i] for p in week_profiles) / len(week_profiles)
+            for i in range(PERIODS_PER_DAY)
+        ]
+    else:
+        week_avg_profile = yesterday_profile.copy()
+
+    # Recent 24h mean (from data up to start of target_date)
+    cutoff = pd.Timestamp(target_date, tz=target_col.index.tz)
+    recent = target_col[target_col.index < cutoff].tail(PERIODS_PER_DAY)
+    recent_24h_mean = float(recent.mean()) if not recent.empty else 0.0
+
+    return {
+        "yesterday_profile": yesterday_profile,
+        "yesterday_total": yesterday_total,
+        "week_avg_profile": week_avg_profile,
+        "recent_24h_mean": recent_24h_mean,
+    }
+
+
+def _add_history_context_to_training_data(
+    raw_df: pd.DataFrame,
+    config: dict,
+) -> pd.DataFrame:
+    """Add per-day history context columns to training data.
+
+    For each unique day in the training data, computes history context
+    from earlier days and adds the context columns.
+
+    Returns:
+        DataFrame with history context columns added.
+    """
+    target_col = raw_df["target"]
+    if config["target"].get("unit") == "W":
+        target_col = target_col * WATTS_TO_KWH_15MIN
+
+    unique_dates = sorted(set(raw_df.index.date))
+
+    # Pre-compute context for each day
+    context_cache: dict[date, dict] = {}
+    for d in unique_dates:
+        context_cache[d] = _compute_per_day_history_context(raw_df, d, config)
+
+    # Build columns
+    yesterday_same_hour = []
+    yesterday_total_vals = []
+    week_avg_same_hour = []
+    recent_24h_mean_vals = []
+
+    for ts in raw_df.index:
+        d = ts.date()
+        qi = ts.hour * 4 + ts.minute // 15
+        ctx = context_cache[d]
+
+        yesterday_same_hour.append(
+            ctx["yesterday_profile"][min(qi, PERIODS_PER_DAY - 1)]
+        )
+        yesterday_total_vals.append(ctx["yesterday_total"])
+        week_avg_same_hour.append(ctx["week_avg_profile"][min(qi, PERIODS_PER_DAY - 1)])
+        recent_24h_mean_vals.append(ctx["recent_24h_mean"])
+
+    result = raw_df.copy()
+    result["yesterday_same_hour"] = yesterday_same_hour
+    result["yesterday_total"] = yesterday_total_vals
+    result["week_avg_same_hour"] = week_avg_same_hour
+    result["recent_24h_mean"] = recent_24h_mean_vals
+
+    _LOGGER.info(
+        "Added history context for %d unique days in training data",
+        len(unique_dates),
+    )
+
+    return result
+
+
+def _compute_baseline_metrics(
+    feature_df: pd.DataFrame,
+    test_fraction: float,
+) -> dict[str, dict[str, float]]:
+    """Compute naive baseline metrics on the test set.
+
+    Baselines:
+    - same_as_yesterday: predict today = yesterday's same quarter
+    - hourly_mean: predict each quarter = historical mean for that quarter-of-day
+    - flat_estimate: predict every quarter = overall mean of training data
+
+    Returns:
+        Dict mapping baseline name to metrics dict.
+    """
+    split_idx = int(len(feature_df) * (1 - test_fraction))
+    train_df = feature_df.iloc[:split_idx]
+    test_df = feature_df.iloc[split_idx:]
+
+    y_test = test_df["target"].values
+    baselines: dict[str, dict[str, float]] = {}
+
+    # Baseline 1: Same as yesterday
+    if "yesterday_same_hour" in test_df.columns:
+        y_yesterday = test_df["yesterday_same_hour"].values
+        baselines["same_as_yesterday"] = _compute_metrics(y_test, y_yesterday)
+
+    # Baseline 2: Hourly mean (average by quarter-of-day from training set)
+    train_quarters = train_df.index.hour * 4 + train_df.index.minute // 15
+    quarter_means = train_df.assign(qi=train_quarters).groupby("qi")["target"].mean()
+
+    test_quarters = test_df.index.hour * 4 + test_df.index.minute // 15
+    y_hourly_mean = np.array(
+        [quarter_means.get(qi, train_df["target"].mean()) for qi in test_quarters]
+    )
+    baselines["hourly_mean"] = _compute_metrics(y_test, y_hourly_mean)
+
+    # Baseline 3: Flat estimate (overall training mean)
+    overall_mean = train_df["target"].mean()
+    y_flat = np.full_like(y_test, overall_mean)
+    baselines["flat_estimate"] = _compute_metrics(y_test, y_flat)
+
+    return baselines
+
+
+def train_model(config: dict, target_date: date | None = None) -> dict:
+    """Full training pipeline: fetch, engineer, train, evaluate, save.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for training window. Defaults to yesterday.
+
+    Returns:
+        Dict with keys: metrics, baselines, feature_importance, model_path,
+        train_size, test_size.
+
+    Raises:
+        RuntimeError: If data fetching or training fails.
+    """
+    # Step 1: Fetch historical data
+    _LOGGER.info("Step 1/5: Fetching training data from InfluxDB...")
+    raw_df = fetch_training_data(config, target_date=target_date)
+
+    # Step 2: Add per-day history context to training data
+    _LOGGER.info("Step 2/5: Computing per-day history context...")
+    raw_with_context = _add_history_context_to_training_data(raw_df, config)
+
+    # Step 3: Engineer features (no weather_df for training - uses observed temp)
+    _LOGGER.info("Step 3/5: Engineering features...")
+    feature_df, feature_columns = engineer_features(
+        raw_with_context, config, history_context=None
+    )
+
+    min_samples = 20
+    if len(feature_df) < min_samples:
+        raise RuntimeError(
+            f"Insufficient training data: {len(feature_df)} samples "
+            f"(minimum {min_samples}). Need more days of InfluxDB history."
+        )
+
+    # Step 4: Train/test split and model training
+    _LOGGER.info("Step 4/5: Training XGBoost model...")
+    test_fraction = config["training"]["test_split"]
+    X_train, X_test, y_train, y_test = _temporal_train_test_split(
+        feature_df, feature_columns, test_fraction
+    )
+
+    model_params = config["training"]["model_params"]
+    model = XGBRegressor(
+        n_estimators=model_params["n_estimators"],
+        max_depth=model_params["max_depth"],
+        learning_rate=model_params["learning_rate"],
+        min_child_weight=model_params["min_child_weight"],
+        random_state=42,
+        objective="reg:squarederror",
+    )
+
+    model.fit(
+        X_train,
+        y_train,
+        verbose=False,
+    )
+
+    # Step 5: Evaluate, compute baselines, and save
+    _LOGGER.info("Step 5/5: Evaluating model and computing baselines...")
+    y_pred = model.predict(X_test)
+    metrics = _compute_metrics(y_test, y_pred)
+    feature_importance = _get_feature_importance(model, feature_columns)
+    baselines = _compute_baseline_metrics(feature_df, test_fraction)
+
+    # Save model
+    model_path = config["model_path"]
+    Path(model_path).parent.mkdir(parents=True, exist_ok=True)
+    model.save_model(model_path)
+
+    # Save feature column names alongside model for prediction
+    feature_meta_path = str(Path(model_path).with_suffix(".features.txt"))
+    with open(feature_meta_path, "w") as f:
+        f.write("\n".join(feature_columns))
+
+    _LOGGER.info("Model saved to %s", model_path)
+    _LOGGER.info("Feature metadata saved to %s", feature_meta_path)
+
+    # Save training report sidecar for the web UI
+    report_data = {
+        "trained_at": datetime.now().isoformat(),
+        "train_size": len(X_train),
+        "test_size": len(X_test),
+        "metrics": metrics,
+        "baselines": baselines,
+        "feature_importance": [
+            {"name": name, "importance": round(float(imp), 6)}
+            for name, imp in feature_importance
+        ],
+    }
+    report_path = str(Path(model_path).with_suffix(".report.json"))
+    with open(report_path, "w") as f:
+        json.dump(report_data, f, indent=2)
+    _LOGGER.info("Training report saved to %s", report_path)
+
+    return {
+        "metrics": metrics,
+        "baselines": baselines,
+        "feature_importance": feature_importance,
+        "model_path": model_path,
+        "train_size": len(X_train),
+        "test_size": len(X_test),
+    }
+
+
+def evaluate_model(config: dict, target_date: date | None = None) -> dict:
+    """Load a trained model and evaluate on recent test data.
+
+    Uses the same training data but only evaluates the test split,
+    useful for checking model performance without retraining.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for evaluation window. Defaults to yesterday.
+
+    Returns:
+        Dict with metrics and per-period analysis.
+
+    Raises:
+        FileNotFoundError: If no trained model exists.
+        RuntimeError: If data fetching fails.
+    """
+    model_path = config["model_path"]
+    if not Path(model_path).exists():
+        raise FileNotFoundError(
+            f"No trained model found at {model_path}. Run 'train' first."
+        )
+
+    # Load model
+    model = XGBRegressor()
+    model.load_model(model_path)
+
+    # Fetch and prepare test data
+    raw_df = fetch_training_data(config, target_date=target_date)
+    raw_with_context = _add_history_context_to_training_data(raw_df, config)
+    feature_df, feature_columns = engineer_features(
+        raw_with_context, config, history_context=None
+    )
+
+    test_fraction = config["training"]["test_split"]
+    _, X_test, _, y_test = _temporal_train_test_split(
+        feature_df, feature_columns, test_fraction
+    )
+
+    y_pred = model.predict(X_test)
+    metrics = _compute_metrics(y_test, y_pred)
+
+    # Per-hour analysis: average error by hour of day
+    split_idx = int(len(feature_df) * (1 - test_fraction))
+    test_df = feature_df.iloc[split_idx:].copy()
+    test_df["predicted"] = y_pred
+    test_df["error"] = test_df["predicted"] - test_df["target"]
+    test_df["abs_error"] = test_df["error"].abs()
+    test_df["hour"] = test_df.index.hour
+
+    hourly_errors = (
+        test_df.groupby("hour")
+        .agg(
+            mean_error=pd.NamedAgg(column="error", aggfunc="mean"),
+            mae=pd.NamedAgg(column="abs_error", aggfunc="mean"),
+            count=pd.NamedAgg(column="error", aggfunc="count"),
+        )
+        .round(4)
+    )
+
+    return {
+        "metrics": metrics,
+        "hourly_errors": hourly_errors.to_dict("index"),
+        "test_size": len(X_test),
+    }
+
+
+def compute_baselines(config: dict, target_date: date | None = None) -> dict:
+    """Compute baseline metrics on the test set without training a model.
+
+    Fetches data, engineers features (to get history context columns),
+    then computes naive baseline metrics.
+
+    Args:
+        config: Resolved ML config dict.
+        target_date: End date for data window. Defaults to yesterday.
+
+    Returns:
+        Dict with baseline metrics for each heuristic.
+
+    Raises:
+        RuntimeError: If data fetching fails.
+    """
+    raw_df = fetch_training_data(config, target_date=target_date)
+    raw_with_context = _add_history_context_to_training_data(raw_df, config)
+    feature_df, _ = engineer_features(raw_with_context, config, history_context=None)
+
+    test_fraction = config["training"]["test_split"]
+    baselines = _compute_baseline_metrics(feature_df, test_fraction)
+
+    return {
+        "baselines": baselines,
+        "total_samples": len(feature_df),
+        "test_samples": int(len(feature_df) * test_fraction),
+    }


### PR DESCRIPTION
> **⚠️ WIP / casual work-in-progress.** I'm still tinkering with this feature casually on my own hardware. This PR is raised purely so anyone else who's interested can follow along, comment, or contribute — no expectation of merge. The "should this live in core?" question below is still open; happy to keep this as a draft indefinitely or close it again if you'd rather.

Re-opens #34 against v8.1.1. Still experimental — see the open question below.

## Summary

Adds an optional `ml_prediction` consumption strategy using XGBoost to predict 24h energy consumption at 15-minute resolution, plus an ML Report dashboard page showing model metrics, feature importance, and a forecast-vs-actual chart.

- Complete `ml/` module: training, prediction, feature engineering, standalone CLI
- `/api/ml-report` endpoint + frontend page
- Daily retrain scheduler (23:00)
- Docker base image: Alpine → Debian Bookworm (xgboost / scikit-learn wheels)

## Changes since #34

- Rebased onto `upstream/main` (v8.1.1).
- **ML forecast cache bug fix** (commit `9cb535c`): forecast cache is now anchored by `target_date` so the ML Report chart stays aligned after midnight rollover.

## Open question — does this belong in core?

The [original PR discussion](https://github.com/johanzander/bess-manager/pull/34#issuecomment-4050207515) flagged this as unresolved. Summary for the record:

> **@johanzander (2026-03-12):** "it probably makes more sense to have it outside the BESS manager. [...] would you be open to create a separate HA Add-On for this? then that could serve as another configurable consumption strategy option..."

> **@pookey (2026-03-12):** "So far, it's been trash and after 8 days of training data, the 'weekly average' is working better for me. [...] I think the ML stuff currently falls into the 'cool experiment, but probably not useful' category!"

Model accuracy has not materially improved since, but the ML Report page is a useful playground for prediction experimentation. **This PR is re-opened as a draft purely to invite comment/contribution** — totally happy for it to stay closed if you'd rather keep ML out of core and eventually spin it into its own add-on using `ha-add-on-template`. In the meantime the `feat/ml-predictor-v8` branch lives on my fork and merges cleanly into a local `deploy` branch for testing.

Costs of merging:

- ~180 MB added dependencies (xgboost, scikit-learn, astral)
- Alpine → Debian base image
- 3–5s retrain-on-boot + weather-fetch startup cost
- Requires weather entity + InfluxDB configured

## Test plan

- [ ] ML model trains on boot when `ml` config is present
- [ ] ML Report page renders metrics, feature importance, chart
- [ ] `ml_prediction` strategy produces 96-period forecast
- [ ] Fallback to `fixed` when `ml` config is missing
- [ ] Daily retrain fires at 23:00
- [ ] System starts when `ml` section absent (no ML features loaded)

## References

- Supersedes #34
- Depends on the consumption-strategy plumbing from #33 (now merged)