### PR TITLE
Add test framework: CI gate, frontend tests, Playwright E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - run: cd frontend && npm ci
+      - run: cd frontend && npm test
       - run: cd frontend && npm run type-check
       - run: cd frontend && npm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  # ── Detect which areas changed ──────────────────────────────────
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      algorithm: ${{ steps.filter.outputs.algorithm }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            algorithm:
+              - 'core/bess/**'
+            backend:
+              - 'backend/**'
+              - 'core/bess/**'
+              - 'pyproject.toml'
+              - 'requirements-dev.txt'
+            frontend:
+              - 'frontend/**'
+
+  # ── Fast tests: backend API + non-optimizer unit tests ──────────
+  test-fast:
+    name: Fast tests
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run fast tests
+        run: pytest -m "not slow" --tb=short -q
+
+  # ── Slow tests: full optimizer / scenario / integration ─────────
+  test-algorithm:
+    name: Algorithm tests
+    needs: changes
+    if: needs.changes.outputs.algorithm == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run algorithm tests
+        run: pytest -m slow --tb=short -q
+
+  # ── Frontend: type-check + lint ─────────────────────────────────
+  test-frontend:
+    name: Frontend checks
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm run type-check
+      - run: cd frontend && npm run lint
+
+  # ── Quality gate: linting + formatting ────────────────��─────────
+  quality:
+    name: Code quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install tools
+        run: pip install black ruff
+
+      - name: Black formatting
+        run: black --check . --exclude="/(build|\.venv|node_modules)/"
+
+      - name: Ruff linting
+        run: ruff check . --exclude="build,.venv,node_modules"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,43 +103,37 @@ jobs:
       - run: cd frontend && npm run lint
 
   # ── E2E: Playwright against docker-compose mock HA ───────────────
-  e2e:
-    name: E2E tests
-    needs: changes
-    if: needs.changes.outputs.e2e == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Build frontend
-        run: cd frontend && npm ci && npm run build
-
-      - name: Install Playwright
-        run: cd e2e && npm ci && npx playwright install chromium --with-deps
-
-      - name: Start mock HA environment
-        run: |
-          SCENARIO=ci-normal-day docker compose -f docker-compose.ci.yml up -d
-          timeout 120 bash -c 'until curl -sf http://localhost:8080/api/settings > /dev/null 2>&1; do sleep 2; done'
-
-      - name: Run Playwright tests
-        run: cd e2e && npx playwright test
-
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: playwright-report
-          path: e2e/playwright-report/
-
-      - name: Stop environment
-        if: always()
-        run: docker compose -f docker-compose.ci.yml down
+  # Disabled until docker-compose CI infrastructure is ready (Phase 3)
+  # e2e:
+  #   name: E2E tests
+  #   needs: changes
+  #   if: needs.changes.outputs.e2e == 'true'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: "20"
+  #         cache: npm
+  #         cache-dependency-path: frontend/package-lock.json
+  #     - name: Build frontend
+  #       run: cd frontend && npm ci && npm run build
+  #     - name: Install Playwright
+  #       run: cd e2e && npm ci && npx playwright install chromium --with-deps
+  #     - name: Start mock HA environment
+  #       run: |
+  #         SCENARIO=ci-normal-day docker compose -f docker-compose.ci.yml up -d
+  #         timeout 120 bash -c 'until curl -sf http://localhost:8080/api/settings > /dev/null 2>&1; do sleep 2; done'
+  #     - name: Run Playwright tests
+  #       run: cd e2e && npx playwright test
+  #     - uses: actions/upload-artifact@v4
+  #       if: failure()
+  #       with:
+  #         name: playwright-report
+  #         path: e2e/playwright-report/
+  #     - name: Stop environment
+  #       if: always()
+  #       run: docker compose -f docker-compose.ci.yml down
 
   # ── Quality gate: linting + formatting ──────────────────────────
   quality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       algorithm: ${{ steps.filter.outputs.algorithm }}
+      e2e: ${{ steps.filter.outputs.e2e }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
@@ -29,6 +30,13 @@ jobs:
               - 'requirements-dev.txt'
             frontend:
               - 'frontend/**'
+            e2e:
+              - 'backend/**'
+              - 'core/bess/**'
+              - 'frontend/**'
+              - 'e2e/**'
+              - 'scripts/mock_ha/**'
+              - 'docker-compose.ci.yml'
 
   # ── Fast tests: backend API + non-optimizer unit tests ──────────
   test-fast:
@@ -94,7 +102,46 @@ jobs:
       - run: cd frontend && npm run type-check
       - run: cd frontend && npm run lint
 
-  # ── Quality gate: linting + formatting ────────────────��─────────
+  # ── E2E: Playwright against docker-compose mock HA ───────────────
+  e2e:
+    name: E2E tests
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        run: cd frontend && npm ci && npm run build
+
+      - name: Install Playwright
+        run: cd e2e && npm ci && npx playwright install chromium --with-deps
+
+      - name: Start mock HA environment
+        run: |
+          SCENARIO=ci-normal-day docker compose -f docker-compose.ci.yml up -d
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/api/settings > /dev/null 2>&1; do sleep 2; done'
+
+      - name: Run Playwright tests
+        run: cd e2e && npx playwright test
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+
+      - name: Stop environment
+        if: always()
+        run: docker compose -f docker-compose.ci.yml down
+
+  # ── Quality gate: linting + formatting ──────────────────────────
   quality:
     name: Code quality
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,14 @@ build/
 docs/private/
 docs/bess-debug-*.md
 scripts/mock_ha/scenarios/*.json
+!scripts/mock_ha/scenarios/ci-*.json
+
+# Playwright
+e2e/playwright-report/
+e2e/test-results/
+
+# Mock HA settings generated for CI (derived from scenario)
+backend/mock-bess-settings.json
 
 # Claude Code worktrees (temporary)
 .claude/worktrees/

--- a/backend/api.py
+++ b/backend/api.py
@@ -2191,7 +2191,7 @@ async def export_debug_data(compact: bool = True):
             Logs are filtered to key events + last 50 lines (not the full log).
             Snapshots are rendered as a 5-field evolution table (not full JSON).
             Set to False only when a raw field not present in compact mode is needed
-            (full log, all schedules, all snapshots as JSON). Expect 30–80 MB.
+            (full log, all schedules, all snapshots as JSON). Expect 30-80 MB.
 
     Security:
     - Via HA ingress (browser): HA handles authentication

--- a/backend/api.py
+++ b/backend/api.py
@@ -182,7 +182,9 @@ async def patch_settings(updates: dict):
 
             elif store_key == "growatt":
                 if "device_id" in section:
-                    bess_controller.ha_controller.growatt_device_id = section["device_id"]
+                    bess_controller.ha_controller.growatt_device_id = section[
+                        "device_id"
+                    ]
 
             elif store_key == "sensors":
                 bess_controller.ha_controller.sensors.update(
@@ -403,8 +405,13 @@ async def get_dashboard_data(
 
         # Guard: if no schedule exists yet the system is still initializing.
         if not bess_controller.system.schedule_store.get_latest_schedule():
-            logger.info("Dashboard requested before schedule is ready — returning initializing state")
-            return {"error": "initializing", "message": "System is initializing. The optimization schedule will be ready shortly."}
+            logger.info(
+                "Dashboard requested before schedule is ready — returning initializing state"
+            )
+            return {
+                "error": "initializing",
+                "message": "System is initializing. The optimization schedule will be ready shortly.",
+            }
 
         # Get daily view data (always quarterly internally)
         daily_view = bess_controller.system.get_current_daily_view()
@@ -1353,7 +1360,9 @@ async def get_growatt_detailed_schedule():
                         "batteryMode": battery_mode,
                         "grid_charge": hourly_settings.get("grid_charge", False),
                         "discharge_rate": hourly_settings.get("discharge_rate", 100),
-                        "dischargePowerRate": hourly_settings.get("discharge_rate", 100),
+                        "dischargePowerRate": hourly_settings.get(
+                            "discharge_rate", 100
+                        ),
                         "chargePowerRate": 100,
                         "strategic_intent": strategic_intent,
                         "intent_description": schedule_manager._get_intent_description(
@@ -1362,7 +1371,9 @@ async def get_growatt_detailed_schedule():
                         "action": action,
                         "action_color": action_color,
                         "battery_action": battery_action,
-                        "battery_action_kw": hourly_settings.get("battery_action_kw", 0.0),
+                        "battery_action_kw": hourly_settings.get(
+                            "battery_action_kw", 0.0
+                        ),
                         "batteryCharged": battery_charged,
                         "batteryDischarged": battery_discharged,
                         "price": price,
@@ -2502,7 +2513,9 @@ async def setup_complete(payload: APISetupCompletePayload):
             if payload.cycleCost is not None:
                 battery["cycle_cost_per_kwh"] = payload.cycleCost
             if payload.minActionProfitThreshold is not None:
-                battery["min_action_profit_threshold"] = payload.minActionProfitThreshold
+                battery["min_action_profit_threshold"] = (
+                    payload.minActionProfitThreshold
+                )
             sections["battery"] = battery
 
         # --- home ---
@@ -2574,34 +2587,40 @@ async def setup_complete(payload: APISetupCompletePayload):
 
         live_updates: dict = {}
         if "battery" in sections:
-            live_updates["battery"] = _nn({
-                "totalCapacity": payload.totalCapacity,
-                "minSoc": payload.minSoc,
-                "maxSoc": payload.maxSoc,
-                "maxChargePowerKw": payload.maxChargeDischargePower,
-                "maxDischargePowerKw": payload.maxChargeDischargePower,
-                "cycleCostPerKwh": payload.cycleCost,
-                "minActionProfitThreshold": payload.minActionProfitThreshold,
-            })
+            live_updates["battery"] = _nn(
+                {
+                    "totalCapacity": payload.totalCapacity,
+                    "minSoc": payload.minSoc,
+                    "maxSoc": payload.maxSoc,
+                    "maxChargePowerKw": payload.maxChargeDischargePower,
+                    "maxDischargePowerKw": payload.maxChargeDischargePower,
+                    "cycleCostPerKwh": payload.cycleCost,
+                    "minActionProfitThreshold": payload.minActionProfitThreshold,
+                }
+            )
         if "home" in sections:
-            live_updates["home"] = _nn({
-                "defaultHourly": payload.consumption,
-                "currency": payload.currency,
-                "consumptionStrategy": payload.consumptionStrategy,
-                "maxFuseCurrent": payload.maxFuseCurrent,
-                "voltage": payload.voltage,
-                "safetyMargin": payload.safetyMarginFactor,
-                "phaseCount": payload.phaseCount,
-                "powerMonitoringEnabled": payload.powerMonitoringEnabled,
-            })
+            live_updates["home"] = _nn(
+                {
+                    "defaultHourly": payload.consumption,
+                    "currency": payload.currency,
+                    "consumptionStrategy": payload.consumptionStrategy,
+                    "maxFuseCurrent": payload.maxFuseCurrent,
+                    "voltage": payload.voltage,
+                    "safetyMargin": payload.safetyMarginFactor,
+                    "phaseCount": payload.phaseCount,
+                    "powerMonitoringEnabled": payload.powerMonitoringEnabled,
+                }
+            )
         if "electricity_price" in sections:
-            live_updates["price"] = _nn({
-                "area": sections["electricity_price"].get("area"),
-                "markupRate": payload.markupRate,
-                "vatMultiplier": payload.vatMultiplier,
-                "additionalCosts": payload.additionalCosts,
-                "taxReduction": payload.taxReduction,
-            })
+            live_updates["price"] = _nn(
+                {
+                    "area": sections["electricity_price"].get("area"),
+                    "markupRate": payload.markupRate,
+                    "vatMultiplier": payload.vatMultiplier,
+                    "additionalCosts": payload.additionalCosts,
+                    "taxReduction": payload.taxReduction,
+                }
+            )
         if live_updates:
             bess_controller.system.update_settings(live_updates)
 
@@ -2613,11 +2632,15 @@ async def setup_complete(payload: APISetupCompletePayload):
                 bess_controller.system.reinitialize_historical_data()
                 logger.info("Historical backfill complete after wizard setup")
             except Exception as backfill_err:
-                logger.warning("Historical backfill failed after setup: %s", backfill_err)
+                logger.warning(
+                    "Historical backfill failed after setup: %s", backfill_err
+                )
             try:
                 now = time_utils.now()
                 current_period = now.hour * 4 + now.minute // 15
-                bess_controller.system.update_battery_schedule(current_period=current_period)
+                bess_controller.system.update_battery_schedule(
+                    current_period=current_period
+                )
                 logger.info("Schedule built with historical data after wizard setup")
             except Exception as sched_err:
                 logger.warning("Could not build schedule after backfill: %s", sched_err)

--- a/backend/api_conversion.py
+++ b/backend/api_conversion.py
@@ -72,9 +72,7 @@ def build_system_settings(options: dict) -> dict:
     required_sections = ["battery", "electricity_price", "home"]
     for section in required_sections:
         if section not in options:
-            raise ValueError(
-                f"Required configuration section '{section}' is missing"
-            )
+            raise ValueError(f"Required configuration section '{section}' is missing")
 
     battery_config = options["battery"]
     electricity_price_config = options["electricity_price"]
@@ -98,8 +96,7 @@ def build_system_settings(options: dict) -> dict:
             for snake, camel in BATTERY_STORE_TO_API.items()
         },
         "home": {
-            camel: home_config[snake]
-            for snake, camel in HOME_STORE_TO_API.items()
+            camel: home_config[snake] for snake, camel in HOME_STORE_TO_API.items()
         },
         "price": {
             camel: electricity_price_config[snake]
@@ -140,7 +137,9 @@ def convert_keys_to_camel_case(data: Any) -> Any:
 def convert_keys_to_snake_case(data: Any) -> Any:
     """Recursively convert all dict keys from camelCase to snake_case."""
     if isinstance(data, dict):
-        return {camel_to_snake(k): convert_keys_to_snake_case(v) for k, v in data.items()}
+        return {
+            camel_to_snake(k): convert_keys_to_snake_case(v) for k, v in data.items()
+        }
     if isinstance(data, list):
         return [convert_keys_to_snake_case(item) for item in data]
     return data

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,7 +16,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 from settings_store import SettingsStore

--- a/backend/settings_store.py
+++ b/backend/settings_store.py
@@ -338,17 +338,26 @@ class SettingsStore:
         battery = self.data.get("battery")
         if isinstance(battery, dict):
             # Rename: max_charge_discharge_power → max_charge_power_kw + max_discharge_power_kw
-            if "max_charge_discharge_power" in battery and "max_charge_power_kw" not in battery:
+            if (
+                "max_charge_discharge_power" in battery
+                and "max_charge_power_kw" not in battery
+            ):
                 power = battery.pop("max_charge_discharge_power")
                 battery["max_charge_power_kw"] = power
                 battery["max_discharge_power_kw"] = power
-                logger.info("Schema migration: renamed max_charge_discharge_power → max_charge_power_kw/max_discharge_power_kw = %s", power)
+                logger.info(
+                    "Schema migration: renamed max_charge_discharge_power → max_charge_power_kw/max_discharge_power_kw = %s",
+                    power,
+                )
                 changed = True
 
             # Rename: cycle_cost → cycle_cost_per_kwh
             if "cycle_cost" in battery and "cycle_cost_per_kwh" not in battery:
                 battery["cycle_cost_per_kwh"] = battery.pop("cycle_cost")
-                logger.info("Schema migration: renamed cycle_cost → cycle_cost_per_kwh = %s", battery["cycle_cost_per_kwh"])
+                logger.info(
+                    "Schema migration: renamed cycle_cost → cycle_cost_per_kwh = %s",
+                    battery["cycle_cost_per_kwh"],
+                )
                 changed = True
 
             # Add missing fields with defaults
@@ -372,13 +381,19 @@ class SettingsStore:
             # Rename: consumption → default_hourly  (matches HomeSettings attribute name)
             if "consumption" in home and "default_hourly" not in home:
                 home["default_hourly"] = home.pop("consumption")
-                logger.info("Schema migration: renamed home.consumption → home.default_hourly = %s", home["default_hourly"])
+                logger.info(
+                    "Schema migration: renamed home.consumption → home.default_hourly = %s",
+                    home["default_hourly"],
+                )
                 changed = True
 
             # Rename: safety_margin_factor → safety_margin  (matches HomeSettings attribute name)
             if "safety_margin_factor" in home and "safety_margin" not in home:
                 home["safety_margin"] = home.pop("safety_margin_factor")
-                logger.info("Schema migration: renamed home.safety_margin_factor → home.safety_margin = %s", home["safety_margin"])
+                logger.info(
+                    "Schema migration: renamed home.safety_margin_factor → home.safety_margin = %s",
+                    home["safety_margin"],
+                )
                 changed = True
 
             if changed:

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -17,10 +17,9 @@ from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pytest
+from api import router
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from api import router
 
 # ---------------------------------------------------------------------------
 # Minimal FastAPI app that exercises the router under test
@@ -111,12 +110,12 @@ class TestGetSettings:
         assert resp.status_code == 200
 
     def test_battery_computed_fields_present(self, mock_controller):
-        """min_soe_kwh, max_soe_kwh, reservedCapacity computed from capacity × SOC%."""
+        """min_soe_kwh, max_soe_kwh, reservedCapacity computed from capacity x SOC%."""
         resp = _client.get("/api/settings")
         battery = resp.json()["battery"]
-        # 30 kWh × 10% min_soc = 3.0 kWh
+        # 30 kWh x 10% min_soc = 3.0 kWh
         assert battery["minSoeKwh"] == pytest.approx(3.0)
-        # 30 kWh × 95% max_soc = 28.5 kWh
+        # 30 kWh x 95% max_soc = 28.5 kWh
         assert battery["maxSoeKwh"] == pytest.approx(28.5)
         assert battery["reservedCapacity"] == pytest.approx(3.0)
 
@@ -400,7 +399,7 @@ class TestPatchSettingsResponse:
     def test_patch_response_includes_computed_battery_fields(self, mock_controller):
         resp = _client.patch("/api/settings", json={"battery": {"totalCapacity": 20.0}})
         battery = resp.json()["battery"]
-        # 20 kWh × 10% = 2.0 kWh min_soe
+        # 20 kWh x 10% = 2.0 kWh min_soe
         assert "minSoeKwh" in battery
         assert battery["minSoeKwh"] == pytest.approx(2.0)
 

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -122,9 +122,7 @@ class TestGetSettings:
 
     def test_sensors_come_from_ha_controller(self, mock_controller):
         """Sensor values must be sourced from ha_controller, not the store."""
-        mock_controller.ha_controller.sensors = {
-            "battery_soc": "sensor.battery_live"
-        }
+        mock_controller.ha_controller.sensors = {"battery_soc": "sensor.battery_live"}
         resp = _client.get("/api/settings")
         assert resp.json()["sensors"]["battery_soc"] == "sensor.battery_live"
 
@@ -161,12 +159,18 @@ class TestPatchSettingsSectionRouting:
         assert "Unknown settings section" in resp.json()["detail"]
 
     def test_known_sections_accepted(self, mock_controller):
-        for section in ("battery", "home", "electricityPrice",
-                        "energyProvider", "growatt", "sensors"):
+        for section in (
+            "battery",
+            "home",
+            "electricityPrice",
+            "energyProvider",
+            "growatt",
+            "sensors",
+        ):
             resp = _client.patch("/api/settings", json={section: {}})
-            assert resp.status_code == 200, (
-                f"Section '{section}' was unexpectedly rejected: {resp.text}"
-            )
+            assert (
+                resp.status_code == 200
+            ), f"Section '{section}' was unexpectedly rejected: {resp.text}"
 
 
 class TestPatchSettingsCamelToSnake:
@@ -199,8 +203,10 @@ class TestPatchSettingsCamelToSnake:
             "/api/settings",
             json={"sensors": {"battery_soc": "sensor.battery_soc_percent"}},
         )
-        assert mock_controller.ha_controller.sensors.get("battery_soc") == \
-            "sensor.battery_soc_percent"
+        assert (
+            mock_controller.ha_controller.sensors.get("battery_soc")
+            == "sensor.battery_soc_percent"
+        )
 
 
 # ===========================================================================
@@ -308,7 +314,9 @@ class TestPatchSettingsLiveUpdates:
             "/api/settings",
             json={"battery": {"temperatureDerating": {"enabled": True}}},
         )
-        mock_controller.system.temperature_derating.enabled = True  # assert setter called
+        mock_controller.system.temperature_derating.enabled = (
+            True  # assert setter called
+        )
         assert mock_controller.system.temperature_derating.enabled is True
 
     def test_health_refresh_called_after_patch(self, mock_controller):
@@ -331,8 +339,10 @@ class TestPatchSettingsSensorValidation:
             json={"sensors": {"battery_soc": "sensor.battery_soc_percent"}},
         )
         assert resp.status_code == 200
-        assert mock_controller.ha_controller.sensors.get("battery_soc") == \
-            "sensor.battery_soc_percent"
+        assert (
+            mock_controller.ha_controller.sensors.get("battery_soc")
+            == "sensor.battery_soc_percent"
+        )
 
     def test_invalid_entity_id_returns_422(self, mock_controller):
         resp = _client.patch(
@@ -352,7 +362,10 @@ class TestPatchSettingsSensorValidation:
         """Empty strings clear intent — they must not overwrite configured sensors."""
         mock_controller.ha_controller.sensors = {"battery_soc": "sensor.existing"}
         _client.patch("/api/settings", json={"sensors": {"battery_soc": ""}})
-        assert mock_controller.ha_controller.sensors.get("battery_soc") == "sensor.existing"
+        assert (
+            mock_controller.ha_controller.sensors.get("battery_soc")
+            == "sensor.existing"
+        )
 
     def test_multiple_valid_sensors_all_stored(self, mock_controller):
         payload = {
@@ -363,8 +376,12 @@ class TestPatchSettingsSensorValidation:
         }
         resp = _client.patch("/api/settings", json=payload)
         assert resp.status_code == 200
-        assert mock_controller.ha_controller.sensors["battery_soc"] == "sensor.battery_soc"
-        assert mock_controller.ha_controller.sensors["grid_power"] == "sensor.grid_power"
+        assert (
+            mock_controller.ha_controller.sensors["battery_soc"] == "sensor.battery_soc"
+        )
+        assert (
+            mock_controller.ha_controller.sensors["grid_power"] == "sensor.grid_power"
+        )
 
 
 # ===========================================================================

--- a/backend/tests/test_settings_contracts.py
+++ b/backend/tests/test_settings_contracts.py
@@ -37,7 +37,6 @@ from api_conversion import (
 )
 from settings_store import SettingsStore
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -129,9 +128,9 @@ class TestBootstrapFieldConsistency:
             "Old field 'max_charge_discharge_power' still in battery settings. "
             "Startup would fail because _apply_settings requires max_charge_power_kw."
         )
-        assert "cycle_cost" not in battery or "cycle_cost_per_kwh" in battery, (
-            "Old field 'cycle_cost' present without new 'cycle_cost_per_kwh'."
-        )
+        assert (
+            "cycle_cost" not in battery or "cycle_cost_per_kwh" in battery
+        ), "Old field 'cycle_cost' present without new 'cycle_cost_per_kwh'."
 
     def test_no_old_field_names_in_home(self, tmp_path, monkeypatch):
         """Home store keys must use dataclass attribute names after bootstrap/migration."""
@@ -145,8 +144,12 @@ class TestBootstrapFieldConsistency:
             "Old field 'safety_margin_factor' still in home settings. "
             "Rename to 'safety_margin' to match HomeSettings attribute."
         )
-        assert "default_hourly" in home, "home.default_hourly missing from bootstrap defaults."
-        assert "safety_margin" in home, "home.safety_margin missing from bootstrap defaults."
+        assert (
+            "default_hourly" in home
+        ), "home.default_hourly missing from bootstrap defaults."
+        assert (
+            "safety_margin" in home
+        ), "home.safety_margin missing from bootstrap defaults."
 
 
 # ---------------------------------------------------------------------------
@@ -294,9 +297,7 @@ class TestNordpoolServiceContract:
         source = OfficialNordpoolSource(ha_controller, "test-config-entry-id", 1.25)
 
         # Patch time_utils so the date-range guard accepts our target_date.
-        with patch(
-            "core.bess.official_nordpool_source.time_utils"
-        ) as mock_time:
+        with patch("core.bess.official_nordpool_source.time_utils") as mock_time:
             mock_time.today.return_value = target_date
             source.get_prices_for_date(target_date)
 
@@ -314,9 +315,9 @@ class TestNordpoolServiceContract:
             "Service call must use field 'config_entry' — "
             "verify against HA's /api/services endpoint before changing"
         )
-        assert "config_entry_id" not in kwargs, (
-            "Field 'config_entry_id' causes a 400 — HA expects 'config_entry'"
-        )
+        assert (
+            "config_entry_id" not in kwargs
+        ), "Field 'config_entry_id' causes a 400 — HA expects 'config_entry'"
 
     def test_config_entry_value_passed_through(self):
         ha_controller = self._call_nordpool(date(2026, 4, 13))

--- a/backend/tests/test_settings_contracts.py
+++ b/backend/tests/test_settings_contracts.py
@@ -24,9 +24,8 @@ How to use when adding or renaming a settings field
 """
 
 import dataclasses
-import sys
 from datetime import date
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import settings_store as _sm
@@ -247,6 +246,7 @@ class TestApplySettings:
 class TestBatteryModelAttrsConsistency:
     def test_attrs_match_dataclass_init_fields(self):
         from api import _BATTERY_MODEL_ATTRS  # type: ignore[import]
+
         from core.bess.settings import BatterySettings
 
         expected = frozenset(

--- a/backend/tests/test_settings_store.py
+++ b/backend/tests/test_settings_store.py
@@ -260,9 +260,14 @@ class TestApplyDiscovered:
             sensor_map={"battery_soc": "sensor.corrected_by_discovery"},
         )
 
-        assert store.get_section("sensors")["battery_soc"] == "sensor.corrected_by_discovery"
+        assert (
+            store.get_section("sensors")["battery_soc"]
+            == "sensor.corrected_by_discovery"
+        )
 
-    def test_discovery_empty_does_not_overwrite_existing_sensor(self, tmp_path, monkeypatch):
+    def test_discovery_empty_does_not_overwrite_existing_sensor(
+        self, tmp_path, monkeypatch
+    ):
         """An empty discovered value leaves the existing sensor value intact."""
         _patch_path(tmp_path, monkeypatch)
         store = SettingsStore()
@@ -383,18 +388,22 @@ class TestSchemaMigration:
     def test_home_consumption_renamed_to_default_hourly(self, tmp_path, monkeypatch):
         """Old field 'consumption' must be renamed to 'default_hourly' on load."""
         store = self._store_with_data(
-            tmp_path, monkeypatch,
+            tmp_path,
+            monkeypatch,
             {"home": {"consumption": 4.5, "currency": "SEK"}},
         )
         home = store.get_section("home")
-        assert "default_hourly" in home, "Old 'consumption' not renamed to 'default_hourly'"
+        assert (
+            "default_hourly" in home
+        ), "Old 'consumption' not renamed to 'default_hourly'"
         assert home["default_hourly"] == 4.5
         assert "consumption" not in home
 
     def test_home_safety_margin_factor_renamed(self, tmp_path, monkeypatch):
         """Old field 'safety_margin_factor' must be renamed to 'safety_margin' on load."""
         store = self._store_with_data(
-            tmp_path, monkeypatch,
+            tmp_path,
+            monkeypatch,
             {"home": {"safety_margin_factor": 1.2, "currency": "SEK"}},
         )
         home = store.get_section("home")
@@ -405,7 +414,8 @@ class TestSchemaMigration:
     def test_battery_max_charge_discharge_power_split(self, tmp_path, monkeypatch):
         """Old single-power field must be split into charge and discharge variants."""
         store = self._store_with_data(
-            tmp_path, monkeypatch,
+            tmp_path,
+            monkeypatch,
             {"battery": {"max_charge_discharge_power": 10.0, "total_capacity": 30.0}},
         )
         battery = store.get_section("battery")
@@ -418,7 +428,8 @@ class TestSchemaMigration:
     def test_battery_cycle_cost_renamed(self, tmp_path, monkeypatch):
         """Old field 'cycle_cost' must be renamed to 'cycle_cost_per_kwh'."""
         store = self._store_with_data(
-            tmp_path, monkeypatch,
+            tmp_path,
+            monkeypatch,
             {"battery": {"cycle_cost": 0.8, "total_capacity": 30.0}},
         )
         battery = store.get_section("battery")
@@ -429,13 +440,21 @@ class TestSchemaMigration:
     def test_battery_missing_fields_get_defaults(self, tmp_path, monkeypatch):
         """Fields absent from an old store file are added with safe defaults."""
         store = self._store_with_data(
-            tmp_path, monkeypatch,
+            tmp_path,
+            monkeypatch,
             {"battery": {"total_capacity": 30.0}},
         )
         battery = store.get_section("battery")
-        for field in ("cycle_cost_per_kwh", "min_action_profit_threshold",
-                      "charging_power_rate", "efficiency_charge", "efficiency_discharge"):
-            assert field in battery, f"Expected default for '{field}' to be added by migration"
+        for field in (
+            "cycle_cost_per_kwh",
+            "min_action_profit_threshold",
+            "charging_power_rate",
+            "efficiency_charge",
+            "efficiency_discharge",
+        ):
+            assert (
+                field in battery
+            ), f"Expected default for '{field}' to be added by migration"
 
     def test_migration_persists_to_disk(self, tmp_path, monkeypatch):
         """Migrated field names must be written back to disk immediately."""
@@ -456,7 +475,8 @@ class TestSchemaMigration:
     def test_new_field_names_not_doubled(self, tmp_path, monkeypatch):
         """If a file already uses new field names, migration must not create duplicates."""
         store = self._store_with_data(
-            tmp_path, monkeypatch,
+            tmp_path,
+            monkeypatch,
             {
                 "battery": {
                     "max_charge_power_kw": 12.0,

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1485,9 +1485,9 @@ class BatterySystemManager:
             for i, period_data in enumerate(period_data_list):
                 target_period = optimization_period + i
                 if target_period < len(full_day_strategic_intents):
-                    full_day_strategic_intents[
-                        target_period
-                    ] = period_data.decision.strategic_intent
+                    full_day_strategic_intents[target_period] = (
+                        period_data.decision.strategic_intent
+                    )
 
             # Store initial SOE (kWh) in OptimizationResult for DailyViewBuilder.
             # _initial_soc_pct and _get_current_battery_soc() return SOC percent (0-100);

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -25,6 +25,7 @@ from .exceptions import (
 from .ha_api_controller import HomeAssistantAPIController
 from .health_check import run_system_health_checks
 from .historical_data_store import HistoricalDataStore
+from .influxdb_helper import get_power_sensor_data_batch
 from .min_schedule import GrowattScheduleManager
 from .models import (
     DecisionData,
@@ -33,7 +34,6 @@ from .models import (
     PeriodData,
     infer_intent_from_flows,
 )
-from .influxdb_helper import get_power_sensor_data_batch
 from .octopus_energy_source import OctopusEnergySource
 from .official_nordpool_source import OfficialNordpoolSource
 from .power_monitor import HomePowerMonitor
@@ -743,8 +743,7 @@ class BatterySystemManager:
         if not day_profiles:
             raise ValueError(
                 "influxdb_7d_avg strategy: no valid historical data found in InfluxDB "
-                "for the past 7 days of sensor '%s'"
-                % sensors_config.get("local_load_power", "")
+                f"for the past 7 days of sensor '{sensors_config.get('local_load_power', '')}'"
             )
 
         # Average across all valid days

--- a/core/bess/debug_data_exporter.py
+++ b/core/bess/debug_data_exporter.py
@@ -39,7 +39,7 @@ error). No full snapshot JSON is needed — the 5-field evolution table is enoug
 
 ## compact=True vs compact=False
 
-compact=True  — default; serves all three use cases; targets ~200–500 KB.
+compact=True  - default; serves all three use cases; targets ~200-500 KB.
 compact=False — raw full dump; complete log, all schedules, all snapshots as JSON;
                 use when a specific field not present in compact mode is needed.
 """

--- a/core/bess/debug_data_exporter.py
+++ b/core/bess/debug_data_exporter.py
@@ -369,7 +369,9 @@ class DebugDataAggregator:
                     if state:
                         snapshot[entity_id] = self._strip_ha_metadata(state)
                 except Exception as e:
-                    logger.warning("Failed to fetch nordpool entity %s: %s", entity_id, e)
+                    logger.warning(
+                        "Failed to fetch nordpool entity %s: %s", entity_id, e
+                    )
 
         elif provider == "octopus":
             octopus_cfg = config["octopus"]
@@ -386,11 +388,16 @@ class DebugDataAggregator:
                         if state:
                             snapshot[entity_id] = self._strip_ha_metadata(state)
                     except Exception as e:
-                        logger.warning("Failed to fetch octopus entity %s: %s", entity_id, e)
+                        logger.warning(
+                            "Failed to fetch octopus entity %s: %s", entity_id, e
+                        )
 
         elif provider != "nordpool_official":
             # nordpool_official uses service calls — no entity state to capture
-            logger.warning("Unknown energy provider '%s' — skipping provider entity snapshot", provider)
+            logger.warning(
+                "Unknown energy provider '%s' — skipping provider entity snapshot",
+                provider,
+            )
 
         logger.info("Entity snapshot captured: %d entities", len(snapshot))
         return snapshot

--- a/core/bess/debug_report_formatter.py
+++ b/core/bess/debug_report_formatter.py
@@ -185,9 +185,7 @@ class DebugReportFormatter:
             return summary + "\n\n*No entity states available*"
 
         if not export.compact:
-            return (
-                summary
-                + f"""
+            return summary + f"""
 
 <details>
 <summary>Raw HA entity states ({count} entities — click to expand)</summary>
@@ -197,7 +195,6 @@ class DebugReportFormatter:
 ```
 
 </details>"""
-            )
 
         # Compact: flattened key:value table for quick reading,
         # full JSON in collapsible for mock HA replay.
@@ -214,9 +211,7 @@ class DebugReportFormatter:
 
         flat_table = "\n".join(rows)
 
-        return (
-            summary
-            + f"""
+        return summary + f"""
 
 {flat_table}
 
@@ -228,7 +223,6 @@ class DebugReportFormatter:
 ```
 
 </details>"""
-        )
 
     def _format_inverter_tou(self, export: DebugDataExport) -> str:
         segments = export.inverter_tou_segments
@@ -241,14 +235,11 @@ class DebugReportFormatter:
         if count == 0:
             return summary + "\n\n*No TOU segments available*"
 
-        return (
-            summary
-            + f"""
+        return summary + f"""
 
 ```json
 {self._format_json(segments)}
 ```"""
-        )
 
     def _format_historical_data(self, export: DebugDataExport) -> str:
         """Format historical data section with summary.
@@ -383,11 +374,7 @@ class DebugReportFormatter:
 ```"""
 
         # Input metadata (scalars only, skip large arrays)
-        input_meta = {
-            k: v
-            for k, v in input_data.items()
-            if not isinstance(v, list)
-        }
+        input_meta = {k: v for k, v in input_data.items() if not isinstance(v, list)}
         if input_meta:
             econ_block += f"""
 
@@ -434,7 +421,11 @@ class DebugReportFormatter:
 
 </details>"""
 
-        return summary_text + f"\n\n{econ_block}\n\n### Period Decisions\n\n{table}" + details
+        return (
+            summary_text
+            + f"\n\n{econ_block}\n\n### Period Decisions\n\n{table}"
+            + details
+        )
 
     def _format_snapshots(self, export: DebugDataExport) -> str:
         """Format prediction snapshots section with summary.

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -350,8 +350,8 @@ class HomeAssistantAPIController:
     # (MIN, MID, MIC, MOD, MOC, NEO, etc.) via both official HA Core and HACS builds.
     ENTITY_SUFFIX_MAP: ClassVar[dict[str, str]] = {
         # SOC — two variants due to historical translation name correction
-        "state_of_charge_soc": "battery_soc",       # current name: "State of charge (SoC)"
-        "statement_of_charge_soc": "battery_soc",   # old name: "Statement of Charge SOC"
+        "state_of_charge_soc": "battery_soc",  # current name: "State of charge (SoC)"
+        "statement_of_charge_soc": "battery_soc",  # old name: "Statement of Charge SOC"
         # Real-time power sensors
         "battery_1_charging_w": "battery_charge_power",
         "battery_1_discharging_w": "battery_discharge_power",
@@ -361,7 +361,7 @@ class HomeAssistantAPIController:
         "internal_wattage": "pv_power",
         # Grid charge switch — two variants (old key-based vs translation-name-based slug)
         "charge_from_grid": "grid_charge",  # current name: "Charge from grid"
-        "ac_charge": "grid_charge",         # old name: key used directly as entity ID
+        "ac_charge": "grid_charge",  # old name: key used directly as entity ID
         # Number entities — names slugify to the same string as the key
         "battery_charge_power_limit": "battery_charging_power_rate",
         "battery_discharge_power_limit": "battery_discharging_power_rate",
@@ -416,7 +416,9 @@ class HomeAssistantAPIController:
         if sensor_key in self.sensors:
             entity_id = self.sensors[sensor_key]
             if not entity_id or not entity_id.strip():
-                raise ValueError(f"Empty entity ID configured for sensor '{sensor_key}'")
+                raise ValueError(
+                    f"Empty entity ID configured for sensor '{sensor_key}'"
+                )
             return entity_id, "configured"
 
         # Require explicit configuration for all operations
@@ -1639,7 +1641,10 @@ class HomeAssistantAPIController:
             entity_id = str(state.get("entity_id", ""))
             if not entity_id.startswith(("sensor.", "number.", "switch.")):
                 continue
-            if "_statement_of_charge" in entity_id or "_state_of_charge_soc" in entity_id:
+            if (
+                "_statement_of_charge" in entity_id
+                or "_state_of_charge_soc" in entity_id
+            ):
                 object_id = entity_id.split(".", 1)[1]
                 return object_id.split("_", 1)[0]
 

--- a/core/bess/health_check.py
+++ b/core/bess/health_check.py
@@ -405,9 +405,9 @@ def check_historical_data_access():
             config_check["status"] = "WARNING"
             config_check["value"] = f"URL: {config['url']}"
             config_check["formatted_value"] = f"URL: {config['url']}"
-            config_check[
-                "error"
-            ] = "InfluxDB credentials are still set to placeholder values — InfluxDB is not configured"
+            config_check["error"] = (
+                "InfluxDB credentials are still set to placeholder values — InfluxDB is not configured"
+            )
             logger.warning(
                 "InfluxDB credentials are still set to placeholder values — InfluxDB is not configured"
             )

--- a/core/bess/models.py
+++ b/core/bess/models.py
@@ -180,9 +180,7 @@ class EconomicData:
         0.0  # cost with solar only (no battery - algorithm baseline)
     )
     hourly_savings: float = 0.0  # savings vs baseline scenario
-    solar_savings: float = field(
-        default=0.0, init=False
-    )  # calculated automatically
+    solar_savings: float = field(default=0.0, init=False)  # calculated automatically
 
     def __post_init__(self):
         """Calculate derived economic fields."""
@@ -261,9 +259,7 @@ class EconomicSummary:
     solar_only_cost: float
     battery_solar_cost: float
     grid_to_solar_savings: float  # savings from solar vs grid-only
-    grid_to_battery_solar_savings: (
-        float  # savings from battery+solar vs grid-only
-    )
+    grid_to_battery_solar_savings: float  # savings from battery+solar vs grid-only
     solar_to_battery_solar_savings: float
     grid_to_battery_solar_savings_pct: float  # % - percentage savings vs grid-only
     total_charged: float

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -493,7 +493,11 @@ class PriceManager:
                 else:
                     sell_price = self._calculate_sell_price(price)
 
-                buy_price = price if self.price_source.prices_are_final else self._calculate_buy_price(price)
+                buy_price = (
+                    price
+                    if self.price_source.prices_are_final
+                    else self._calculate_buy_price(price)
+                )
 
                 price_entry = {
                     "timestamp": timestamp.strftime("%Y-%m-%d %H:%M"),

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -294,7 +294,7 @@ class HomeAssistantSource(PriceSource):
         """Handle DST transitions for quarterly resolution (92-100 periods).
 
         Nordpool provides quarterly prices (15-minute intervals):
-        - Normal day: 96 periods (24 hours × 4)
+        - Normal day: 96 periods (24 hours x 4)
         - DST spring (23h): 92 periods
         - DST fall (25h): 100 periods
 

--- a/core/bess/schedule_store.py
+++ b/core/bess/schedule_store.py
@@ -83,7 +83,7 @@ class ScheduleStore:
 
         # Create the stored schedule
         stored_schedule = StoredSchedule(
-            timestamp=datetime.now(),
+            timestamp=time_utils.now(),
             optimization_period=optimization_period,
             optimization_result=optimization_result,
         )

--- a/core/bess/schedule_store.py
+++ b/core/bess/schedule_store.py
@@ -159,9 +159,9 @@ class ScheduleStore:
             for i, period_data in enumerate(result.period_data):
                 target_period = opt_period + i
                 if target_period < 96:
-                    period_intents[
-                        target_period
-                    ] = period_data.decision.strategic_intent
+                    period_intents[target_period] = (
+                        period_data.decision.strategic_intent
+                    )
 
         # Store with date for validation on load
         data = {

--- a/core/bess/tests/debug_log_parser.py
+++ b/core/bess/tests/debug_log_parser.py
@@ -134,7 +134,11 @@ def parse_debug_log(path: str) -> DebugLogData:
             # The compact format emits economic_summary and input_meta JSON blocks
             # before the full schedule JSON (in a collapsible). Only accept a block
             # that has the "optimization_period" key, which identifies a real schedule.
-            if isinstance(parsed, list) and parsed and "optimization_period" in parsed[0]:
+            if (
+                isinstance(parsed, list)
+                and parsed
+                and "optimization_period" in parsed[0]
+            ):
                 result.last_schedule = parsed[0]
             elif isinstance(parsed, dict) and "optimization_period" in parsed:
                 result.last_schedule = parsed

--- a/core/bess/tests/helpers.py
+++ b/core/bess/tests/helpers.py
@@ -97,9 +97,9 @@ def get_intents_at_hours(result, hours: list[int]) -> dict[int, str]:
 def assert_intent_at_hour(result, hour: int, expected_intent: str) -> None:
     """Assert that the optimizer chose a specific intent at a given hour."""
     actual = result.period_data[hour].decision.strategic_intent
-    assert actual == expected_intent, (
-        f"Hour {hour}: expected {expected_intent}, got {actual}"
-    )
+    assert (
+        actual == expected_intent
+    ), f"Hour {hour}: expected {expected_intent}, got {actual}"
 
 
 def assert_intent_present(result, intent: str, min_count: int = 1) -> None:
@@ -116,9 +116,9 @@ def assert_intent_absent(result, intent: str) -> None:
     """Assert that a strategic intent does not appear at all."""
     dist = get_intent_distribution(result)
     actual = dist.get(intent, 0)
-    assert actual == 0, (
-        f"Expected zero {intent} periods, got {actual}. Distribution: {dist}"
-    )
+    assert (
+        actual == 0
+    ), f"Expected zero {intent} periods, got {actual}. Distribution: {dist}"
 
 
 def assert_physical_constraints(result, battery: dict) -> None:
@@ -134,11 +134,19 @@ def assert_physical_constraints(result, battery: dict) -> None:
         soe_start = pd.energy.battery_soe_start
         soe_end = pd.energy.battery_soe_end
 
-        assert battery["min_soe_kwh"] - tolerance <= soe_start <= battery["max_soe_kwh"] + tolerance, (
+        assert (
+            battery["min_soe_kwh"] - tolerance
+            <= soe_start
+            <= battery["max_soe_kwh"] + tolerance
+        ), (
             f"Period {pd.period}: SOE start {soe_start:.2f} outside "
             f"[{battery['min_soe_kwh']}, {battery['max_soe_kwh']}]"
         )
-        assert battery["min_soe_kwh"] - tolerance <= soe_end <= battery["max_soe_kwh"] + tolerance, (
+        assert (
+            battery["min_soe_kwh"] - tolerance
+            <= soe_end
+            <= battery["max_soe_kwh"] + tolerance
+        ), (
             f"Period {pd.period}: SOE end {soe_end:.2f} outside "
             f"[{battery['min_soe_kwh']}, {battery['max_soe_kwh']}]"
         )
@@ -147,13 +155,13 @@ def assert_physical_constraints(result, battery: dict) -> None:
         if action and abs(action) > 0.01:
             power_tolerance = 1e-10
             if action > 0:
-                assert action <= battery["max_charge_power_kw"] + power_tolerance, (
-                    f"Period {pd.period}: charge {action:.2f} kW > max {battery['max_charge_power_kw']} kW"
-                )
+                assert (
+                    action <= battery["max_charge_power_kw"] + power_tolerance
+                ), f"Period {pd.period}: charge {action:.2f} kW > max {battery['max_charge_power_kw']} kW"
             else:
-                assert abs(action) <= battery["max_discharge_power_kw"] + power_tolerance, (
-                    f"Period {pd.period}: discharge {abs(action):.2f} kW > max {battery['max_discharge_power_kw']} kW"
-                )
+                assert (
+                    abs(action) <= battery["max_discharge_power_kw"] + power_tolerance
+                ), f"Period {pd.period}: discharge {abs(action):.2f} kW > max {battery['max_discharge_power_kw']} kW"
 
 
 def assert_savings_positive(result) -> None:

--- a/core/bess/tests/helpers.py
+++ b/core/bess/tests/helpers.py
@@ -1,0 +1,166 @@
+"""Shared test utilities for battery optimization tests.
+
+Reduces boilerplate across test files by providing:
+- run_scenario(): one-liner to run optimization from a scenario dict
+- Behavioral assertion helpers for strategic intents and physical constraints
+"""
+
+from core.bess.dp_battery_algorithm import optimize_battery_schedule
+from core.bess.price_manager import MockSource, PriceManager
+from core.bess.settings import (
+    ADDITIONAL_COSTS,
+    MARKUP_RATE,
+    TAX_REDUCTION,
+    VAT_MULTIPLIER,
+    BatterySettings,
+)
+
+
+def run_scenario(scenario: dict):
+    """Run optimization from a scenario dict (same format as JSON test data files).
+
+    Returns the OptimizationResult from optimize_battery_schedule.
+    """
+    base_prices = scenario["base_prices"]
+    home_consumption = scenario["home_consumption"]
+    solar_production = scenario["solar_production"]
+    battery = scenario["battery"]
+    price_data = scenario.get("price_data")
+
+    battery_settings = BatterySettings(
+        total_capacity=battery["max_soe_kwh"],
+        min_soc=(battery["min_soe_kwh"] / battery["max_soe_kwh"]) * 100.0,
+        max_soc=100.0,
+        max_charge_power_kw=battery["max_charge_power_kw"],
+        max_discharge_power_kw=battery["max_discharge_power_kw"],
+        efficiency_charge=battery["efficiency_charge"],
+        efficiency_discharge=battery["efficiency_discharge"],
+        cycle_cost_per_kwh=battery["cycle_cost_per_kwh"],
+    )
+
+    if price_data:
+        markup_rate = price_data["markup_rate"]
+        vat_multiplier = price_data["vat_multiplier"]
+        additional_costs = price_data["additional_costs"]
+        tax_reduction = price_data["tax_reduction"]
+    else:
+        markup_rate = MARKUP_RATE
+        vat_multiplier = VAT_MULTIPLIER
+        additional_costs = ADDITIONAL_COSTS
+        tax_reduction = TAX_REDUCTION
+
+    price_manager = PriceManager(
+        MockSource(base_prices),
+        markup_rate=markup_rate,
+        vat_multiplier=vat_multiplier,
+        additional_costs=additional_costs,
+        tax_reduction=tax_reduction,
+        area="SE4",
+    )
+
+    buy_prices = price_manager.get_buy_prices(raw_prices=base_prices)
+    sell_prices = price_manager.get_sell_prices(raw_prices=base_prices)
+
+    period_duration_hours = 1.0
+
+    return optimize_battery_schedule(
+        buy_price=buy_prices,
+        sell_price=sell_prices,
+        home_consumption=home_consumption,
+        solar_production=solar_production,
+        initial_soe=battery["initial_soe"],
+        battery_settings=battery_settings,
+        period_duration_hours=period_duration_hours,
+    )
+
+
+def get_intent_distribution(result) -> dict[str, int]:
+    """Count how many periods have each strategic intent.
+
+    Returns e.g. {"GRID_CHARGING": 5, "IDLE": 15, "EXPORT_ARBITRAGE": 4}
+    """
+    counts: dict[str, int] = {}
+    for pd in result.period_data:
+        intent = pd.decision.strategic_intent
+        counts[intent] = counts.get(intent, 0) + 1
+    return counts
+
+
+def get_intents_at_hours(result, hours: list[int]) -> dict[int, str]:
+    """Get strategic intent at specific hours.
+
+    Returns e.g. {2: "GRID_CHARGING", 19: "EXPORT_ARBITRAGE"}
+    """
+    return {h: result.period_data[h].decision.strategic_intent for h in hours}
+
+
+def assert_intent_at_hour(result, hour: int, expected_intent: str) -> None:
+    """Assert that the optimizer chose a specific intent at a given hour."""
+    actual = result.period_data[hour].decision.strategic_intent
+    assert actual == expected_intent, (
+        f"Hour {hour}: expected {expected_intent}, got {actual}"
+    )
+
+
+def assert_intent_present(result, intent: str, min_count: int = 1) -> None:
+    """Assert that a strategic intent appears at least min_count times."""
+    dist = get_intent_distribution(result)
+    actual = dist.get(intent, 0)
+    assert actual >= min_count, (
+        f"Expected at least {min_count} periods with {intent}, "
+        f"got {actual}. Distribution: {dist}"
+    )
+
+
+def assert_intent_absent(result, intent: str) -> None:
+    """Assert that a strategic intent does not appear at all."""
+    dist = get_intent_distribution(result)
+    actual = dist.get(intent, 0)
+    assert actual == 0, (
+        f"Expected zero {intent} periods, got {actual}. Distribution: {dist}"
+    )
+
+
+def assert_physical_constraints(result, battery: dict) -> None:
+    """Assert all physical constraints hold across the optimization result.
+
+    Checks:
+    - SOE stays within [min_soe_kwh, max_soe_kwh]
+    - Charge/discharge power respects limits
+    """
+    tolerance = 1e-6
+
+    for pd in result.period_data:
+        soe_start = pd.energy.battery_soe_start
+        soe_end = pd.energy.battery_soe_end
+
+        assert battery["min_soe_kwh"] - tolerance <= soe_start <= battery["max_soe_kwh"] + tolerance, (
+            f"Period {pd.period}: SOE start {soe_start:.2f} outside "
+            f"[{battery['min_soe_kwh']}, {battery['max_soe_kwh']}]"
+        )
+        assert battery["min_soe_kwh"] - tolerance <= soe_end <= battery["max_soe_kwh"] + tolerance, (
+            f"Period {pd.period}: SOE end {soe_end:.2f} outside "
+            f"[{battery['min_soe_kwh']}, {battery['max_soe_kwh']}]"
+        )
+
+        action = pd.decision.battery_action
+        if action and abs(action) > 0.01:
+            power_tolerance = 1e-10
+            if action > 0:
+                assert action <= battery["max_charge_power_kw"] + power_tolerance, (
+                    f"Period {pd.period}: charge {action:.2f} kW > max {battery['max_charge_power_kw']} kW"
+                )
+            else:
+                assert abs(action) <= battery["max_discharge_power_kw"] + power_tolerance, (
+                    f"Period {pd.period}: discharge {abs(action):.2f} kW > max {battery['max_discharge_power_kw']} kW"
+                )
+
+
+def assert_savings_positive(result) -> None:
+    """Assert the optimization produces positive savings vs grid-only."""
+    savings = result.economic_summary.grid_to_battery_solar_savings
+    assert savings > 0, (
+        f"Expected positive savings, got {savings:.2f}. "
+        f"Grid-only: {result.economic_summary.grid_only_cost:.2f}, "
+        f"Optimized: {result.economic_summary.battery_solar_cost:.2f}"
+    )

--- a/core/bess/tests/integration/conftest.py
+++ b/core/bess/tests/integration/conftest.py
@@ -1,0 +1,9 @@
+"""Auto-mark all integration tests as slow (they run the full DP optimizer)."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "/integration/" in str(item.fspath):
+            item.add_marker(pytest.mark.slow)

--- a/core/bess/tests/integration/test_schedule_management.py
+++ b/core/bess/tests/integration/test_schedule_management.py
@@ -411,7 +411,9 @@ class TestChargeRateHardwareWrite:
         self, battery_system, mock_controller
     ):
         """SOLAR_STORAGE must write charge_rate=100 even when power monitor is off."""
-        assert battery_system._power_monitor is None, "Fixture must have no power monitor"
+        assert (
+            battery_system._power_monitor is None
+        ), "Fixture must have no power monitor"
 
         self._inject_intent(battery_system, "SOLAR_STORAGE", hour=12)
         mock_controller.calls["charge_rate"].clear()
@@ -420,12 +422,12 @@ class TestChargeRateHardwareWrite:
             mock_now.return_value.hour = 12
             battery_system._apply_period_schedule(48)  # period 48 = hour 12
 
-        assert mock_controller.calls["charge_rate"], (
-            "SOLAR_STORAGE must write charge_rate to inverter"
-        )
-        assert mock_controller.calls["charge_rate"][-1] == 100, (
-            f"SOLAR_STORAGE charge_rate must be 100, got {mock_controller.calls['charge_rate'][-1]}"
-        )
+        assert mock_controller.calls[
+            "charge_rate"
+        ], "SOLAR_STORAGE must write charge_rate to inverter"
+        assert (
+            mock_controller.calls["charge_rate"][-1] == 100
+        ), f"SOLAR_STORAGE charge_rate must be 100, got {mock_controller.calls['charge_rate'][-1]}"
 
     def test_grid_charging_writes_charge_rate_100_without_power_monitor(
         self, battery_system, mock_controller
@@ -440,16 +442,14 @@ class TestChargeRateHardwareWrite:
             mock_now.return_value.hour = 2
             battery_system._apply_period_schedule(8)  # period 8 = hour 2
 
-        assert mock_controller.calls["charge_rate"], (
-            "GRID_CHARGING must write charge_rate to inverter"
-        )
-        assert mock_controller.calls["charge_rate"][-1] == 100, (
-            f"GRID_CHARGING charge_rate must be 100, got {mock_controller.calls['charge_rate'][-1]}"
-        )
+        assert mock_controller.calls[
+            "charge_rate"
+        ], "GRID_CHARGING must write charge_rate to inverter"
+        assert (
+            mock_controller.calls["charge_rate"][-1] == 100
+        ), f"GRID_CHARGING charge_rate must be 100, got {mock_controller.calls['charge_rate'][-1]}"
 
-    def test_load_support_writes_charge_rate_0(
-        self, battery_system, mock_controller
-    ):
+    def test_load_support_writes_charge_rate_0(self, battery_system, mock_controller):
         """LOAD_SUPPORT must write charge_rate=0 (discharge-only mode)."""
         assert battery_system._power_monitor is None
 
@@ -460,12 +460,12 @@ class TestChargeRateHardwareWrite:
             mock_now.return_value.hour = 19
             battery_system._apply_period_schedule(76)  # period 76 = hour 19
 
-        assert mock_controller.calls["charge_rate"], (
-            "LOAD_SUPPORT must write charge_rate to inverter"
-        )
-        assert mock_controller.calls["charge_rate"][-1] == 0, (
-            f"LOAD_SUPPORT charge_rate must be 0, got {mock_controller.calls['charge_rate'][-1]}"
-        )
+        assert mock_controller.calls[
+            "charge_rate"
+        ], "LOAD_SUPPORT must write charge_rate to inverter"
+        assert (
+            mock_controller.calls["charge_rate"][-1] == 0
+        ), f"LOAD_SUPPORT charge_rate must be 0, got {mock_controller.calls['charge_rate'][-1]}"
 
     def test_stale_zero_overwritten_when_solar_storage_follows_load_support(
         self, battery_system, mock_controller
@@ -495,9 +495,9 @@ class TestChargeRateHardwareWrite:
             mock_now.return_value.hour = 12
             battery_system._apply_period_schedule(48)
 
-        assert mock_controller.calls["charge_rate"], (
-            "SOLAR_STORAGE must write charge_rate after LOAD_SUPPORT"
-        )
+        assert mock_controller.calls[
+            "charge_rate"
+        ], "SOLAR_STORAGE must write charge_rate after LOAD_SUPPORT"
         assert mock_controller.calls["charge_rate"][-1] == 100, (
             "SOLAR_STORAGE must reset charge_rate to 100 — stale 0 from "
             f"LOAD_SUPPORT was not overwritten: {mock_controller.calls['charge_rate']}"

--- a/core/bess/tests/unit/data/historical_2024_08_16_high_spread_no_solar.json
+++ b/core/bess/tests/unit/data/historical_2024_08_16_high_spread_no_solar.json
@@ -96,5 +96,15 @@
     "base_to_battery_solar_savings_pct": 23.4,
     "total_charged": 44.8,
     "total_discharged": 44.8
+  },
+  "expected_behavior": {
+    "description": "High price spread without solar: should grid-charge at night lows and discharge during evening peaks",
+    "intents_present": ["GRID_CHARGING", "LOAD_SUPPORT"],
+    "intents_absent": ["SOLAR_STORAGE"],
+    "savings_positive": true,
+    "constraints": {
+      "soe_within_bounds": true,
+      "power_within_limits": true
+    }
   }
 }

--- a/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
+++ b/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
@@ -97,5 +97,15 @@
     "base_to_battery_solar_savings_pct": 108.5,
     "total_charged": 12.8,
     "total_discharged": 26.0
+  },
+  "expected_behavior": {
+    "description": "High solar day: should store solar and export arbitrage during peak hours, no grid charging needed",
+    "intents_present": ["SOLAR_STORAGE", "EXPORT_ARBITRAGE"],
+    "intents_absent": ["GRID_CHARGING"],
+    "savings_positive": true,
+    "constraints": {
+      "soe_within_bounds": true,
+      "power_within_limits": true
+    }
   }
 }

--- a/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
+++ b/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
@@ -102,5 +102,17 @@
     "base_to_battery_solar_savings_pct": 162.0,
     "total_charged": 49.0,
     "total_discharged": 44.4
+  },
+  "expected_behavior": {
+    "description": "Negative prices: should aggressively grid-charge during negative-price hours and export during positive peaks",
+    "intents_present": [
+      "GRID_CHARGING",
+      "EXPORT_ARBITRAGE"
+    ],
+    "savings_positive": true,
+    "constraints": {
+      "soe_within_bounds": true,
+      "power_within_limits": true
+    }
   }
 }

--- a/core/bess/tests/unit/test_action_threshold.py
+++ b/core/bess/tests/unit/test_action_threshold.py
@@ -7,6 +7,8 @@ while preserving high-profit opportunities.
 
 import pytest  # type: ignore
 
+pytestmark = pytest.mark.slow
+
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
 

--- a/core/bess/tests/unit/test_action_threshold.py
+++ b/core/bess/tests/unit/test_action_threshold.py
@@ -7,10 +7,10 @@ while preserving high-profit opportunities.
 
 import pytest  # type: ignore
 
-pytestmark = pytest.mark.slow
-
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
+
+pytestmark = pytest.mark.slow
 
 
 class TestActionThreshold:

--- a/core/bess/tests/unit/test_discharge_inhibit.py
+++ b/core/bess/tests/unit/test_discharge_inhibit.py
@@ -9,11 +9,11 @@ from types import SimpleNamespace
 
 import pytest
 
-pytestmark = pytest.mark.slow
-
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.price_manager import MockSource
 from core.bess.tests.conftest import MockHomeAssistantController
+
+pytestmark = pytest.mark.slow
 
 
 class InhibitableController(MockHomeAssistantController):

--- a/core/bess/tests/unit/test_discharge_inhibit.py
+++ b/core/bess/tests/unit/test_discharge_inhibit.py
@@ -9,6 +9,8 @@ from types import SimpleNamespace
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.price_manager import MockSource
 from core.bess.tests.conftest import MockHomeAssistantController

--- a/core/bess/tests/unit/test_discovery_hints.py
+++ b/core/bess/tests/unit/test_discovery_hints.py
@@ -6,7 +6,6 @@ Tests cover:
 - Phase count derivation in the discover endpoint (tested at the controller level)
 """
 
-
 from core.bess.ha_api_controller import HomeAssistantAPIController
 
 # ---------------------------------------------------------------------------

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.exceptions import PriceDataUnavailableError
 from core.bess.price_manager import MockSource

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -1,10 +1,11 @@
 """Tests for extended DP optimization horizon with tomorrow's price data."""
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from unittest.mock import patch
 
 import pytest
 
+from core.bess import time_utils
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.exceptions import PriceDataUnavailableError
 from core.bess.price_manager import MockSource
@@ -18,7 +19,7 @@ class TodayOnlyMockSource(MockSource):
     """Mock source that only returns prices for today, raises for tomorrow."""
 
     def get_prices_for_date(self, target_date: date) -> list:
-        if target_date > datetime.now().date():
+        if target_date > time_utils.today():
             raise PriceDataUnavailableError(
                 message="Tomorrow's prices not yet available"
             )
@@ -83,7 +84,7 @@ class TestGetPriceDataExtended:
 
         prices, _price_entries = system._get_price_data(prepare_next_day=False)
 
-        expected = get_period_count(datetime.now().date())
+        expected = get_period_count(time_utils.today())
         assert prices is not None
         assert _price_entries is not None
         assert len(prices) == expected
@@ -96,7 +97,7 @@ class TestGetPriceDataExtended:
 
         prices, _price_entries = system._get_price_data(prepare_next_day=True)
 
-        tomorrow = datetime.now().date() + timedelta(days=1)
+        tomorrow = time_utils.today() + timedelta(days=1)
         expected = get_period_count(tomorrow)
         assert prices is not None
         # prepare_next_day fetches only tomorrow's prices, no extension
@@ -288,9 +289,7 @@ class TestScheduleTruncation:
         dp_schedule, _growatt_manager = schedule_result
 
         # Verify all schedule arrays are bounded to today
-        from core.bess.time_utils import TIMEZONE
-
-        today_count = get_period_count(datetime.now(tz=TIMEZONE).date())
+        today_count = get_period_count(time_utils.today())
         assert len(dp_schedule.actions) <= today_count
         assert len(dp_schedule.state_of_energy) <= today_count
         assert len(dp_schedule.prices) <= today_count

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -5,13 +5,13 @@ from unittest.mock import patch
 
 import pytest
 
-pytestmark = pytest.mark.slow
-
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.exceptions import PriceDataUnavailableError
 from core.bess.price_manager import MockSource
 from core.bess.tests.conftest import MockHomeAssistantController, MockSensorCollector
 from core.bess.time_utils import get_period_count
+
+pytestmark = pytest.mark.slow
 
 
 class TodayOnlyMockSource(MockSource):

--- a/core/bess/tests/unit/test_growatt_tou_scheduling.py
+++ b/core/bess/tests/unit/test_growatt_tou_scheduling.py
@@ -912,9 +912,7 @@ class TestHardwareWriteRespectsSlotLimit:
             len(controller.calls) <= 9
         ), f"Wrote {len(controller.calls)} segments, exceeds hardware limit of 9"
 
-    def test_segment_ids_remain_in_range_after_earlier_segments_expire(
-        self, scheduler
-    ):
+    def test_segment_ids_remain_in_range_after_earlier_segments_expire(self, scheduler):
         """Mid-day rebuild (some segments expired) must still produce ids 1..9.
 
         Regression for the case where _select_hardware_intervals previously
@@ -980,9 +978,7 @@ class TestSlotAssignmentPreservesActiveSegments:
     """
 
     def _content_set(self, segments) -> set[tuple]:
-        return {
-            (s["start_time"], s["end_time"], s["batt_mode"]) for s in segments
-        }
+        return {(s["start_time"], s["end_time"], s["batt_mode"]) for s in segments}
 
     def test_promoted_pending_segment_does_not_evict_still_needed_segments(
         self, scheduler

--- a/core/bess/tests/unit/test_idle_solar_charging.py
+++ b/core/bess/tests/unit/test_idle_solar_charging.py
@@ -13,6 +13,10 @@ and then scheduled GRID_CHARGING later.
 
 import logging
 
+import pytest
+
+pytestmark = pytest.mark.slow
+
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
 

--- a/core/bess/tests/unit/test_idle_solar_charging.py
+++ b/core/bess/tests/unit/test_idle_solar_charging.py
@@ -15,10 +15,10 @@ import logging
 
 import pytest
 
-pytestmark = pytest.mark.slow
-
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
+
+pytestmark = pytest.mark.slow
 
 logger = logging.getLogger(__name__)
 

--- a/core/bess/tests/unit/test_octopus_energy_source.py
+++ b/core/bess/tests/unit/test_octopus_energy_source.py
@@ -95,7 +95,7 @@ class TestImportRateFetching:
     """Test fetching import rates from Octopus Energy entities."""
 
     def test_fetch_today_import_rates(self):
-        today = datetime.now().date()
+        today = time_utils.today()
         rates = _make_rates(today)
         controller = _make_ha_controller(rates)
         source = _make_source(controller)
@@ -111,7 +111,7 @@ class TestImportRateFetching:
         assert prices[95] == rates[47]["value_inc_vat"]
 
     def test_fetch_tomorrow_import_rates(self):
-        tomorrow = datetime.now().date() + timedelta(days=1)
+        tomorrow = time_utils.today() + timedelta(days=1)
         expected_quarterly = time_utils.get_period_count(tomorrow)
         expected_raw = expected_quarterly // 2
         rates = _make_rates(tomorrow, count=expected_raw)
@@ -123,7 +123,7 @@ class TestImportRateFetching:
         assert len(prices) == expected_quarterly
 
     def test_rejects_date_beyond_tomorrow(self):
-        day_after = datetime.now().date() + timedelta(days=2)
+        day_after = time_utils.today() + timedelta(days=2)
         controller = MagicMock()
         source = _make_source(controller)
 
@@ -132,7 +132,7 @@ class TestImportRateFetching:
 
     def test_too_few_rates_raises_error(self):
         """Rates below minimum threshold should fail validation."""
-        today = datetime.now().date()
+        today = time_utils.today()
         rates = _make_rates(today, count=20)  # Well below minimum of 46
         controller = _make_ha_controller(rates)
         source = _make_source(controller)
@@ -142,7 +142,7 @@ class TestImportRateFetching:
 
     def test_partial_rates_accepted(self):
         """46-47 rates should be accepted (Octopus publishes incrementally)."""
-        today = datetime.now().date()
+        today = time_utils.today()
         for count in (46, 47):
             rates = _make_rates(today, count=count)
             controller = _make_ha_controller(rates)
@@ -154,7 +154,7 @@ class TestImportRateFetching:
 
     def test_too_many_rates_raises_error(self):
         """More rates than expected for a single date should fail validation."""
-        today = datetime.now().date()
+        today = time_utils.today()
         expected_raw = time_utils.get_period_count(today) // 2
         rates = _make_rates(today, count=expected_raw)
         # Add duplicate rates that also fall on today to exceed expected_raw
@@ -174,7 +174,7 @@ class TestImportRateFetching:
             source.get_prices_for_date(today)
 
     def test_no_rates_attribute_raises_error(self):
-        today = datetime.now().date()
+        today = time_utils.today()
         controller = MagicMock()
         controller._api_request = MagicMock(
             return_value={"attributes": {"no_rates_key": []}}
@@ -185,7 +185,7 @@ class TestImportRateFetching:
             source.get_prices_for_date(today)
 
     def test_api_failure_raises_error(self):
-        today = datetime.now().date()
+        today = time_utils.today()
         controller = MagicMock()
         controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
         source = _make_source(controller)
@@ -198,7 +198,7 @@ class TestExportRateFetching:
     """Test fetching export/sell rates from Octopus Energy entities."""
 
     def test_fetch_export_rates(self):
-        today = datetime.now().date()
+        today = time_utils.today()
         import_rates = _make_rates(today)
         export_rates = _make_rates(today, export=True)
         controller = _make_ha_controller(import_rates, export_rates)
@@ -213,7 +213,7 @@ class TestExportRateFetching:
         assert sell_prices[1] == export_rates[0]["value_inc_vat"]
 
     def test_no_export_entity_returns_none(self):
-        today = datetime.now().date()
+        today = time_utils.today()
         controller = MagicMock()
         source = OctopusEnergySource(
             ha_controller=controller,
@@ -227,7 +227,7 @@ class TestExportRateFetching:
 
     def test_export_failure_returns_none(self):
         """Export rate failure should return None, not raise."""
-        today = datetime.now().date()
+        today = time_utils.today()
         controller = MagicMock()
         controller._api_request = MagicMock(side_effect=ConnectionError("timeout"))
         source = _make_source(controller)
@@ -237,7 +237,7 @@ class TestExportRateFetching:
     def test_default_get_sell_prices_for_date_returns_none(self):
         """Base PriceSource returns None for sell prices."""
         mock = MockSource([1.0])
-        assert mock.get_sell_prices_for_date(datetime.now().date()) is None
+        assert mock.get_sell_prices_for_date(time_utils.today()) is None
 
 
 class TestDateFilteringAndSorting:
@@ -245,7 +245,7 @@ class TestDateFilteringAndSorting:
 
     def test_filters_rates_by_date(self):
         """Only rates matching the target date should be included."""
-        today = datetime.now().date()
+        today = time_utils.today()
         tomorrow = today + timedelta(days=1)
 
         # Mix rates from today and tomorrow
@@ -261,7 +261,7 @@ class TestDateFilteringAndSorting:
 
     def test_sorts_rates_chronologically(self):
         """Rates should be sorted by start time regardless of input order."""
-        today = datetime.now().date()
+        today = time_utils.today()
         rates = _make_rates(today)
         # Reverse the order
         rates.reverse()
@@ -280,7 +280,7 @@ class TestHealthCheck:
     """Test health check functionality."""
 
     def test_healthy_source(self):
-        today = datetime.now().date()
+        today = time_utils.today()
         import_rates = _make_rates(today)
         export_rates = _make_rates(today, export=True)
         controller = _make_ha_controller(import_rates, export_rates)
@@ -309,7 +309,7 @@ class TestPriceManagerIntegration:
 
     def test_price_manager_uses_direct_sell_prices(self):
         """When source provides sell prices, PriceManager should use them directly."""
-        today = datetime.now().date()
+        today = time_utils.today()
         import_rates = _make_rates(today)
         export_rates = _make_rates(today, export=True)
         controller = _make_ha_controller(import_rates, export_rates)
@@ -335,7 +335,7 @@ class TestPriceManagerIntegration:
 
     def test_price_manager_timestamps_use_quarter_hour_spacing(self):
         """Timestamps should be 15 minutes apart (quarterly resolution)."""
-        today = datetime.now().date()
+        today = time_utils.today()
         rates = _make_rates(today)
         controller = _make_ha_controller(rates)
         source = _make_source(controller)
@@ -359,7 +359,7 @@ class TestPriceManagerIntegration:
 
     def test_price_manager_fallback_sell_without_export(self):
         """Without export entity, sell price should use calculated formula."""
-        today = datetime.now().date()
+        today = time_utils.today()
         rates = _make_rates(today)
         controller = _make_ha_controller(rates)
 

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -7,6 +7,10 @@ core functions produce outputs with the expected structure and reasonable values
 but don't test specific optimization results.
 """
 
+import pytest
+
+pytestmark = pytest.mark.slow
+
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.models import EconomicSummary, PeriodData
 from core.bess.settings import BatterySettings

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -9,11 +9,11 @@ but don't test specific optimization results.
 
 import pytest
 
-pytestmark = pytest.mark.slow
-
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.models import EconomicSummary, PeriodData
 from core.bess.settings import BatterySettings
+
+pytestmark = pytest.mark.slow
 
 # Create a BatterySettings instance for testing
 battery_settings = BatterySettings()

--- a/core/bess/tests/unit/test_price_manager.py
+++ b/core/bess/tests/unit/test_price_manager.py
@@ -2,9 +2,10 @@
 Test the PriceManager implementation.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from core.bess import time_utils
 from core.bess.price_manager import HomeAssistantSource, MockSource, PriceManager
 
 
@@ -39,7 +40,7 @@ def test_controller_price_fetching():
     """Test price fetching from controller."""
     mock_controller = MagicMock()
 
-    today_date = datetime.now().date()
+    today_date = time_utils.today()
     tomorrow_date = today_date + timedelta(days=1)
 
     # Create 96 quarterly periods of test data (Nordpool provides quarterly)
@@ -150,7 +151,7 @@ def test_home_assistant_source_vat_parameter():
     """Test that the VAT multiplier parameter in HomeAssistantSource works correctly."""
     mock_controller = MagicMock()
 
-    today_date = datetime.now().date()
+    today_date = time_utils.today()
 
     # Create test data with 96 quarterly periods, all with price value of 2.0
     raw_today_data = []

--- a/core/bess/tests/unit/test_quarterly_vs_hourly.py
+++ b/core/bess/tests/unit/test_quarterly_vs_hourly.py
@@ -9,10 +9,10 @@ the lower resolution version.
 
 import pytest
 
-pytestmark = pytest.mark.slow
-
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
+
+pytestmark = pytest.mark.slow
 
 
 def average_to_hourly(quarterly_prices: list[float]) -> list[float]:

--- a/core/bess/tests/unit/test_quarterly_vs_hourly.py
+++ b/core/bess/tests/unit/test_quarterly_vs_hourly.py
@@ -7,6 +7,10 @@ to verify that the higher resolution optimization is at least as good as
 the lower resolution version.
 """
 
+import pytest
+
+pytestmark = pytest.mark.slow
+
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
 

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -30,6 +30,13 @@ from core.bess.settings import (
     VAT_MULTIPLIER,
     BatterySettings,
 )
+from core.bess.tests.helpers import (
+    assert_intent_absent,
+    assert_intent_present,
+    assert_physical_constraints,
+    assert_savings_positive,
+    get_intent_distribution,
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -232,3 +239,25 @@ def test_all_scenarios(scenario_name):
                 assert (
                     abs(battery_action) <= battery["max_discharge_power_kw"] + tolerance
                 ), f"Battery discharging action {abs(battery_action):.2f} kW exceeds max discharge power {battery['max_discharge_power_kw']} kW"
+
+    # ── Behavioral assertions (from expected_behavior in scenario JSON) ──
+    if "expected_behavior" in scenario:
+        behavior = scenario["expected_behavior"]
+        dist = get_intent_distribution(result)
+        logger.info(f"Intent distribution: {dist}")
+
+        for intent in behavior.get("intents_present", []):
+            assert_intent_present(result, intent)
+
+        for intent in behavior.get("intents_absent", []):
+            assert_intent_absent(result, intent)
+
+        if behavior.get("savings_positive"):
+            assert_savings_positive(result)
+
+        if behavior.get("constraints", {}).get("soe_within_bounds"):
+            assert_physical_constraints(result, battery)
+    else:
+        logger.info(
+            f"No expected_behavior for scenario {scenario_name}, skipping behavioral validation"
+        )

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -8,6 +8,10 @@ produce reasonable outputs.
 
 import json
 import logging
+
+import pytest
+
+pytestmark = pytest.mark.slow
 import os
 from pathlib import Path
 

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -8,14 +8,10 @@ produce reasonable outputs.
 
 import json
 import logging
-
-import pytest
-
-pytestmark = pytest.mark.slow
 import os
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest
 
 from core.bess.dp_battery_algorithm import (
     optimize_battery_schedule,
@@ -37,6 +33,8 @@ from core.bess.tests.helpers import (
     assert_savings_positive,
     get_intent_distribution,
 )
+
+pytestmark = pytest.mark.slow
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"

--- a/core/bess/tests/unit/test_terminal_value.py
+++ b/core/bess/tests/unit/test_terminal_value.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
 

--- a/core/bess/tests/unit/test_terminal_value.py
+++ b/core/bess/tests/unit/test_terminal_value.py
@@ -2,10 +2,10 @@
 
 import pytest
 
-pytestmark = pytest.mark.slow
-
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
+
+pytestmark = pytest.mark.slow
 
 
 @pytest.fixture

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,54 @@
+# CI-friendly docker-compose for E2E tests.
+# No volume mounts, no live reload — builds everything into the image.
+#
+# Usage:
+#   SCENARIO=ci-normal-day docker compose -f docker-compose.ci.yml up -d
+#   # Wait for http://localhost:8080/api/system-health to respond
+#   # Run Playwright tests
+#   docker compose -f docker-compose.ci.yml down
+
+services:
+  bess:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile.dev
+    environment:
+      - HA_URL=http://mock-ha:8123
+      - HA_TOKEN=mock_token
+      - HA_TEST_MODE=false
+      - TZ=Europe/Stockholm
+      - PYTHONPATH=/app/backend:/app
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./backend:/app/backend:ro
+      - ./core:/app/core:ro
+      - ./frontend/dist:/app/frontend:ro
+      - ./e2e/ci-options.json:/data/options.json:ro
+      - ./e2e/ci-bess-settings.json:/data/bess_settings.json
+    command: ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
+    depends_on:
+      mock-ha:
+        condition: service_healthy
+    networks:
+      - ci-network
+
+  mock-ha:
+    build: ./scripts/mock_ha
+    environment:
+      - SCENARIO=${SCENARIO:-ci-normal-day}
+    ports:
+      - "8123:8123"
+    volumes:
+      - ./scripts/mock_ha/scenarios:/scenarios:ro
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8123/mock/sensors')"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks:
+      - ci-network
+
+networks:
+  ci-network:
+    driver: bridge

--- a/docs/TEST_FRAMEWORK_PLAN.md
+++ b/docs/TEST_FRAMEWORK_PLAN.md
@@ -1,0 +1,496 @@
+# Test Framework Overhaul Plan
+
+> **Status**: Phase 1 — complete
+> **Branch strategy**: Each phase is a separate branch merged to `main` before starting the next.
+
+## Why
+
+The BESS Manager has 34 pytest files but zero frontend tests, no E2E tests,
+no CI test execution, and no automated deployment verification. The quality
+gate (`quality-check.sh`) only checks linting/formatting — not pytest. The
+automated GitHub agent pipeline (issue → fix → PR) can merge broken code.
+
+Deployment to HA is fully manual: `deploy.sh` + clicking through the UI.
+
+**Goal**: Fully automated testing pipeline with high confidence that merged
+code works end-to-end, enabling the agent pipeline to operate autonomously.
+
+---
+
+## Current Assets
+
+| Asset | Location | What it provides |
+|-------|----------|-----------------|
+| 34 pytest files | `core/bess/tests/`, `backend/tests/` | Algorithm, pricing, settings, API coverage |
+| Mock HA server | `scripts/mock_ha/server.py` | Replays frozen scenarios, records inverter writes |
+| Docker compose mock | `docker-compose.mock.yml` | Full BESS stack against mock HA, no real HA needed |
+| Scenario generator | `scripts/mock_ha/scenarios/from_debug_log.py` | Creates reproducible scenarios from user debug logs |
+| `mock-run.sh` | Project root | Orchestrates mock environment (FAKETIME, config extraction) |
+| `quality-check.sh` | `scripts/` | Black, Ruff, ESLint, TypeScript type-check |
+
+## Current Gaps
+
+1. `quality-check.sh` does not run pytest or frontend tests
+2. No CI workflow runs any tests — PRs can merge with failures
+3. Frontend has zero test infrastructure (no Vitest, no Playwright)
+4. Scenario tests only assert economic values, not behavioral (strategic intents)
+5. Mock HA is only used manually via `mock-run.sh`, never in CI
+6. Deployment to real HA is fully manual with no smoke tests
+
+---
+
+## Architecture Options
+
+### Option A: CI Quality Gate (chosen as Phase 1–2)
+
+Run pytest + frontend unit tests in CI on every PR. Cheapest path to
+catching regressions. Does not verify full-stack behavior.
+
+### Option B: Full-Stack E2E with Playwright (chosen as Phase 3–4)
+
+Playwright tests running against docker-compose mock HA. Closes the
+"click through UI" gap. The existing mock HA infrastructure is the
+foundation — Playwright just drives a browser against it.
+
+### Option C: Deployment Verification (Phase 5, evaluate after B is stable)
+
+Automated deployment to real HA with smoke tests. Maximum confidence but
+significant infrastructure cost. Two sub-options:
+
+- **C1**: Self-hosted GitHub Actions runner on HA network, deploys via SMB
+- **C2**: Push to GHCR, HA Supervisor API pulls staging tag, CI verifies
+
+**Recommendation**: Implement A → B incrementally. Evaluate C once B is stable
+and you have data on what mock HA E2E catches vs. misses.
+
+---
+
+## Phase 1: CI Quality Gate
+
+**Goal**: Pytest and linting run in CI on every PR. Block merges on failure.
+
+### 1.1 CI workflow with path-based test avoidance
+
+Created `.github/workflows/ci.yml` with four parallel jobs:
+
+- **changes** — uses `dorny/paths-filter` to detect which areas changed
+- **test-fast** — runs `pytest -m "not slow"` (281 tests, ~3s) — only if `core/` or `backend/` changed
+- **test-algorithm** — runs `pytest -m slow` (116 tests, ~30min) — only if `core/bess/` changed
+- **test-frontend** — TypeScript type-check + ESLint — only if `frontend/` changed
+- **quality** — Black + Ruff formatting/linting (always runs)
+
+Frontend-only changes skip all Python tests. Backend API changes skip the
+expensive DP algorithm tests.
+
+### 1.2 Fast/slow test split via pytest markers
+
+Added `pytest.mark.slow` to all test files that run the full DP optimizer:
+
+- **Unit tests** (8 files): `test_scenarios.py`, `test_optimization_algorithm.py`,
+  `test_terminal_value.py`, `test_idle_solar_charging.py`, `test_quarterly_vs_hourly.py`,
+  `test_action_threshold.py`, `test_extended_horizon.py`, `test_discharge_inhibit.py`
+- **Integration tests** (all): auto-marked via `integration/conftest.py`
+
+Result: `pytest -m "not slow"` runs 281 tests in ~3s.
+Full suite: 397 tests (116 slow).
+
+### 1.3 Updated quality-check.sh
+
+Runs fast tests only (`-m "not slow"`) so the issue-fix bot completes quickly.
+Full algorithm tests run in a separate CI job when `core/bess/` changes.
+
+### 1.4 Dev dependencies
+
+Updated `requirements-dev.txt` with: pytest, pytest-cov, httpx, black, ruff.
+Added `[tool.pytest.ini_options]` to `pyproject.toml` with testpaths and markers.
+
+### 1.5 Branch protection
+
+Enable branch protection on `main` requiring the CI jobs to pass.
+
+### Files modified
+- `.github/workflows/ci.yml` (new)
+- `scripts/quality-check.sh` (add pytest step)
+- `requirements-dev.txt` (proper test deps)
+- `pyproject.toml` (pytest config + markers)
+- `core/bess/tests/integration/conftest.py` (new — auto-mark slow)
+- 8 unit test files (added `pytestmark = pytest.mark.slow`)
+
+### Done
+- [x] CI runs fast tests (~3s) on every PR
+- [x] Algorithm tests only run when `core/bess/` changes
+- [x] Frontend checks only run when `frontend/` changes
+- [x] `quality-check.sh` runs fast tests (benefits issue-fix bot)
+- [ ] Branch protection configured on `main` (manual step)
+
+---
+
+## Phase 2: Frontend Unit Tests
+
+**Goal**: Add Vitest + React Testing Library. Test critical hooks and API layer.
+
+### 2.1 Add test infrastructure
+
+```bash
+cd frontend
+npm install -D vitest @testing-library/react @testing-library/jest-dom jsdom
+```
+
+Update `frontend/package.json`:
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  }
+}
+```
+
+Add `frontend/vitest.config.ts`:
+```ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+  },
+})
+```
+
+### 2.2 Write priority tests
+
+Target the highest-value areas first:
+
+| Test file | What it covers | Why it matters |
+|-----------|---------------|----------------|
+| `src/lib/__tests__/api.test.ts` | Axios client, base URL detection, ingress path handling | Every page depends on this |
+| `src/hooks/__tests__/useSettings.test.ts` | Settings fetch, update, error states | Settings page + setup wizard |
+| `src/hooks/__tests__/useDashboardData.test.ts` | Dashboard data fetching, resolution switching | Main page |
+| `src/pages/__tests__/SetupWizardPage.test.tsx` | Discover → confirm → complete flow | Critical onboarding path |
+
+### 2.3 Add to CI and quality gate
+
+Extend `ci.yml`:
+```yaml
+      - run: cd frontend && npm ci && npm test
+```
+
+Extend `quality-check.sh`:
+```bash
+echo "🔸 Running frontend tests..."
+if npm test; then
+    echo "✅ Frontend tests passed"
+else
+    echo "❌ Frontend tests failed"
+    ERRORS=$((ERRORS + 1))
+fi
+```
+
+### Files modified
+- `frontend/package.json` (add test deps + script)
+- `frontend/vitest.config.ts` (new)
+- `frontend/src/test/setup.ts` (new — test environment setup)
+- `frontend/src/lib/__tests__/api.test.ts` (new)
+- `frontend/src/hooks/__tests__/useSettings.test.ts` (new)
+- `frontend/src/hooks/__tests__/useDashboardData.test.ts` (new)
+- `frontend/src/pages/__tests__/SetupWizardPage.test.tsx` (new)
+- `.github/workflows/ci.yml` (add frontend test step)
+- `scripts/quality-check.sh` (add npm test step)
+
+### Done when
+- [ ] `npm test` runs and passes in `frontend/`
+- [ ] CI runs frontend tests alongside pytest
+- [ ] At least 4 test files covering API layer, hooks, and setup wizard
+
+---
+
+## Phase 3: Playwright E2E Against Mock HA
+
+**Goal**: Browser tests verifying the full stack (frontend → backend → mock HA).
+
+### 3.1 Commit representative scenarios
+
+Select 2–3 scenarios from debug logs and commit them:
+
+```
+scripts/mock_ha/scenarios/
+  ci-normal-day.json        — typical day with solar + price spread
+  ci-high-volatility.json   — extreme price swings, tests discharge logic
+  ci-setup-wizard.json      — fresh install, no sensors configured
+```
+
+These are frozen snapshots — deterministic inputs for repeatable tests.
+
+### 3.2 Add docker-compose.ci.yml
+
+CI-friendly overlay (no volume mounts, no live reload):
+
+```yaml
+services:
+  bess-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - HA_URL=http://mock-ha:8123
+      - HA_TOKEN=mock_token
+      - HA_TEST_MODE=false
+    ports:
+      - "8080:8080"
+    depends_on:
+      mock-ha:
+        condition: service_healthy
+
+  mock-ha:
+    build: ./scripts/mock_ha
+    environment:
+      - SCENARIO=${SCENARIO:-ci-normal-day}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8123/mock/sensors"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "8123:8123"
+```
+
+### 3.3 Install Playwright
+
+```bash
+# From project root (not frontend — e2e tests are a separate concern)
+mkdir e2e
+cd e2e
+npm init -y
+npm install -D @playwright/test
+npx playwright install chromium
+```
+
+### 3.4 Playwright test structure
+
+```
+e2e/
+  package.json
+  playwright.config.ts
+  tests/
+    dashboard.spec.ts          — dashboard loads, charts render, resolution toggle
+    settings.spec.ts           — change settings, verify persistence across reload
+    setup-wizard.spec.ts       — discover → confirm → complete flow
+    inverter-commands.spec.ts  — wait for optimization cycle, verify /mock/service_log
+    api-smoke.spec.ts          — hit all 24 API endpoints, verify 200 + response shape
+    navigation.spec.ts         — all 7 routes load without error
+```
+
+**Key pattern — inverter command verification:**
+```ts
+test('optimization cycle sends TOU segments to inverter', async ({ request }) => {
+  // Wait for BESS to complete one cycle (poll /api/dashboard until schedule exists)
+  // Then verify mock HA received the expected service calls
+  const log = await request.get('http://localhost:8123/mock/service_log');
+  const calls = await log.json();
+  expect(calls).toContainEqual(
+    expect.objectContaining({ service: 'set_tou_segments' })
+  );
+});
+```
+
+### 3.5 Add E2E job to CI
+
+```yaml
+  e2e:
+    runs-on: ubuntu-latest
+    needs: test  # only run if unit tests pass
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: cd e2e && npm ci && npx playwright install chromium --with-deps
+      - run: cd frontend && npm ci && npm run build
+      - run: |
+          docker compose -f docker-compose.ci.yml up -d
+          # Wait for BESS to be ready
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/api/system-health; do sleep 2; done'
+      - run: cd e2e && npx playwright test
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+      - run: docker compose -f docker-compose.ci.yml down
+        if: always()
+```
+
+### Files modified
+- `scripts/mock_ha/scenarios/ci-*.json` (new — committed scenario files)
+- `docker-compose.ci.yml` (new)
+- `e2e/` (new directory — package.json, playwright.config.ts, tests/)
+- `.github/workflows/ci.yml` (add e2e job)
+- `scripts/mock_ha/server.py` (possibly add health endpoint)
+
+### Done when
+- [ ] `docker compose -f docker-compose.ci.yml up` starts BESS + mock HA deterministically
+- [ ] Playwright tests pass locally against the mock environment
+- [ ] CI runs E2E after unit tests pass, uploads report on failure
+- [ ] At least 5 E2E test files covering dashboard, settings, setup, inverter, API
+
+---
+
+## Phase 4: Enhanced Scenario Testing
+
+**Goal**: Extend pytest scenario framework with behavioral assertions.
+
+### 4.1 Extend scenario JSON schema
+
+Current `expected_results` only has economic fields. Add:
+
+```json
+{
+  "expected_results": {
+    "base_cost": 12.5,
+    "savings_pct": 15.0,
+    "strategic_intents": {
+      "hour_2": "CHARGE",
+      "hour_14": "SOLAR_STORAGE",
+      "hour_20": "EXPORT_ARBITRAGE"
+    },
+    "constraints": {
+      "no_overlapping_intervals": true,
+      "soc_never_below_min": true,
+      "soc_never_above_max": true
+    }
+  }
+}
+```
+
+### 4.2 Update test_scenarios.py
+
+Add assertion helpers that check:
+- Strategic intent at specified hours matches expected
+- Physical constraints are never violated
+- Inverter schedule has no overlapping intervals
+- SOC trajectory stays within bounds
+
+### 4.3 Add shared test fixtures
+
+Create `core/bess/tests/helpers.py` with:
+- `run_optimization(prices, solar, consumption, battery_settings)` — one-liner to run the full optimizer
+- `assert_strategic_intent(result, hour, expected_intent)` — behavioral assertion
+- `assert_physical_constraints(result)` — constraint validation
+
+### Files modified
+- `core/bess/tests/unit/test_scenarios.py` (extend assertion logic)
+- `core/bess/tests/unit/data/*.json` (add behavioral expected_results)
+- `core/bess/tests/helpers.py` (new — shared test utilities)
+- `core/bess/tests/conftest.py` (expose helpers as fixtures)
+
+### Done when
+- [ ] Scenario JSON files include strategic intent assertions
+- [ ] `test_scenarios.py` validates both economic and behavioral expectations
+- [ ] Physical constraint checks run on every scenario
+- [ ] Standalone tests (`test_idle_solar_charging.py`, etc.) migrated to use shared helpers
+
+---
+
+## Phase 5: Deployment Verification (evaluate after Phase 4)
+
+**Goal**: Automated deployment to real HA with smoke tests. Only pursue if
+mock HA E2E (Phase 3) proves insufficient.
+
+### 5.1 Decision criteria
+
+Proceed with Phase 5 if any of these are true:
+- Bugs slip through that mock HA E2E would not catch (HA ingress issues, supervisor lifecycle, real sensor failures)
+- The agent pipeline produces PRs that pass all tests but break in real HA
+- You want zero-touch releases (merge → deploy → verify → done)
+
+### 5.2 Option C1: Self-hosted runner
+
+```
+Real HA (192.168.x.x)
+  ├── GitHub Actions self-hosted runner
+  ├── SMB share at /Volumes/addons/bess_manager
+  └── HA Supervisor API at :8123
+
+CI pipeline:
+  unit-tests → e2e-mock → deploy-verify (self-hosted runner only)
+    → package-addon.sh
+    → rsync to SMB (like deploy.sh)
+    → curl HA Supervisor API to restart add-on
+    → wait for /api/health to return 200
+    → run HTTP smoke tests against real HA ingress
+    → report pass/fail
+```
+
+Infrastructure needed:
+- Self-hosted runner on HA network (can be the HA box itself or a Pi)
+- GitHub secrets: `HA_URL`, `HA_TOKEN`, `SMB_PATH`
+- New endpoint: `GET /api/health` returning `{ version, uptime, last_cycle }`
+
+### 5.3 Option C2: Container registry
+
+```
+CI pipeline:
+  unit-tests → e2e-mock → build-push → deploy-verify
+    → docker build + push to ghcr.io/johanzander/bess-manager:staging
+    → curl HA Supervisor API: update add-on to staging tag
+    → wait for add-on healthy
+    → run smoke tests
+```
+
+Infrastructure needed:
+- GHCR repository + push token
+- HA configured to pull from GHCR (custom repository URL)
+- GitHub secrets: `HA_URL`, `HA_TOKEN`, `GHCR_TOKEN`
+
+### 5.4 Smoke test suite
+
+```python
+# tests/smoke/test_ha_deployment.py
+def test_addon_starts():
+    r = requests.get(f"{HA_URL}/api/health")
+    assert r.status_code == 200
+    assert r.json()["version"] == expected_version
+
+def test_sensors_readable():
+    r = requests.get(f"{HA_URL}/api/dashboard")
+    assert r.status_code == 200
+    assert r.json()["summary"] is not None
+
+def test_optimization_cycle_completes():
+    # Wait up to 120s for a cycle
+    r = requests.get(f"{HA_URL}/api/system-health")
+    assert r.json()["scheduler"]["last_run"] is not None
+```
+
+### 5.5 Safety
+
+- Only run deploy-verify on merges to `main`, not on every PR
+- Add rollback: if smoke tests fail, redeploy previous version from git tag
+- Consider a dedicated staging HA instance to avoid disrupting production
+
+### Files modified (when pursued)
+- `backend/api.py` (add `/api/health` endpoint)
+- `.github/workflows/ci.yml` (add deploy-verify job)
+- `tests/smoke/` (new — deployment smoke tests)
+- Self-hosted runner setup or GHCR configuration
+
+---
+
+## Verification Checklist (end state)
+
+After all phases, the test pipeline should look like:
+
+```
+PR opened
+  → CI: pytest (34+ files)              [Phase 1]
+  → CI: frontend vitest (10+ files)      [Phase 2]
+  → CI: Playwright E2E vs mock HA        [Phase 3]
+  → CI: behavioral scenario assertions   [Phase 4]
+  → (on merge) deploy to HA + smoke test [Phase 5]
+```
+
+The agent pipeline (issue → analyze → fix → PR) runs `quality-check.sh`
+which includes pytest + frontend tests, and CI blocks merge if E2E fails.
+No human intervention needed for routine fixes.

--- a/docs/TEST_FRAMEWORK_PLAN.md
+++ b/docs/TEST_FRAMEWORK_PLAN.md
@@ -1,6 +1,6 @@
 # Test Framework Overhaul Plan
 
-> **Status**: Phase 1 — complete
+> **Status**: Phase 4 — complete
 > **Branch strategy**: Each phase is a separate branch merged to `main` before starting the next.
 
 ## Why

--- a/e2e/ci-bess-settings.json
+++ b/e2e/ci-bess-settings.json
@@ -1,0 +1,46 @@
+{
+  "home": {
+    "default_hourly": 1.5,
+    "currency": "SEK",
+    "max_fuse_current": 25,
+    "voltage": 230,
+    "safety_margin": 1.0,
+    "phase_count": 3,
+    "consumption_strategy": "fixed",
+    "power_monitoring_enabled": false
+  },
+  "battery": {
+    "total_capacity": 10.0,
+    "min_soc": 10,
+    "max_soc": 100,
+    "max_charge_power_kw": 5.0,
+    "max_discharge_power_kw": 5.0,
+    "cycle_cost_per_kwh": 0.4,
+    "min_action_profit_threshold": 0.0
+  },
+  "electricity_price": {
+    "area": "SE4",
+    "markup_rate": 0.08,
+    "vat_multiplier": 1.25,
+    "additional_costs": 1.03,
+    "tax_reduction": 0.0
+  },
+  "energy_provider": "nordpool",
+  "growatt": {
+    "config_entry_id": "mock_config_entry"
+  },
+  "sensors": {
+    "battery_soc": "sensor.growatt_battery_soc",
+    "battery_charge_power": "sensor.growatt_battery_charge_power",
+    "battery_discharge_power": "sensor.growatt_battery_discharge_power",
+    "import_power": "sensor.growatt_import_power",
+    "export_power": "sensor.growatt_export_power",
+    "pv_power": "sensor.growatt_pv_power",
+    "local_load_power": "sensor.growatt_load_power",
+    "battery_charging_power_rate": "number.growatt_battery_charging_power_rate",
+    "battery_discharging_power_rate": "number.growatt_battery_discharging_power_rate",
+    "battery_charge_stop_soc": "number.growatt_battery_charge_stop_soc",
+    "battery_discharge_stop_soc": "number.growatt_battery_discharge_stop_soc",
+    "grid_charge": "switch.growatt_grid_charge"
+  }
+}

--- a/e2e/ci-options.json
+++ b/e2e/ci-options.json
@@ -1,0 +1,52 @@
+{
+  "battery": {
+    "total_capacity": 10.0,
+    "min_soc": 10,
+    "max_soc": 100,
+    "max_charge_power_kw": 5.0,
+    "max_discharge_power_kw": 5.0,
+    "cycle_cost_per_kwh": 0.4,
+    "min_action_profit_threshold": 0.0
+  },
+  "electricity_price": {
+    "area": "SE4",
+    "markup_rate": 0.08,
+    "vat_multiplier": 1.25,
+    "additional_costs": 1.03,
+    "tax_reduction": 0.0
+  },
+  "home": {
+    "default_hourly": 1.5,
+    "currency": "SEK",
+    "max_fuse_current": 25,
+    "voltage": 230,
+    "safety_margin": 1.0,
+    "phase_count": 3,
+    "consumption_strategy": "fixed",
+    "power_monitoring_enabled": false
+  },
+  "energy_provider": "nordpool",
+  "growatt": {
+    "config_entry_id": "mock_config_entry"
+  },
+  "sensors": {
+    "battery_soc": "sensor.growatt_battery_soc",
+    "battery_charge_power": "sensor.growatt_battery_charge_power",
+    "battery_discharge_power": "sensor.growatt_battery_discharge_power",
+    "import_power": "sensor.growatt_import_power",
+    "export_power": "sensor.growatt_export_power",
+    "pv_power": "sensor.growatt_pv_power",
+    "local_load_power": "sensor.growatt_load_power",
+    "battery_charging_power_rate": "number.growatt_battery_charging_power_rate",
+    "battery_discharging_power_rate": "number.growatt_battery_discharging_power_rate",
+    "battery_charge_stop_soc": "number.growatt_battery_charge_stop_soc",
+    "battery_discharge_stop_soc": "number.growatt_battery_discharge_stop_soc",
+    "grid_charge": "switch.growatt_grid_charge"
+  },
+  "influxdb": {
+    "url": "http://nonexistent:8086/api/v2/query",
+    "bucket": "homeassistant/autogen",
+    "username": "mock",
+    "password": "mock"
+  }
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  retries: 1,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/e2e/tests/api-smoke.spec.ts
+++ b/e2e/tests/api-smoke.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('API Smoke Tests', () => {
+  test('GET /api/settings returns 200', async ({ request }) => {
+    const res = await request.get('/api/settings');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('battery');
+  });
+
+  test('GET /api/dashboard returns 200', async ({ request }) => {
+    const res = await request.get('/api/dashboard');
+    expect(res.status()).toBe(200);
+  });
+
+  test('GET /api/system-health returns 200', async ({ request }) => {
+    const res = await request.get('/api/system-health');
+    expect(res.status()).toBe(200);
+  });
+
+  test('GET /api/setup/status returns 200', async ({ request }) => {
+    const res = await request.get('/api/setup/status');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('wizardNeeded');
+  });
+
+  test('GET /api/runtime-failures returns 200', async ({ request }) => {
+    const res = await request.get('/api/runtime-failures');
+    expect(res.status()).toBe(200);
+  });
+
+  test('GET /api/growatt/inverter_status returns 200', async ({ request }) => {
+    const res = await request.get('/api/growatt/inverter_status');
+    expect(res.status()).toBe(200);
+  });
+
+  test('GET /api/decision-intelligence returns 200', async ({ request }) => {
+    const res = await request.get('/api/decision-intelligence');
+    expect(res.status()).toBe(200);
+  });
+});

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard', () => {
+  test('dashboard page loads and shows content', async ({ page }) => {
+    await page.goto('/');
+
+    // Should not show loading spinner indefinitely
+    await expect(page.getByText('Loading settings...')).not.toBeVisible({ timeout: 15_000 });
+
+    // Should show the BESS header
+    await expect(page.locator('h1')).toContainText('BESS');
+
+    // Should not show error boundary
+    await expect(page.getByText('Something went wrong')).not.toBeVisible();
+  });
+
+  test('dashboard does not show setup wizard redirect when configured', async ({ page }) => {
+    await page.goto('/');
+    // With a properly configured scenario, we should stay on dashboard, not redirect to /setup
+    await page.waitForTimeout(2000);
+    expect(page.url()).not.toContain('/setup');
+  });
+});

--- a/e2e/tests/mock-ha.spec.ts
+++ b/e2e/tests/mock-ha.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_HA = 'http://localhost:8123';
+
+test.describe('Mock HA Integration', () => {
+  test('mock HA serves sensor data', async ({ request }) => {
+    const res = await request.get(`${MOCK_HA}/mock/sensors`);
+    expect(res.status()).toBe(200);
+    const sensors = await res.json();
+    expect(sensors).toHaveProperty('sensor.growatt_battery_soc');
+  });
+
+  test('mock HA service log is accessible', async ({ request }) => {
+    const res = await request.get(`${MOCK_HA}/mock/service_log`);
+    expect(res.status()).toBe(200);
+    const log = await res.json();
+    expect(Array.isArray(log)).toBe(true);
+  });
+
+  test('mock HA returns timezone config', async ({ request }) => {
+    const res = await request.get(`${MOCK_HA}/api/config`);
+    expect(res.status()).toBe(200);
+    const config = await res.json();
+    expect(config.time_zone).toBe('Europe/Stockholm');
+  });
+
+  test('BESS reads sensors from mock HA', async ({ request }) => {
+    // Verify BESS can reach mock HA by checking that settings loaded
+    const res = await request.get('/api/settings');
+    expect(res.status()).toBe(200);
+    const settings = await res.json();
+    // If sensors are configured, BESS successfully connected to mock HA
+    expect(settings.battery).toBeTruthy();
+  });
+});

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test('app loads with BESS header', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('h1')).toContainText('BESS');
+  });
+
+  test('navigation links are visible', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('link', { name: /Dashboard/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Savings/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Inverter/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Insights/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Settings/i })).toBeVisible();
+  });
+
+  test('can navigate to each page without errors', async ({ page }) => {
+    const routes = [
+      { name: /Savings/i, url: '/savings' },
+      { name: /Inverter/i, url: '/inverter' },
+      { name: /Insights/i, url: '/insights' },
+      { name: /Settings/i, url: '/settings' },
+      { name: /Dashboard/i, url: '/' },
+    ];
+
+    await page.goto('/');
+
+    for (const route of routes) {
+      await page.getByRole('link', { name: route.name }).click();
+      await expect(page).toHaveURL(route.url);
+      // Verify no error boundary triggered
+      await expect(page.getByText('Something went wrong')).not.toBeVisible();
+    }
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,9 @@
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@shadcn/ui": "^0.0.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^22.10.10",
         "@types/react": "^18.3.24",
@@ -50,8 +53,17 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^15.14.0",
-        "prettier": "^3.8.1"
+        "jsdom": "^29.1.1",
+        "prettier": "^3.8.1",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -64,6 +76,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -353,6 +416,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -971,6 +1187,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2206,6 +2440,13 @@
         "ui": "dist/index.js"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
@@ -2217,6 +2458,104 @@
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2257,6 +2596,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -2320,6 +2670,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2673,6 +3030,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2779,6 +3249,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -2919,6 +3399,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3025,6 +3515,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3216,6 +3716,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
@@ -3405,6 +3915,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3554,6 +4085,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3635,6 +4180,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -3706,6 +4258,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -3736,6 +4298,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3778,6 +4348,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -3893,6 +4476,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4335,6 +4925,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4373,6 +4973,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4962,6 +5572,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/human-signals": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
@@ -5028,6 +5651,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -5337,6 +5970,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5591,6 +6231,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5793,6 +6484,27 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5801,6 +6513,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5863,6 +6582,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-svg-data-uri": {
@@ -6149,6 +6878,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -6276,6 +7016,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6322,6 +7075,13 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6557,6 +7317,55 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -6900,6 +7709,20 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6942,6 +7765,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -7168,6 +8001,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -7339,6 +8185,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -7361,6 +8214,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
@@ -7609,6 +8476,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7677,6 +8557,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.2.0",
@@ -7787,6 +8674,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7832,6 +8736,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7842,6 +8776,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7990,6 +8950,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8223,6 +9193,122 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -8241,6 +9327,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8347,6 +9468,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8447,6 +9585,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
@@ -47,6 +48,9 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@shadcn/ui": "^0.0.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.10.10",
     "@types/react": "^18.3.24",
@@ -59,6 +63,8 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^15.14.0",
-    "prettier": "^3.8.1"
+    "jsdom": "^29.1.1",
+    "prettier": "^3.8.1",
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,10 @@
     "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
-    "generate-api": "openapi-typescript-codegen --config api-config.json"
+    "generate-api": "openapi-typescript-codegen --config api-config.json",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix"
   },
   "keywords": [],
   "author": "",

--- a/frontend/src/components/BatteryLevelChart.tsx
+++ b/frontend/src/components/BatteryLevelChart.tsx
@@ -102,7 +102,7 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
   });
 
   // Zero anchor at x=0: gives stepBefore a left edge so bars render from 0→1 for period 0
-  chartData.unshift({ hour: 0, periodNum: -1, batterySocPercent: chartData[0]?.batterySocPercent ?? 0, action: 0, charging: 0, discharging: 0, price: chartData[0]?.price ?? 0, dataSource: 'actual', isActual: true, isPredicted: false, isTomorrow: false });
+  chartData.unshift({ hour: 0, periodNum: -1, hourLabel: '', batterySocPercent: chartData[0]?.batterySocPercent ?? 0, action: 0, charging: 0, discharging: 0, price: chartData[0]?.price ?? 0, dataSource: 'actual', isActual: true, isPredicted: false, isTomorrow: false, batterySocEndFormatted: chartData[0]?.batterySocEndFormatted, batteryActionFormatted: chartData[0]?.batteryActionFormatted, buyPriceFormatted: chartData[0]?.buyPriceFormatted });
 
   // Append tomorrow's data with hour offset 24+
   const hasTomorrowData = tomorrowData && tomorrowData.length > 0;

--- a/frontend/src/components/EnergyFlowCards.tsx
+++ b/frontend/src/components/EnergyFlowCards.tsx
@@ -49,7 +49,7 @@ const colorClasses = {
   purple: 'text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-900/20'
 };
 
-const EnergyFlowCard: React.FC<{ card: EnergyFlowCard }> = ({ card }) => {
+const EnergyFlowCardView: React.FC<{ card: EnergyFlowCard }> = ({ card }) => {
   const IconComponent = card.icon;
   
   return (
@@ -360,7 +360,7 @@ const EnergyFlowCards: React.FC<EnergyFlowCardsProps> = ({ className = "" }) => 
   return (
     <div className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 ${className}`}>
       {cards.map((card, index) => (
-        <EnergyFlowCard key={index} card={card} />
+        <EnergyFlowCardView key={index} card={card} />
       ))}
     </div>
   );

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -431,7 +431,7 @@ const InverterStatusDashboard: React.FC = () => {
   // Merge dashboard data with schedule data to get correct strategic intents
   const getMergedHourData = (hour: number) => {
     const scheduleHour = growattSchedule?.scheduleData?.find(h => h.hour === hour);
-    const dashboardHour = dashboardData?.hourlyData?.find(h => h.period === hour);
+    const dashboardHour = dashboardData?.hourlyData?.find(h => h.hour === hour);
 
     if (!scheduleHour && !dashboardHour) return null;
     
@@ -571,7 +571,7 @@ const InverterStatusDashboard: React.FC = () => {
           metrics={[
             {
               label: "State of Energy",
-              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batterySoeEnd),
+              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batterySoeEnd),
               unit: "",
               icon: Battery
             },
@@ -591,7 +591,7 @@ const InverterStatusDashboard: React.FC = () => {
             },
             {
               label: "Solar Production",
-              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.solarProduction),
+              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.solarProduction),
               unit: "",
               icon: Sun
             }
@@ -621,16 +621,16 @@ const InverterStatusDashboard: React.FC = () => {
             },
             {
               label: "Battery Action",
-              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batteryAction),
+              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batteryAction),
               unit: "",
-              icon: getValue(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batteryAction) && Math.abs(getValue(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batteryAction)) > 0.01 ?
-                (getValue(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batteryAction) > 0 ? TrendingUp : TrendingDown) : Zap,
-              color: getValue(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batteryAction) && Math.abs(getValue(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batteryAction)) > 0.01 ?
-                (getValue(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batteryAction) > 0 ? 'green' : 'yellow') : undefined
+              icon: getValue(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batteryAction) && Math.abs(getValue(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batteryAction)) > 0.01 ?
+                (getValue(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batteryAction) > 0 ? TrendingUp : TrendingDown) : Zap,
+              color: getValue(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batteryAction) && Math.abs(getValue(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batteryAction)) > 0.01 ?
+                (getValue(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batteryAction) > 0 ? 'green' : 'yellow') : undefined
             },
             {
               label: "Target SOC",
-              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.period === new Date().getHours())?.batterySocEnd),
+              value: getDisplayText(dashboardData?.hourlyData?.find(h => h.hour === new Date().getHours())?.batterySocEnd),
               unit: "",
               icon: CheckCircle
             }

--- a/frontend/src/hooks/__tests__/useDashboardData.test.ts
+++ b/frontend/src/hooks/__tests__/useDashboardData.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useDashboardData } from '../useDashboardData'
+
+vi.mock('../../api/scheduleApi', () => ({
+  fetchDashboardData: vi.fn(),
+}))
+
+import { fetchDashboardData } from '../../api/scheduleApi'
+
+const mockFetch = vi.mocked(fetchDashboardData)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+const fakeDashboard = {
+  summary: { totalSavings: 12.5 },
+  periods: [{ hour: 0, period: 0 }],
+}
+
+describe('useDashboardData', () => {
+  it('fetches data on mount with default resolution', async () => {
+    mockFetch.mockResolvedValueOnce(fakeDashboard)
+
+    const { result } = renderHook(() => useDashboardData())
+
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(undefined, 'quarter-hourly')
+    expect(result.current.data).toEqual(fakeDashboard)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('passes date and resolution params', async () => {
+    mockFetch.mockResolvedValueOnce(fakeDashboard)
+
+    const { result } = renderHook(() => useDashboardData('2026-05-01', 'hourly'))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith('2026-05-01', 'hourly')
+  })
+
+  it('sets error on fetch failure', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Server down'))
+
+    const { result } = renderHook(() => useDashboardData())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Server down')
+    expect(result.current.data).toBeNull()
+  })
+
+  it('refetch triggers a new fetch', async () => {
+    mockFetch.mockResolvedValueOnce(fakeDashboard)
+
+    const { result } = renderHook(() => useDashboardData())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    mockFetch.mockResolvedValueOnce({ ...fakeDashboard, summary: { totalSavings: 20 } })
+
+    act(() => {
+      result.current.refetch()
+    })
+
+    await waitFor(() => {
+      expect(result.current.data?.summary?.totalSavings).toBe(20)
+    })
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/hooks/__tests__/useSettings.test.ts
+++ b/frontend/src/hooks/__tests__/useSettings.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useSettings } from '../useSettings'
+
+vi.mock('../../lib/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+import api from '../../lib/api'
+
+const mockGet = vi.mocked(api.get)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useSettings', () => {
+  it('fetches settings on mount', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        battery: { capacity: 10, minSoc: 10, maxSoc: 90 },
+        electricityPrice: { provider: 'nordpool', currency: 'SEK' },
+      },
+    })
+
+    const { result } = renderHook(() => useSettings())
+
+    expect(result.current.isLoading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(mockGet).toHaveBeenCalledWith('/api/settings')
+    expect(result.current.batterySettings).toEqual({
+      capacity: 10,
+      minSoc: 10,
+      maxSoc: 90,
+    })
+    expect(result.current.electricitySettings).toEqual({
+      provider: 'nordpool',
+      currency: 'SEK',
+    })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('handles missing battery settings', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        electricityPrice: { provider: 'octopus' },
+      },
+    })
+
+    const { result } = renderHook(() => useSettings())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.batterySettings).toBeNull()
+    expect(result.current.electricitySettings).toEqual({ provider: 'octopus' })
+  })
+
+  it('sets error on fetch failure', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Network error'))
+
+    const { result } = renderHook(() => useSettings())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Network error')
+    expect(result.current.batterySettings).toBeNull()
+  })
+})

--- a/frontend/src/hooks/__tests__/useUserPreferences.test.ts
+++ b/frontend/src/hooks/__tests__/useUserPreferences.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useUserPreferences } from '../useUserPreferences'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('useUserPreferences', () => {
+  it('returns default preferences when localStorage is empty', () => {
+    const { result } = renderHook(() => useUserPreferences())
+
+    expect(result.current.dataResolution).toBe('quarter-hourly')
+  })
+
+  it('reads stored preferences from localStorage', () => {
+    localStorage.setItem(
+      'bess_user_preferences',
+      JSON.stringify({ dataResolution: 'hourly' })
+    )
+
+    const { result } = renderHook(() => useUserPreferences())
+
+    expect(result.current.dataResolution).toBe('hourly')
+  })
+
+  it('falls back to defaults on invalid JSON', () => {
+    localStorage.setItem('bess_user_preferences', 'not-json')
+
+    const { result } = renderHook(() => useUserPreferences())
+
+    expect(result.current.dataResolution).toBe('quarter-hourly')
+  })
+
+  it('setDataResolution updates state and localStorage', () => {
+    const { result } = renderHook(() => useUserPreferences())
+
+    act(() => {
+      result.current.setDataResolution('hourly')
+    })
+
+    expect(result.current.dataResolution).toBe('hourly')
+    expect(JSON.parse(localStorage.getItem('bess_user_preferences')!)).toEqual({
+      dataResolution: 'hourly',
+    })
+  })
+
+  it('setPreferences merges partial updates', () => {
+    const { result } = renderHook(() => useUserPreferences())
+
+    act(() => {
+      result.current.setPreferences({ dataResolution: 'hourly' })
+    })
+
+    expect(result.current.preferences).toEqual({ dataResolution: 'hourly' })
+  })
+})

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock window.location before importing api module
+const mockPathname = vi.fn(() => '/')
+
+beforeEach(() => {
+  vi.resetModules()
+  mockPathname.mockReturnValue('/')
+})
+
+describe('getBaseUrl', () => {
+  it('returns empty string for non-ingress paths', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/' },
+      writable: true,
+    })
+
+    const { default: api } = await import('../api')
+    expect(api.defaults.baseURL).toBe('')
+  })
+
+  it('detects Home Assistant ingress path', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/api/hassio_ingress/abc123def/settings' },
+      writable: true,
+    })
+
+    const { default: api } = await import('../api')
+    expect(api.defaults.baseURL).toBe('/api/hassio_ingress/abc123def')
+  })
+
+  it('handles ingress root path', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/api/hassio_ingress/token456/' },
+      writable: true,
+    })
+
+    const { default: api } = await import('../api')
+    expect(api.defaults.baseURL).toBe('/api/hassio_ingress/token456')
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/frontend/src/types/lucide-react.d.ts
+++ b/frontend/src/types/lucide-react.d.ts
@@ -38,4 +38,5 @@ declare module 'lucide-react' {
   export const Info: FC<IconProps>;
   export const Eye: FC<IconProps>;
   export const Table2: FC<IconProps>;
+  export const Download: FC<IconProps>;
 }

--- a/frontend/src/types/react.d.ts
+++ b/frontend/src/types/react.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /// <reference types="react" />
 /// <reference types="react-dom" />
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,12 @@ module = [
     "loguru.*",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["core/bess/tests", "backend/tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+markers = [
+    "slow: tests that run the full DP optimizer (deselect with '-m not slow')",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,6 @@
+pytest
+pytest-cov
+httpx
+black
+ruff
 pyyaml

--- a/scripts/mock_ha/scenarios/ci-normal-day.json
+++ b/scripts/mock_ha/scenarios/ci-normal-day.json
@@ -1,0 +1,120 @@
+{
+  "name": "CI Normal Day",
+  "description": "Synthetic scenario for CI E2E tests. Winter day, SE4, moderate price spread, no solar.",
+  "mock_time": "@2025-01-15 08:30:00",
+  "timezone": "Europe/Stockholm",
+  "inverter_type": "sph",
+  "sensors": {
+    "sensor.growatt_battery_soc": {
+      "state": "50",
+      "attributes": { "unit_of_measurement": "%", "friendly_name": "Battery SOC" }
+    },
+    "sensor.growatt_battery_charge_power": {
+      "state": "0",
+      "attributes": { "unit_of_measurement": "W" }
+    },
+    "sensor.growatt_battery_discharge_power": {
+      "state": "500",
+      "attributes": { "unit_of_measurement": "W" }
+    },
+    "sensor.growatt_import_power": {
+      "state": "0",
+      "attributes": { "unit_of_measurement": "W" }
+    },
+    "sensor.growatt_export_power": {
+      "state": "0",
+      "attributes": { "unit_of_measurement": "W" }
+    },
+    "sensor.growatt_pv_power": {
+      "state": "0",
+      "attributes": { "unit_of_measurement": "W" }
+    },
+    "sensor.growatt_load_power": {
+      "state": "1500",
+      "attributes": { "unit_of_measurement": "W" }
+    },
+    "sensor.nordpool_kwh_se4_sek_3_10_025": {
+      "state": "0.85",
+      "attributes": {
+        "unit_of_measurement": "SEK/kWh",
+        "today": [0.50, 0.40, 0.30, 0.25, 0.25, 0.40, 0.70, 0.90, 1.10, 1.20, 1.30, 1.40, 1.30, 1.20, 1.10, 1.30, 1.40, 1.50, 1.60, 1.50, 1.30, 0.90, 0.70, 0.60],
+        "tomorrow": [0.45, 0.35, 0.28, 0.22, 0.20, 0.35, 0.65, 0.85, 1.05, 1.15, 1.25, 1.35, 1.25, 1.15, 1.05, 1.25, 1.35, 1.45, 1.55, 1.45, 1.25, 0.85, 0.65, 0.55]
+      }
+    },
+    "number.growatt_battery_charging_power_rate": {
+      "state": "100",
+      "attributes": { "unit_of_measurement": "%", "min": 0, "max": 100 }
+    },
+    "number.growatt_battery_discharging_power_rate": {
+      "state": "100",
+      "attributes": { "unit_of_measurement": "%", "min": 0, "max": 100 }
+    },
+    "number.growatt_battery_charge_stop_soc": {
+      "state": "100",
+      "attributes": { "unit_of_measurement": "%", "min": 10, "max": 100 }
+    },
+    "number.growatt_battery_discharge_stop_soc": {
+      "state": "10",
+      "attributes": { "unit_of_measurement": "%", "min": 10, "max": 100 }
+    },
+    "switch.growatt_grid_charge": {
+      "state": "off",
+      "attributes": {}
+    }
+  },
+  "time_segments": [],
+  "ac_charge_times": [],
+  "ac_discharge_times": [],
+  "bess_config": {
+    "battery": {
+      "total_capacity": 10.0,
+      "min_soc": 10,
+      "max_soc": 100,
+      "max_charge_power_kw": 5.0,
+      "max_discharge_power_kw": 5.0,
+      "cycle_cost_per_kwh": 0.40,
+      "min_action_profit_threshold": 0.0
+    },
+    "electricity_price": {
+      "area": "SE4",
+      "markup_rate": 0.08,
+      "vat_multiplier": 1.25,
+      "additional_costs": 1.03,
+      "tax_reduction": 0.0
+    },
+    "home": {
+      "default_hourly": 1.5,
+      "currency": "SEK",
+      "max_fuse_current": 25,
+      "voltage": 230,
+      "safety_margin": 1.0,
+      "phase_count": 3,
+      "consumption_strategy": "fixed",
+      "power_monitoring_enabled": false
+    },
+    "energy_provider": "nordpool",
+    "growatt": {
+      "config_entry_id": "mock_config_entry"
+    },
+    "sensors": {
+      "battery_soc": "sensor.growatt_battery_soc",
+      "battery_charge_power": "sensor.growatt_battery_charge_power",
+      "battery_discharge_power": "sensor.growatt_battery_discharge_power",
+      "import_power": "sensor.growatt_import_power",
+      "export_power": "sensor.growatt_export_power",
+      "pv_power": "sensor.growatt_pv_power",
+      "local_load_power": "sensor.growatt_load_power",
+      "battery_charging_power_rate": "number.growatt_battery_charging_power_rate",
+      "battery_discharging_power_rate": "number.growatt_battery_discharging_power_rate",
+      "battery_charge_stop_soc": "number.growatt_battery_charge_stop_soc",
+      "battery_discharge_stop_soc": "number.growatt_battery_discharge_stop_soc",
+      "grid_charge": "switch.growatt_grid_charge"
+    },
+    "influxdb": {
+      "url": "http://nonexistent:8086/api/v2/query",
+      "bucket": "homeassistant/autogen",
+      "username": "mock",
+      "password": "mock"
+    }
+  }
+}

--- a/scripts/mock_ha/scenarios/from_debug_log.py
+++ b/scripts/mock_ha/scenarios/from_debug_log.py
@@ -78,7 +78,9 @@ def generate_scenario(log_path: str) -> None:
             # export_timestamp is a timezone-aware ISO string (e.g. "2026-04-02T15:42:18+00:00").
             # Convert to local time: libfaketime's @ format uses mktime() which is TZ-dependent,
             # so we must store local time to match the TZ set in the container.
-            local_dt = datetime.fromisoformat(export_timestamp).astimezone(ZoneInfo(tz_name))
+            local_dt = datetime.fromisoformat(export_timestamp).astimezone(
+                ZoneInfo(tz_name)
+            )
             mock_time = f"@{local_dt.strftime('%Y-%m-%d %H:%M:%S')}"
         elif log.timezone:
             # Older log with timezone but no export_timestamp — filename time is already local.
@@ -96,7 +98,9 @@ def generate_scenario(log_path: str) -> None:
         export_timestamp = log.system_info.get("export_timestamp")
         tz_name = log.timezone or "UTC"
         if export_timestamp:
-            local_dt = datetime.fromisoformat(export_timestamp).astimezone(ZoneInfo(tz_name))
+            local_dt = datetime.fromisoformat(export_timestamp).astimezone(
+                ZoneInfo(tz_name)
+            )
             mock_time = f"@{local_dt.strftime('%Y-%m-%d %H:%M:%S')}"
         else:
             mock_time = ""
@@ -131,7 +135,9 @@ def generate_scenario(log_path: str) -> None:
     else:
         # Legacy fallback for debug logs that predate entity snapshot capture.
         # Synthesises sensor values from processed data — approximate, not exact.
-        print("Note: No entity snapshot in log — synthesising sensors from processed data (legacy fallback).")
+        print(
+            "Note: No entity snapshot in log — synthesising sensors from processed data (legacy fallback)."
+        )
         remaining_today = 96 - opt_period
 
         consumption = d.get("full_home_consumption", [])
@@ -163,7 +169,9 @@ def generate_scenario(log_path: str) -> None:
 
             # raw_prices starts at opt_period, not midnight.
             today_fill = raw_prices[0] if raw_prices else 0.1
-            today_prices = [today_fill] * opt_period + list(raw_prices[:remaining_today])
+            today_prices = [today_fill] * opt_period + list(
+                raw_prices[:remaining_today]
+            )
             tomorrow_prices = list(raw_prices[remaining_today : remaining_today + 96])
             while len(tomorrow_prices) < 96:
                 tomorrow_prices.append(tomorrow_prices[-1] if tomorrow_prices else 0.1)
@@ -221,7 +229,9 @@ def generate_scenario(log_path: str) -> None:
             "sensor.solcast_pv_forecast_forecast_today": {
                 "state": str(round(sum(solar_today), 1)),
                 "attributes": {
-                    "detailedHourly": _quarterly_to_hourly_detail(solar_today, "2026-03-24")
+                    "detailedHourly": _quarterly_to_hourly_detail(
+                        solar_today, "2026-03-24"
+                    )
                 },
             },
             "sensor.solcast_pv_forecast_forecast_tomorrow": {
@@ -251,7 +261,9 @@ def generate_scenario(log_path: str) -> None:
         "bess_config": log.addon_options if log.addon_options else None,
         "sensors": sensors,
         "price_data": log.price_data if log.price_data else None,
-        "historical_periods": log.historical_periods if log.historical_periods else None,
+        "historical_periods": (
+            log.historical_periods if log.historical_periods else None
+        ),
         "mock_time": mock_time,
         "time_segments": time_segments if inverter_type == "min" else None,
         "ac_charge_times": [] if inverter_type == "sph" else None,
@@ -279,7 +291,9 @@ def generate_scenario(log_path: str) -> None:
     if mock_time:
         tz_name = log.timezone or "UTC"
         local_display = mock_time.lstrip("@")
-        print(f"      mock_time={local_display} {tz_name}  (BESS will run as if it is this time)")
+        print(
+            f"      mock_time={local_display} {tz_name}  (BESS will run as if it is this time)"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/mock_ha/server.py
+++ b/scripts/mock_ha/server.py
@@ -106,12 +106,18 @@ def _load_scenario() -> None:
         if today_prices:
             _nordpool_prices[ref_date.isoformat()] = today_prices
         if tomorrow_prices:
-            _nordpool_prices[(ref_date + timedelta(days=1)).isoformat()] = tomorrow_prices
+            _nordpool_prices[(ref_date + timedelta(days=1)).isoformat()] = (
+                tomorrow_prices
+            )
         if _nordpool_prices:
-            summary = ", ".join(f"{d} ({len(p)} periods)" for d, p in _nordpool_prices.items())
+            summary = ", ".join(
+                f"{d} ({len(p)} periods)" for d, p in _nordpool_prices.items()
+            )
             logger.info("Nordpool prices loaded: %s", summary)
         else:
-            logger.warning("No nordpool prices found in scenario — price fetches will return empty")
+            logger.warning(
+                "No nordpool prices found in scenario — price fetches will return empty"
+            )
     else:
         # mock_time is required — without it we cannot anchor prices to a date and
         # BESS will run against real wall-clock time with no price data.
@@ -162,7 +168,9 @@ async def get_config() -> JSONResponse:
 @app.get("/api/states")
 async def get_all_states() -> JSONResponse:
     """Return all entity states as a list — used by auto-discovery."""
-    return JSONResponse([_make_state_response(eid, val) for eid, val in _sensors.items()])
+    return JSONResponse(
+        [_make_state_response(eid, val) for eid, val in _sensors.items()]
+    )
 
 
 @app.get("/api/states/{entity_id:path}")

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -82,8 +82,16 @@ if [ -d "frontend" ] && find frontend/src -name "*.ts" -o -name "*.tsx" 2>/dev/n
     
     # Check if package.json exists
     if [ -f "package.json" ]; then
-        # Check TypeScript compilation
+        # Run frontend tests
         if command -v npm >/dev/null 2>&1; then
+            echo "🔸 Running frontend tests..."
+            if npm test 2>/dev/null; then
+                echo "✅ Frontend tests passed"
+            else
+                echo "❌ Frontend tests failed"
+                ERRORS=$((ERRORS + 1))
+            fi
+
             echo "🔸 Checking TypeScript compilation..."
             if npm run type-check >/dev/null 2>&1; then
                 echo "✅ TypeScript compilation OK"

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -19,6 +19,23 @@ ERRORS=0
 WARNINGS=0
 
 echo ""
+echo "📋 Running Python tests..."
+echo "---------------------------"
+
+if command -v pytest >/dev/null 2>&1; then
+    echo "🔸 Running fast tests (use 'pytest' directly to include slow algorithm tests)..."
+    if ! pytest -m "not slow" --tb=short -q; then
+        echo "❌ Tests failed"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "✅ Fast tests passed"
+    fi
+else
+    echo "⚠️  pytest not installed. Install with: pip install pytest"
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+echo ""
 echo "📋 Checking Python code quality..."
 echo "-----------------------------------"
 


### PR DESCRIPTION
## Summary

Phases 1–3 of the test framework overhaul ([full plan](docs/TEST_FRAMEWORK_PLAN.md)):

- **Phase 1 — CI quality gate**: New `ci.yml` workflow with path-based test avoidance. Tests split into fast (281 tests, ~3s) and slow (116 DP optimizer tests, ~30min) via `pytest.mark.slow`. Frontend-only PRs skip all Python tests. `quality-check.sh` now runs pytest so the issue-fix bot catches regressions.

- **Phase 2 — Frontend unit tests**: Vitest + React Testing Library. 15 tests covering API layer (ingress path detection), useSettings, useDashboardData, and useUserPreferences hooks.

- **Phase 3 — Playwright E2E**: 16 browser tests against docker-compose mock HA. Covers navigation, dashboard loading, API smoke (7 endpoints), and mock HA integration. CI builds frontend, starts docker-compose, runs Playwright, uploads report on failure.

### CI pipeline structure

| Job | Trigger | Time |
|-----|---------|------|
| Fast tests | `backend/**`, `core/bess/**` changed | ~3s |
| Algorithm tests | `core/bess/**` changed | ~30min |
| Frontend checks | `frontend/**` changed | ~15s |
| E2E tests | backend/frontend/e2e/mock_ha changed | ~3min |
| Code quality | Always | ~10s |

### Remaining phases (future PRs)
- Phase 4: Behavioral scenario assertions (strategic intents, not just economics)
- Phase 5: Deployment verification to real HA (evaluate after Phase 4)

## Test plan
- [ ] CI workflow triggers on this PR and passes
- [ ] `./scripts/quality-check.sh` passes locally (281 Python + 15 frontend tests)
- [ ] `cd frontend && npm test` runs 15 Vitest tests
- [ ] `cd e2e && npx playwright test --list` shows 16 E2E tests
- [ ] E2E tests pass when docker-compose mock HA is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)