### PR TITLE
Fix Octopus wizard persistence, improve analysis agent, sync agent docs

### DIFF
--- a/.claude/agents/bess-analyst.md
+++ b/.claude/agents/bess-analyst.md
@@ -81,20 +81,47 @@ theory without checking whether the evidence actually supports it.
 
 ## Analysis Process
 
-1. **Read the design docs first** — No exceptions
-2. **Triage the debug bundle BEFORE reading code** — Check:
+### Phase 1: Understand What the User Is Asking NOW
+
+1. **Read ALL issue comments, not just the issue body.** Long-running issues
+   evolve — the current problem may be completely different from the original
+   report. Identify:
+   - What is the user's **latest** complaint or question?
+   - What has already been resolved or is no longer relevant?
+   - What version are they running? Is it current?
+2. **Use the LATEST debug bundle** — if multiple bundles were posted, use the
+   most recent one. Older bundles may reflect problems that are already fixed.
+
+### Phase 2: Triage the Debug Bundle FIRST — Before Reading Any Code
+
+3. **Triage the debug bundle thoroughly** — Check:
    - Sensor availability: are battery/inverter sensors reporting values or "unavailable"?
    - System health: any connectivity errors, missing data, failed service calls?
    - HA integration type: which integration is the user running? Does BESS Manager
      support it via the same code path?
    - Error origin: do the error messages in the bundle come from BESS Manager, or
      from HA / a third-party integration that BESS Manager doesn't control?
-3. **Understand the specific calculation/flow** being questioned
-4. **Read the relevant code** to confirm understanding
-5. **Then cross-reference logs/data** with what the code actually does
-6. **Trace through the actual code path** that produced the data
-7. **Conclude independently** — your root cause may differ from the reporter's.
+   - Setup wizard state: did discovery find the expected entities? Are any
+     required sensors misconfigured or missing?
+   - Inverter type: MIN vs SPH vs SolaX have different sensor patterns and
+     capabilities. Check which the user has and whether the code path matches.
+
+### Phase 3: Read Code Targeted by the Triage Findings
+
+4. **Read the design docs** for components relevant to the triage findings —
+   not the entire design doc set. Focus your reading budget on the subsystem
+   the debug bundle pointed to.
+5. **Read the relevant source code** to confirm understanding
+6. **Cross-reference logs/data** with what the code actually does
+7. **Trace through the actual code path** that produced the data
+
+### Phase 4: Conclude
+
+8. **Conclude independently** — your root cause may differ from the reporter's.
    That is expected and correct.
+9. **Sanity check before reporting:** re-read the last 3-5 user comments.
+   Does your analysis address what the user is actually struggling with NOW?
+   If not, you've likely analyzed a stale problem.
 
 ## Common Analysis Tasks
 
@@ -169,11 +196,16 @@ Pivot the results for easier analysis - timestamps in rows, sensors in columns.
 
 When reporting findings:
 
-1. **Debug bundle triage** — Sensor health, system state, connectivity.
+1. **Current problem** — What is the user struggling with NOW? State this
+   explicitly. If the issue has evolved from the original report, call out
+   what has changed and what is no longer relevant.
+2. **Debug bundle triage** — Sensor health, system state, connectivity.
    Flag any fundamental issues (unavailable sensors, missing data) here.
-2. **What you read** — List the docs/code you reviewed
-3. **How it actually works** — Explain the real implementation
-4. **Root cause** — Your independent diagnosis. State clearly if it differs
+3. **What you read** — List the docs/code you reviewed
+4. **How it actually works** — Explain the real implementation
+5. **Root cause** — Your independent diagnosis. State clearly if it differs
    from the reporter's theory and why.
-5. **Evidence** — Code references and debug bundle data that support your
+6. **Evidence** — Code references and debug bundle data that support your
    conclusion (not the reporter's narrative)
+7. **Sanity check** — Does this analysis address the user's LATEST comments
+   and current problem? If not, flag what you missed.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,19 +8,42 @@
       "Bash(python3 -m pytest:*)",
       "Bash(python -m pytest:*)",
       "Bash(./.venv/bin/pytest:*)",
-      "Bash(./.venv/bin/python -m pytest:*)"
+      "Bash(./.venv/bin/python -m pytest:*)",
+      "Bash(colima start *)",
+      "Bash(colima start)",
+      "Bash(colima stop *)",
+      "Bash(colima stop)"
     ],
-    "deny": [],
+    "deny": [
+      "Bash(colima delete *)",
+      "Bash(colima delete)"
+    ],
     "ask": [
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(git reset:*)",
       "Bash(git rebase:*)",
       "Bash(git merge:*)",
-      "Bash(rm:*)"
+      "Bash(rm:*)",
+      "Bash(rm -rf *)",
+      "Bash(git push --force *)",
+      "Bash(git reset --hard *)"
     ]
   },
   "enabledPlugins": {
     "code-review@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"import sys,json,subprocess; d=json.load(sys.stdin); f=d.get('tool_response',{}).get('filePath') or d.get('tool_input',{}).get('file_path',''); sys.exit(0) if not f.endswith('.py') else None; r=subprocess.run(['ruff','check',f]); sys.exit(r.returncode)\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/issue-analyze.yml
+++ b/.github/workflows/issue-analyze.yml
@@ -57,26 +57,53 @@ jobs:
             1. Get full issue context:
                  gh issue view ${{ github.event.issue.number }} --json title,body,labels,comments
 
-            2. **Delegate the investigation to the `bess-analyst` sub-agent.**
+            2. **Identify the CURRENT problem.** Long-running issues evolve.
+               Read ALL comments chronologically and determine:
+               - What is the user struggling with RIGHT NOW (latest comments)?
+               - What problems from the original report have already been
+                 resolved or are no longer relevant?
+               - What is the LATEST debug bundle? (Use that one, not older ones.)
+               - What version is the user running? Is it current?
+
+               If the issue has evolved significantly, the analysis MUST focus
+               on the current problem, not the original report.
+
+            3. **Delegate the investigation to the `bess-analyst` sub-agent.**
                Use the Agent tool with `subagent_type: bess-analyst`. Pass it:
                  - The issue title and body
-                 - The debug bundle (from issue body or attachments — download it)
+                 - A summary of how the issue has evolved (what's resolved,
+                   what the current problem is)
+                 - The LATEST debug bundle (from issue body or attachments —
+                   download it). If multiple bundles exist, use the most recent.
                  - This task: "Diagnose this issue independently. The reporter's
                    explanation is a HYPOTHESIS — do not assume it is correct.
 
-                   Step 1: Triage the debug bundle FIRST. Check sensor
+                   Step 1: Read ALL issue comments to understand what the user
+                   is struggling with NOW, not just the original report. Issues
+                   evolve — the current problem may be completely different.
+
+                   Step 2: Triage the LATEST debug bundle FIRST. Check sensor
                    availability, system health, connectivity errors, and whether
                    the reporter's HA integration matches the code path BESS
-                   Manager uses. If sensors are unavailable or the system has
-                   fundamental issues, that is likely the real problem.
+                   Manager uses. Check inverter type (MIN vs SPH vs SolaX) and
+                   whether the expected sensors exist. If sensors are unavailable
+                   or the system has fundamental issues, that is likely the real
+                   problem — not a subtle code bug.
 
-                   Step 2: Only after triage, read the design docs and source
-                   files listed in your agent definition.
+                   Step 3: Only after triage, read the design docs and source
+                   files relevant to what the triage revealed. Do NOT read the
+                   entire codebase — focus on the subsystem the debug bundle
+                   points to.
 
-                   Step 3: If the reporter claims a code bug, verify that
+                   Step 4: If the reporter claims a code bug, verify that
                    (a) the error actually originates from BESS Manager code,
                    (b) the behavior isn't intentional per the design docs, and
                    (c) the debug bundle evidence supports the claim.
+
+                   Step 5: Before finalizing, re-read the last 3-5 user
+                   comments and verify your analysis addresses what the user
+                   is actually asking about. If it doesn't, you analyzed a
+                   stale problem — go back and fix it.
 
                    Report: your independent diagnosis (which may differ from
                    the reporter's), file:line references, and whether the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with
 this repository. Read `docs/agents/rules.md` first — those constraints are
 non-negotiable and apply to all agents.
 
+## Verification Before Action
+
+- ALWAYS run tests locally before pushing commits
+- ALWAYS verify against actual source code/repos before making assumptions about APIs, entity names, or naming patterns
+- NEVER speculate about file contents or behavior - read the file or run the code first
+
 ## Agent Documentation Index
 
 | File | When to Read |
@@ -13,6 +19,7 @@ non-negotiable and apply to all agents.
 | [`docs/agents/patterns.md`](docs/agents/patterns.md) | Before writing new code |
 | [`docs/agents/testing.md`](docs/agents/testing.md) | Before writing or changing tests |
 | [`docs/agents/workflow.md`](docs/agents/workflow.md) | Before any commit, PR, or release |
+| [`docs/agents/memory/`](docs/agents/memory/) | Project-specific memory (beta workflow, release train) |
 
 ## Project Overview
 
@@ -112,6 +119,22 @@ of `analyzed`.
   do not unsuspend it.
 - Stage 2 must invoke the `bess-analyst` sub-agent. Skipping that step is
   the failure mode the previous design suffered from.
+
+## Release Workflow
+
+- Always check the current published version before tagging (e.g., check GitHub releases) to avoid version collisions
+- Confirm the target remote and branch BEFORE pushing releases (beta vs main, origin vs beta remote)
+- Run the full test suite locally before any release tag or beta push
+
+## Scope Discipline
+
+- Do NOT modify, remove, or 'clean up' items the user hasn't asked you to change
+- When doing cleanup, list what you plan to change and confirm before editing
+- Do not revert intentional linter changes or simplifications without explicit instruction
+
+## Worktree Conventions
+
+- Create worktrees as sibling folders to the main repo (e.g., `../repo-feature/`), NOT inside `.claude/worktrees/`, so they open cleanly in VS Code
 
 ## Home Assistant Integration
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -2648,6 +2648,29 @@ async def setup_complete(payload: APISetupCompletePayload):
         if payload.provider is not None:
             ep = bess_controller.settings_store.get_section("energy_provider")
             ep["provider"] = payload.provider
+            # Persist Octopus Energy entity IDs when provider is octopus
+            if any(
+                [
+                    payload.octopusImportTodayEntity,
+                    payload.octopusImportTomorrowEntity,
+                    payload.octopusExportTodayEntity,
+                    payload.octopusExportTomorrowEntity,
+                ]
+            ):
+                octopus = ep.get("octopus", {})
+                if payload.octopusImportTodayEntity:
+                    octopus["import_today_entity"] = payload.octopusImportTodayEntity
+                if payload.octopusImportTomorrowEntity:
+                    octopus["import_tomorrow_entity"] = (
+                        payload.octopusImportTomorrowEntity
+                    )
+                if payload.octopusExportTodayEntity:
+                    octopus["export_today_entity"] = payload.octopusExportTodayEntity
+                if payload.octopusExportTomorrowEntity:
+                    octopus["export_tomorrow_entity"] = (
+                        payload.octopusExportTomorrowEntity
+                    )
+                ep["octopus"] = octopus
             sections["energy_provider"] = ep
 
         # --- inverter ---

--- a/backend/api_dataclasses.py
+++ b/backend/api_dataclasses.py
@@ -993,6 +993,11 @@ class APISetupCompletePayload(BaseModel):
     taxReduction: float | None = None
     # Energy provider
     provider: str | None = None
+    # Octopus Energy entity IDs (event.* entities for Flux tariffs etc.)
+    octopusImportTodayEntity: str | None = None
+    octopusImportTomorrowEntity: str | None = None
+    octopusExportTodayEntity: str | None = None
+    octopusExportTomorrowEntity: str | None = None
     # Inverter
     inverterType: str | None = None
 

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -94,6 +94,98 @@ class TestConfirmSetup:
         assert resp.status_code == 200
 
 
+class TestSetupComplete:
+    """POST /api/setup/complete."""
+
+    def test_persists_octopus_entities(self, mock_controller):
+        """Octopus Energy entity IDs from the wizard are saved to settings."""
+        # get_section returns a fresh dict each time (read-modify-write pattern)
+        mock_controller.settings_store.get_section.return_value = {}
+
+        resp = _client.post(
+            "/api/setup/complete",
+            json={
+                "sensors": {"battery_soc": "sensor.growatt_battery_soc"},
+                "provider": "octopus",
+                "currency": "GBP",
+                "octopusImportTodayEntity": "event.octopus_electricity_import_current_day_rates",
+                "octopusImportTomorrowEntity": "event.octopus_electricity_import_next_day_rates",
+                "octopusExportTodayEntity": "event.octopus_electricity_export_current_day_rates",
+                "octopusExportTomorrowEntity": "event.octopus_electricity_export_next_day_rates",
+            },
+        )
+        assert resp.status_code == 200
+
+        # Find the save_all call and verify octopus entities were persisted
+        save_all_call = mock_controller.settings_store.save_all.call_args
+        assert save_all_call is not None
+        sections = save_all_call[0][0]
+
+        ep = sections["energy_provider"]
+        assert ep["provider"] == "octopus"
+        assert (
+            ep["octopus"]["import_today_entity"]
+            == "event.octopus_electricity_import_current_day_rates"
+        )
+        assert (
+            ep["octopus"]["import_tomorrow_entity"]
+            == "event.octopus_electricity_import_next_day_rates"
+        )
+        assert (
+            ep["octopus"]["export_today_entity"]
+            == "event.octopus_electricity_export_current_day_rates"
+        )
+        assert (
+            ep["octopus"]["export_tomorrow_entity"]
+            == "event.octopus_electricity_export_next_day_rates"
+        )
+
+    def test_persists_without_octopus_entities(self, mock_controller):
+        """Non-Octopus wizard completion does not create octopus section."""
+        mock_controller.settings_store.get_section.return_value = {}
+
+        resp = _client.post(
+            "/api/setup/complete",
+            json={
+                "sensors": {"battery_soc": "sensor.growatt_battery_soc"},
+                "provider": "nordpool_official",
+                "currency": "SEK",
+                "nordpoolArea": "SE4",
+            },
+        )
+        assert resp.status_code == 200
+
+        sections = mock_controller.settings_store.save_all.call_args[0][0]
+        ep = sections["energy_provider"]
+        assert ep["provider"] == "nordpool_official"
+        assert "octopus" not in ep
+
+    def test_persists_battery_and_home_settings(self, mock_controller):
+        """Core wizard fields (battery, home) are persisted correctly."""
+        mock_controller.settings_store.get_section.return_value = {}
+
+        resp = _client.post(
+            "/api/setup/complete",
+            json={
+                "sensors": {},
+                "provider": "nordpool_official",
+                "totalCapacity": 30.0,
+                "minSoc": 15,
+                "maxSoc": 95,
+                "currency": "SEK",
+                "consumption": 3.5,
+            },
+        )
+        assert resp.status_code == 200
+
+        sections = mock_controller.settings_store.save_all.call_args[0][0]
+        assert sections["battery"]["total_capacity"] == 30.0
+        assert sections["battery"]["min_soc"] == 15
+        assert sections["battery"]["max_soc"] == 95
+        assert sections["home"]["currency"] == "SEK"
+        assert sections["home"]["default_hourly"] == 3.5
+
+
 class TestRuntimeFailures:
     """GET/POST /api/runtime-failures."""
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -67,13 +67,13 @@ Frontend mirrors these in `frontend/src/types.ts`.
 return perform_health_check(
     component_name="Battery Monitoring",
     description="Real-time battery state monitoring",
-    is_required=True,
+    is_required=True,            # True -> failure = ERROR, False -> failure = WARNING
     controller=self.ha_controller,
     all_methods=battery_methods,
-    required_methods=required_battery_methods,
 )
 ```
 
+Severity is derived from `is_required` — no separate `required_methods` parameter.
 Never implement custom health check logic — always use `perform_health_check()`.
 
 ## Settings

--- a/docs/agents/memory/MEMORY.md
+++ b/docs/agents/memory/MEMORY.md
@@ -1,0 +1,4 @@
+- [Beta release workflow](project_beta_release_workflow.md) — Use version suffix `b1`/`b2` for beta releases, HA Supervisor handles channel filtering
+- [Beta releases go to beta remote](feedback_beta_remote.md) — Push beta branches/tags to `beta` remote, never `origin`
+- [Worktree sibling location](feedback_worktree_location.md) — Create worktrees as sibling folders, not inside .claude/worktrees/
+- [Parallel release train](feedback_parallel_release.md) — Use concurrent subagents for beta releases; check GitHub releases for version numbers

--- a/docs/agents/memory/feedback_beta_remote.md
+++ b/docs/agents/memory/feedback_beta_remote.md
@@ -1,0 +1,15 @@
+---
+name: Beta releases go to beta remote main branch
+description: Push beta releases to the 'beta' remote's main branch, never to 'origin' or feature branches on beta
+type: feedback
+originSessionId: 1229ad8f-3bfa-4c05-8c12-014e71b97589
+---
+Beta releases (v9.0.0bN) must be pushed to the `beta` remote's **main** branch, not `origin`.
+
+**Why:** The beta repo (bess-manager-beta) is a separate GitHub repo used by HA Supervisor's beta add-on channel. GitHub/HA picks up releases from `main`, not feature branches. The main repo (origin/bess-manager) tracks stable releases (currently 8.3.x) and must not have beta branches or tags.
+
+**How to apply:** When releasing a beta:
+1. `git push beta release/v9.0.0b1:main` — push local branch to beta's main
+2. `git push beta v9.0.0bN` — push the tag
+3. Never push beta branches/tags to `origin`
+4. Don't create feature branches on the beta remote — only main matters

--- a/docs/agents/memory/feedback_parallel_release.md
+++ b/docs/agents/memory/feedback_parallel_release.md
@@ -1,0 +1,11 @@
+---
+name: Parallel release train with agents
+description: Use concurrent subagents for beta releases — test-runner, changelog, version-bumper, release-notes — gate on all green
+type: feedback
+originSessionId: 74ef2e47-02dd-4057-a65d-bc2ae8bea026
+---
+For beta releases, orchestrate parallel subagents: (1) test-runner: pytest + frontend type-check + E2E tests. (2) changelog-writer: diff commits since last tag, group by fix/feat/chore. (3) version-bumper: check GitHub releases (not local tags) for next beta number, update manifest.json and build.yaml. (4) release-notes-drafter: user-facing notes in existing style. Wait for all four, present unified diff, push only to beta remote after confirmation.
+
+**Why:** 67 commits across 7 release sessions show a repeatable pipeline. The b6->b10 cycle was serial and slow. Duplicate versions were shipped because local tags were checked instead of GitHub releases.
+
+**How to apply:** When asked to do a beta release, fan out the work with agents. Always check GitHub releases (not local tags) for version numbers. Gate everything on user approval before pushing to beta remote.

--- a/docs/agents/memory/feedback_worktree_location.md
+++ b/docs/agents/memory/feedback_worktree_location.md
@@ -1,0 +1,11 @@
+---
+name: Worktree sibling location
+description: User prefers worktrees as sibling folders, not inside .claude/worktrees/
+type: feedback
+originSessionId: 3c427ddc-6dd1-4bc2-b841-54e3f1c0f4ba
+---
+Create worktrees as sibling folders to the main repo (e.g. `../bess-manager-feature-name`), not inside `.claude/worktrees/`.
+
+**Why:** The `.claude/worktrees/` path is hard to find and open in VS Code. Sibling folders are easy to navigate to and open for local testing.
+
+**How to apply:** Use `git worktree add ../bess-manager-<name> -b <branch>` instead of the `EnterWorktree` tool.

--- a/docs/agents/memory/project_beta_release_workflow.md
+++ b/docs/agents/memory/project_beta_release_workflow.md
@@ -1,0 +1,25 @@
+---
+name: Beta release workflow
+description: How to release beta versions — must use PR with CI checks before merging to beta/main
+type: project
+originSessionId: 65d25685-af51-429c-80ea-1d6975329e1d
+---
+HA Supervisor has built-in beta channel support based on version string conventions.
+
+**Beta release**: set `version` in `config.yaml` to e.g. `"9.0.0b11"`, tag as `v9.0.0b11`.
+**Stable release**: set `version` to `"9.0.0"`, tag as `v9.0.0`.
+
+Only users who enable "Show beta and dev channel releases" in the add-on UI will see beta versions.
+
+**Release process (since 2026-05-18):**
+1. Never push directly to `beta/main` — always go through a PR
+2. Push branch to beta remote, create PR against `beta/main`
+3. CI runs automatically (Fast tests, Frontend checks, E2E tests, Code quality)
+4. Merge only after CI passes
+5. Tag the merged commit and push tag
+
+Branch protection is enabled on `beta/main` requiring these CI checks to pass.
+
+**Why:** Direct pushes skip CI validation. A prior release (v9.0.0b11) was pushed without CI. PRs ensure all tests run before code reaches users.
+
+**How to apply:** Use the release skill (`/release beta`) which encodes the full PR-based workflow. Version in `config.yaml` must match the git tag.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -83,10 +83,37 @@ CI runs automatically on every PR and push to `main` (`.github/workflows/ci.yml`
 | **Code quality** | Always | Black + Ruff formatting/linting |
 | **Docker build & boot** | `backend/`, `core/`, `frontend/`, or `Dockerfile` changed | Builds production Dockerfile, boots with mock-HA, smoke-tests endpoints |
 
-The E2E job runs 60 Playwright tests covering API contract validation, page-level
+The E2E job runs Playwright tests covering API contract validation, page-level
 rendering, and the setup wizard flow. It starts in two phases:
-1. Normal day scenario — tests all pages, API contracts, and navigation
-2. Wizard scenario — tests the setup wizard with empty settings + mock HA discovery
+1. **Normal day** — tests all pages, API contracts, and navigation
+2. **Wizard** — runs the setup wizard against 7 scenario combinations
+
+### Wizard Scenario Matrix
+
+Each scenario boots a fresh mock-HA + BESS stack with different integrations
+installed, validating that discovery, auto-selection, and the full wizard flow
+work for every supported configuration.
+
+| # | Scenario | Pricing | Inverter | Phase | Solcast | Cons.F | Disch.Inhib | Weather |
+|---|----------|---------|----------|-------|---------|--------|-------------|---------|
+| 1 | `ci-wizard-nordpool-min` | Nordpool Official | MIN | 3 | - | - | - | - |
+| 2 | `ci-wizard-nordpool-sph` | Nordpool Official | SPH | 3 | - | - | - | - |
+| 3 | `ci-wizard-octopus` | Octopus | MIN | - | - | - | - | - |
+| 4 | `ci-wizard-full` | Nordpool Official | MIN | 3 | YES | YES | YES | YES |
+| 5 | `ci-wizard-nordpool-hacs` | Nordpool HACS | MIN | 1 | YES | - | - | YES |
+| 6 | `ci-wizard-octopus-sph` | Octopus | SPH | 3 | - | YES | YES | - |
+| 7 | `ci-wizard-both-providers` | Nordpool + Octopus | MIN | 1 | - | - | YES | YES |
+
+**What each test validates per scenario:**
+- Correct pricing provider auto-selected (Nordpool vs Octopus)
+- Correct inverter type auto-detected (MIN vs SPH)
+- Optional integrations shown as found/not-found with correct status
+- Provider-specific fields shown/hidden correctly
+- Can switch between providers when both are available (scenario 7)
+- Full wizard completion end-to-end
+
+Scenario expectations are defined in `e2e/tests/wizard-expectations.ts`.
+Scenario data files live in `scripts/mock_ha/scenarios/ci-wizard-*.json`.
 
 The Docker build & boot job catches a common failure mode: the production
 `Dockerfile` explicitly lists backend files in its `COPY` command. If a new

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -177,6 +177,11 @@ const SetupWizardPage: React.FC = () => {
         // Restore saved config entry IDs so manual entries survive a wizard re-run
         nordpoolConfigEntryId: ep.nordpoolOfficial?.configEntryId ?? f.nordpoolConfigEntryId,
         nordpoolEntity:        ep.nordpool?.entity               ?? f.nordpoolEntity,
+        // Restore Octopus Energy entity IDs
+        octopusImportTodayEntity:    ep.octopus?.importTodayEntity    ?? f.octopusImportTodayEntity,
+        octopusImportTomorrowEntity: ep.octopus?.importTomorrowEntity ?? f.octopusImportTomorrowEntity,
+        octopusExportTodayEntity:    ep.octopus?.exportTodayEntity    ?? f.octopusExportTodayEntity,
+        octopusExportTomorrowEntity: ep.octopus?.exportTomorrowEntity ?? f.octopusExportTomorrowEntity,
       }));
       if (inv.inverterType) setInverterForm(f => ({ ...f, inverterType: inv.inverterType }));
       if (inv.deviceId) setInverterForm(f => ({ ...f, deviceId: inv.deviceId }));
@@ -244,6 +249,11 @@ const SetupWizardPage: React.FC = () => {
         vatMultiplier: pricingForm.vatMultiplier,
         additionalCosts: pricingForm.additionalCosts,
         taxReduction: pricingForm.taxReduction,
+        // Octopus Energy entity IDs
+        octopusImportTodayEntity: pricingForm.octopusImportTodayEntity || undefined,
+        octopusImportTomorrowEntity: pricingForm.octopusImportTomorrowEntity || undefined,
+        octopusExportTodayEntity: pricingForm.octopusExportTodayEntity || undefined,
+        octopusExportTomorrowEntity: pricingForm.octopusExportTomorrowEntity || undefined,
         // Inverter
         inverterType: inverterForm.inverterType,
       });


### PR DESCRIPTION
## Summary

- **Fix #60**: Setup wizard now persists Octopus Energy entity IDs when completing setup
- **Fix analysis agent**: Restructure bot to focus on the current problem, not stale reports (triggered by shallow analysis on #60)
- **Sync agent docs**: Backport infrastructure improvements from bess-manager-beta

## What went wrong with the bot on #60

Both @claude-bot analyze runs on issue #60 produced shallow, wrong analyses. The issue evolved over 2 months (31 comments), but the bot:
1. Focused on the **March 2026 entity format error** from the original report (already self-resolved)
2. Found easy cosmetic wins (log label says "Agile", empty entity 404s)
3. **Completely missed the Growatt SPH sensor discovery failures** that the user was actively struggling with

Root cause: the bess-analyst agent was ordered to "read design docs first — no exceptions", spending its budget on code before looking at the debug bundle. For long-running issues, it never identified what the user was *currently* asking about.

## Changes

### Commit 1: Octopus fix
- `backend/api_dataclasses.py`: Add 4 optional Octopus entity fields to APISetupCompletePayload
- `backend/api.py`: Persist entities under energy_provider.octopus in setup_complete handler
- `frontend/src/pages/SetupWizardPage.tsx`: Pass entities in handleComplete, restore on wizard re-run
- `backend/tests/test_setup_api.py`: New TestSetupComplete class (3 tests)

### Commit 2: Agent docs sync from beta
- `.claude/settings.json`: Colima permissions, deny rules, ruff PostToolUse hook
- `CLAUDE.md`: Verification, Release Workflow, Scope Discipline, Worktree sections
- `docs/agents/testing.md`: 7-scenario wizard E2E matrix documentation
- `docs/agents/architecture.md`: Simplified health check pattern
- `docs/agents/memory/`: 5 new project-level agent memory files

### Commit 3: Analysis agent improvement
- `bess-analyst.md`: Restructured into 4 phases — (1) identify current problem from latest comments, (2) triage latest debug bundle FIRST, (3) read targeted code, (4) conclude with sanity check
- `issue-analyze.yml`: Added step to identify current problem before delegation; sub-agent prompt now includes latest-comments sanity check

## Test plan
- [x] 336 fast tests pass (3 new)
- [x] TypeScript compiles cleanly
- [x] Black + Ruff pass
- [ ] CI pipeline

Generated with [Claude Code](https://claude.com/claude-code)
