### PR TITLE
fix: model Growatt hardware solar behavior in DP optimizer

### DIFF
--- a/core/bess/decision_intelligence.py
+++ b/core/bess/decision_intelligence.py
@@ -443,16 +443,16 @@ def create_decision_data(
     Returns:
         Enhanced DecisionData with all fields populated including advanced flow patterns
     """
-    # Determine strategic intent based on actual energy flows
-    # CRITICAL: Intent controls hardware behavior via Growatt schedule
-    # Must accurately reflect actual action, not just economic conditions
-    if power < -0.1:  # Discharging
-        # Check actual flows: are we exporting to grid?
+    # Determine strategic intent based on actual energy flows (post-override)
+    # CRITICAL: Intent controls hardware behavior via Growatt schedule.
+    # Must use energy_data (which reflects hardware overrides like discharge
+    # suppression when solar >= consumption) rather than raw DP power.
+    if energy_data.battery_discharged > 0.1:  # Effective discharge
         if energy_data.battery_to_grid > 0.1:
             strategic_intent = "EXPORT_ARBITRAGE"
         else:
             strategic_intent = "LOAD_SUPPORT"
-    elif power > 0.1:  # Charging
+    elif energy_data.battery_charged > 0.1:  # Effective charge
         if energy_data.grid_to_battery >= 0.1:
             strategic_intent = "GRID_CHARGING"
         else:
@@ -506,8 +506,10 @@ def create_decision_data(
         future_target_hours = [hour]
 
     # Create DecisionData with only fields we can implement
-    # Convert power (kW) to energy (kWh) for consistency with other period data
-    battery_action_kwh = power * dt
+    # Derive effective battery action from actual energy flows (post-override),
+    # not raw DP power which may have been overridden by hardware behavior
+    # (e.g., discharge suppressed when solar >= consumption).
+    battery_action_kwh = energy_data.battery_charged - energy_data.battery_discharged
     return DecisionData(
         strategic_intent=strategic_intent,
         battery_action=battery_action_kwh,

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -139,8 +139,55 @@ def _discretize_state_action_space(
     return soe_levels, power_levels
 
 
+def _compute_idle_solar_charging(
+    solar_production: float,
+    home_consumption: float,
+    soe: float,
+    battery_settings: BatterySettings,
+    dt: float,
+) -> tuple[float, float]:
+    """Compute implicit solar charging from excess solar production.
+
+    In all Growatt operating modes (load_first, battery_first), excess solar
+    charges the battery before exporting to grid. This function computes the
+    minimum solar charging that occurs regardless of the DP's power action:
+
+    - IDLE (power=0) / load_first: excess solar charges battery automatically.
+    - Discharge (power<0) with solar >= consumption: hardware overrides discharge,
+      charges from excess solar instead.
+    - Charging (power>0) / battery_first: hardware charges from at least all
+      excess solar. The DP's power determines any additional grid charging.
+
+    Args:
+        solar_production: Solar energy produced this period (kWh).
+        home_consumption: Home energy consumed this period (kWh).
+        soe: Current state of energy (kWh).
+        battery_settings: Battery configuration.
+        dt: Period duration in hours.
+
+    Returns:
+        (battery_charged, actual_energy_stored) where battery_charged is the
+        energy drawn from solar (pre-efficiency) and actual_energy_stored is
+        the energy added to the battery (post-efficiency).
+    """
+    excess_solar = max(0.0, solar_production - home_consumption)
+    charge_rate_limit = battery_settings.max_charge_power_kw * dt
+    available_capacity = max(
+        0.0,
+        (battery_settings.max_soe_kwh - soe) / battery_settings.efficiency_charge,
+    )
+    battery_charged = min(excess_solar, charge_rate_limit, available_capacity)
+    actual_energy_stored = battery_charged * battery_settings.efficiency_charge
+    return battery_charged, actual_energy_stored
+
+
 def _state_transition(
-    soe: float, power: float, battery_settings: BatterySettings, dt: float
+    soe: float,
+    power: float,
+    battery_settings: BatterySettings,
+    dt: float,
+    solar_production: float = 0.0,
+    home_consumption: float = 0.0,
 ) -> float:
     """
     Calculate the next state of energy based on current SOE and power action.
@@ -149,21 +196,35 @@ def _state_transition(
     - Charging: power x dt x efficiency = energy actually stored
     - Discharging: power x dt / efficiency = energy removed from storage
     This ensures that efficiency losses are properly accounted for in energy balance.
+
+    IMPLICIT SOLAR CHARGING:
+    In all Growatt modes, excess solar charges the battery. When solar >= consumption,
+    discharge commands are overridden by hardware. When power > 0 (battery_first mode),
+    the hardware charges from at least all excess solar regardless of the DP's power
+    setting — the DP's power only determines additional grid charging.
     """
-    if power > 0:  # Charging
-        # Energy stored = power throughput x charging efficiency
-        charge_energy = power * dt * battery_settings.efficiency_charge
+    if power > 0:  # Charging (battery_first mode on hardware)
+        # In battery_first mode, hardware charges from at least all excess solar.
+        # The DP's power determines any additional grid charging beyond solar.
+        _, solar_stored = _compute_idle_solar_charging(
+            solar_production, home_consumption, soe, battery_settings, dt
+        )
+        dp_stored = power * dt * battery_settings.efficiency_charge
+        charge_energy = max(dp_stored, solar_stored)
         next_soe = min(battery_settings.max_soe_kwh, soe + charge_energy)
 
-    elif power < 0:  # Discharging
+    elif power < 0 and solar_production < home_consumption:  # Discharging (no excess solar)
         # Energy removed from storage = power throughput ÷ discharging efficiency
         discharge_energy = abs(power) * dt / battery_settings.efficiency_discharge
         available_energy = soe - battery_settings.min_soe_kwh
         actual_discharge = min(discharge_energy, available_energy)
         next_soe = soe - actual_discharge
 
-    else:  # Hold
-        next_soe = soe
+    else:  # Hold / discharge overridden by solar — implicit solar charging
+        _, actual_energy_stored = _compute_idle_solar_charging(
+            solar_production, home_consumption, soe, battery_settings, dt
+        )
+        next_soe = soe + actual_energy_stored
 
     # Ensure SOE stays within physical bounds
     next_soe = min(
@@ -218,8 +279,28 @@ def _compute_reward(
     _power_tolerance = 0.001  # kW
 
     # Battery flows
-    battery_charged = max(0, power * dt) if power > _power_tolerance else 0.0
-    battery_discharged = max(0, -power * dt) if power < -_power_tolerance else 0.0
+    # In load_first mode, solar covers home first. When solar >= consumption,
+    # excess solar charges battery — any discharge command is overridden by hardware.
+    _discharge_effective = (
+        power < -_power_tolerance and solar_production < home_consumption
+    )
+
+    if power > _power_tolerance:
+        # In battery_first mode, hardware charges from at least all excess solar.
+        solar_charged_implicit, _ = _compute_idle_solar_charging(
+            solar_production, home_consumption, soe, battery_settings, dt
+        )
+        battery_charged = max(power * dt, solar_charged_implicit)
+        battery_discharged = 0.0
+    elif _discharge_effective:
+        battery_charged = 0.0
+        battery_discharged = abs(power) * dt
+    else:
+        # IDLE or discharge overridden by solar: implicit solar charging
+        battery_charged, _ = _compute_idle_solar_charging(
+            solar_production, home_consumption, soe, battery_settings, dt
+        )
+        battery_discharged = 0.0
 
     # Grid flows from energy balance
     energy_balance = (
@@ -234,12 +315,12 @@ def _compute_reward(
     new_cost_basis = cost_basis
 
     if power > _power_tolerance:  # Charging
-        energy_stored = power * dt * battery_settings.efficiency_charge
+        energy_stored = battery_charged * battery_settings.efficiency_charge
         battery_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
 
         solar_available = max(0, solar_production - home_consumption)
-        solar_to_battery = min(solar_available, power * dt)
-        grid_to_battery = max(0, (power * dt) - solar_to_battery)
+        solar_to_battery = min(solar_available, battery_charged)
+        grid_to_battery = max(0, battery_charged - solar_to_battery)
         grid_energy_cost = grid_to_battery * current_buy_price
         total_new_cost = grid_energy_cost + battery_wear_cost
 
@@ -251,7 +332,7 @@ def _compute_reward(
                 (total_new_cost / energy_stored) if energy_stored > 0 else cost_basis
             )
 
-    elif power < -_power_tolerance:  # Discharging
+    elif _discharge_effective:  # Discharging (solar < consumption)
         battery_wear_cost = 0.0
 
         # Profitability check: only discharge if value exceeds cost basis
@@ -262,8 +343,14 @@ def _compute_reward(
         if effective_value_per_kwh_stored <= cost_basis:
             return float("-inf"), cost_basis
 
-    else:  # Idle
-        battery_wear_cost = 0.0
+    else:  # Idle / discharge overridden by solar — cycle wear on solar charging
+        actual_energy_stored = battery_charged * battery_settings.efficiency_charge
+        battery_wear_cost = actual_energy_stored * battery_settings.cycle_cost_per_kwh
+
+        if actual_energy_stored > 0 and next_soe > battery_settings.min_soe_kwh:
+            existing_cost = soe * cost_basis
+            # Solar energy has zero marginal cost; only cycle wear contributes
+            new_cost_basis = (existing_cost + battery_wear_cost) / next_soe
 
     # ============================================================================
     # REWARD CALCULATION
@@ -298,8 +385,26 @@ def _build_period_data(
     current_buy_price = buy_price[period]
     current_sell_price = sell_price[period]
 
-    battery_charged = max(0, power * dt) if power > 0 else 0.0
-    battery_discharged = max(0, -power * dt) if power < 0 else 0.0
+    # In load_first mode, when solar >= consumption, discharge is overridden —
+    # excess solar charges battery instead. Same logic as _compute_reward.
+    _discharge_effective = power < 0 and solar_production < home_consumption
+
+    if power > 0:
+        # In battery_first mode, hardware charges from at least all excess solar.
+        solar_charged_implicit, _ = _compute_idle_solar_charging(
+            solar_production, home_consumption, soe, battery_settings, dt
+        )
+        battery_charged = max(power * dt, solar_charged_implicit)
+        battery_discharged = 0.0
+    elif _discharge_effective:
+        battery_charged = 0.0
+        battery_discharged = abs(power) * dt
+    else:
+        # IDLE or discharge overridden by solar: implicit solar charging
+        battery_charged, _ = _compute_idle_solar_charging(
+            solar_production, home_consumption, soe, battery_settings, dt
+        )
+        battery_discharged = 0.0
 
     energy_balance = (
         solar_production + battery_discharged - home_consumption - battery_charged
@@ -319,7 +424,7 @@ def _build_period_data(
     )
 
     if power > 0:  # Charging
-        energy_stored = power * dt * battery_settings.efficiency_charge
+        energy_stored = battery_charged * battery_settings.efficiency_charge
         battery_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
 
         expected_stored = next_soe - soe
@@ -328,6 +433,9 @@ def _build_period_data(
                 f"Energy stored mismatch: calculated={energy_stored:.3f}, "
                 f"SOE delta={expected_stored:.3f}"
             )
+    elif not _discharge_effective and battery_charged > 0:  # Solar charging (IDLE or overridden discharge)
+        actual_energy_stored = battery_charged * battery_settings.efficiency_charge
+        battery_wear_cost = actual_energy_stored * battery_settings.cycle_cost_per_kwh
     else:
         battery_wear_cost = 0.0
 
@@ -584,7 +692,14 @@ def _run_dynamic_programming(
                 # else: IDLE (near-zero power) - no physical constraints to check
 
                 # Calculate next state
-                next_soe = _state_transition(soe, power, battery_settings, dt)
+                next_soe = _state_transition(
+                    soe,
+                    power,
+                    battery_settings,
+                    dt,
+                    solar_production=solar_production[t],
+                    home_consumption=home_consumption[t],
+                )
                 if (
                     next_soe < battery_settings.min_soe_kwh
                     or next_soe > battery_settings.max_soe_kwh
@@ -651,29 +766,43 @@ def _run_dynamic_programming(
                     f"No valid action found for period {t}, state {i} (SOE={soe:.1f}). "
                     f"Creating default IDLE state."
                 )
-                # Calculate IDLE scenario: no battery action, just grid covering consumption
-                idle_grid_imported = max(0, home_consumption[t] - solar_production[t])
-                idle_grid_exported = max(0, solar_production[t] - home_consumption[t])
+                # Calculate IDLE scenario with implicit solar charging
+                idle_charged, idle_stored = _compute_idle_solar_charging(
+                    solar_production[t], home_consumption[t], soe, battery_settings, dt
+                )
+                idle_soe_end = soe + idle_stored
+                idle_grid_imported = max(
+                    0, home_consumption[t] - solar_production[t]
+                )
+                idle_grid_exported = max(
+                    0, solar_production[t] - home_consumption[t] - idle_charged
+                )
+                idle_wear_cost = idle_stored * battery_settings.cycle_cost_per_kwh
                 idle_energy = EnergyData(
                     solar_production=solar_production[t],
                     home_consumption=home_consumption[t],
-                    battery_charged=0.0,
+                    battery_charged=idle_charged,
                     battery_discharged=0.0,
                     grid_imported=idle_grid_imported,
                     grid_exported=idle_grid_exported,
                     battery_soe_start=soe,
-                    battery_soe_end=soe,
+                    battery_soe_end=idle_soe_end,
                 )
                 idle_economic = EconomicData.from_energy_data(
                     energy_data=idle_energy,
                     buy_price=buy_price[t],
                     sell_price=sell_price[t],
-                    battery_cycle_cost=0.0,
+                    battery_cycle_cost=idle_wear_cost,
                 )
+                # Update cost basis for solar charging (zero input cost, cycle wear only)
+                idle_cost_basis = C[t, i]
+                if idle_stored > 0 and idle_soe_end > battery_settings.min_soe_kwh:
+                    existing_cost = soe * C[t, i]
+                    idle_cost_basis = (existing_cost + idle_wear_cost) / idle_soe_end
                 idle_decision = DecisionData(
                     strategic_intent="IDLE",
                     battery_action=0.0,
-                    cost_basis=C[t, i],
+                    cost_basis=idle_cost_basis,
                 )
                 idle_period_data = PeriodData(
                     period=t,
@@ -688,16 +817,23 @@ def _run_dynamic_programming(
                 # including future value to preserve backward propagation.
                 # Without V[t+1, i], export profits beyond this state are lost
                 # and the optimizer cannot distinguish cheap vs expensive charging paths.
+                # Use the next state index matching idle_soe_end for future value lookup
+                idle_next_i = round(
+                    (idle_soe_end - battery_settings.min_soe_kwh) / SOE_STEP_KWH
+                )
+                idle_next_i = min(max(0, idle_next_i), len(soe_levels) - 1)
                 V[t, i] = (
                     -(
                         idle_grid_imported * buy_price[t]
                         - idle_grid_exported * sell_price[t]
+                        + idle_wear_cost
                     )
-                    + V[t + 1, i]
+                    + V[t + 1, idle_next_i]
                 )
 
-            # Update cost basis for next time step
-            if best_action != 0 and t + 1 < horizon:
+            # Update cost basis for next time step (includes IDLE solar charging
+            # which changes SOE even though best_action == 0)
+            if best_next_soe != soe and t + 1 < horizon:
                 next_i = round(
                     (best_next_soe - battery_settings.min_soe_kwh) / SOE_STEP_KWH
                 )
@@ -731,33 +867,43 @@ def _create_idle_schedule(
     solar_production: list[float],
     initial_soe: float,
     battery_settings: BatterySettings,
+    dt: float = 0.25,
 ) -> OptimizationResult:
     """
-    Create an all-IDLE schedule where battery does nothing.
+    Create an all-IDLE schedule where battery does nothing except implicit solar charging.
 
     Used as fallback when optimization doesn't meet minimum profit threshold.
+    In load_first mode, excess solar still charges the battery before exporting to grid.
     """
     period_data_list = []
     current_soe = initial_soe
 
     for t in range(horizon):
-        # No battery action - pure grid consumption
+        # IDLE with implicit solar charging from excess solar (load_first mode)
+        idle_charged, idle_stored = _compute_idle_solar_charging(
+            solar_production[t], home_consumption[t], current_soe, battery_settings, dt
+        )
+        next_soe = current_soe + idle_stored
+        idle_wear_cost = idle_stored * battery_settings.cycle_cost_per_kwh
+
         energy_data = EnergyData(
             solar_production=solar_production[t],
             home_consumption=home_consumption[t],
-            battery_charged=0.0,
+            battery_charged=idle_charged,
             battery_discharged=0.0,
             grid_imported=max(0, home_consumption[t] - solar_production[t]),
-            grid_exported=max(0, solar_production[t] - home_consumption[t]),
+            grid_exported=max(
+                0, solar_production[t] - home_consumption[t] - idle_charged
+            ),
             battery_soe_start=current_soe,
-            battery_soe_end=current_soe,
+            battery_soe_end=next_soe,
         )
 
         economic_data = EconomicData.from_energy_data(
             energy_data=energy_data,
             buy_price=buy_price[t],
             sell_price=sell_price[t],
-            battery_cycle_cost=0.0,
+            battery_cycle_cost=idle_wear_cost,
         )
 
         decision_data = DecisionData(
@@ -776,21 +922,28 @@ def _create_idle_schedule(
         )
 
         period_data_list.append(period_data)
+        current_soe = next_soe  # Propagate SOE for next period
 
     # Calculate economic summary for idle schedule
     total_base_cost = sum(home_consumption[i] * buy_price[i] for i in range(horizon))
     total_optimized_cost = sum(h.economic.hourly_cost for h in period_data_list)
+
+    total_charged = sum(h.energy.battery_charged for h in period_data_list)
+    total_discharged = sum(h.energy.battery_discharged for h in period_data_list)
+    idle_savings = total_base_cost - total_optimized_cost
 
     economic_summary = EconomicSummary(
         grid_only_cost=total_base_cost,
         solar_only_cost=total_base_cost,
         battery_solar_cost=total_optimized_cost,
         grid_to_solar_savings=0.0,
-        grid_to_battery_solar_savings=0.0,  # No savings - doing nothing
-        solar_to_battery_solar_savings=0.0,
-        grid_to_battery_solar_savings_pct=0.0,
-        total_charged=0.0,
-        total_discharged=0.0,
+        grid_to_battery_solar_savings=idle_savings,
+        solar_to_battery_solar_savings=idle_savings,
+        grid_to_battery_solar_savings_pct=(
+            (idle_savings / total_base_cost) * 100 if total_base_cost > 0 else 0.0
+        ),
+        total_charged=total_charged,
+        total_discharged=total_discharged,
     )
 
     return OptimizationResult(
@@ -980,6 +1133,7 @@ def optimize_battery_schedule(
             solar_production=solar_production,
             initial_soe=initial_soe,
             battery_settings=battery_settings,
+            dt=dt,
         )
 
     return OptimizationResult(

--- a/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
+++ b/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
@@ -92,10 +92,10 @@
   },
   "expected_results": {
     "base_cost": 68.61,
-    "battery_solar_cost": -5.77,
+    "battery_solar_cost": -5.78,
     "base_to_battery_solar_savings": 74.39,
     "base_to_battery_solar_savings_pct": 108.4,
-    "total_charged": 12.8,
-    "total_discharged": 26.0
+    "total_charged": 13.6,
+    "total_discharged": 26.8
   }
 }

--- a/core/bess/tests/unit/data/synthetic_consumption_efficient.json
+++ b/core/bess/tests/unit/data/synthetic_consumption_efficient.json
@@ -97,10 +97,10 @@
   },
   "expected_results": {
     "base_cost": 30.28,
-    "battery_solar_cost": -45.67,
-    "base_to_battery_solar_savings": 75.9,
-    "base_to_battery_solar_savings_pct": 250.8,
-    "total_charged": 28.4,
-    "total_discharged": 25.8
+    "battery_solar_cost": -44.13,
+    "base_to_battery_solar_savings": 74.41,
+    "base_to_battery_solar_savings_pct": 245.74,
+    "total_charged": 28.3,
+    "total_discharged": 25.6
   }
 }

--- a/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
+++ b/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
@@ -97,10 +97,10 @@
   },
   "expected_results": {
     "base_cost": 50.31,
-    "battery_solar_cost": -31.29,
-    "base_to_battery_solar_savings": 81.6,
-    "base_to_battery_solar_savings_pct": 162.19,
-    "total_charged": 49.0,
-    "total_discharged": 44.4
+    "battery_solar_cost": -27.59,
+    "base_to_battery_solar_savings": 77.9,
+    "base_to_battery_solar_savings_pct": 154.8,
+    "total_charged": 41.7,
+    "total_discharged": 37.6
   }
 }

--- a/core/bess/tests/unit/data/synthetic_seasonal_spring.json
+++ b/core/bess/tests/unit/data/synthetic_seasonal_spring.json
@@ -97,10 +97,10 @@
   },
   "expected_results": {
     "base_cost": 67.67,
-    "battery_solar_cost": 14.45,
-    "base_to_battery_solar_savings": 53.22,
-    "base_to_battery_solar_savings_pct": 78.65,
-    "total_charged": 29.2,
-    "total_discharged": 26.6
+    "battery_solar_cost": 14.72,
+    "base_to_battery_solar_savings": 52.9,
+    "base_to_battery_solar_savings_pct": 78.2,
+    "total_charged": 28.4,
+    "total_discharged": 25.6
   }
 }

--- a/core/bess/tests/unit/data/synthetic_seasonal_summer.json
+++ b/core/bess/tests/unit/data/synthetic_seasonal_summer.json
@@ -97,10 +97,10 @@
   },
   "expected_results": {
     "base_cost": 60.9,
-    "battery_solar_cost": -15.0,
-    "base_to_battery_solar_savings": 75.9,
-    "base_to_battery_solar_savings_pct": 124.7,
+    "battery_solar_cost": -14.73,
+    "base_to_battery_solar_savings": 75.63,
+    "base_to_battery_solar_savings_pct": 124.18,
     "total_charged": 28.4,
-    "total_discharged": 25.8
+    "total_discharged": 25.6
   }
 }

--- a/core/bess/tests/unit/test_battery_first_solar_charging.py
+++ b/core/bess/tests/unit/test_battery_first_solar_charging.py
@@ -1,0 +1,243 @@
+"""
+Tests for implicit solar charging during battery_first (charging) periods.
+
+When the DP selects a positive charge action (power > 0), the Growatt inverter
+enters battery_first mode. In this mode, the hardware charges from ALL excess
+solar before using grid power. The DP algorithm must model this by ensuring
+battery_charged = max(dp_power * dt, implicit_solar_charge).
+
+Without this, the optimizer could plan a small grid charge (e.g., 0.4 kW) and
+assume the rest of the solar gets exported — but the hardware would actually
+absorb all excess solar, making the DP's energy balance incorrect.
+"""
+
+import pytest
+
+from core.bess.dp_battery_algorithm import (
+    _compute_idle_solar_charging,
+    _state_transition,
+    optimize_battery_schedule,
+)
+from core.bess.settings import BatterySettings
+
+
+@pytest.fixture
+def battery():
+    """Small battery for focused testing."""
+    return BatterySettings(
+        total_capacity=10.0,
+        min_soc=10,
+        max_soc=100,
+        max_charge_power_kw=5.0,
+        max_discharge_power_kw=5.0,
+        efficiency_charge=0.95,
+        efficiency_discharge=0.95,
+        cycle_cost_per_kwh=0.40,
+    )
+
+
+class TestStateTransitionChargingAbsorbsSolar:
+    """_state_transition must reflect that battery_first absorbs all excess solar."""
+
+    def test_small_charge_absorbs_all_excess_solar(self, battery):
+        """A small DP charge action should still absorb all excess solar in SOE."""
+        # 3 kW solar, 1 kW home → 2 kW excess solar
+        # DP requests 0.4 kW charge → dp_stored = 0.4 * 1.0 * 0.95 = 0.38
+        # But solar_stored = 2.0 * 0.95 = 1.9, so charge_energy = max(0.38, 1.9) = 1.9
+        next_soe = _state_transition(
+            power=0.4,
+            soe=5.0,
+            solar_production=3.0,
+            home_consumption=1.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        _, solar_stored = _compute_idle_solar_charging(
+            solar_production=3.0,
+            home_consumption=1.0,
+            soe=5.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        expected_soe = 5.0 + solar_stored
+        assert next_soe == pytest.approx(expected_soe)
+
+    def test_large_charge_exceeds_solar(self, battery):
+        """When DP charge exceeds solar, the DP power determines SOE change."""
+        # 2 kW solar, 1 kW home → 1 kW excess solar
+        # DP requests 3.0 kW charge → dp_stored = 3.0 * 1.0 * 0.95 = 2.85
+        # solar_stored = 1.0 * 0.95 = 0.95, so charge_energy = max(2.85, 0.95) = 2.85
+        next_soe = _state_transition(
+            power=3.0,
+            soe=5.0,
+            solar_production=2.0,
+            home_consumption=1.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        expected_soe = 5.0 + 3.0 * 1.0 * battery.efficiency_charge
+        assert next_soe == pytest.approx(expected_soe)
+
+    def test_charge_with_no_solar_uses_dp_power(self, battery):
+        """Without solar, charging follows DP power exactly."""
+        next_soe = _state_transition(
+            power=2.0,
+            soe=5.0,
+            solar_production=0.0,
+            home_consumption=1.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        expected_soe = 5.0 + 2.0 * 1.0 * battery.efficiency_charge
+        assert next_soe == pytest.approx(expected_soe)
+
+
+class TestChargingEnergyBalance:
+    """Verify energy balance when charging absorbs all excess solar."""
+
+    def test_small_charge_with_excess_solar_no_export(self, battery):
+        """A small charge with excess solar should show zero export in period data."""
+        # Single period: 3 kW solar, 1 kW home → 2 kW excess
+        # Even a small charge action should absorb all excess solar
+        n = 1
+        results = optimize_battery_schedule(
+            buy_price=[0.5],
+            sell_price=[0.3],
+            home_consumption=[1.0],
+            solar_production=[3.0],
+            initial_soe=5.0,
+            battery_settings=battery,
+            period_duration_hours=1.0,
+        )
+
+        p = results.period_data[0]
+        if p.energy.battery_charged > 0:
+            # When charging with excess solar, export should be zero or near-zero
+            # because battery_first absorbs all excess solar
+            excess = p.energy.solar_production - p.energy.home_consumption
+            assert p.energy.battery_charged >= excess - 0.01, (
+                f"Battery charged {p.energy.battery_charged:.3f} but excess solar "
+                f"was {excess:.3f} — should absorb all of it"
+            )
+
+    def test_charge_with_no_excess_solar_uses_grid(self, battery):
+        """When consumption exceeds solar, charging requires grid import."""
+        n = 4
+        # Force charging by making evening prices very expensive
+        buy_price = [0.10] * 2 + [3.00] * 2
+        sell_price = [0.05] * 2 + [1.50] * 2
+        home_consumption = [0.75] * n  # 3 kWh/h, exceeds solar
+        solar_production = [0.25] * n  # 1 kWh/h
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        # During cheap periods with charging, grid should be imported
+        for p in results.period_data[:2]:
+            if p.energy.battery_charged > 0.01:
+                assert p.energy.grid_imported > 0, (
+                    f"Period {p.period}: charging without excess solar should need grid"
+                )
+
+
+class TestOptimizationChargingAbsorbsSolar:
+    """End-to-end optimization tests for battery_first solar absorption."""
+
+    def test_optimizer_does_not_export_while_charging(self, battery):
+        """When optimizer chooses to charge, it should not simultaneously export solar."""
+        # Scenario: moderate solar with price spread encouraging charge→discharge
+        n = 8
+        buy_price = [0.20] * 4 + [1.50] * 4  # cheap morning, expensive evening
+        sell_price = [0.10] * 4 + [0.80] * 4
+        home_consumption = [0.25] * n  # 1 kWh/h
+        solar_production = [0.75] * 4 + [0.0] * 4  # solar in morning only
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        for p in results.period_data:
+            if p.energy.battery_charged > 0.01:
+                excess = p.energy.solar_production - p.energy.home_consumption
+                if excess > 0:
+                    # Battery should absorb at least the excess solar.
+                    # Export should only be whatever exceeds battery capacity/rate limits.
+                    assert p.energy.battery_charged >= excess - 0.01, (
+                        f"Period {p.period}: battery charged {p.energy.battery_charged:.3f} "
+                        f"but excess solar was {excess:.3f} — should absorb all of it"
+                    )
+
+    def test_cross_temporal_arbitrage_prevented(self, battery):
+        """Optimizer should not export solar at low price to buy grid at same/higher price."""
+        # This was the original bug: optimizer exported solar at sell_price and
+        # bought grid at buy_price, even when buy_price > sell_price
+        n = 12
+        buy_price = [0.50] * n
+        sell_price = [0.12] * n  # sell price much lower than buy
+        home_consumption = [0.25] * n
+        solar_production = [0.75] * 6 + [0.0] * 6  # solar first half
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        # During solar periods, any charging action should absorb all excess solar
+        # rather than exporting it at 0.12 and importing from grid at 0.50
+        for p in results.period_data[:6]:
+            excess = p.energy.solar_production - p.energy.home_consumption
+            if excess > 0 and p.energy.battery_charged > 0.01:
+                # Battery should absorb at least as much as the excess solar
+                assert p.energy.battery_charged >= excess - 0.01, (
+                    f"Period {p.period}: battery charged {p.energy.battery_charged:.3f} "
+                    f"but excess solar was {excess:.3f} — should absorb all of it"
+                )
+
+    def test_solar_charging_improves_savings(self, battery):
+        """Battery_first solar absorption should yield better savings than exporting."""
+        # With expensive evening prices and free solar, storing solar should beat exporting
+        n = 16
+        buy_price = [0.30] * 8 + [2.00] * 8
+        sell_price = [0.10] * 8 + [1.00] * 8
+        home_consumption = [0.25] * n
+        solar_production = [1.0] * 8 + [0.0] * 8  # 3 kWh excess per quarter in morning
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        # Battery should have charged from solar and discharged in expensive periods
+        total_charged = sum(p.energy.battery_charged for p in results.period_data)
+        total_discharged = sum(p.energy.battery_discharged for p in results.period_data)
+        assert total_charged > 0, "Battery should charge from solar"
+        assert total_discharged > 0, "Battery should discharge during expensive periods"
+
+        # Total cost with battery should be less than without
+        assert results.economic_summary.battery_solar_cost < results.economic_summary.grid_only_cost, (
+            f"Battery should reduce cost: {results.economic_summary.battery_solar_cost:.2f} "
+            f">= {results.economic_summary.grid_only_cost:.2f}"
+        )

--- a/core/bess/tests/unit/test_data_models.py
+++ b/core/bess/tests/unit/test_data_models.py
@@ -95,7 +95,13 @@ class TestEnergyData:
         assert energy.grid_to_battery == 0.0  # No grid charging
 
     def test_detailed_flow_calculation_idle_scenario(self):
-        """Test detailed flow calculation for idle battery scenario."""
+        """Test detailed flow calculation for idle battery scenario.
+
+        Note: The DP algorithm now provides non-zero battery_charged for IDLE
+        periods with excess solar (implicit solar charging). This test validates
+        EnergyData accounting with battery_charged=0, which is still a valid
+        input — EnergyData correctly distributes whatever flows it receives.
+        """
         energy = EnergyData(
             solar_production=4.0,  # 4 kWh solar
             home_consumption=3.0,  # 3 kWh home consumption

--- a/core/bess/tests/unit/test_idle_solar_charging.py
+++ b/core/bess/tests/unit/test_idle_solar_charging.py
@@ -1,0 +1,420 @@
+"""
+Tests for implicit solar charging during IDLE (load_first) periods.
+
+The Growatt inverter in load_first mode charges the battery from excess solar
+before exporting to grid. The DP algorithm must model this behavior so that
+SOE increases, grid_exported decreases, and the optimizer can see the value
+of free solar charging during IDLE periods.
+"""
+
+import pytest
+
+from core.bess.dp_battery_algorithm import (
+    _compute_idle_solar_charging,
+    _create_idle_schedule,
+    optimize_battery_schedule,
+)
+from core.bess.settings import BatterySettings
+
+
+@pytest.fixture
+def battery():
+    """Small battery for focused testing."""
+    return BatterySettings(
+        total_capacity=10.0,
+        min_soc=10,
+        max_soc=100,
+        max_charge_power_kw=5.0,
+        max_discharge_power_kw=5.0,
+        efficiency_charge=0.95,
+        efficiency_discharge=0.95,
+        cycle_cost_per_kwh=0.40,
+    )
+
+
+class TestComputeIdleSolarCharging:
+    """Unit tests for the _compute_idle_solar_charging helper."""
+
+    def test_excess_solar_charges_battery(self, battery):
+        """Excess solar should produce non-zero battery_charged."""
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=3.0,
+            home_consumption=1.0,
+            soe=5.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        assert charged == pytest.approx(2.0)
+        assert stored == pytest.approx(2.0 * 0.95)
+
+    def test_no_excess_solar_no_charging(self, battery):
+        """When solar < consumption, no charging occurs."""
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=1.0,
+            home_consumption=3.0,
+            soe=5.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        assert charged == 0.0
+        assert stored == 0.0
+
+    def test_zero_solar_no_charging(self, battery):
+        """When solar is zero, no charging occurs."""
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=0.0,
+            home_consumption=2.0,
+            soe=5.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        assert charged == 0.0
+        assert stored == 0.0
+
+    def test_respects_capacity_limit(self, battery):
+        """Charging should be clamped when battery is nearly full."""
+        # Battery at 9.5 kWh, max is 10.0 kWh → only 0.5 kWh capacity
+        # Available capacity pre-efficiency = 0.5 / 0.95 ≈ 0.526
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=5.0,
+            home_consumption=0.0,
+            soe=9.5,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        available_capacity = (10.0 - 9.5) / 0.95
+        assert charged == pytest.approx(available_capacity)
+        assert stored == pytest.approx(available_capacity * 0.95)
+        assert stored <= 10.0 - 9.5 + 1e-10  # Must not exceed available capacity
+
+    def test_respects_charge_rate(self, battery):
+        """Charging should be clamped by max charge power * dt."""
+        # max_charge_power_kw=5.0, dt=0.25 → limit = 1.25 kWh
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=10.0,
+            home_consumption=0.0,
+            soe=5.0,
+            battery_settings=battery,
+            dt=0.25,
+        )
+        assert charged == pytest.approx(1.25)
+        assert stored == pytest.approx(1.25 * 0.95)
+
+    def test_efficiency_applied(self, battery):
+        """Energy stored should be less than energy charged due to efficiency."""
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=4.0,
+            home_consumption=2.0,
+            soe=5.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        assert charged == pytest.approx(2.0)
+        assert stored == pytest.approx(2.0 * battery.efficiency_charge)
+        assert stored < charged
+
+    def test_full_battery_no_charging(self, battery):
+        """When battery is full, no charging occurs."""
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=5.0,
+            home_consumption=1.0,
+            soe=battery.max_soe_kwh,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        assert charged == 0.0
+        assert stored == 0.0
+
+
+class TestIdleSolarChargingInOptimization:
+    """Integration tests verifying the DP algorithm models IDLE solar charging."""
+
+    def test_idle_charges_battery_from_excess_solar(self, battery):
+        """IDLE periods with excess solar should show battery charging and reduced export."""
+        # Single period scenario: high solar, low consumption
+        # Flat prices so the optimizer has no reason to actively charge/discharge
+        n = 4  # 4 quarter-hour periods = 1 hour
+        buy_price = [0.5] * n
+        sell_price = [0.3] * n
+        home_consumption = [0.25] * n  # 1 kWh/h → 0.25 per quarter
+        solar_production = [0.75] * n  # 3 kWh/h → 0.75 per quarter, excess = 0.5 per q
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        total_charged = sum(p.energy.battery_charged for p in results.period_data)
+        total_exported = sum(p.energy.grid_exported for p in results.period_data)
+        total_excess = sum(s - c for s, c in zip(solar_production, home_consumption))
+
+        # Battery should have charged from excess solar
+        assert total_charged > 0, "IDLE should charge battery from excess solar"
+        # Grid export should be less than total excess solar
+        assert total_exported < total_excess, (
+            "Grid export should be reduced by solar charging"
+        )
+
+    def test_idle_no_solar_excess_no_charging(self, battery):
+        """When solar < consumption during IDLE, no battery charging should occur."""
+        n = 4
+        buy_price = [0.5] * n
+        sell_price = [0.3] * n
+        home_consumption = [1.0] * n  # 4 kWh/h
+        solar_production = [0.5] * n  # 2 kWh/h, all consumed by home
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        # With flat prices and no excess solar, battery should stay idle
+        # Check that no phantom charging occurred
+        for p in results.period_data:
+            if p.energy.solar_production <= p.energy.home_consumption:
+                assert p.energy.battery_charged == pytest.approx(0.0, abs=1e-10), (
+                    "No charging should occur when solar <= consumption"
+                )
+
+    def test_idle_solar_charging_respects_capacity_limit(self, battery):
+        """Battery nearly full — solar charging should be clamped to available capacity."""
+        n = 4
+        buy_price = [0.5] * n
+        sell_price = [0.3] * n
+        home_consumption = [0.25] * n
+        solar_production = [2.0] * n  # Lots of excess solar
+
+        # Start at 95% SOE
+        initial_soe = battery.max_soe_kwh * 0.95
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=initial_soe,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        # SOE should not exceed max
+        for p in results.period_data:
+            assert p.energy.battery_soe_end <= battery.max_soe_kwh + 1e-10
+
+    def test_idle_solar_charging_applies_efficiency(self, battery):
+        """Energy stored should reflect charging efficiency losses."""
+        charged, stored = _compute_idle_solar_charging(
+            solar_production=3.0,
+            home_consumption=1.0,
+            soe=5.0,
+            battery_settings=battery,
+            dt=1.0,
+        )
+        assert stored == pytest.approx(charged * battery.efficiency_charge)
+        assert stored < charged
+
+
+class TestCreateIdleSchedule:
+    """Tests for _create_idle_schedule with solar charging and SOE propagation."""
+
+    def test_idle_schedule_propagates_soe(self, battery):
+        """SOE should increase period-over-period when excess solar is available."""
+        n = 8  # 2 hours of quarter-hour periods
+        buy_price = [0.5] * n
+        sell_price = [0.3] * n
+        home_consumption = [0.25] * n  # 1 kWh/h
+        solar_production = [0.75] * n  # 3 kWh/h, 2 kWh/h excess
+
+        result = _create_idle_schedule(
+            horizon=n,
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+        )
+
+        # SOE should increase across periods
+        soe_values = [p.energy.battery_soe_end for p in result.period_data]
+        for i in range(1, len(soe_values)):
+            assert soe_values[i] >= soe_values[i - 1], (
+                f"SOE should not decrease: period {i-1}={soe_values[i-1]:.3f}, "
+                f"period {i}={soe_values[i]:.3f}"
+            )
+
+        # SOE should actually increase (not stay flat) with excess solar
+        assert soe_values[-1] > soe_values[0], (
+            "SOE should increase over time with excess solar"
+        )
+
+        # Verify continuity: soe_end of period N == soe_start of period N+1
+        for i in range(len(result.period_data) - 1):
+            assert result.period_data[i].energy.battery_soe_end == pytest.approx(
+                result.period_data[i + 1].energy.battery_soe_start
+            ), f"SOE discontinuity between periods {i} and {i+1}"
+
+    def test_idle_schedule_no_solar_soe_unchanged(self, battery):
+        """Without solar, SOE should remain unchanged across all periods."""
+        n = 4
+        buy_price = [0.5] * n
+        sell_price = [0.3] * n
+        home_consumption = [0.5] * n
+        solar_production = [0.0] * n
+
+        result = _create_idle_schedule(
+            horizon=n,
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=5.0,
+            battery_settings=battery,
+        )
+
+        for p in result.period_data:
+            assert p.energy.battery_soe_start == pytest.approx(5.0)
+            assert p.energy.battery_soe_end == pytest.approx(5.0)
+            assert p.energy.battery_charged == 0.0
+
+    def test_idle_schedule_grid_export_reduced(self, battery):
+        """Grid export should be reduced by the amount charged into battery."""
+        n = 4
+        buy_price = [0.5] * n
+        sell_price = [0.3] * n
+        home_consumption = [0.25] * n
+        solar_production = [0.75] * n  # 0.5 excess per quarter
+
+        result = _create_idle_schedule(
+            horizon=n,
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+        )
+
+        for p in result.period_data:
+            excess = p.energy.solar_production - p.energy.home_consumption
+            if excess > 0:
+                # Export = excess - what went to battery
+                assert p.energy.grid_exported == pytest.approx(
+                    excess - p.energy.battery_charged
+                )
+
+
+class TestDischargeOverriddenBySolar:
+    """When solar >= consumption, discharge actions are overridden by hardware."""
+
+    def test_no_discharge_when_solar_exceeds_consumption(self, battery):
+        """Optimizer should not show battery discharge during periods with excess solar."""
+        # Scenario with excess solar in every period — discharge should never appear
+        n = 8
+        buy_price = [0.50] * n
+        sell_price = [0.30] * n
+        home_consumption = [0.25] * n  # 1 kWh/h
+        solar_production = [0.75] * n  # 3 kWh/h → 2 kWh/h excess
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=5.0,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        for p in results.period_data:
+            if p.energy.solar_production > p.energy.home_consumption:
+                assert p.energy.battery_discharged == pytest.approx(0.0, abs=1e-10), (
+                    f"Period {p.period}: battery should not discharge when solar "
+                    f"({p.energy.solar_production}) > consumption ({p.energy.home_consumption})"
+                )
+
+    def test_excess_solar_charges_battery_not_exported(self, battery):
+        """During periods with excess solar, export should be reduced by solar charging."""
+        n = 4
+        buy_price = [0.50] * n
+        sell_price = [0.30] * n
+        home_consumption = [0.25] * n
+        solar_production = [0.75] * n  # 0.5 excess per quarter
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        for p in results.period_data:
+            excess = p.energy.solar_production - p.energy.home_consumption
+            if excess > 0:
+                # Some or all excess should go to battery, not all to grid
+                assert p.energy.grid_exported < excess + 1e-10, (
+                    f"Period {p.period}: grid export ({p.energy.grid_exported:.3f}) "
+                    f"should be less than excess solar ({excess:.3f})"
+                )
+
+
+class TestIdlePreferredOverGridCharging:
+    """Test that the optimizer prefers free solar charging over paid grid charging."""
+
+    def test_idle_preferred_over_explicit_charging_when_solar_sufficient(self, battery):
+        """When solar excess covers charging need, optimizer should not pay for grid charging."""
+        # Scenario: cheap morning prices, expensive evening, lots of midday solar
+        # The optimizer should prefer IDLE solar charging over grid charging
+        n = 24  # 6 hours at quarter-hour resolution
+        # Morning: cheap. Midday: moderate. Evening: expensive.
+        buy_price = (
+            [0.10] * 8  # hours 0-1: cheap
+            + [0.50] * 8  # hours 2-3: moderate with solar
+            + [2.00] * 8  # hours 4-5: expensive (discharge opportunity)
+        )
+        sell_price = [p * 0.7 for p in buy_price]
+        home_consumption = [0.25] * n  # 1 kWh/h steady
+        solar_production = (
+            [0.0] * 8  # no solar hours 0-1
+            + [1.5] * 8  # excess solar hours 2-3 (1.25 excess per quarter after home)
+            + [0.0] * 8  # no solar hours 4-5
+        )
+
+        results = optimize_battery_schedule(
+            buy_price=buy_price,
+            sell_price=sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=battery.min_soe_kwh,
+            battery_settings=battery,
+            period_duration_hours=0.25,
+        )
+
+        # Check that grid imports for charging are minimized during solar hours
+        # During periods 8-15 (solar hours), if battery charges, it should prefer
+        # solar over grid
+        solar_period_grid_imports = sum(
+            p.energy.grid_imported for p in results.period_data[8:16]
+        )
+        solar_period_consumption = sum(home_consumption[8:16])
+
+        # Grid imports during solar hours should not significantly exceed consumption
+        # (i.e., the optimizer shouldn't be importing from grid to charge when solar
+        # excess is available for free)
+        assert solar_period_grid_imports <= solar_period_consumption + 0.1, (
+            f"Grid imports during solar hours ({solar_period_grid_imports:.2f}) "
+            f"should not exceed consumption ({solar_period_consumption:.2f})"
+        )


### PR DESCRIPTION
## Summary

The DP optimizer's energy model did not match how the Growatt inverter actually handles solar in its operating modes, causing incorrect schedules:

- **battery_first mode**: Hardware absorbs ALL excess solar, but the DP only modeled the requested charge power — allowing it to plan impossible cross-temporal arbitrage (export solar cheap, buy grid expensive)
- **Discharge override**: When solar >= consumption, the Growatt overrides discharge commands and charges from excess solar instead. The DP had no knowledge of this and planned discharge during sunny periods
- **Dashboard mismatch**: `create_decision_data()` derived intent and `batteryAction` from the raw DP power, ignoring hardware overrides — the dashboard showed "Powering Home" with phantom discharge during solar-covered periods

### Changes

- `_state_transition`, `_compute_reward`, `_build_period_data`: three-way branching (charge / effective-discharge / idle-or-override) matching actual Growatt hardware behavior
- `_compute_idle_solar_charging`: shared helper for implicit solar charging (excess solar clamped by charge rate and available capacity)
- `_create_idle_schedule`: propagates SOE with implicit solar charging instead of flat SOE
- `create_decision_data`: derives strategic intent and `battery_action_kwh` from post-override energy flows (`energy_data.battery_charged`/`battery_discharged`) instead of raw DP power
- Updated 5 scenario test expected values
- Added `test_battery_first_solar_charging.py` (8 tests) and `test_idle_solar_charging.py` (16 tests)

## Test plan

- [x] All 277 unit tests pass
- [x] All 50 integration tests pass (3 skipped)
- [ ] Verify on dashboard: during SOLAR_STORAGE periods, excess solar goes to battery (not exported)
- [ ] Verify on dashboard: during periods where solar covers load, no phantom discharge shown
- [ ] Verify schedule bar shows correct mode labels (IDLE not LOAD_SUPPORT when solar covers load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)