### PR TITLE
fix: reset price fields when switching to Octopus provider

### DIFF
--- a/frontend/src/components/settings/PricingFormSection.tsx
+++ b/frontend/src/components/settings/PricingFormSection.tsx
@@ -26,6 +26,16 @@ export function PricingFormSection({ form, onChange }: Props) {
   const isOctopus = form.provider === 'octopus';
   const currency = isOctopus ? 'GBP' : form.currency;
 
+  const handleChange = (next: PricingForm) => {
+    // When switching TO Octopus, reset fields that are hidden but still sent to
+    // the backend.  Octopus rates are already all-in (VAT-inclusive, GBP/kWh),
+    // so markup / VAT / additional costs must be zero / neutral.
+    if (next.provider === 'octopus' && form.provider !== 'octopus') {
+      next = { ...next, markupRate: 0, vatMultiplier: 1, additionalCosts: 0 };
+    }
+    onChange(next);
+  };
+
   const previewSpot = 1.0;
   const previewBuy = Number(
     ((previewSpot + form.markupRate) * form.vatMultiplier + form.additionalCosts).toFixed(4),
@@ -46,7 +56,7 @@ export function PricingFormSection({ form, onChange }: Props) {
             { value: 'octopus', label: 'Octopus Energy' },
           ],
           form.provider,
-          v => onChange({ ...form, provider: v }),
+          v => handleChange({ ...form, provider: v }),
         )}
 
         {form.provider === 'nordpool_official' && (


### PR DESCRIPTION
## Summary

- When switching from Nord Pool to Octopus Energy in the settings UI, the markup rate, VAT multiplier, and additional costs fields are hidden but their old values persist and are still sent to the backend. This causes the optimizer to apply incorrect price adjustments (e.g. Swedish 25% VAT and grid fees) on top of Octopus rates that are already all-in.
- Auto-reset these fields to safe defaults (`markupRate=0`, `vatMultiplier=1`, `additionalCosts=0`) when the provider radio switches to Octopus.

## Test plan

- [ ] Open Settings → Electricity Pricing
- [ ] Set provider to Nord Pool, enter non-zero markup/VAT/additional costs
- [ ] Switch provider to Octopus Energy
- [ ] Verify markup rate = 0, VAT multiplier = 1, additional costs = 0
- [ ] Save and confirm backend receives the reset values
- [ ] Switch back to Nord Pool — fields should remain at their reset values (user re-enters as needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)