### PR TITLE
release: v9.4.1 — keep optimizing when InfluxDB history is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.4.1] - 2026-06-14
+
+### Fixed
+
+- **Optimization no longer freezes when InfluxDB history is unavailable** — Historical reconstruction from InfluxDB is an optional enhancement (it backfills the actuals/savings view) and is never required to run the optimization, which uses live battery SOC plus the configured forecast. Previously a broken InfluxDB connection (e.g. after a Home Assistant update) raised a fatal error that aborted every re-optimization, silently freezing the battery on the midnight forecast for the whole day. The missing-history condition is now surfaced as a runtime failure banner and the hourly optimization continues. Note: the `influxdb_7d_avg` consumption strategy still genuinely requires InfluxDB.
+
 ## [9.4.0] - 2026-06-12
 
 ### Fixed

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.4.0"
+version: "9.4.1"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -21,6 +21,7 @@ from .dp_battery_algorithm import (
 from .dp_schedule import DPSchedule
 from .exceptions import (
     HAStatisticsUnavailableError,
+    HistoricalDataUnavailableError,
     SystemConfigurationError,
 )
 from .growatt_min_controller import GrowattMinController
@@ -1313,75 +1314,107 @@ class BatterySystemManager:
                 f"Collecting data for previous period: {prev_period} ({format_period(prev_period)})"
             )
 
-            # Use sensor collector to get complete energy data with detailed flows
-            # Uses live sensors for current data (fast)
-            # Falls back to InfluxDB for historical data at startup/restart
-            energy_data = self.sensor_collector.collect_energy_data(prev_period)
+            # Use sensor collector to get complete energy data with detailed flows.
+            # Uses live sensors for current data; reconstructs from InfluxDB during
+            # startup/restart backfill. InfluxDB historical reconstruction is an
+            # optional enhancement (it only backfills the actuals/savings view) —
+            # if it is unavailable we surface it and skip this period's actuals,
+            # because the optimization itself runs on live SOC + the configured
+            # forecast (see _gather_optimization_data, which falls back to
+            # predictions for any period without recorded actuals).
+            try:
+                energy_data = self.sensor_collector.collect_energy_data(prev_period)
 
-            logger.info(
-                f"Collected energy data for period {prev_period} ({format_period(prev_period)}) - "
-                f"Solar: {energy_data.solar_production:.3f} kWh, "
-                f"Load: {energy_data.home_consumption:.3f} kWh, "
-                f"SOC: {energy_data.battery_soe_start:.1f}% → {energy_data.battery_soe_end:.1f}%"
-            )
-
-            # Get prices for this period
-            buy_prices, sell_prices = self.price_manager.get_available_prices()
-            if 0 <= prev_period < len(buy_prices):
-                buy_price = buy_prices[prev_period]
-                sell_price = sell_prices[prev_period]
-
-                # Calculate battery cycle cost based on actual charging
-                battery_cycle_cost_sek = (
-                    energy_data.battery_charged
-                    * self.battery_settings.cycle_cost_per_kwh
-                )
-
-                # Calculate economic data from actual energy flows
-                economic_data = EconomicData.from_energy_data(
-                    energy_data=energy_data,
-                    buy_price=buy_price,
-                    sell_price=sell_price,
-                    battery_cycle_cost=battery_cycle_cost_sek,
-                )
-            else:
-                # Period beyond available prices
-                economic_data = EconomicData(
-                    buy_price=0.0, sell_price=0.0, hourly_savings=0.0
-                )
-
-            # Store using period-based API with both planned and observed intents
-            # Get DP-planned intent (authoritative) if available
-            planned_intent = self._get_planned_intent_for_period(prev_period)
-            # Infer observed intent from actual flows
-            battery_power = energy_data.battery_net_change
-            observed = infer_intent_from_flows(battery_power, energy_data)
-
-            period_data = PeriodData(
-                period=prev_period,
-                energy=energy_data,
-                timestamp=time_utils.now(),
-                data_source="actual",
-                economic=economic_data,
-                decision=DecisionData(
-                    strategic_intent=planned_intent or "IDLE",
-                    observed_intent=observed,
-                ),
-            )
-            self.historical_store.record_period(prev_period, period_data)
-            logger.info(
-                f"Recorded energy data for period {prev_period} ({format_period(prev_period)})"
-            )
-
-            # Verify storage
-            stored_data = self.historical_store.get_period(prev_period)
-            if stored_data:
                 logger.info(
-                    f"Verified: Period {prev_period} stored with intent {stored_data.decision.strategic_intent}"
+                    f"Collected energy data for period {prev_period} ({format_period(prev_period)}) - "
+                    f"Solar: {energy_data.solar_production:.3f} kWh, "
+                    f"Load: {energy_data.home_consumption:.3f} kWh, "
+                    f"SOC: {energy_data.battery_soe_start:.1f}% → {energy_data.battery_soe_end:.1f}%"
                 )
-            else:
-                raise RuntimeError(
-                    f"Failed to store energy data for period {prev_period}"
+
+                # Get prices for this period
+                buy_prices, sell_prices = self.price_manager.get_available_prices()
+                if 0 <= prev_period < len(buy_prices):
+                    buy_price = buy_prices[prev_period]
+                    sell_price = sell_prices[prev_period]
+
+                    # Calculate battery cycle cost based on actual charging
+                    battery_cycle_cost_sek = (
+                        energy_data.battery_charged
+                        * self.battery_settings.cycle_cost_per_kwh
+                    )
+
+                    # Calculate economic data from actual energy flows
+                    economic_data = EconomicData.from_energy_data(
+                        energy_data=energy_data,
+                        buy_price=buy_price,
+                        sell_price=sell_price,
+                        battery_cycle_cost=battery_cycle_cost_sek,
+                    )
+                else:
+                    # Period beyond available prices
+                    economic_data = EconomicData(
+                        buy_price=0.0, sell_price=0.0, hourly_savings=0.0
+                    )
+
+                # Store using period-based API with both planned and observed intents
+                # Get DP-planned intent (authoritative) if available
+                planned_intent = self._get_planned_intent_for_period(prev_period)
+                # Infer observed intent from actual flows
+                battery_power = energy_data.battery_net_change
+                observed = infer_intent_from_flows(battery_power, energy_data)
+
+                period_data = PeriodData(
+                    period=prev_period,
+                    energy=energy_data,
+                    timestamp=time_utils.now(),
+                    data_source="actual",
+                    economic=economic_data,
+                    decision=DecisionData(
+                        strategic_intent=planned_intent or "IDLE",
+                        observed_intent=observed,
+                    ),
+                )
+                self.historical_store.record_period(prev_period, period_data)
+                logger.info(
+                    f"Recorded energy data for period {prev_period} ({format_period(prev_period)})"
+                )
+
+                # Verify storage
+                stored_data = self.historical_store.get_period(prev_period)
+                if stored_data:
+                    logger.info(
+                        f"Verified: Period {prev_period} stored with intent {stored_data.decision.strategic_intent}"
+                    )
+                else:
+                    raise RuntimeError(
+                        f"Failed to store energy data for period {prev_period}"
+                    )
+
+                # Reconstruction succeeded — clear any prior unavailable banner
+                self._runtime_failure_tracker.dismiss_by_category(
+                    "HISTORICAL_DATA_UNAVAILABLE"
+                )
+            except HistoricalDataUnavailableError as e:
+                # Optional dependency: keep optimizing, but surface the gap so the
+                # user knows actuals/savings are incomplete (e.g. InfluxDB broken
+                # by an HA update). record_failure_once coalesces the recurring
+                # per-cycle failure into a single banner.
+                self._runtime_failure_tracker.record_failure_once(
+                    category="HISTORICAL_DATA_UNAVAILABLE",
+                    operation=(
+                        "Historical energy-flow reconstruction from InfluxDB — "
+                        "skipping actuals for this period; optimization continues "
+                        "on live SOC and forecast"
+                    ),
+                    error=e,
+                )
+                logger.warning(
+                    "Historical data unavailable for period %d (%s): %s — "
+                    "skipping actuals, optimization continues",
+                    prev_period,
+                    format_period(prev_period),
+                    e,
                 )
 
         else:

--- a/core/bess/exceptions.py
+++ b/core/bess/exceptions.py
@@ -42,3 +42,16 @@ class HAStatisticsUnavailableError(BESSException):
 
     def __init__(self, message: str | None = None):
         super().__init__(message or "HA Statistics data is not available")
+
+
+class HistoricalDataUnavailableError(BESSException):
+    """Raised when InfluxDB historical energy-flow data is unavailable.
+
+    Historical reconstruction is an optional enhancement (it backfills actuals
+    for the daily/savings view); it is never required to run the optimization,
+    which uses live SOC plus the configured forecast. Callers should treat this
+    as a recoverable, surfaced condition rather than aborting the schedule.
+    """
+
+    def __init__(self, message: str | None = None):
+        super().__init__(message or "Historical energy-flow data is not available")

--- a/core/bess/sensor_collector.py
+++ b/core/bess/sensor_collector.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 
 from . import time_utils
 from .energy_flow_calculator import EnergyFlowCalculator
+from .exceptions import HistoricalDataUnavailableError
 from .health_check import perform_health_check
 from .influxdb_helper import get_power_sensor_data_batch, get_sensor_data_batch
 from .models import EnergyData
@@ -163,7 +164,7 @@ class SensorCollector:
             # Get current period readings from InfluxDB
             current_readings = self._get_period_readings(period, date_offset=0)
             if not current_readings:
-                raise RuntimeError(
+                raise HistoricalDataUnavailableError(
                     f"No InfluxDB data available for period {period}. Cannot calculate energy flows."
                 )
 
@@ -181,7 +182,7 @@ class SensorCollector:
                 prev_period, date_offset=date_offset
             )
             if not previous_readings:
-                raise RuntimeError(
+                raise HistoricalDataUnavailableError(
                     f"No InfluxDB data available for period {prev_period} (date_offset={date_offset}). "
                     f"Cannot calculate delta for period {period}."
                 )
@@ -213,7 +214,7 @@ class SensorCollector:
                     prev_period, date_offset=date_offset
                 )
                 if not previous_readings:
-                    raise RuntimeError(
+                    raise HistoricalDataUnavailableError(
                         f"No InfluxDB data available for period {prev_period} (date_offset={date_offset})"
                     )
             else:

--- a/core/bess/tests/unit/test_energy_data_collection_resilience.py
+++ b/core/bess/tests/unit/test_energy_data_collection_resilience.py
@@ -1,0 +1,88 @@
+"""Optimization must survive missing InfluxDB historical data.
+
+Historical reconstruction is an optional enhancement. When InfluxDB is
+unavailable (e.g. broken by a Home Assistant update), collecting a completed
+period's actuals must not abort the schedule update — the optimization runs on
+live SOC + forecast. The gap must instead be surfaced via the runtime failure
+tracker so the user knows actuals/savings are incomplete.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from core.bess.battery_system_manager import BatterySystemManager
+from core.bess.exceptions import HistoricalDataUnavailableError
+
+
+def _make_bsm():
+    bsm = BatterySystemManager.__new__(BatterySystemManager)
+    bsm.sensor_collector = MagicMock()
+    bsm._runtime_failure_tracker = MagicMock()
+    bsm.historical_store = MagicMock()
+    bsm.historical_store.get_today_periods.return_value = []
+    bsm._price_manager = MagicMock()
+    bsm.battery_settings = MagicMock(cycle_cost_per_kwh=0.5)
+    bsm._log_energy_balance = MagicMock()
+    return bsm
+
+
+class TestMissingHistoricalDataIsNonFatal:
+    def test_does_not_raise_when_influxdb_history_unavailable(self):
+        bsm = _make_bsm()
+        bsm.sensor_collector.collect_energy_data.side_effect = (
+            HistoricalDataUnavailableError("no data for period")
+        )
+
+        # Must not raise — the schedule update should continue past this point.
+        bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
+
+    def test_surfaces_failure_for_the_user(self):
+        bsm = _make_bsm()
+        bsm.sensor_collector.collect_energy_data.side_effect = (
+            HistoricalDataUnavailableError("no data for period")
+        )
+
+        bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
+
+        bsm._runtime_failure_tracker.record_failure_once.assert_called_once()
+        _args, kwargs = bsm._runtime_failure_tracker.record_failure_once.call_args
+        assert kwargs["category"] == "HISTORICAL_DATA_UNAVAILABLE"
+
+    def test_does_not_record_actuals_when_history_unavailable(self):
+        bsm = _make_bsm()
+        bsm.sensor_collector.collect_energy_data.side_effect = (
+            HistoricalDataUnavailableError("no data for period")
+        )
+
+        bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
+
+        bsm.historical_store.record_period.assert_not_called()
+
+
+class TestSuccessfulReconstructionClearsBanner:
+    @patch(
+        "core.bess.battery_system_manager.infer_intent_from_flows", return_value="IDLE"
+    )
+    @patch("core.bess.battery_system_manager.EconomicData")
+    def test_dismisses_unavailable_banner_on_success(
+        self, _economic_data, _infer_intent
+    ):
+        bsm = _make_bsm()
+        energy_data = MagicMock(
+            solar_production=1.0,
+            home_consumption=2.0,
+            battery_soe_start=10.0,
+            battery_soe_end=11.0,
+            battery_charged=0.5,
+            battery_net_change=0.5,
+        )
+        bsm.sensor_collector.collect_energy_data.return_value = energy_data
+        bsm._price_manager.get_available_prices.return_value = ([1.0] * 96, [0.5] * 96)
+        bsm._get_planned_intent_for_period = MagicMock(return_value="IDLE")
+        bsm.historical_store.get_period.return_value = MagicMock()
+
+        bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
+
+        bsm._runtime_failure_tracker.dismiss_by_category.assert_any_call(
+            "HISTORICAL_DATA_UNAVAILABLE"
+        )
+        bsm._runtime_failure_tracker.record_failure_once.assert_not_called()


### PR DESCRIPTION
## Summary

Historical reconstruction from InfluxDB is an **optional** enhancement (it backfills the actuals/savings view) and is **never required** to run the optimization, which uses live battery SOC plus the configured forecast.

Previously a broken InfluxDB connection (e.g. after a Home Assistant update) raised a generic `RuntimeError` that aborted **every** re-optimization, silently freezing the battery on the midnight forecast for the whole day. This was discovered in a user debug log where the schedule never updated after `00:02` despite 77 failed re-optimization attempts.

## Changes

- Add `HistoricalDataUnavailableError` to distinguish this recoverable condition from real errors (no string matching, per rules.md)
- Raise it (not `RuntimeError`) at the InfluxDB-missing-data sites in `SensorCollector`
- `_update_energy_data` now catches it, surfaces it via the runtime failure tracker (coalesced banner, same pattern as `HA_STATISTICS_FALLBACK`), and continues so the hourly optimization still runs
- The `influxdb_7d_avg` consumption-forecast path is untouched: InfluxDB remains genuinely required there

## Testing

- New unit tests (`test_energy_data_collection_resilience.py`): missing history is non-fatal, surfaces a failure, records no actuals; success clears the banner
- Fast suite: 595 passed
- Slow suite: 310 passed (1:14:54)
- Frontend: `tsc --noEmit` clean, `vitest` 15 passed
- `black --check .` + `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)