### PR TITLE
fix: drop i386/armhf from release build matrix

### DIFF
--- a/.github/workflows/release-addon.yml
+++ b/.github/workflows/release-addon.yml
@@ -15,13 +15,12 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - aarch64
           - amd64
-          - armhf
           - armv7
-          - i386
         include:
           - arch: aarch64
             platform: linux/arm64
@@ -29,15 +28,9 @@ jobs:
           - arch: amd64
             platform: linux/amd64
             base_image: ghcr.io/home-assistant/amd64-base:3.19
-          - arch: armhf
-            platform: linux/arm/v6
-            base_image: ghcr.io/home-assistant/armhf-base:3.19
           - arch: armv7
             platform: linux/arm/v7
             base_image: ghcr.io/home-assistant/armv7-base:3.19
-          - arch: i386
-            platform: linux/386
-            base_image: ghcr.io/home-assistant/i386-base:3.19
 
     steps:
       - uses: actions/checkout@v5

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -7,9 +7,7 @@ init: false
 arch:
   - aarch64
   - amd64
-  - armhf
   - armv7
-  - i386
 startup: application
 boot: auto
 ports:


### PR DESCRIPTION
## Summary

- Rollup native bindings don't support i386/armhf under QEMU emulation, causing the v9.3.0 release build to fail
- Adds `fail-fast: false` so remaining arch builds complete if one fails
- These architectures are effectively dead for Home Assistant

## Test plan

- [ ] Re-tag v9.3.0 after merge, verify all 3 arch builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)