### PR TITLE
fix: MIN inverter 500 errors when TOU schedule exceeds 9 slots

### DIFF
--- a/core/bess/min_schedule.py
+++ b/core/bess/min_schedule.py
@@ -520,14 +520,6 @@ class GrowattScheduleManager:
         non_expired.sort(key=lambda x: x["start_time"])
         hardware_intervals = non_expired[: self.max_intervals]
 
-        # Renumber to 1..N so segment_ids are always within the inverter's
-        # 1-9 hardware slot range, even after earlier segments expire.
-        # Without this, segment_ids inherited from self.tou_intervals (which
-        # can grow >9 on volatile days) get pushed to the Growatt service and
-        # the integration returns 500.
-        for i, interval in enumerate(hardware_intervals, 1):
-            interval["segment_id"] = i
-
         if len(non_expired) > self.max_intervals:
             pending_count = len(non_expired) - self.max_intervals
             logger.info(
@@ -552,6 +544,64 @@ class GrowattScheduleManager:
             )
 
         return hardware_intervals
+
+    def _assign_hardware_slots(
+        self, new_tou: list[dict], current_tou: list[dict]
+    ) -> None:
+        """Stamp each new_tou entry with a hardware slot id in 1..max_intervals.
+
+        The Growatt MIN inverter addresses its TOU table by slot number (1-9).
+        The slot id on a new interval must either match the slot that already
+        holds the same content on hardware (so we skip a redundant write) or
+        target a slot that is either unoccupied or being freed in this cycle.
+        Otherwise the write would overwrite a still-needed segment.
+
+        Mutates new_tou in place. current_tou is read-only.
+        """
+
+        def content_key(segment: dict) -> tuple:
+            return (
+                segment["start_time"],
+                segment["end_time"],
+                segment["batt_mode"],
+                segment.get("enabled", True),
+            )
+
+        new_keys = {content_key(s) for s in new_tou}
+
+        # Current segments whose content survives into new_tou keep their slot.
+        preserved_slot_by_key: dict[tuple, int] = {}
+        occupied_slots: set[int] = set()
+        for current in current_tou:
+            slot = current.get("segment_id")
+            if not isinstance(slot, int) or not (1 <= slot <= self.max_intervals):
+                continue
+            key = content_key(current)
+            if key in new_keys and key not in preserved_slot_by_key:
+                preserved_slot_by_key[key] = slot
+                occupied_slots.add(slot)
+
+        needs_slot: list[dict] = []
+        for segment in new_tou:
+            key = content_key(segment)
+            if key in preserved_slot_by_key:
+                segment["segment_id"] = preserved_slot_by_key[key]
+            else:
+                needs_slot.append(segment)
+
+        free_slots = sorted(
+            set(range(1, self.max_intervals + 1)) - occupied_slots
+        )
+        if len(needs_slot) > len(free_slots):
+            # active_tou_intervals is capped at max_intervals, so this should
+            # never trigger. Surfacing it rather than silently skipping keeps
+            # the hardware invariant visible.
+            raise RuntimeError(
+                f"Not enough hardware slots: need {len(needs_slot)}, "
+                f"have {len(free_slots)} (occupied={sorted(occupied_slots)})"
+            )
+        for segment, slot in zip(needs_slot, free_slots, strict=False):
+            segment["segment_id"] = slot
 
     def _calculate_hourly_settings_with_strategic_intents(self):
         """Pre-calculate hourly settings using strategic intents and proper power rates.
@@ -1449,6 +1499,12 @@ class GrowattScheduleManager:
         # set_inverter_time_segment, otherwise the Growatt service rejects the
         # out-of-range segment_id with 500.
         new_tou = self.active_tou_intervals
+
+        # Assign hardware slot ids (segment_id 1..max_intervals) to new_tou.
+        # Preserves the slot of any interval already on hardware (matched by
+        # content) so still-needed segments are not overwritten when a
+        # previously-pending interval is promoted into the active 9.
+        self._assign_hardware_slots(new_tou, current_tou)
 
         logger.info(
             "TOU comparison: Current=%d intervals, New=%d intervals",

--- a/core/bess/min_schedule.py
+++ b/core/bess/min_schedule.py
@@ -520,6 +520,14 @@ class GrowattScheduleManager:
         non_expired.sort(key=lambda x: x["start_time"])
         hardware_intervals = non_expired[: self.max_intervals]
 
+        # Renumber to 1..N so segment_ids are always within the inverter's
+        # 1-9 hardware slot range, even after earlier segments expire.
+        # Without this, segment_ids inherited from self.tou_intervals (which
+        # can grow >9 on volatile days) get pushed to the Growatt service and
+        # the integration returns 500.
+        for i, interval in enumerate(hardware_intervals, 1):
+            interval["segment_id"] = i
+
         if len(non_expired) > self.max_intervals:
             pending_count = len(non_expired) - self.max_intervals
             logger.info(
@@ -1435,7 +1443,12 @@ class GrowattScheduleManager:
         Returns:
             Tuple of (segments_updated, segments_disabled)
         """
-        new_tou = self.tou_intervals
+        # Only the active (hardware-programmed) intervals are eligible to be
+        # written. self.tou_intervals can hold more than the 9 slots the MIN
+        # inverter supports; the overflow is pending_write and must not reach
+        # set_inverter_time_segment, otherwise the Growatt service rejects the
+        # out-of-range segment_id with 500.
+        new_tou = self.active_tou_intervals
 
         logger.info(
             "TOU comparison: Current=%d intervals, New=%d intervals",

--- a/core/bess/tests/unit/test_growatt_tou_scheduling.py
+++ b/core/bess/tests/unit/test_growatt_tou_scheduling.py
@@ -928,3 +928,118 @@ class TestHardwareWriteRespectsSlotLimit:
             assert (
                 1 <= call["segment_id"] <= 9
             ), f"segment_id {call['segment_id']} exceeds hardware slot range 1-9"
+
+
+class _SimulatingController(_CapturingController):
+    """Controller stub that also models the inverter's TOU slot table.
+
+    Writes with enabled=True occupy the slot; enabled=False clears it.
+    `hardware_segments()` returns the currently programmed segments, suitable
+    for passing back as `current_tou` on the next cycle.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.slots: dict[int, dict] = {}
+
+    def set_inverter_time_segment(
+        self,
+        segment_id: int,
+        batt_mode: str,
+        start_time: str,
+        end_time: str,
+        enabled: bool,
+    ) -> None:
+        super().set_inverter_time_segment(
+            segment_id, batt_mode, start_time, end_time, enabled
+        )
+        if enabled:
+            self.slots[segment_id] = {
+                "segment_id": segment_id,
+                "batt_mode": batt_mode,
+                "start_time": start_time,
+                "end_time": end_time,
+                "enabled": True,
+            }
+        else:
+            self.slots.pop(segment_id, None)
+
+    def hardware_segments(self) -> list[dict]:
+        return [dict(s) for s in self.slots.values()]
+
+
+class TestSlotAssignmentPreservesActiveSegments:
+    """When a previously-pending segment promotes to active across cycles, the
+    write logic must place it in a freed slot — not overwrite a slot that
+    still holds a needed segment.
+    """
+
+    def _content_set(self, segments) -> set[tuple]:
+        return {
+            (s["start_time"], s["end_time"], s["batt_mode"]) for s in segments
+        }
+
+    def test_promoted_pending_segment_does_not_evict_still_needed_segments(
+        self, scheduler
+    ):
+        scheduler.strategic_intents = _OVERCAPACITY_INTENTS
+
+        # Cycle 1 at start of day: 9 of the 10 strategic segments fit on hardware.
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
+        controller = _SimulatingController()
+        scheduler.write_schedule_to_hardware(
+            controller, effective_period=0, current_tou=[]
+        )
+
+        cycle1_hardware = self._content_set(controller.hardware_segments())
+        assert (
+            len(cycle1_hardware) == 9
+        ), f"Cycle 1 must populate all 9 slots, got {len(cycle1_hardware)}"
+
+        # Cycle 2 at 03:00: the 01:00 segment has expired and the previously
+        # pending 19:00 segment is now part of the active 9.
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=12)
+        scheduler.write_schedule_to_hardware(
+            controller,
+            effective_period=12,
+            current_tou=controller.hardware_segments(),
+        )
+
+        hardware_after = self._content_set(controller.hardware_segments())
+        wanted = self._content_set(scheduler.active_tou_intervals)
+
+        # Every interval the scheduler considers active must actually be on
+        # hardware after cycle 2 — none silently evicted by slot collision.
+        missing = wanted - hardware_after
+        assert not missing, (
+            f"Active intervals missing from hardware after pending promotion: "
+            f"{sorted(missing)}"
+        )
+
+        # And every slot id used is still in the legal 1..9 range.
+        for slot_id in controller.slots:
+            assert 1 <= slot_id <= 9
+
+    def test_unchanged_segments_are_not_rewritten_across_cycles(self, scheduler):
+        """Idempotency: if nothing changes between cycles, no hardware write
+        should be emitted in the second cycle."""
+        scheduler.strategic_intents = _OVERCAPACITY_INTENTS
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
+
+        controller = _SimulatingController()
+        scheduler.write_schedule_to_hardware(
+            controller, effective_period=0, current_tou=[]
+        )
+        cycle1_call_count = len(controller.calls)
+        assert cycle1_call_count > 0
+
+        # Re-run the same conversion at the same period — no state has changed.
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
+        scheduler.write_schedule_to_hardware(
+            controller,
+            effective_period=0,
+            current_tou=controller.hardware_segments(),
+        )
+        assert (
+            len(controller.calls) == cycle1_call_count
+        ), "Cycle 2 with identical state should not issue any new writes"

--- a/core/bess/tests/unit/test_growatt_tou_scheduling.py
+++ b/core/bess/tests/unit/test_growatt_tou_scheduling.py
@@ -841,3 +841,90 @@ class TestHardwareSlotCascading:
             "An interval with the same time range but a different mode must be "
             "marked pending_write=True — it has not been written to hardware"
         )
+
+
+class _CapturingController:
+    """Minimal controller stub that records every set_inverter_time_segment call."""
+
+    def __init__(self):
+        self.failure_tracker = None
+        self.calls: list[dict] = []
+
+    def set_inverter_time_segment(
+        self,
+        segment_id: int,
+        batt_mode: str,
+        start_time: str,
+        end_time: str,
+        enabled: bool,
+    ) -> None:
+        self.calls.append(
+            {
+                "segment_id": segment_id,
+                "batt_mode": batt_mode,
+                "start_time": start_time,
+                "end_time": end_time,
+                "enabled": enabled,
+            }
+        )
+
+
+class TestHardwareWriteRespectsSlotLimit:
+    """Regression tests: the inverter only accepts segment_id 1-9.
+
+    Writing a segment_id outside that range causes the Growatt HA service to
+    return 500. These tests verify that write_schedule_to_hardware never
+    issues such a call regardless of how many TOU intervals were generated.
+    """
+
+    def test_no_segment_id_above_nine_is_ever_written(self, scheduler):
+        """Even with overcapacity intents, every write uses a segment_id in 1..9."""
+        scheduler.strategic_intents = _OVERCAPACITY_INTENTS
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
+
+        controller = _CapturingController()
+        scheduler.write_schedule_to_hardware(
+            controller, effective_period=0, current_tou=[]
+        )
+
+        assert controller.calls, "Expected at least one hardware write"
+        for call in controller.calls:
+            assert (
+                1 <= call["segment_id"] <= 9
+            ), f"segment_id {call['segment_id']} exceeds hardware slot range 1-9"
+
+    def test_write_count_never_exceeds_hardware_slot_count(self, scheduler):
+        """write_schedule_to_hardware must not push more than 9 segments."""
+        scheduler.strategic_intents = _OVERCAPACITY_INTENTS
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
+
+        controller = _CapturingController()
+        scheduler.write_schedule_to_hardware(
+            controller, effective_period=0, current_tou=[]
+        )
+
+        assert (
+            len(controller.calls) <= 9
+        ), f"Wrote {len(controller.calls)} segments, exceeds hardware limit of 9"
+
+    def test_segment_ids_remain_in_range_after_earlier_segments_expire(
+        self, scheduler
+    ):
+        """Mid-day rebuild (some segments expired) must still produce ids 1..9.
+
+        Regression for the case where _select_hardware_intervals previously
+        preserved inherited ids like 10..18 from the renumbered tou_intervals.
+        """
+        scheduler.strategic_intents = _OVERCAPACITY_INTENTS
+        # period 12 = 03:00 — the 01:00 segment has expired, leaving 9 candidates.
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=12)
+
+        controller = _CapturingController()
+        scheduler.write_schedule_to_hardware(
+            controller, effective_period=12, current_tou=[]
+        )
+
+        for call in controller.calls:
+            assert (
+                1 <= call["segment_id"] <= 9
+            ), f"segment_id {call['segment_id']} exceeds hardware slot range 1-9"


### PR DESCRIPTION
## Summary

`write_schedule_to_hardware` was iterating `self.tou_intervals`, which can grow beyond the 9-slot hardware limit on price-volatile days, and pushing every interval to `set_inverter_time_segment`. The Growatt HA integration rejects out-of-range `segment_id`s with HTTP 500 — visible in logs as repeated retries:

```
WARNING | core.bess.ha_api_controller:601 - API request to .../growatt_server/update_time_segment failed on attempt 1/4: 500 Server Error
ERROR   | core.bess.min_schedule:1628 - FAILED: Failed to update TOU segment: 500 Server Error
WARNING | core.bess.runtime_failure_tracker:91 - Runtime failure recorded [inverter_control]: Write TOU segment 19: grid_first 21:00-21:14 (enabled) - 500 Server Error
```

`segment_id=19` is well outside the MIN inverter's valid 1-9 range.

## Root cause

`_consolidate_and_convert_with_strategic_intents` renumbers every entry in `self.tou_intervals` `1..N` (can exceed 9 on volatile days). `_select_hardware_intervals` picks the first 9 non-expired into `self.active_tou_intervals` but inherits those ids — so when earlier segments expire, the active list can hold ids `10..18`. Then `write_schedule_to_hardware` iterated `self.tou_intervals` (not `active_tou_intervals`), pushing every overflow interval regardless of slot capacity.

The existing `TestHardwareSlotCascading` tests verified the cap on `active_tou_intervals` but never inspected what was actually written to hardware, which is why the regression slipped through.

## Fix

Two coordinated changes:

1. **`write_schedule_to_hardware` iterates `self.active_tou_intervals`** (already capped to 9), not `self.tou_intervals`.
2. **New `_assign_hardware_slots` helper** assigns slot ids `1..max_intervals` at write time, based on what's currently on the inverter:
   - Intervals already on hardware (matched by `start_time`/`end_time`/`batt_mode`/`enabled`) keep their existing slot id, so the differential update can skip them with no write.
   - New intervals take the lowest-numbered slot that's either unoccupied or being freed by a disable in this cycle.

The slot-assignment helper is needed because a naive renumbering to `1..9` (which I tried first) introduced silent slot eviction across cycles — when a previously-pending segment was promoted into the active 9, a write to "slot 9" of the new segment overwrote whichever segment was already in slot 9 even though it was still scheduled.

## Test plan

Adds two test classes:

- `TestHardwareWriteRespectsSlotLimit` — verifies that no `set_inverter_time_segment` call ever uses a `segment_id` outside `1..9`, that the total number of writes never exceeds 9, and that this holds at start-of-day and mid-day-after-expiry.
- `TestSlotAssignmentPreservesActiveSegments` — uses a simulating controller that models the inverter's slot table across cycles. Verifies that after a previously-pending segment is promoted into the active 9, every active segment is still present on hardware (no eviction), and that re-running the same cycle issues no additional writes (idempotency).

All 271 existing unit tests still pass.