### PR TITLE
fix: drop armv7 from supported architectures

### DIFF
--- a/.github/workflows/release-addon.yml
+++ b/.github/workflows/release-addon.yml
@@ -20,7 +20,6 @@ jobs:
         arch:
           - aarch64
           - amd64
-          - armv7
         include:
           - arch: aarch64
             platform: linux/arm64
@@ -28,9 +27,6 @@ jobs:
           - arch: amd64
             platform: linux/amd64
             base_image: ghcr.io/home-assistant/amd64-base:3.19
-          - arch: armv7
-            platform: linux/arm/v7
-            base_image: ghcr.io/home-assistant/armv7-base:3.19
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-addon.yml
+++ b/.github/workflows/release-addon.yml
@@ -15,13 +15,12 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - aarch64
           - amd64
-          - armhf
           - armv7
-          - i386
         include:
           - arch: aarch64
             platform: linux/arm64
@@ -29,15 +28,9 @@ jobs:
           - arch: amd64
             platform: linux/amd64
             base_image: ghcr.io/home-assistant/amd64-base:3.19
-          - arch: armhf
-            platform: linux/arm/v6
-            base_image: ghcr.io/home-assistant/armhf-base:3.19
           - arch: armv7
             platform: linux/arm/v7
             base_image: ghcr.io/home-assistant/armv7-base:3.19
-          - arch: i386
-            platform: linux/386
-            base_image: ghcr.io/home-assistant/i386-base:3.19
 
     steps:
       - uses: actions/checkout@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,27 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=python:3.13-alpine
+
+# Build frontend on native amd64 to avoid QEMU npm timeouts on ARM
+FROM --platform=linux/amd64 node:20-alpine AS frontend-builder
+ARG BUILD_VERSION
+WORKDIR /tmp/frontend
+RUN echo "Building frontend for version ${BUILD_VERSION}"
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
 FROM $BUILD_FROM
 
-# Set version labels
 ARG BUILD_VERSION
 ARG BUILD_DATE
 ARG BUILD_REF
 
-# Labels
 LABEL \
     io.hass.name="BESS Battery Manager" \
     io.hass.description="Battery Energy Storage System optimization and management" \
     io.hass.version=${BUILD_VERSION} \
     io.hass.type="addon" \
-    io.hass.arch="aarch64,amd64,armhf,armv7,i386" \
+    io.hass.arch="aarch64,amd64,armv7" \
     maintainer="Johan Zander <johanzander@gmail.com>" \
     org.label-schema.build-date=${BUILD_DATE} \
     org.label-schema.description="Battery Energy Storage System optimization and management" \
@@ -21,63 +30,36 @@ LABEL \
     org.label-schema.vcs-ref=${BUILD_REF} \
     org.label-schema.vcs-url="https://github.com/johanzander/bess-manager"
 
-# Install requirements for add-on
 RUN apk add --no-cache \
     python3 \
     py3-pip \
     python3-dev \
     gcc \
     musl-dev \
-    bash \
-    nodejs \
-    npm
+    bash
 
-# Set working directory
 WORKDIR /app
 
-# Copy Python application files from backend directory
 COPY backend/app.py backend/api.py backend/api_conversion.py backend/api_dataclasses.py backend/ai_chat.py backend/log_config.py backend/settings_store.py backend/requirements.txt ./
 
-# Copy core directory
 COPY core/ /app/core/
 
-# Copy domain knowledge (used as system prompt by AI analyst)
 COPY docs/agents/bess-knowledge.md /app/agents/bess-knowledge.md
 
-# Build and copy frontend
-# BUILD_VERSION is used here so every new version busts the Docker layer cache,
-# forcing npm run build to re-run with the latest source files.
-WORKDIR /tmp/frontend
-RUN echo "Building frontend for version ${BUILD_VERSION}"
-COPY frontend/package*.json ./
-RUN npm ci
+# Copy pre-built frontend from native build stage
+COPY --from=frontend-builder /tmp/frontend/dist/ /app/frontend/
 
-COPY frontend/ ./
-RUN npm run build
-
-# Move built frontend to app directory
-RUN mkdir -p /app/frontend && mv dist/* /app/frontend/
-
-# Back to app directory
-WORKDIR /app
-
-# Copy run script
 COPY backend/run.sh ./
 
-# Create and use virtual environment
 RUN python3 -m venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"
 ENV PYTHONPATH="/app:${PYTHONPATH}"
 ENV BESS_VERSION=${BUILD_VERSION}
 
-# Install Python requirements in the virtual environment
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Make scripts executable
 RUN chmod a+x /app/run.sh
 
-# Expose the port
 EXPOSE 8080
 
-# Launch application
 CMD ["/usr/bin/with-contenv", "bash", "/app/run.sh"]

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -7,7 +7,6 @@ init: false
 arch:
   - aarch64
   - amd64
-  - armv7
 startup: application
 boot: auto
 ports:

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -7,9 +7,7 @@ init: false
 arch:
   - aarch64
   - amd64
-  - armhf
   - armv7
-  - i386
 startup: application
 boot: auto
 ports:


### PR DESCRIPTION
## Summary

- armv7 pip install fails (Rust-based deps can't compile for arm-musleabihf)
- Popular addons (ESPHome, Matter Server) only support amd64 + aarch64
- amd64 + aarch64 covers Intel NUCs, Raspberry Pi 3/4/5 (64-bit), and all modern HA hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)