### PR TITLE
fix: persist locale defaults from discovery for non-Nordpool users

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -2760,6 +2760,46 @@ async def run_setup_discovery():
             integrations.get("vat_multiplier"),
         )
 
+        # Persist locale-appropriate defaults when discovery detects a
+        # non-Swedish locale.  Bootstrap defaults hardcode SEK/SE4/1.25 which
+        # are wrong for e.g. UK Octopus users.  Overwrite the pricing fields
+        # now so the store has correct values even if the wizard never
+        # completes.  (#113)
+        detected_currency = integrations.get("currency")
+        detected_vat = integrations.get("vat_multiplier")
+        if detected_currency or detected_vat is not None:
+            home = bess_controller.settings_store.get_section("home")
+            elec = bess_controller.settings_store.get_section("electricity_price")
+            changed = False
+            if detected_currency and home.get("currency") != detected_currency:
+                home["currency"] = detected_currency
+                changed = True
+            if detected_vat is not None and elec.get("vat_multiplier") != detected_vat:
+                elec["vat_multiplier"] = detected_vat
+                changed = True
+            # For Octopus-only users, clear Swedish-specific cost fields
+            if integrations.get("octopus_found") and not integrations.get(
+                "nordpool_found"
+            ):
+                if elec.get("additional_costs", 0) != 0:
+                    elec["additional_costs"] = 0.0
+                    changed = True
+                if elec.get("tax_reduction", 0) != 0:
+                    elec["tax_reduction"] = 0.0
+                    changed = True
+                ep = bess_controller.settings_store.get_section("energy_provider")
+                if ep.get("provider") != "octopus":
+                    ep["provider"] = "octopus"
+                    bess_controller.settings_store.save_section("energy_provider", ep)
+            if changed:
+                bess_controller.settings_store.save_section("home", home)
+                bess_controller.settings_store.save_section("electricity_price", elec)
+                logger.info(
+                    "Persisted locale defaults: currency=%s, vat=%s",
+                    detected_currency,
+                    detected_vat,
+                )
+
         sensors: dict[str, str] = {}
         missing_sensors: list[str] = []
         platform_sensors: dict[str, dict[str, str]] = {}

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -621,3 +621,146 @@ class TestSetupComplete:
         _client.post("/api/setup/complete", json=payload)
         call_args = complete_controller.settings_store.save_all.call_args[0][0]
         assert "battery" not in call_args
+
+
+# ---------------------------------------------------------------------------
+# Discovery locale persistence (#113)
+# ---------------------------------------------------------------------------
+
+
+def _make_discover_controller(store_data: dict) -> MagicMock:
+    """Build a bess_controller mock for /api/setup/discover tests.
+
+    The mock stores data mutably so save_section calls are visible in asserts.
+    """
+    ctrl = MagicMock()
+    ctrl.settings_store.data = store_data
+
+    def _get_section(name: str) -> dict:
+        return dict(store_data.get(name, {}))
+
+    def _save_section(name: str, data: dict) -> None:
+        store_data[name] = dict(data)
+
+    ctrl.settings_store.get_section.side_effect = _get_section
+    ctrl.settings_store.save_section.side_effect = _save_section
+    return ctrl
+
+
+class TestDiscoverLocaleDefaults:
+    """POST /api/setup/discover — locale-appropriate defaults (#113)."""
+
+    def _run_discover(self, ctrl, integrations):
+        """Helper: mock HA calls and POST /api/setup/discover."""
+        ha = ctrl.ha_controller
+        ha.discover_integrations.return_value = (integrations, [])
+        ha.fetch_entity_registry.return_value = []
+        ha.discover_sensors_from_registry.return_value = ({}, None)
+        ha.discover_current_sensors.return_value = {}
+        ha.discover_optional_sensors.return_value = {}
+        ha.discover_octopus_entities.return_value = {}
+        ha.ENTITY_SUFFIX_MAP = {}
+        ha.SOLAX_GROWATT_MIN_SUFFIX_MAP = {}
+        ha.SOLAX_GROWATT_SPH_SUFFIX_MAP = {}
+        ha.SOLAX_NATIVE_SUFFIX_MAP = {}
+        sys.modules["app"].bess_controller = ctrl
+        return _client.post("/api/setup/discover")
+
+    def test_octopus_only_persists_gbp_defaults(self):
+        """Octopus-only discovery overwrites Swedish bootstrap defaults with UK values."""
+        store = deepcopy(_PRE_EXISTING_STORE)
+        store["home"]["currency"] = "SEK"
+        store["electricity_price"]["vat_multiplier"] = 1.25
+        store["electricity_price"]["additional_costs"] = 0.773
+        store["electricity_price"]["tax_reduction"] = 0.1988
+        store["energy_provider"]["provider"] = "nordpool_official"
+
+        ctrl = _make_discover_controller(store)
+        integrations = {
+            "growatt_found": False,
+            "device_sn": None,
+            "growatt_device_id": None,
+            "solax_found": False,
+            "nordpool_found": False,
+            "nordpool_area": None,
+            "nordpool_custom_area": None,
+            "nordpool_custom_entity": None,
+            "nordpool_config_entry_id": None,
+            "octopus_found": True,
+            "detected_inverter_platforms": [],
+            "detected_phase_count": None,
+            "currency": "GBP",
+            "vat_multiplier": 1.0,
+        }
+        resp = self._run_discover(ctrl, integrations)
+        assert resp.status_code == 200
+
+        assert store["home"]["currency"] == "GBP"
+        assert store["electricity_price"]["vat_multiplier"] == 1.0
+        assert store["electricity_price"]["additional_costs"] == 0.0
+        assert store["electricity_price"]["tax_reduction"] == 0.0
+        assert store["energy_provider"]["provider"] == "octopus"
+
+    def test_nordpool_discovery_does_not_clear_costs(self):
+        """Nordpool discovery updates currency/vat but keeps additional_costs/tax_reduction."""
+        store = deepcopy(_PRE_EXISTING_STORE)
+        store["home"]["currency"] = "SEK"
+        store["electricity_price"]["vat_multiplier"] = 1.25
+        store["electricity_price"]["additional_costs"] = 0.773
+        store["electricity_price"]["tax_reduction"] = 0.1988
+
+        ctrl = _make_discover_controller(store)
+        integrations = {
+            "growatt_found": False,
+            "device_sn": None,
+            "growatt_device_id": None,
+            "solax_found": False,
+            "nordpool_found": True,
+            "nordpool_area": "SE3",
+            "nordpool_custom_area": None,
+            "nordpool_custom_entity": None,
+            "nordpool_config_entry_id": "entry-123",
+            "octopus_found": False,
+            "detected_inverter_platforms": [],
+            "detected_phase_count": None,
+            "currency": "SEK",
+            "vat_multiplier": 1.25,
+        }
+        resp = self._run_discover(ctrl, integrations)
+        assert resp.status_code == 200
+
+        # Currency and VAT unchanged (already correct)
+        assert store["home"]["currency"] == "SEK"
+        assert store["electricity_price"]["vat_multiplier"] == 1.25
+        # Swedish cost fields preserved
+        assert store["electricity_price"]["additional_costs"] == 0.773
+        assert store["electricity_price"]["tax_reduction"] == 0.1988
+
+    def test_no_locale_hints_leaves_defaults_unchanged(self):
+        """When discovery returns no currency/vat hints, store is untouched."""
+        store = deepcopy(_PRE_EXISTING_STORE)
+        original_currency = store["home"]["currency"]
+        original_vat = store["electricity_price"]["vat_multiplier"]
+
+        ctrl = _make_discover_controller(store)
+        integrations = {
+            "growatt_found": False,
+            "device_sn": None,
+            "growatt_device_id": None,
+            "solax_found": False,
+            "nordpool_found": False,
+            "nordpool_area": None,
+            "nordpool_custom_area": None,
+            "nordpool_custom_entity": None,
+            "nordpool_config_entry_id": None,
+            "octopus_found": False,
+            "detected_inverter_platforms": [],
+            "detected_phase_count": None,
+            "currency": None,
+            "vat_multiplier": None,
+        }
+        resp = self._run_discover(ctrl, integrations)
+        assert resp.status_code == 200
+
+        assert store["home"]["currency"] == original_currency
+        assert store["electricity_price"]["vat_multiplier"] == original_vat

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -736,6 +736,38 @@ class TestDiscoverLocaleDefaults:
         assert store["electricity_price"]["additional_costs"] == 0.773
         assert store["electricity_price"]["tax_reduction"] == 0.1988
 
+    def test_norwegian_nordpool_updates_currency_preserves_costs(self):
+        """Non-Swedish Nordpool updates currency but keeps cost fields as rough defaults."""
+        store = deepcopy(_PRE_EXISTING_STORE)
+        store["home"]["currency"] = "SEK"
+        store["electricity_price"]["additional_costs"] = 0.773
+        store["electricity_price"]["tax_reduction"] = 0.1988
+
+        ctrl = _make_discover_controller(store)
+        integrations = {
+            "growatt_found": False,
+            "device_sn": None,
+            "growatt_device_id": None,
+            "solax_found": False,
+            "nordpool_found": True,
+            "nordpool_area": "NO1",
+            "nordpool_custom_area": None,
+            "nordpool_custom_entity": None,
+            "nordpool_config_entry_id": "entry-456",
+            "octopus_found": False,
+            "detected_inverter_platforms": [],
+            "detected_phase_count": None,
+            "currency": "NOK",
+            "vat_multiplier": 1.25,
+        }
+        resp = self._run_discover(ctrl, integrations)
+        assert resp.status_code == 200
+
+        assert store["home"]["currency"] == "NOK"
+        # Cost fields kept — Swedish values are a rough approximation, better than zero
+        assert store["electricity_price"]["additional_costs"] == 0.773
+        assert store["electricity_price"]["tax_reduction"] == 0.1988
+
     def test_no_locale_hints_leaves_defaults_unchanged(self):
         """When discovery returns no currency/vat hints, store is untouched."""
         store = deepcopy(_PRE_EXISTING_STORE)


### PR DESCRIPTION
## Summary
- When discovery detects a non-Swedish locale (e.g. UK Octopus user), persist currency, VAT, and pricing defaults to the settings store immediately — not just as frontend display hints
- For Octopus-only users (no Nordpool), clear Swedish-specific `additional_costs` and `tax_reduction` fields and set provider to `octopus`
- Previously, bootstrap defaults hardcoded SEK/1.25 VAT/Swedish grid costs which stuck permanently for non-Swedish users unless the full wizard completed

Closes #113

## Test plan
- [x] `pytest -m 'not slow'` — 579 passed
- [x] `ruff check` — clean
- [x] New tests: `TestDiscoverLocaleDefaults` (3 tests covering Octopus-only, Nordpool, and no-hints scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)