### PR TITLE
Fix stale TOU segments and SOLAR_STORAGE mode mapping

### DIFF
--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -398,9 +398,18 @@ class BatterySystemManager:
             else:
                 # Update current schedule even when TOU doesn't change
                 self._current_schedule = temp_schedule
-                self._schedule_manager = (
-                    temp_growatt  # Update manager with new schedule
-                )
+                # Carry forward hardware TOU state so stale segment detection
+                # keeps working. temp_growatt has fresh schedule/intents/hourly
+                # settings but empty TOU intervals — without this, the in-memory
+                # record of what's on the inverter is erased every cycle.
+                temp_growatt.tou_intervals = self._schedule_manager.tou_intervals.copy()
+                # Growatt tracks active (hardware-written) intervals separately;
+                # SPH derives active_tou_intervals from tou_intervals via property.
+                if isinstance(self._schedule_manager, GrowattScheduleManager):
+                    temp_growatt.active_tou_intervals = (
+                        self._schedule_manager.active_tou_intervals.copy()
+                    )
+                self._schedule_manager = temp_growatt
 
             # Capture prediction snapshot after schedule is applied
             if not prepare_next_day:

--- a/core/bess/min_schedule.py
+++ b/core/bess/min_schedule.py
@@ -685,43 +685,41 @@ class GrowattScheduleManager:
             ) = self._calculate_power_rates_from_action(battery_action, intent)
 
             # Determine settings based on strategic intent
+            if intent not in self.INTENT_TO_MODE:
+                raise ValueError(f"Unknown strategic intent at hour {hour}: {intent}")
+
+            batt_mode = self.INTENT_TO_MODE[intent]
+
             if intent == "GRID_CHARGING":
                 grid_charge = True
                 discharge_rate = 0
                 # Always full power; power monitor caps to fuse headroom
                 charge_rate = 100
                 state = "charging"
-                batt_mode = "battery_first"
 
             elif intent == "SOLAR_STORAGE":
                 grid_charge = False
                 discharge_rate = 0
                 charge_rate = 100
                 state = "charging" if battery_action > 0.01 else "idle"
-                batt_mode = "battery_first"
 
             elif intent == "LOAD_SUPPORT":
                 grid_charge = False
                 discharge_rate = 100
                 charge_rate = 0
                 state = "discharging"
-                batt_mode = "load_first"
 
             elif intent == "EXPORT_ARBITRAGE":
                 grid_charge = False
                 discharge_rate = discharge_power_rate
                 charge_rate = 0
                 state = "grid_first"
-                batt_mode = "grid_first"
 
             elif intent == "IDLE":
                 grid_charge = False
                 discharge_rate = 0
                 charge_rate = 100
                 state = "idle"
-                batt_mode = self.INTENT_TO_MODE["IDLE"]
-            else:
-                raise ValueError(f"Unknown strategic intent at hour {hour}: {intent}")
 
             self.hourly_settings[hour] = {
                 "grid_charge": grid_charge,


### PR DESCRIPTION
## Summary
- **Stale TOU fix**: When schedules matched, replacing `_schedule_manager` with a fresh instance erased `tou_intervals`/`active_tou_intervals`, making stale segment detection blind. Now carries forward hardware TOU state to the new manager.
- **Intent mapping fix**: `SOLAR_STORAGE` hardcoded `batt_mode = "battery_first"` instead of using `INTENT_TO_MODE` (`load_first`). All intents now derive `batt_mode` from the single `INTENT_TO_MODE` mapping.

## Root cause
After an optimization cycle where schedules "matched", the fresh `temp_growatt` (with 0 TOU intervals) replaced the manager. From that point, every comparison was 0 vs 0 → "match" → repeat. Any stale segment on the inverter hardware became invisible to BESS and would fire daily (e.g. battery_first at 14:00–15:44 causing grid charging → negative savings).

## Test plan
- [ ] Verify unit tests pass (`pytest core/bess/tests/unit/`)
- [ ] Deploy and confirm stale segment detection works across optimization cycles without restart
- [ ] Confirm SOLAR_STORAGE hours show `load_first` mode in schedule logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)