### PR TITLE
fix: SPH per-period apply + Octopus gas entity discovery (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.2.1] - 2026-06-10
+
+### Fixed
+
+- **SPH per-period apply failed every 15 minutes** — `GrowattSphController` inherited base class `_write_period_to_hardware` which tried to set `grid_charge` and `discharging_power_rate` entities that don't exist for SPH. Added no-op override since SPH deploys the full schedule atomically via service calls. (#60)
+- **Octopus discovery picked gas entities for electricity import** — Discovery used keyword matching on `entity_id` instead of `unique_id` regex matching (like all other platforms). Gas rate entities matched the import pattern. Rewritten to use regex on `unique_id` requiring `octopus_energy_electricity_` prefix, which inherently excludes gas. (#60)
+- **Debug export missing Octopus Energy entities** — Added `octopus_energy` to entity registry export domains so Octopus entities appear in debug logs.
+
 ## [9.2.0] - 2026-06-09
 
 ### Fixed

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.2.0"
+version: "9.2.1"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/debug_data_exporter.py
+++ b/core/bess/debug_data_exporter.py
@@ -95,13 +95,13 @@ _WS_TARGET_DOMAINS = frozenset(
 
 # Domains whose entities are captured from the entity registry.
 _ENTITY_REGISTRY_DOMAINS = frozenset(
-    {"growatt_server", "solax_modbus", "solax", "nordpool"}
+    {"growatt_server", "solax_modbus", "solax", "nordpool", "octopus_energy"}
 )
 
 # Keywords matched against entity_id and unique_id to capture entities
 # that belong to BESS-relevant integrations even if they register under
 # an unexpected platform name.
-_ENTITY_REGISTRY_KEYWORDS = ("growatt", "solax", "nordpool")
+_ENTITY_REGISTRY_KEYWORDS = ("growatt", "solax", "nordpool", "octopus")
 
 # Entity registry fields that are useful for debugging discovery and
 # sensor mapping. unique_id is redacted (last-4) since it often contains

--- a/core/bess/growatt_sph_controller.py
+++ b/core/bess/growatt_sph_controller.py
@@ -57,6 +57,18 @@ class GrowattSphController(InverterController):
         self._charge_periods: list[dict] = []
         self._discharge_periods: list[dict] = []
 
+    def _write_period_to_hardware(
+        self, controller, grid_charge: bool, discharge_rate: int
+    ) -> tuple[bool, str]:
+        """No-op: SPH deploys the full schedule atomically via service calls.
+
+        SPH inverters have no per-period entity controls (grid_charge switch,
+        discharge rate number).  The entire schedule is written in
+        ``write_schedule_to_hardware`` using ``write_ac_charge_times`` /
+        ``write_ac_discharge_times``.
+        """
+        return True, ""
+
     @property
     def active_tou_intervals(self) -> list[dict]:
         """All TOU intervals are active for SPH (no 9-slot hardware constraint)."""

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -507,6 +507,37 @@ class HomeAssistantAPIController:
         "mix_load_consumption_lifetime": "lifetime_load_consumption",  # unique_id sensor key
     }
 
+    # ── Octopus Energy rate event patterns ────────────────────────────────
+    #
+    # The Octopus Energy integration (BottlecapDave/HomeAssistant-OctopusEnergy)
+    # creates event entities for electricity and gas rate data.  unique_id format:
+    #
+    #   Electricity import:  octopus_energy_electricity_{serial}_{mpan}_current_day_rates
+    #   Electricity export:  octopus_energy_electricity_{serial}_{mpan}_export_current_day_rates
+    #   Gas:                 octopus_energy_gas_{serial}_{mprn}_current_day_rates
+    #
+    # Discovery uses regex on unique_id to match electricity entities only
+    # (gas entities are excluded by the ``_electricity_`` requirement).
+    # Named groups map directly to the BESS form field keys.
+    _OCTOPUS_RATE_PATTERNS: ClassVar[list[tuple[re.Pattern, str]]] = [
+        (
+            re.compile(r"octopus_energy_electricity_.+_export_current_day_rates$"),
+            "exportToday",
+        ),
+        (
+            re.compile(r"octopus_energy_electricity_.+_export_next_day_rates$"),
+            "exportTomorrow",
+        ),
+        (
+            re.compile(r"octopus_energy_electricity_.+(?<!export)_current_day_rates$"),
+            "importToday",
+        ),
+        (
+            re.compile(r"octopus_energy_electricity_.+(?<!export)_next_day_rates$"),
+            "importTomorrow",
+        ),
+    ]
+
     # ── Per-platform suffix maps for solax_modbus discovery ─────────────
     #
     # The solax_modbus integration (github.com/wills106/homeassistant-solax-modbus)
@@ -2489,9 +2520,11 @@ class HomeAssistantAPIController:
     def discover_octopus_entities(self, entity_registry: list[dict]) -> dict[str, str]:
         """Discover Octopus Energy pricing entity IDs from the entity registry.
 
-        Uses the immutable ``platform`` field (same approach as Growatt/SolaX
-        discovery) so renamed entities are still found.  Classifies each entity
-        by keywords in the ``entity_id``.
+        Uses the immutable ``unique_id`` field (same approach as Growatt/SolaX
+        discovery) so renamed entities are still found.  Matches
+        ``_OCTOPUS_RATE_PATTERNS`` regex patterns against the unique_id to
+        identify electricity rate entities — gas entities are excluded by
+        requiring ``_electricity_`` in the unique_id pattern.
 
         Args:
             entity_registry: Entity registry list from HA WebSocket API.
@@ -2500,20 +2533,23 @@ class HomeAssistantAPIController:
             dict mapping form field keys to entity_ids, empty if not found
         """
         result: dict[str, str] = {}
+
         for entry in entity_registry:
             if entry.get("platform") != "octopus_energy":
                 continue
             entity_id = str(entry.get("entity_id", ""))
-            lower_id = entity_id.lower()
-            if "export" in lower_id:
-                if "next_day" in lower_id:
-                    result["exportTomorrow"] = entity_id
-                elif "current_day" in lower_id:
-                    result["exportToday"] = entity_id
-            elif "next_day" in lower_id and "rate" in lower_id:
-                result["importTomorrow"] = entity_id
-            elif "current_day" in lower_id and "rate" in lower_id:
-                result["importToday"] = entity_id
+            unique_id = str(entry.get("unique_id", ""))
+
+            for pattern, bess_key in self._OCTOPUS_RATE_PATTERNS:
+                if pattern.search(unique_id) and bess_key not in result:
+                    result[bess_key] = entity_id
+                    break
+
+        if result:
+            logger.info(
+                "Octopus discovery: matched %d entities from unique_id patterns",
+                len(result),
+            )
         return result
 
     def discover_optional_sensors(self, states: list[dict]) -> dict[str, str]:

--- a/core/bess/tests/integration/test_cross_platform.py
+++ b/core/bess/tests/integration/test_cross_platform.py
@@ -73,7 +73,11 @@ class TestCrossPlatformHardwareWrites:
 
         platform_system._apply_period_schedule(PERIOD)
 
-        if _is_solax(platform_system):
+        if _is_sph(platform_system):
+            # SPH uses atomic schedule writes — no per-period hardware calls
+            assert mock_controller.calls["grid_charge"] == []
+            assert mock_controller.calls["discharge_rate"] == []
+        elif _is_solax(platform_system):
             assert len(mock_controller.calls["vpp_calls"]) == 1
             assert mock_controller.calls["vpp_calls"][0] > 0
         else:
@@ -85,7 +89,11 @@ class TestCrossPlatformHardwareWrites:
 
         platform_system._apply_period_schedule(PERIOD)
 
-        if _is_solax(platform_system):
+        if _is_sph(platform_system):
+            # SPH uses atomic schedule writes — no per-period hardware calls
+            assert mock_controller.calls["grid_charge"] == []
+            assert mock_controller.calls["discharge_rate"] == []
+        elif _is_solax(platform_system):
             assert len(mock_controller.calls["vpp_calls"]) == 1
             assert mock_controller.calls["vpp_calls"][0] < 0
         else:
@@ -98,7 +106,11 @@ class TestCrossPlatformHardwareWrites:
 
         platform_system._apply_period_schedule(PERIOD)
 
-        if _is_solax(platform_system):
+        if _is_sph(platform_system):
+            # SPH uses atomic schedule writes — no per-period hardware calls
+            assert mock_controller.calls["grid_charge"] == []
+            assert mock_controller.calls["discharge_rate"] == []
+        elif _is_solax(platform_system):
             assert len(mock_controller.calls["vpp_calls"]) == 1
             assert mock_controller.calls["vpp_calls"][0] < 0
         else:
@@ -110,7 +122,11 @@ class TestCrossPlatformHardwareWrites:
 
         platform_system._apply_period_schedule(PERIOD)
 
-        if _is_solax(platform_system):
+        if _is_sph(platform_system):
+            # SPH uses atomic schedule writes — no per-period hardware calls
+            assert mock_controller.calls["grid_charge"] == []
+            assert mock_controller.calls["discharge_rate"] == []
+        elif _is_solax(platform_system):
             assert len(mock_controller.calls["vpp_disabled"]) == 1
             assert len(mock_controller.calls["vpp_calls"]) == 0
         else:
@@ -124,7 +140,10 @@ class TestCrossPlatformHardwareWrites:
 
         platform_system._apply_period_schedule(PERIOD)
 
-        if _is_solax(platform_system):
+        if _is_sph(platform_system):
+            # SPH uses atomic schedule writes — no per-period hardware calls
+            assert mock_controller.calls["grid_charge"] == []
+        elif _is_solax(platform_system):
             assert len(mock_controller.calls["vpp_disabled"]) == 1
         else:
             assert mock_controller.calls["grid_charge"][-1] is False

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -991,27 +991,32 @@ class TestDiscoverOctopusEntities:
         self.ctrl = _make_controller()
 
     def _octopus_registry(self) -> list[dict]:
-        """Typical Octopus Energy registry with all 4 rate entities."""
+        """Typical Octopus Energy registry with all 4 rate entities.
+
+        Uses realistic unique_ids matching the BottlecapDave integration format:
+          octopus_energy_electricity_{serial}_{mpan}[_export]_{suffix}
+          octopus_energy_gas_{serial}_{mprn}_{suffix}
+        """
         return [
             _entity(
                 "event.octopus_energy_electricity_current_day_rates",
                 "octopus_energy",
-                "oe_current_day_rates",
+                "octopus_energy_electricity_21L4726831_2000023585834_current_day_rates",
             ),
             _entity(
                 "event.octopus_energy_electricity_next_day_rates",
                 "octopus_energy",
-                "oe_next_day_rates",
+                "octopus_energy_electricity_21L4726831_2000023585834_next_day_rates",
             ),
             _entity(
                 "event.octopus_energy_electricity_export_current_day_rates",
                 "octopus_energy",
-                "oe_export_current_day_rates",
+                "octopus_energy_electricity_21L4726831_2000023585834_export_current_day_rates",
             ),
             _entity(
                 "event.octopus_energy_electricity_export_next_day_rates",
                 "octopus_energy",
-                "oe_export_next_day_rates",
+                "octopus_energy_electricity_21L4726831_2000023585834_export_next_day_rates",
             ),
             # Non-Octopus entity should be ignored
             _entity(
@@ -1045,7 +1050,7 @@ class TestDiscoverOctopusEntities:
             _entity(
                 "event.my_custom_name_current_day_rates",
                 "octopus_energy",
-                "oe_current_day_rates",
+                "octopus_energy_electricity_21L4726831_2000023585834_current_day_rates",
             ),
         ]
         result = self.ctrl.discover_octopus_entities(registry)
@@ -1059,12 +1064,12 @@ class TestDiscoverOctopusEntities:
             _entity(
                 "event.octopus_energy_electricity_current_day_rates",
                 "octopus_energy",
-                "oe_current_day_rates",
+                "octopus_energy_electricity_21L4726831_2000023585834_current_day_rates",
             ),
             _entity(
                 "event.octopus_energy_electricity_next_day_rates",
                 "octopus_energy",
-                "oe_next_day_rates",
+                "octopus_energy_electricity_21L4726831_2000023585834_next_day_rates",
             ),
         ]
         result = self.ctrl.discover_octopus_entities(registry)
@@ -1074,3 +1079,65 @@ class TestDiscoverOctopusEntities:
         }
         assert "exportToday" not in result
         assert "exportTomorrow" not in result
+
+    def test_gas_entities_excluded(self):
+        """Gas rate entities must not be matched as electricity import."""
+        registry = [
+            _entity(
+                "event.current_day_rates_gas_E6S20077472161_3948152604",
+                "octopus_energy",
+                "octopus_energy_gas_E6S20077472161_3948152604_current_day_rates",
+            ),
+            _entity(
+                "event.next_day_rates_gas_E6S20077472161_3948152604",
+                "octopus_energy",
+                "octopus_energy_gas_E6S20077472161_3948152604_next_day_rates",
+            ),
+        ]
+        result = self.ctrl.discover_octopus_entities(registry)
+        assert result == {}
+
+    def test_gas_entities_excluded_electricity_still_matched(self):
+        """When both gas and electricity entities exist, only electricity is matched."""
+        registry = [
+            # Gas entities (should be excluded)
+            _entity(
+                "event.current_day_rates_gas_E6S20077472161_3948152604",
+                "octopus_energy",
+                "octopus_energy_gas_E6S20077472161_3948152604_current_day_rates",
+            ),
+            _entity(
+                "event.next_day_rates_gas_E6S20077472161_3948152604",
+                "octopus_energy",
+                "octopus_energy_gas_E6S20077472161_3948152604_next_day_rates",
+            ),
+            # Electricity export entities
+            _entity(
+                "event.current_day_rates_export_electricity_21L4726831_2000060563359",
+                "octopus_energy",
+                "octopus_energy_electricity_21L4726831_2000060563359_export_current_day_rates",
+            ),
+            _entity(
+                "event.next_day_rates_export_electricity_21L4726831_2000060563359",
+                "octopus_energy",
+                "octopus_energy_electricity_21L4726831_2000060563359_export_next_day_rates",
+            ),
+            # Electricity import entities
+            _entity(
+                "event.current_day_rates_electricity_21L4726831_2000023585834",
+                "octopus_energy",
+                "octopus_energy_electricity_21L4726831_2000023585834_current_day_rates",
+            ),
+            _entity(
+                "event.next_day_rates_electricity_21L4726831_2000023585834",
+                "octopus_energy",
+                "octopus_energy_electricity_21L4726831_2000023585834_next_day_rates",
+            ),
+        ]
+        result = self.ctrl.discover_octopus_entities(registry)
+        assert result == {
+            "importToday": "event.current_day_rates_electricity_21L4726831_2000023585834",
+            "importTomorrow": "event.next_day_rates_electricity_21L4726831_2000023585834",
+            "exportToday": "event.current_day_rates_export_electricity_21L4726831_2000060563359",
+            "exportTomorrow": "event.next_day_rates_export_electricity_21L4726831_2000060563359",
+        }

--- a/scripts/mock_ha/scenarios/ci-wizard-octopus-sph.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-octopus-sph.json
@@ -358,25 +358,25 @@
       "entity_id": "event.octopus_energy_electricity_current_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-import-today"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000023585834_current_day_rates"
     },
     {
       "entity_id": "event.octopus_energy_electricity_next_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-import-tomorrow"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000023585834_next_day_rates"
     },
     {
       "entity_id": "event.octopus_energy_electricity_export_current_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-export-today"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000060563359_export_current_day_rates"
     },
     {
       "entity_id": "event.octopus_energy_electricity_export_next_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-export-tomorrow"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000060563359_export_next_day_rates"
     }
   ],
   "time_segments": [],

--- a/scripts/mock_ha/scenarios/ci-wizard-octopus.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-octopus.json
@@ -717,25 +717,25 @@
       "entity_id": "event.octopus_energy_electricity_current_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-import-today"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000023585834_current_day_rates"
     },
     {
       "entity_id": "event.octopus_energy_electricity_next_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-import-tomorrow"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000023585834_next_day_rates"
     },
     {
       "entity_id": "event.octopus_energy_electricity_export_current_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-export-today"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000060563359_export_current_day_rates"
     },
     {
       "entity_id": "event.octopus_energy_electricity_export_next_day_rates",
       "platform": "octopus_energy",
       "config_entry_id": "mock_octopus_config_entry",
-      "unique_id": "octopus-export-tomorrow"
+      "unique_id": "octopus_energy_electricity_21L4726831_2000060563359_export_next_day_rates"
     },
     {
       "entity_id": "sensor.mock_inverter_soc",


### PR DESCRIPTION
## Summary

- **SPH per-period apply**: GrowattSphController now overrides `_write_period_to_hardware` as no-op — SPH deploys schedules atomically via service calls, not per-entity control
- **Octopus discovery**: Rewritten from entity_id keyword matching to unique_id regex, excluding gas entities by requiring `octopus_energy_electricity_` prefix
- **Debug exporter**: Added `octopus_energy` to registry export domains so Octopus entities appear in debug logs

## Test plan

- [x] 591 fast tests pass, 32 cross-platform integration tests pass
- [x] Regex patterns verified against all Octopus unique_id variants (import, export, gas)
- [ ] User re-runs wizard after update to verify correct Octopus entity discovery

Generated with [Claude Code](https://claude.com/claude-code)