### PR TITLE
Fix bot: bypass perms in CI + use Pro OAuth token + Haiku for triage

### DIFF
--- a/.github/workflows/issue-analyze.yml
+++ b/.github/workflows/issue-analyze.yml
@@ -40,7 +40,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot analyze"
-          claude_args: "--max-turns 60"
+          claude_args: "--max-turns 100 --permission-mode bypassPermissions"
           prompt: |
             You are the **Stage 2 Deep Analysis** bot for issue #${{ github.event.issue.number }} in johanzander/bess-manager.
 

--- a/.github/workflows/issue-analyze.yml
+++ b/.github/workflows/issue-analyze.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot analyze"
           claude_args: "--max-turns 100 --permission-mode bypassPermissions"

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot fix"
           claude_args: "--max-turns 120 --permission-mode bypassPermissions"

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -50,7 +50,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot fix"
-          claude_args: "--max-turns 80"
+          claude_args: "--max-turns 120 --permission-mode bypassPermissions"
           prompt: |
             You are the **Stage 3 Fix** bot for issue #${{ github.event.issue.number }} in johanzander/bess-manager.
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
-          claude_args: "--max-turns 12"
+          claude_args: "--max-turns 12 --permission-mode bypassPermissions"
           prompt: |
             You are the **Stage 1 Triage** bot for issue #${{ github.event.issue.number || github.event.inputs.issue_number }} in johanzander/bess-manager.
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,9 +45,10 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
-          claude_args: "--max-turns 12 --permission-mode bypassPermissions"
+          # Haiku is plenty for classify+label; saves ~3x vs Sonnet.
+          claude_args: "--max-turns 12 --permission-mode bypassPermissions --model claude-haiku-4-5"
           prompt: |
             You are the **Stage 1 Triage** bot for issue #${{ github.event.issue.number || github.event.inputs.issue_number }} in johanzander/bess-manager.
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot"
           claude_args: "--max-turns 60 --permission-mode bypassPermissions"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -38,7 +38,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot"
-          claude_args: "--max-turns 40"
+          claude_args: "--max-turns 60 --permission-mode bypassPermissions"
           prompt: |
             You are the **PR Review** bot for PR #${{ github.event.issue.number }} in johanzander/bess-manager.
 


### PR DESCRIPTION
## Summary

PR #83 introduced the new 4-stage pipeline but missed two follow-up fixes that were committed on the same branch after the squash-merge. Without these, issue #78's `@claude-bot analyze` ran for 19 min, hit 33 permission denials, spent $3.61, and posted nothing.

## Two fixes

**1. Bypass permission prompts in CI** — `.claude/settings.json` (correctly strict for local dev) only allows `Read/Glob/Grep/Bash(pytest:*)`. The action loads it via `setting_sources: [user, project, local]`, so `Agent` (sub-agent), `Bash(gh:*)`, `Edit`, `Write` were all denied in the runner. Adds `--permission-mode bypassPermissions` to every workflow.

**2. Switch to Claude Code OAuth + Haiku for triage** — replaces `anthropic_api_key` with `claude_code_oauth_token` so runs bill against the Pro subscription instead of the API. Triage uses `claude-haiku-4-5` (classification doesn't need Sonnet, ~3x cheaper anyway).

## Setup confirmed

- [x] `CLAUDE_CODE_OAUTH_TOKEN` secret created
- [x] `bypassPermissions` flag added to all 4 workflows
- [x] Triage model set to `claude-haiku-4-5`

## Test plan

- [ ] Merge this PR
- [ ] Comment `@claude-bot analyze` on issue #78
- [ ] Run should complete in well under 19 minutes with the bess-analyst sub-agent invoked and a structured diagnosis posted
- [ ] Pro subscription usage, not API billing
