### PR TITLE
Fix Nordpool area discovery to match official HA integration format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.4.3] - 2026-05-07
+
+### Fixed
+
+- Nordpool area discovery now reads `data.areas` (list) matching the official HA integration format; previous `options.area`/`data.area` lookup never matched real config entries. ([#91](https://github.com/johanzander/bess-manager/issues/91))
+
 ## [8.4.2] - 2026-05-03
 
 ### Fixed

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "8.4.2"
+version: "8.4.3"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -1444,11 +1444,10 @@ class HomeAssistantAPIController:
         for entry in config_entries_result:
             if entry.get("domain") == "nordpool" and entry.get("state") == "loaded":
                 nordpool_config_entry_id = entry["entry_id"]
-                raw_area = entry.get("options", {}).get("area") or entry.get(
-                    "data", {}
-                ).get("area")
-                if raw_area:
-                    nordpool_area = str(raw_area).upper()
+                # Official HA integration stores areas as a list in config entry data
+                raw_areas = entry.get("data", {}).get("areas")
+                if isinstance(raw_areas, list) and raw_areas:
+                    nordpool_area = str(raw_areas[0]).upper()
                 break
 
         # Find growatt device_id by matching device name to device_sn

--- a/core/bess/tests/unit/test_discovery_hints.py
+++ b/core/bess/tests/unit/test_discovery_hints.py
@@ -197,31 +197,31 @@ class TestDiscoverHaMetadataNordpoolArea:
         # _ws_query returns [config_entries_result, devices_result, services_result]
         return lambda cmds: [entries, [], {}]
 
-    def test_area_read_from_options(self, monkeypatch):
-        """Area in config entry options is returned as nordpool_area."""
-        entry = {
-            "domain": "nordpool",
-            "state": "loaded",
-            "entry_id": "abc",
-            "options": {"area": "SE3"},
-            "data": {},
-        }
-        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry]))
-        result = self.ctrl.discover_ha_metadata(None)
-        assert result["nordpool_area"] == "SE3"
-
-    def test_area_read_from_data_when_options_empty(self, monkeypatch):
-        """Area in config entry data is used when options has no area key."""
+    def test_areas_list_read_from_data(self, monkeypatch):
+        """Official HA integration stores areas as a list in config entry data."""
         entry = {
             "domain": "nordpool",
             "state": "loaded",
             "entry_id": "abc",
             "options": {},
-            "data": {"area": "NO1"},
+            "data": {"areas": ["SE3"]},
         }
         monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry]))
         result = self.ctrl.discover_ha_metadata(None)
-        assert result["nordpool_area"] == "NO1"
+        assert result["nordpool_area"] == "SE3"
+
+    def test_multiple_areas_uses_first(self, monkeypatch):
+        """When multiple areas are configured, the first one is used."""
+        entry = {
+            "domain": "nordpool",
+            "state": "loaded",
+            "entry_id": "abc",
+            "options": {},
+            "data": {"areas": ["SE3", "SE4"]},
+        }
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry]))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "SE3"
 
     def test_area_is_uppercased(self, monkeypatch):
         """Area codes are normalised to upper case regardless of source format."""
@@ -229,12 +229,25 @@ class TestDiscoverHaMetadataNordpoolArea:
             "domain": "nordpool",
             "state": "loaded",
             "entry_id": "abc",
-            "options": {"area": "se3"},
-            "data": {},
+            "options": {},
+            "data": {"areas": ["se3"]},
         }
         monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry]))
         result = self.ctrl.discover_ha_metadata(None)
         assert result["nordpool_area"] == "SE3"
+
+    def test_empty_areas_list_returns_none(self, monkeypatch):
+        """An empty areas list results in None nordpool_area."""
+        entry = {
+            "domain": "nordpool",
+            "state": "loaded",
+            "entry_id": "abc",
+            "options": {},
+            "data": {"areas": []},
+        }
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry]))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] is None
 
     def test_no_nordpool_entry_returns_none_area(self, monkeypatch):
         """nordpool_area is None when there is no loaded nordpool config entry."""
@@ -248,8 +261,8 @@ class TestDiscoverHaMetadataNordpoolArea:
             "domain": "nordpool",
             "state": "not_loaded",
             "entry_id": "abc",
-            "options": {"area": "SE3"},
-            "data": {},
+            "options": {},
+            "data": {"areas": ["SE3"]},
         }
         monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry]))
         result = self.ctrl.discover_ha_metadata(None)


### PR DESCRIPTION
## Summary

- Reads `data.areas` (list) instead of the non-existent `options.area`/`data.area` (scalar) from the Nordpool config entry, matching the actual official HA integration format.
- The previous lookup (PR #85) used fabricated key names that never existed in the real integration, so area discovery silently failed and fell back to the SE4 bootstrap default.

Fixes #91

## Test plan

- [x] Unit tests updated and passing (26/26)
- [ ] CI green (formatting, linting, fast tests)
- [ ] Hardware test: verify wizard/auto-config detects correct area