### PR TITLE
fix: SPH platform capability gating (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.4.0] - 2026-06-12
+
+### Fixed
+
+- **SPH platform capability gating** — UI and backend now disable features unsupported by SPH inverters (grid charge toggle, discharge power rate, fuse protection). Prevents "No entity ID configured for Grid Charge Enabled" errors. (#60)
+- **SPH sensor definitions and device discovery** — Fixed sensor key mappings and discovery logic for SPH inverters. UI no longer incorrectly shows "solax" for SPH configurations. (#60)
+- **Dead lifetime sensors removed** — Removed non-existent lifetime sensor keys from all platform UI definitions.
+
 ## [9.3.0] - 2026-06-12
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -584,6 +584,24 @@ Both are called sequentially from `run_setup_discovery()` in `api.py`. They serv
 
 **Files**: `core/bess/ha_api_controller.py` (`_parse_ha_metadata`, `discover_sensors_from_registry`), `backend/api.py` (`run_setup_discovery`)
 
+### Remove device_id discovery fallbacks and dead `device_sn` code
+
+**Impact**: Low | **Effort**: Low | **Dependencies**: `ha_api_controller.py`, `api.py`, `sensorDefinitions.ts`
+
+**Description**: Device ID discovery has two strategies: config_entry match (primary, always works) and identifiers/SN match (fallback). The fallback depends on `_extract_growatt_device_sn()`, which fragily parses SOC entity IDs to extract the serial number. Real HA devices always have `config_entries` on the device object, so the fallback is unnecessary.
+
+Additionally, `device_sn` is extracted, returned in the API response as `deviceSn`, and declared in the frontend `DiscoveryResult` type — but nothing in the frontend or backend ever reads it. It's dead code end to end.
+
+**What to remove**:
+- `_extract_growatt_device_sn()` method
+- Identifiers-based device_id fallback (strategy 2 in `_parse_ha_metadata`)
+- `device_sn` from discovery result dict and API response
+- `deviceSn` from frontend `DiscoveryResult` type
+
+**Files**: `core/bess/ha_api_controller.py`, `backend/api.py`, `frontend/src/components/settings/SensorConfigSection.tsx`
+
+---
+
 ### Other Technical Debt
 
 - Refactor all API endpoints to use dataclass-based serialization (with robust mapping for all field variants) for consistent, type-safe, and future-proof API responses. Ensure all details and fields are preserved as in the original dict-based implementation.

--- a/bess_manager/CHANGELOG.md
+++ b/bess_manager/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.4.0] - 2026-06-12
+
+### Fixed
+
+- **SPH platform capability gating** — UI and backend now disable features unsupported by SPH inverters (grid charge toggle, discharge power rate, fuse protection). Prevents "No entity ID configured for Grid Charge Enabled" errors. (#60)
+- **SPH sensor definitions and device discovery** — Fixed sensor key mappings and discovery logic for SPH inverters. UI no longer incorrectly shows "solax" for SPH configurations. (#60)
+- **Dead lifetime sensors removed** — Removed non-existent lifetime sensor keys from all platform UI definitions.
+
 ## [9.3.0] - 2026-06-12
 
 ### Changed

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.3.0"
+version: "9.4.0"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.3.0"
+version: "9.4.0"
 slug: "bess_manager"
 init: false
 arch:

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -232,6 +232,12 @@ class BatterySystemManager:
         )
         return platform
 
+    @property
+    def _supports_charge_rate_control(self) -> bool:
+        if not self._inverter_controller:
+            return False
+        return self._inverter_controller.supports_charge_rate_control
+
     def _create_inverter_controller(self) -> InverterController | None:
         """Create an inverter controller for ``self.inverter_platform``.
 
@@ -383,8 +389,12 @@ class BatterySystemManager:
 
         try:
             if self._controller:
-                # Initialize power monitor only when feature is enabled
-                if self.home_settings.power_monitoring_enabled:
+                # Initialize power monitor only when feature is enabled and
+                # the platform has per-period charge rate control
+                if (
+                    self.home_settings.power_monitoring_enabled
+                    and self._supports_charge_rate_control
+                ):
                     self._power_monitor = HomePowerMonitor(
                         self._controller,
                         home_settings=self.home_settings,
@@ -2676,12 +2686,12 @@ class BatterySystemManager:
     def adjust_charging_power(self) -> None:
         """Adjust charging power based on house consumption.
 
-        SolaX inverters control power via VPP commands, not charge rate registers,
-        so this method is a no-op for SolaX platforms.
+        Platforms that use atomic schedule writes (SPH, SolaX) have no
+        per-period charge rate register — skip entirely.
         """
         if not self.is_configured:
             return
-        if self.inverter_platform == "solax":
+        if not self._supports_charge_rate_control:
             return
 
         try:
@@ -2754,6 +2764,7 @@ class BatterySystemManager:
                     self.home_settings.power_monitoring_enabled
                     and self._power_monitor is None
                     and self._controller is not None
+                    and self._supports_charge_rate_control
                 ):
                     self._power_monitor = HomePowerMonitor(
                         self._controller,

--- a/core/bess/growatt_sph_controller.py
+++ b/core/bess/growatt_sph_controller.py
@@ -34,6 +34,8 @@ class GrowattSphController(InverterController):
     BatterySystemManager can use either interchangeably via InverterController.
     """
 
+    supports_charge_rate_control: ClassVar[bool] = False
+
     MAX_CHARGE_PERIODS = 3
     MAX_DISCHARGE_PERIODS = 3
 

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -2145,14 +2145,16 @@ class HomeAssistantAPIController:
                 break
 
         # Find growatt device_id from device registry.
-        # Strategy 1: match by identifiers containing the device SN
-        #   (immutable, unaffected by user renames)
-        # Strategy 2: match by config_entry belonging to growatt_server
-        #   (works even without a detected SN)
-        # Strategy 3: match by device name equal to device SN
-        #   (legacy fallback)
+        # Primary: match by config_entry belonging to growatt_server
+        # Fallback: match by identifiers containing the device SN
         growatt_device_id: str | None = None
-        if device_sn:
+        if growatt_config_entry_id:
+            for device in devices_result:
+                if growatt_config_entry_id in device.get("config_entries", []):
+                    growatt_device_id = device["id"]
+                    break
+
+        if not growatt_device_id and device_sn:
             sn_upper = device_sn.upper()
             for device in devices_result:
                 for ident in device.get("identifiers", []):
@@ -2164,20 +2166,6 @@ class HomeAssistantAPIController:
                         growatt_device_id = device["id"]
                         break
                 if growatt_device_id:
-                    break
-
-        if not growatt_device_id and growatt_config_entry_id:
-            for device in devices_result:
-                if growatt_config_entry_id in device.get("config_entries", []):
-                    growatt_device_id = device["id"]
-                    break
-
-        if not growatt_device_id and device_sn:
-            sn_upper = device_sn.upper()
-            for device in devices_result:
-                name = str(device.get("name", "")).upper()
-                if name == sn_upper:
-                    growatt_device_id = device["id"]
                     break
 
         # Determine inverter type from entity registry unique_id prefixes.

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -64,6 +64,14 @@ class InverterController(ABC):
         "IDLE": "No significant battery activity",
     }
 
+    # ── Platform capabilities ──────────────────────────────────────────────
+    # Subclasses override to declare what the hardware supports.
+
+    # Per-period charge/discharge rate register that power monitoring can
+    # read and write.  False on platforms that bake power % into atomic
+    # TOU schedule writes (SPH, SolaX native).
+    supports_charge_rate_control: ClassVar[bool] = True
+
     def __init__(self, battery_settings: BatterySettings) -> None:
         """Initialize shared inverter controller state."""
         if battery_settings is None:

--- a/core/bess/solax_controller.py
+++ b/core/bess/solax_controller.py
@@ -48,6 +48,8 @@ class SolaxController(InverterController):
     push to the inverter.
     """
 
+    supports_charge_rate_control: ClassVar[bool] = False
+
     def __init__(self, battery_settings: BatterySettings) -> None:
         """Initialise the SolaX controller."""
         super().__init__(battery_settings)

--- a/core/bess/tests/unit/test_platform_capabilities.py
+++ b/core/bess/tests/unit/test_platform_capabilities.py
@@ -5,8 +5,6 @@ capabilities and that BatterySystemManager respects them (e.g. not
 initializing the power monitor on platforms without charge rate control).
 """
 
-import pytest  # type: ignore
-
 from core.bess.growatt_min_controller import GrowattMinController
 from core.bess.growatt_sph_controller import GrowattSphController
 from core.bess.inverter_controller import InverterController

--- a/core/bess/tests/unit/test_platform_capabilities.py
+++ b/core/bess/tests/unit/test_platform_capabilities.py
@@ -1,0 +1,74 @@
+"""Tests for platform capability declarations and their effect on BSM behavior.
+
+Verifies that each InverterController subclass declares the correct
+capabilities and that BatterySystemManager respects them (e.g. not
+initializing the power monitor on platforms without charge rate control).
+"""
+
+import pytest  # type: ignore
+
+from core.bess.growatt_min_controller import GrowattMinController
+from core.bess.growatt_sph_controller import GrowattSphController
+from core.bess.inverter_controller import InverterController
+from core.bess.solax_controller import SolaxController
+from core.bess.solax_modbus_growatt_controller import SolaxModbusGrowattController
+
+
+# ── Capability declarations ──────────────────────────────────────────────────
+
+
+class TestChargeRateControlCapability:
+    """Verify supports_charge_rate_control is declared correctly per platform."""
+
+    def test_base_class_defaults_to_true(self):
+        assert InverterController.supports_charge_rate_control is True
+
+    def test_growatt_min_supports_charge_rate(self):
+        assert GrowattMinController.supports_charge_rate_control is True
+
+    def test_growatt_sph_does_not_support_charge_rate(self):
+        assert GrowattSphController.supports_charge_rate_control is False
+
+    def test_solax_native_does_not_support_charge_rate(self):
+        assert SolaxController.supports_charge_rate_control is False
+
+    def test_solax_modbus_growatt_inherits_charge_rate_support(self):
+        # SolaxModbusGrowattController extends GrowattMinController and
+        # has charge rate registers available via Modbus
+        assert SolaxModbusGrowattController.supports_charge_rate_control is True
+
+
+# ── BSM capability property ─────────────────────────────────────────────────
+
+
+class TestBSMCapabilityProperty:
+    """Verify BSM._supports_charge_rate_control reflects the active controller."""
+
+    def test_sph_reports_no_charge_rate_control(self, platform_system):
+        if platform_system.inverter_platform == "growatt_server_sph":
+            assert platform_system._supports_charge_rate_control is False
+
+    def test_solax_native_reports_no_charge_rate_control(self, platform_system):
+        if platform_system.inverter_platform == "solax_modbus_native":
+            assert platform_system._supports_charge_rate_control is False
+
+    def test_min_platforms_report_charge_rate_control(self, platform_system):
+        if platform_system.inverter_platform in (
+            "growatt_server_min",
+            "solax_modbus_growatt_min",
+        ):
+            assert platform_system._supports_charge_rate_control is True
+
+
+# ── adjust_charging_power gating ─────────────────────────────────────────────
+
+
+class TestAdjustChargingPowerSkipsUnsupported:
+    """Verify adjust_charging_power is a no-op on unsupported platforms."""
+
+    def test_sph_adjust_charging_power_is_noop(self, platform_system):
+        """On platforms without charge rate control, adjust_charging_power
+        must return without touching the controller."""
+        if not platform_system._supports_charge_rate_control:
+            # Should not raise — just silently return
+            platform_system.adjust_charging_power()

--- a/core/bess/tests/unit/test_platform_capabilities.py
+++ b/core/bess/tests/unit/test_platform_capabilities.py
@@ -13,7 +13,6 @@ from core.bess.inverter_controller import InverterController
 from core.bess.solax_controller import SolaxController
 from core.bess.solax_modbus_growatt_controller import SolaxModbusGrowattController
 
-
 # ── Capability declarations ──────────────────────────────────────────────────
 
 

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -7,6 +7,7 @@ Tests cover:
 - Derived lifetime sensor fallbacks (GEN3/GEN4)
 """
 
+from typing import ClassVar
 from unittest.mock import patch
 
 from core.bess.ha_api_controller import HomeAssistantAPIController
@@ -1141,3 +1142,116 @@ class TestDiscoverOctopusEntities:
             "exportToday": "event.current_day_rates_export_electricity_21L4726831_2000060563359",
             "exportTomorrow": "event.next_day_rates_export_electricity_21L4726831_2000060563359",
         }
+
+
+# ---------------------------------------------------------------------------
+# Frontend ↔ backend sensor key consistency
+# ---------------------------------------------------------------------------
+
+
+class TestFrontendSensorKeysMatchBackend:
+    """Every sensor key shown in the frontend UI must exist in the backend suffix map.
+
+    Prevents showing "Not detected" fields for sensors that don't exist on a
+    platform (e.g. local_load_power on SPH cloud).
+    """
+
+    # Map frontend platform IDs to backend suffix map class attributes.
+    PLATFORM_TO_SUFFIX_MAP: ClassVar[dict[str, str]] = {
+        "growatt_server_min": "GROWATT_MIN_SUFFIX_MAP",
+        "growatt_server_sph": "GROWATT_SPH_SUFFIX_MAP",
+        "solax_modbus_native": "SOLAX_NATIVE_SUFFIX_MAP",
+        "solax_modbus_growatt_min": "SOLAX_GROWATT_MIN_SUFFIX_MAP",
+        "solax_modbus_growatt_sph": "SOLAX_GROWATT_SPH_SUFFIX_MAP",
+    }
+
+    @staticmethod
+    def _parse_frontend_sensor_keys() -> dict[str, set[str]]:
+        """Parse sensorDefinitions.ts to extract sensor keys per platform.
+
+        Returns dict mapping platform_id -> set of sensor keys shown in the UI.
+        """
+        import re
+        from pathlib import Path
+
+        ts_path = (
+            Path(__file__).parents[4]
+            / "frontend"
+            / "src"
+            / "lib"
+            / "sensorDefinitions.ts"
+        )
+        source = ts_path.read_text()
+
+        result: dict[str, set[str]] = {}
+
+        # Find all { id: 'xxx', ... sensorGroups: ... } blocks
+        # and extract key: 'yyy' from each.
+        blocks = re.split(r"\{\s*\n\s*id:\s*'", source)
+        for block in blocks[1:]:  # skip preamble before first id
+            platform_match = re.match(r"([^']+)'", block)
+            if not platform_match:
+                continue
+            platform_id = platform_match.group(1)
+
+            # Skip non-inverter integrations
+            if platform_id in (
+                "nordpool",
+                "solar_forecast",
+                "consumption_forecast",
+                "phase_current",
+                "discharge_inhibit",
+                "weather",
+            ):
+                continue
+
+            # Check if sensorGroups references a named constant
+            groups_ref = re.search(r"sensorGroups:\s*(\w+)", block)
+            if groups_ref:
+                const_name = groups_ref.group(1)
+                # Find the constant definition in the full source
+                const_match = re.search(
+                    rf"const\s+{const_name}.*?=\s*\[(.*?)\];",
+                    source,
+                    re.DOTALL,
+                )
+                if const_match:
+                    search_text = const_match.group(1)
+                    # The constant may reference other constants — expand them
+                    for ref in re.findall(
+                        r"\b([A-Z_]+(?:_MONITORING|_LIFETIME))\b", search_text
+                    ):
+                        ref_match = re.search(
+                            rf"const\s+{ref}.*?sensors:\s*\[(.*?)\]",
+                            source,
+                            re.DOTALL,
+                        )
+                        if ref_match:
+                            search_text += ref_match.group(1)
+                else:
+                    search_text = block
+            else:
+                search_text = block
+
+            keys = set(re.findall(r"key:\s*'([^']+)'", search_text))
+            if keys:
+                result[platform_id] = keys
+
+        return result
+
+    def test_all_frontend_keys_exist_in_suffix_map(self):
+        """For each platform, every frontend sensor key must be discoverable."""
+        frontend_keys = self._parse_frontend_sensor_keys()
+
+        for platform_id, suffix_map_attr in self.PLATFORM_TO_SUFFIX_MAP.items():
+            suffix_map = getattr(HomeAssistantAPIController, suffix_map_attr)
+            backend_keys = set(suffix_map.values())
+
+            ui_keys = frontend_keys.get(platform_id, set())
+            assert ui_keys, f"No frontend keys found for {platform_id} — parser broken?"
+
+            extra = ui_keys - backend_keys
+            assert not extra, (
+                f"{platform_id}: frontend shows sensors that the backend "
+                f"suffix map ({suffix_map_attr}) cannot discover: {sorted(extra)}"
+            )

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -1253,7 +1253,6 @@ class TestFrontendSensorKeysMatchBackend:
         },
         "solax_modbus_growatt_min": {
             "lifetime_system_production",
-            "lifetime_load_consumption",  # discoverable but not in UI for GEN4 modbus
             *(
                 f"tou_time_{n}_{f}"
                 for n in range(2, 10)

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -1239,6 +1239,30 @@ class TestFrontendSensorKeysMatchBackend:
 
         return result
 
+    # Sensor keys that exist in backend suffix maps but are intentionally
+    # NOT shown in the frontend wizard UI.  Every entry needs a reason.
+    #
+    # - lifetime_system_production: discoverable but BESS derives it from
+    #   lifetime_solar_energy via EnergyFlowCalculator — no config needed.
+    # - lifetime_self_consumption: Growatt cloud only, always derived.
+    # - TOU time slots 2-9: managed by backend, only slot 1 shown in UI.
+    BACKEND_ONLY_KEYS: ClassVar[dict[str, set[str]]] = {
+        "growatt_server_min": {
+            "lifetime_system_production",
+            "lifetime_self_consumption",
+        },
+        "solax_modbus_growatt_min": {
+            "lifetime_system_production",
+            "lifetime_load_consumption",  # discoverable but not in UI for GEN4 modbus
+            *(
+                f"tou_time_{n}_{f}"
+                for n in range(2, 10)
+                for f in ("enabled", "begin", "end", "mode", "update")
+            ),
+        },
+        "solax_modbus_native": {"lifetime_system_production"},
+    }
+
     def test_all_frontend_keys_exist_in_suffix_map(self):
         """For each platform, every frontend sensor key must be discoverable."""
         frontend_keys = self._parse_frontend_sensor_keys()
@@ -1254,4 +1278,29 @@ class TestFrontendSensorKeysMatchBackend:
             assert not extra, (
                 f"{platform_id}: frontend shows sensors that the backend "
                 f"suffix map ({suffix_map_attr}) cannot discover: {sorted(extra)}"
+            )
+
+    def test_no_undeclared_backend_only_keys(self):
+        """Backend suffix map values not in the frontend must be in BACKEND_ONLY_KEYS.
+
+        Prevents "Not detected" phantom fields: if a new sensor is added to a
+        suffix map but not to the frontend, this test forces an explicit decision
+        — either add it to the UI or add it to BACKEND_ONLY_KEYS with a reason.
+        """
+        frontend_keys = self._parse_frontend_sensor_keys()
+
+        for platform_id, suffix_map_attr in self.PLATFORM_TO_SUFFIX_MAP.items():
+            suffix_map = getattr(HomeAssistantAPIController, suffix_map_attr)
+            backend_keys = set(suffix_map.values())
+
+            ui_keys = frontend_keys.get(platform_id, set())
+            allowed = self.BACKEND_ONLY_KEYS.get(platform_id, set())
+
+            backend_not_in_ui = backend_keys - ui_keys
+            undeclared = backend_not_in_ui - allowed
+            assert not undeclared, (
+                f"{platform_id}: backend suffix map ({suffix_map_attr}) has keys "
+                f"not shown in the frontend and not in BACKEND_ONLY_KEYS: "
+                f"{sorted(undeclared)}. Either add them to the frontend "
+                f"sensorDefinitions.ts or to BACKEND_ONLY_KEYS with a reason."
             )

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -384,6 +384,56 @@ The active platform is stored in `inverter.platform`. Switching platform at runt
 
 `GrowattSolaxModbusController` subclasses `GrowattMinController` — the scheduling algorithm (9 TOU slots, differential updates, corruption recovery) is identical. Only the hardware I/O differs: `growatt_server` uses a single service call per slot, while `solax_modbus` uses 4 entity writes (`select.select_option`) plus a button press per slot.
 
+### Platform Capabilities
+
+Different inverter platforms support different hardware features. The class hierarchy handles **behavioral** differences (TOU scheduling vs. period lists vs. VPP commands — genuinely different algorithms). Capabilities handle the narrower question: what does code *outside* the controller need to know about the platform?
+
+Currently only one capability exists: `charge_rate_control`. It is declared as a `ClassVar[bool]` on `InverterController` (default `True`) and overridden to `False` by subclasses whose hardware lacks per-period charge/discharge rate registers (SPH, SolaX native). BSM checks this flag to decide whether to initialize the power monitor and whether `adjust_charging_power()` should run.
+
+```python
+# inverter_controller.py (base class)
+supports_charge_rate_control: ClassVar[bool] = True
+
+# growatt_sph_controller.py
+supports_charge_rate_control: ClassVar[bool] = False
+
+# solax_controller.py
+supports_charge_rate_control: ClassVar[bool] = False
+```
+
+| Capability | Description | MIN | SPH | SolaX Native | Modbus Growatt MIN |
+|---|---|---|---|---|---|
+| `supports_charge_rate_control` | Per-period charge/discharge rate register | Yes | **No** | **No** | Yes |
+
+SPH controls charge power globally via `write_ac_charge_times(charge_power=100%)`. SolaX native uses VPP active-power commands. Neither has a per-period register that the power monitor can read/write, so fuse protection cannot function.
+
+#### Frontend Gating
+
+The frontend disables UI features based on **sensor presence**, which correlates with platform capabilities: if the platform lacks charge rate control, the corresponding sensor entity won't exist after discovery. This avoids needing a dedicated capabilities API endpoint — the sensor config already carries the signal.
+
+- Fuse protection toggle: disabled when `battery_charging_power_rate` sensor is not configured
+- InfluxDB consumption strategy: disabled when `local_load_power` sensor is not configured
+- HA Statistics strategy: disabled when `lifetime_load_consumption` sensor is not configured
+
+Sensor-based gating is the right default. A dedicated capabilities API should only be introduced when the frontend needs to gate on something that doesn't map to sensor presence.
+
+#### Evolution Path
+
+The single `ClassVar[bool]` is sufficient while capabilities are few and boolean. If the number of externally-queried capabilities grows beyond 2–3 flags, consolidate into a frozen `PlatformCapabilities` dataclass with typed fields (booleans, integers, Literals). The decision criteria: add a capability only when code **outside** the controller hierarchy needs to branch on it. Internal differences (schedule model, max slots, power control method) belong in the subclass, not the capability surface.
+
+#### Adding a New Capability
+
+1. Add `supports_foo: ClassVar[bool] = True` to `InverterController`
+2. Override to `False` on subclasses that lack the feature
+3. Gate the feature in BSM / frontend as appropriate
+
+#### Adding a New Inverter Platform
+
+1. Create an `InverterController` subclass implementing the abstract methods
+2. Override any `supports_*` flags where the platform differs from defaults
+3. Add the platform string to `VALID_PLATFORMS` and the factory in `_create_inverter_controller()`
+4. Add entity suffix map entries to `ha_api_controller.py` for sensor discovery
+
 ### Auto-Detection and Integration Discovery
 
 On first startup with no sensors configured, or when the user triggers discovery from the setup wizard or settings page, the system runs a multi-stage auto-detection process via `HAAPIController.discover_integrations()`.

--- a/docs/agents/memory/project_beta_release_workflow.md
+++ b/docs/agents/memory/project_beta_release_workflow.md
@@ -6,20 +6,23 @@ originSessionId: 65d25685-af51-429c-80ea-1d6975329e1d
 ---
 HA Supervisor has built-in beta channel support based on version string conventions.
 
-**Beta release**: set `version` in `config.yaml` to e.g. `"9.0.0b11"`, tag as `v9.0.0b11`.
+**Beta release**: set `version` in `bess_manager/config.yaml` and `config.dev.yaml` to e.g. `"9.0.0b11"`, tag as `v9.0.0b11`.
 **Stable release**: set `version` to `"9.0.0"`, tag as `v9.0.0`.
 
 Only users who enable "Show beta and dev channel releases" in the add-on UI will see beta versions.
 
-**Release process (since 2026-05-18):**
+**Release process (since 2026-06-12):**
 1. Never push directly to `beta/main` — always go through a PR
 2. Push branch to beta remote, create PR against `beta/main`
 3. CI runs automatically (Fast tests, Frontend checks, E2E tests, Code quality)
 4. Merge only after CI passes
-5. Tag the merged commit and push tag
+5. Create a GitHub Release (tag `vX.Y.Zb1`, target branch) — this triggers `release-addon.yml`
+6. Wait for the release workflow to build and push Docker images (amd64 + aarch64) to GHCR
+7. Verify images are pullable
+8. Ensure GHCR packages are public (first release of a new package name requires manual visibility toggle)
 
 Branch protection is enabled on `beta/main` requiring these CI checks to pass.
 
-**Why:** Direct pushes skip CI validation. A prior release (v9.0.0b11) was pushed without CI. PRs ensure all tests run before code reaches users.
+**Why:** Direct pushes skip CI validation. A prior release (v9.0.0b11) was pushed without CI. PRs ensure all tests run before code reaches users. Pre-built Docker images (since v9.3.0) replaced source-based builds for faster installs and no build failures on user hardware.
 
-**How to apply:** Use the release skill (`/release beta`) which encodes the full PR-based workflow. Version in `config.yaml` must match the git tag.
+**How to apply:** Version in `bess_manager/config.yaml` and `config.dev.yaml` must match the git tag. Always verify GHCR images are pullable after the release workflow completes.

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -60,12 +60,16 @@ spends money on its own. Stage 1 is auto but cheap.
 2. **Fix minor issues** — apply small fixes directly; request changes for anything substantial
 3. **Update CHANGELOG** — add entry under new version heading, credit author:
    `(thanks [@username](https://github.com/username))`
-4. **Bump version** in `config.yaml`:
+4. **Bump version** in both `bess_manager/config.yaml` and `config.dev.yaml`:
    - `PATCH` (x.y.**Z**): bug fixes, doc/comment changes, no behavior change
    - `MINOR` (x.**Y**.0): new features, backwards-compatible
    - `MAJOR` (**X**.0.0): breaking changes
 5. **Merge** — squash merge; wait for explicit user approval
-6. **Tag** — after user confirms hardware test: `git tag vX.Y.Z && git push origin vX.Y.Z`
+6. **Release** — create a GitHub Release (tag `vX.Y.Z`, target `main`).
+   This triggers `release-addon.yml` which builds per-arch Docker images
+   (amd64 + aarch64) and pushes them to GHCR.
+7. **Verify** — wait for the release workflow to complete, then confirm
+   images are pullable: `docker pull ghcr.io/johanzander/bess-manager-amd64:X.Y.Z`
 
 Never tag or merge without explicit user instruction.
 

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -240,8 +240,11 @@ test.describe('Setup Wizard', () => {
   });
 
   test('home step gates features by platform capabilities', async ({ page }) => {
+    // SPH lacks local_load_power; SolaX native has it (as house_load)
+    const platformsWithoutLocalLoad = ['growatt_server_sph'];
     const platformsWithoutChargeRate = ['growatt_server_sph', 'solax_modbus_native'];
-    const expectDisabled = platformsWithoutChargeRate.includes(expected.inverterPlatform);
+    const expectInfluxDisabled = platformsWithoutLocalLoad.includes(expected.inverterPlatform);
+    const expectFuseDisabled = platformsWithoutChargeRate.includes(expected.inverterPlatform);
 
     await page.goto('/setup');
     await expectActiveStep(page, 1);
@@ -256,7 +259,7 @@ test.describe('Setup Wizard', () => {
 
     // InfluxDB radio should be disabled on platforms without local_load_power
     const influxRadio = radioByLabel(page, 'InfluxDB (requires InfluxDB integration)');
-    if (expectDisabled) {
+    if (expectInfluxDisabled) {
       await expect(influxRadio).toBeDisabled();
     } else {
       await expect(influxRadio).toBeEnabled();
@@ -264,7 +267,7 @@ test.describe('Setup Wizard', () => {
 
     // Fuse protection toggle should be disabled on platforms without charge rate control
     const fuseToggle = page.getByRole('switch', { name: /Enable fuse protection/i });
-    if (expectDisabled) {
+    if (expectFuseDisabled) {
       await expect(fuseToggle).toBeDisabled();
     } else {
       await expect(fuseToggle).toBeEnabled();

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -238,4 +238,36 @@ test.describe('Setup Wizard', () => {
     await expect(page.getByText('20 kWh')).toBeVisible();
     await expect(page.getByText('10% – 90%')).toBeVisible();
   });
+
+  test('home step gates features by platform capabilities', async ({ page }) => {
+    const platformsWithoutChargeRate = ['growatt_server_sph', 'solax_modbus_native'];
+    const expectDisabled = platformsWithoutChargeRate.includes(expected.inverterPlatform);
+
+    await page.goto('/setup');
+    await expectActiveStep(page, 1);
+
+    // Navigate to Home step (step 4)
+    await page.getByRole('button', { name: /Next: Electricity Pricing/i }).click();
+    await expectActiveStep(page, 2);
+    await page.getByRole('button', { name: /Next: Battery/i }).click();
+    await expectActiveStep(page, 3);
+    await page.getByRole('button', { name: /Next: Home/i }).click();
+    await expectActiveStep(page, 4);
+
+    // InfluxDB radio should be disabled on platforms without local_load_power
+    const influxRadio = radioByLabel(page, 'InfluxDB (requires InfluxDB integration)');
+    if (expectDisabled) {
+      await expect(influxRadio).toBeDisabled();
+    } else {
+      await expect(influxRadio).toBeEnabled();
+    }
+
+    // Fuse protection toggle should be disabled on platforms without charge rate control
+    const fuseToggle = page.getByRole('button', { name: /Enable fuse protection/i });
+    if (expectDisabled) {
+      await expect(fuseToggle).toBeDisabled();
+    } else {
+      await expect(fuseToggle).toBeEnabled();
+    }
+  });
 });

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -263,7 +263,7 @@ test.describe('Setup Wizard', () => {
     }
 
     // Fuse protection toggle should be disabled on platforms without charge rate control
-    const fuseToggle = page.getByRole('button', { name: /Enable fuse protection/i });
+    const fuseToggle = page.getByRole('switch', { name: /Enable fuse protection/i });
     if (expectDisabled) {
       await expect(fuseToggle).toBeDisabled();
     } else {

--- a/frontend/src/components/settings/FormHelpers.tsx
+++ b/frontend/src/components/settings/FormHelpers.tsx
@@ -107,14 +107,16 @@ export function radioGroup<T extends string>(
   );
 }
 
-export function toggle(label: string, value: boolean, onChange: (_: boolean) => void) {
+export function toggle(label: string, value: boolean, onChange: (_: boolean) => void, opts?: { disabled?: boolean }) {
+  const disabled = opts?.disabled ?? false;
   return (
     <div className="flex items-center justify-between">
-      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</span>
+      <span className={`text-sm font-medium ${disabled ? 'text-gray-400 dark:text-gray-500' : 'text-gray-700 dark:text-gray-300'}`}>{label}</span>
       <button
         type="button"
+        disabled={disabled}
         onClick={() => onChange(!value)}
-        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${value ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${disabled ? 'bg-gray-200 dark:bg-gray-700 cursor-not-allowed opacity-50' : value ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
       >
         <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${value ? 'translate-x-6' : 'translate-x-1'}`} />
       </button>

--- a/frontend/src/components/settings/FormHelpers.tsx
+++ b/frontend/src/components/settings/FormHelpers.tsx
@@ -114,6 +114,9 @@ export function toggle(label: string, value: boolean, onChange: (_: boolean) => 
       <span className={`text-sm font-medium ${disabled ? 'text-gray-400 dark:text-gray-500' : 'text-gray-700 dark:text-gray-300'}`}>{label}</span>
       <button
         type="button"
+        role="switch"
+        aria-checked={value}
+        aria-label={label}
         disabled={disabled}
         onClick={() => onChange(!value)}
         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${disabled ? 'bg-gray-200 dark:bg-gray-700 cursor-not-allowed opacity-50' : value ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}

--- a/frontend/src/components/settings/HomeFormSection.tsx
+++ b/frontend/src/components/settings/HomeFormSection.tsx
@@ -19,6 +19,8 @@ interface Props {
 
 export function HomeFormSection({ form, onChange, sensors }: Props) {
   const haStatsSensorConfigured = Boolean(sensors?.['lifetime_load_consumption']);
+  const localLoadSensorConfigured = Boolean(sensors?.['local_load_power']);
+  const chargeRateSensorConfigured = Boolean(sensors?.['battery_charging_power_rate']);
   return (
     <div className="space-y-3">
       <SectionCard
@@ -30,11 +32,17 @@ export function HomeFormSection({ form, onChange, sensors }: Props) {
           [
             { value: 'fixed', label: 'Fixed value' },
             { value: 'sensor', label: 'Home Assistant sensor' },
-            { value: 'influxdb_7d_avg', label: 'InfluxDB (requires InfluxDB integration)' },
+            { value: 'influxdb_7d_avg', label: 'InfluxDB (requires InfluxDB integration)', disabled: !localLoadSensorConfigured },
             { value: 'ha_statistics', label: 'HA Statistics (7-day hourly profile)', disabled: !haStatsSensorConfigured },
           ],
           form.consumptionStrategy,
           v => onChange({ ...form, consumptionStrategy: v }),
+        )}
+        {!localLoadSensorConfigured && (
+          <p className="text-xs text-amber-600 dark:text-amber-400 pt-1">
+            InfluxDB requires the <strong>Local Load Power</strong> sensor to be configured in the{' '}
+            <strong>Sensors</strong> tab. This sensor is not available on all inverter platforms (e.g. Growatt SPH).
+          </p>
         )}
         {!haStatsSensorConfigured && (
           <p className="text-xs text-amber-600 dark:text-amber-400 pt-1">
@@ -77,8 +85,15 @@ export function HomeFormSection({ form, onChange, sensors }: Props) {
         title="Power Monitoring"
         description="Monitors real-time load and limits battery charge power to prevent blowing the main fuse. Enable to configure."
       >
+        {!chargeRateSensorConfigured && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            Fuse protection requires a <strong>Battery Charging Power Rate</strong> entity, which is not
+            available on all inverter platforms (e.g. Growatt SPH).
+          </p>
+        )}
         {toggle('Enable fuse protection', form.powerMonitoringEnabled,
-          v => onChange({ ...form, powerMonitoringEnabled: v }))}
+          v => onChange({ ...form, powerMonitoringEnabled: v }),
+          { disabled: !chargeRateSensorConfigured })}
         {form.powerMonitoringEnabled && (
           <>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 pt-1">

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -137,6 +137,29 @@ const GROWATT_CLOUD_MIN_SENSOR_GROUPS: SensorGroup[] = [
 // SPH cloud: the growatt_server integration exposes NO number or switch
 // entities for SPH — all control is via service calls (write_ac_charge_times,
 // write_ac_discharge_times).  Only sensors (SOC, power, lifetime) exist.
+// SPH also lacks local_load_power (no pac_to_local_load register),
+// lifetime_system_production, and lifetime_self_consumption.
+const GROWATT_CLOUD_SPH_POWER_MONITORING: SensorGroup = {
+  name: 'Power Monitoring',
+  sensors: [
+    { key: 'pv_power', label: 'Solar PV Power', required: false },
+    { key: 'import_power', label: 'Grid Import Power', required: false },
+    { key: 'export_power', label: 'Grid Export Power', required: false },
+  ],
+};
+
+const GROWATT_CLOUD_SPH_LIFETIME: SensorGroup = {
+  name: 'Lifetime Energy Totals',
+  sensors: [
+    { key: 'lifetime_battery_charged', label: 'Total Battery Charged', required: true },
+    { key: 'lifetime_battery_discharged', label: 'Total Battery Discharged', required: true },
+    { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: true },
+    { key: 'lifetime_export_to_grid', label: 'Total Export to Grid', required: true },
+    { key: 'lifetime_import_from_grid', label: 'Total Import from Grid', required: true },
+    { key: 'lifetime_load_consumption', label: 'Total Load Consumption', required: true },
+  ],
+};
+
 const GROWATT_CLOUD_SPH_SENSOR_GROUPS: SensorGroup[] = [
   {
     name: 'Battery Monitoring',
@@ -146,8 +169,8 @@ const GROWATT_CLOUD_SPH_SENSOR_GROUPS: SensorGroup[] = [
       { key: 'battery_discharge_power', label: 'Discharging Power', required: true },
     ],
   },
-  GROWATT_POWER_MONITORING,
-  GROWATT_CLOUD_LIFETIME,
+  GROWATT_CLOUD_SPH_POWER_MONITORING,
+  GROWATT_CLOUD_SPH_LIFETIME,
 ];
 
 export const INTEGRATIONS: IntegrationDef[] = [

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -273,6 +273,7 @@ export const INTEGRATIONS: IntegrationDef[] = [
           { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: false },
           { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: false },
           { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: false },
+          { key: 'lifetime_load_consumption', label: 'Total Load Energy', required: false },
         ],
       },
       {

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -110,8 +110,6 @@ const GROWATT_CLOUD_LIFETIME: SensorGroup = {
     { key: 'lifetime_export_to_grid', label: 'Total Export to Grid', required: true },
     { key: 'lifetime_import_from_grid', label: 'Total Import from Grid', required: true },
     { key: 'lifetime_load_consumption', label: 'Total Load Consumption', required: true },
-    { key: 'lifetime_system_production', label: 'Total System Production', required: false },
-    { key: 'lifetime_self_consumption', label: 'Total Self Consumption', required: false },
   ],
 };
 
@@ -219,7 +217,6 @@ export const INTEGRATIONS: IntegrationDef[] = [
           { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: false },
           { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: false },
           { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: false },
-          { key: 'lifetime_system_production', label: 'Total Yield', required: false },
         ],
       },
       {
@@ -276,7 +273,6 @@ export const INTEGRATIONS: IntegrationDef[] = [
           { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: false },
           { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: false },
           { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: false },
-          { key: 'lifetime_system_production', label: 'Total Yield', required: false },
         ],
       },
       {

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -508,7 +508,7 @@ const SetupWizardPage: React.FC = () => {
               </p>
             </div>
 
-            <HomeFormSection form={homeForm} onChange={setHomeForm} />
+            <HomeFormSection form={homeForm} onChange={setHomeForm} sensors={getActiveSensorsFlat(sensors)} />
 
             {completeError && (
               <p className="text-sm text-red-600 dark:text-red-400">{completeError}</p>

--- a/mock-run.sh
+++ b/mock-run.sh
@@ -69,22 +69,26 @@ import json, sys
 d = json.load(open('$SCENARIO_FILE'))
 cfg = d.get('bess_config')
 if not cfg:
-    print('Error: No bess_config in scenario — regenerate with from_debug_log.py', file=sys.stderr)
-    sys.exit(1)
-json.dump(cfg, open('backend/dev-options.json', 'w'), indent=2)
+    # Wizard scenario — no existing config. Write minimal defaults so the
+    # backend starts in setup-wizard mode (no sensors configured).
+    print('Note: No bess_config — starting in setup-wizard mode (fresh setup)')
+    json.dump({}, open('backend/dev-options.json', 'w'), indent=2)
+    json.dump({}, open('backend/mock-bess-settings.json', 'w'), indent=2)
+else:
+    json.dump(cfg, open('backend/dev-options.json', 'w'), indent=2)
 
-# Reset dev-bess-settings.json from the scenario bess_config so stale sensor
-# state from a previous run cannot override this scenario's sensor mapping.
-OWNED = ('home', 'battery', 'electricity_price', 'energy_provider', 'growatt', 'inverter', 'sensors')
-bess_settings = {k: cfg[k] for k in OWNED if k in cfg}
+    # Reset dev-bess-settings.json from the scenario bess_config so stale sensor
+    # state from a previous run cannot override this scenario's sensor mapping.
+    OWNED = ('home', 'battery', 'electricity_price', 'energy_provider', 'growatt', 'inverter', 'sensors')
+    bess_settings = {k: cfg[k] for k in OWNED if k in cfg}
 
-# influxdb_7d_avg requires access to the original user's InfluxDB instance,
-# which is never available in mock mode. Always override to fixed.
-if bess_settings.get('home', {}).get('consumption_strategy') == 'influxdb_7d_avg':
-    bess_settings['home']['consumption_strategy'] = 'fixed'
-    print('Note: influxdb_7d_avg requires the original user\\'s InfluxDB — overriding to fixed for mock run.')
+    # influxdb_7d_avg requires access to the original user's InfluxDB instance,
+    # which is never available in mock mode. Always override to fixed.
+    if bess_settings.get('home', {}).get('consumption_strategy') == 'influxdb_7d_avg':
+        bess_settings['home']['consumption_strategy'] = 'fixed'
+        print('Note: influxdb_7d_avg requires the original user\\'s InfluxDB — overriding to fixed for mock run.')
 
-json.dump(bess_settings, open('backend/mock-bess-settings.json', 'w'), indent=2)
+    json.dump(bess_settings, open('backend/mock-bess-settings.json', 'w'), indent=2)
 " || exit 1
 
 # Always use the mock HA server, never the real one

--- a/scripts/mock_ha/scenarios/ci-wizard-both-providers.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-both-providers.json
@@ -308,7 +308,9 @@
       "id": "mock_growatt_device_001",
       "name": "ABC1234567",
       "manufacturer": "Growatt",
-      "model": "MIN 6000TL-XH"
+      "model": "MIN 6000TL-XH",
+      "config_entries": ["mock_growatt_config_entry"],
+      "identifiers": [["growatt_server", "ABC1234567"]]
     }
   ],
   "services": {

--- a/scripts/mock_ha/scenarios/ci-wizard-full.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-full.json
@@ -265,7 +265,9 @@
       "id": "mock_growatt_device_001",
       "name": "ABC1234567",
       "manufacturer": "Growatt",
-      "model": "MIN 6000TL-XH"
+      "model": "MIN 6000TL-XH",
+      "config_entries": ["mock_growatt_config_entry"],
+      "identifiers": [["growatt_server", "ABC1234567"]]
     }
   ],
   "services": {

--- a/scripts/mock_ha/scenarios/ci-wizard-hans-issue105.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-hans-issue105.json
@@ -254,6 +254,12 @@
       "model": "MIN 6000TL-XH",
       "config_entries": [
         "mock_growatt_config_entry"
+      ],
+      "identifiers": [
+        [
+          "growatt_server",
+          "ABC1234567"
+        ]
       ]
     },
     {
@@ -263,6 +269,12 @@
       "model": "X1-Hybrid",
       "config_entries": [
         "mock_solax_config_entry"
+      ],
+      "identifiers": [
+        [
+          "solax_modbus",
+          "SolaX Inverter"
+        ]
       ]
     }
   ],

--- a/scripts/mock_ha/scenarios/ci-wizard-nordpool-hacs.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-nordpool-hacs.json
@@ -232,7 +232,9 @@
       "id": "mock_growatt_device_001",
       "name": "ABC1234567",
       "manufacturer": "Growatt",
-      "model": "MIN 6000TL-XH"
+      "model": "MIN 6000TL-XH",
+      "config_entries": ["mock_growatt_config_entry"],
+      "identifiers": [["growatt_server", "ABC1234567"]]
     }
   ],
   "services": {

--- a/scripts/mock_ha/scenarios/ci-wizard-nordpool-min.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-nordpool-min.json
@@ -230,7 +230,9 @@
       "id": "mock_growatt_device_001",
       "name": "ABC1234567",
       "manufacturer": "Growatt",
-      "model": "MIN 6000TL-XH"
+      "model": "MIN 6000TL-XH",
+      "config_entries": ["mock_growatt_config_entry"],
+      "identifiers": [["growatt_server", "ABC1234567"]]
     }
   ],
   "services": {

--- a/scripts/mock_ha/scenarios/ci-wizard-nordpool-solax.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-nordpool-solax.json
@@ -169,7 +169,9 @@
       "id": "mock_solax_device_001",
       "name": "SolaX X1-Hybrid",
       "manufacturer": "SolaX Power",
-      "model": "X1-Hybrid-6.0"
+      "model": "X1-Hybrid-6.0",
+      "config_entries": ["mock_solax_config_entry"],
+      "identifiers": [["solax_modbus", "SolaX X1-Hybrid"]]
     }
   ],
   "services": {},

--- a/scripts/mock_ha/scenarios/ci-wizard-nordpool-sph.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-nordpool-sph.json
@@ -142,7 +142,9 @@
       "id": "mock_growatt_device_002",
       "name": "XYZ9876543",
       "manufacturer": "Growatt",
-      "model": "SPH 10000TL3-BH-UP"
+      "model": "SPH 10000TL3-BH-UP",
+      "config_entries": ["mock_growatt_config_entry"],
+      "identifiers": [["growatt_server", "XYZ9876543"]]
     }
   ],
   "services": {

--- a/scripts/mock_ha/scenarios/ci-wizard-octopus-sph.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-octopus-sph.json
@@ -270,7 +270,9 @@
       "id": "mock_growatt_device_001",
       "name": "XYZ9876543",
       "manufacturer": "Growatt",
-      "model": "SPH 10000TL3-BH-UP"
+      "model": "SPH 10000TL3-BH-UP",
+      "config_entries": ["mock_growatt_config_entry"],
+      "identifiers": [["growatt_server", "XYZ9876543"]]
     }
   ],
   "services": {

--- a/scripts/mock_ha/scenarios/ci-wizard-octopus.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-octopus.json
@@ -703,7 +703,9 @@
       "id": "mock_growatt_device_001",
       "name": "ABC1234567",
       "manufacturer": "Growatt",
-      "model": "MIN 6000TL-XH"
+      "model": "MIN 6000TL-XH",
+      "config_entries": ["mock_growatt_config_entry"],
+      "identifiers": [["growatt_server", "ABC1234567"]]
     }
   ],
   "services": {


### PR DESCRIPTION
## Summary

Fixes crashes, misleading UI options, and phantom sensor fields for Growatt SPH users reported in #60 (starting from [this comment](https://github.com/johanzander/bess-manager/issues/60#issuecomment-4668261662)).

### Platform capability system

Introduce `supports_charge_rate_control` ClassVar on `InverterController` hierarchy. SPH and SolaX native override to `False`. BSM uses this to guard power monitor initialization and `adjust_charging_power()`. Also fixes pre-existing bug where SolaX skip checked `== "solax"` (never matched actual platform `solax_modbus_native`).

### Backend fixes

- **Power monitor crash**: `adjust_charging_power()` tried to read charge rate registers that don't exist on SPH, causing `int - NoneType` TypeError every 5 minutes — now guarded by capability check
- **Wrong consumption strategy**: `influxdb_7d_avg` requires `local_load_power` which SPH doesn't have — UI now disables when sensor missing
- **Fuse protection unusable**: SPH bakes charge power into atomic TOU writes, no per-period register — toggle disabled when `battery_charging_power_rate` sensor missing
- **Device ID discovery**: Simplified to config_entry match (primary) + identifiers (fallback), removed fragile name-match strategy that depended on SOC entity ID parsing

### Frontend fixes

- **SPH-specific sensor groups**: removed `local_load_power`, `lifetime_system_production`, `lifetime_self_consumption` from SPH power monitoring and lifetime sections — these sensors do not exist on SPH hardware and were confusingly shown as "Not detected"
- **Dead sensors removed from all platforms**: `lifetime_system_production` and `lifetime_self_consumption` removed from Growatt MIN, SolaX native, and SolaX Growatt MIN frontend definitions — BESS always derives these via `EnergyFlowCalculator` from the 5 core energy sensors, so showing them as configurable fields was misleading
- **Missing sensor added**: `lifetime_load_consumption` was missing from `solax_modbus_growatt_min` (GEN4 modbus) UI despite being discovered by the backend and actively used by `ha_statistics` energy prediction
- **Toggle accessibility**: added `role="switch"`, `aria-checked`, `aria-label` to toggle component for proper ARIA semantics
- **Sensor-based gating**: InfluxDB and fuse protection options disabled per platform based on sensor availability

### Tests

- **Unit**: Platform capability declarations verified for all 5 controller subclasses; BSM property delegation; `adjust_charging_power` no-op on unsupported platforms
- **Cross-reference (bidirectional)**: `TestFrontendSensorKeysMatchBackend` parses `sensorDefinitions.ts` and verifies:
  1. Every sensor key in the frontend UI exists in the backend suffix map (no undiscoverable sensors)
  2. Every backend suffix map value not in the frontend is explicitly declared in `BACKEND_ONLY_KEYS` with a reason (no phantom "Not detected" fields)
- **E2E**: Wizard home step verifies InfluxDB radio and fuse protection toggle are disabled/enabled per platform capabilities (separate gating for each)

### Mock infrastructure

- All `ci-wizard-*` scenarios: device objects now include `config_entries` and `identifiers` (matches real HA device registry)
- `mock-run.sh`: supports wizard scenarios without `bess_config` (starts in setup-wizard mode)

### Docs

- Platform Capabilities section added to SOFTWARE_DESIGN.md
- TODO: cleanup device_sn dead code and remaining discovery fallbacks

## Test plan

- [x] `pytest -m "not slow"` passes
- [x] `npm run build` clean
- [x] `black --check` + `ruff check` clean
- [x] E2E: all 8 wizard scenarios pass (MIN, SPH, SolaX, Octopus, Full, HACS, Both, Modbus)
- [x] SPH wizard shows only sensors that exist on hardware (no phantom "Not detected" fields)
- [x] All platforms: no dead sensors shown in wizard UI
- [x] Bidirectional cross-reference test catches frontend/backend sensor key mismatches
- [x] InfluxDB + fuse protection options disabled for SPH, enabled for MIN
- [ ] Verify SPH user (GraemeDBlue) no longer gets int-NoneType crash after release

Generated with [Claude Code](https://claude.com/claude-code)