### PR TITLE
release: v9.4.2 — drop redundant runtime-error alert for missing InfluxDB history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.4.2] - 2026-06-15
+
+### Fixed
+
+- **Removed duplicate "Runtime Errors" alert for unavailable InfluxDB history** — When InfluxDB historical data is missing, the dedicated "Incomplete Historical Data" dashboard banner already informs the user. v9.4.1 additionally recorded the same condition in the runtime-failure tracker, so it also appeared in the "Runtime Errors" panel — alarming, since that panel is meant for unexpected, actionable failures and the condition is benign (optimization continues normally). The redundant runtime-error alert is no longer raised; the friendly banner remains the single source of truth.
+
 ## [9.4.1] - 2026-06-14
 
 ### Fixed

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.4.1"
+version: "9.4.2"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1400,25 +1400,12 @@ class BatterySystemManager:
                     raise RuntimeError(
                         f"Failed to store energy data for period {prev_period}"
                     )
-
-                # Reconstruction succeeded — clear any prior unavailable banner
-                self._runtime_failure_tracker.dismiss_by_category(
-                    "HISTORICAL_DATA_UNAVAILABLE"
-                )
             except HistoricalDataUnavailableError as e:
-                # Optional dependency: keep optimizing, but surface the gap so the
-                # user knows actuals/savings are incomplete (e.g. InfluxDB broken
-                # by an HA update). record_failure_once coalesces the recurring
-                # per-cycle failure into a single banner.
-                self._runtime_failure_tracker.record_failure_once(
-                    category="HISTORICAL_DATA_UNAVAILABLE",
-                    operation=(
-                        "Historical energy-flow reconstruction from InfluxDB — "
-                        "skipping actuals for this period; optimization continues "
-                        "on live SOC and forecast"
-                    ),
-                    error=e,
-                )
+                # Optional dependency: keep optimizing on live SOC + forecast.
+                # The gap is already surfaced to the user by the dedicated
+                # "Incomplete Historical Data" dashboard banner, so we do not
+                # also raise a runtime-error alert here — that panel is reserved
+                # for unexpected, actionable failures.
                 logger.warning(
                     "Historical data unavailable for period %d (%s): %s — "
                     "skipping actuals, optimization continues",

--- a/core/bess/tests/unit/test_energy_data_collection_resilience.py
+++ b/core/bess/tests/unit/test_energy_data_collection_resilience.py
@@ -3,11 +3,12 @@
 Historical reconstruction is an optional enhancement. When InfluxDB is
 unavailable (e.g. broken by a Home Assistant update), collecting a completed
 period's actuals must not abort the schedule update — the optimization runs on
-live SOC + forecast. The gap must instead be surfaced via the runtime failure
-tracker so the user knows actuals/savings are incomplete.
+live SOC + forecast. The gap is surfaced to the user by the dedicated
+"Incomplete Historical Data" dashboard banner, so it must NOT also be raised as
+a runtime-error alert (that panel is for unexpected, actionable failures).
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.exceptions import HistoricalDataUnavailableError
@@ -35,7 +36,7 @@ class TestMissingHistoricalDataIsNonFatal:
         # Must not raise — the schedule update should continue past this point.
         bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
 
-    def test_surfaces_failure_for_the_user(self):
+    def test_does_not_raise_runtime_error_alert(self):
         bsm = _make_bsm()
         bsm.sensor_collector.collect_energy_data.side_effect = (
             HistoricalDataUnavailableError("no data for period")
@@ -43,9 +44,10 @@ class TestMissingHistoricalDataIsNonFatal:
 
         bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
 
-        bsm._runtime_failure_tracker.record_failure_once.assert_called_once()
-        _args, kwargs = bsm._runtime_failure_tracker.record_failure_once.call_args
-        assert kwargs["category"] == "HISTORICAL_DATA_UNAVAILABLE"
+        # The dedicated dashboard banner already informs the user; do not add a
+        # redundant entry to the runtime-error panel.
+        bsm._runtime_failure_tracker.record_failure_once.assert_not_called()
+        bsm._runtime_failure_tracker.record_failure.assert_not_called()
 
     def test_does_not_record_actuals_when_history_unavailable(self):
         bsm = _make_bsm()
@@ -56,33 +58,3 @@ class TestMissingHistoricalDataIsNonFatal:
         bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
 
         bsm.historical_store.record_period.assert_not_called()
-
-
-class TestSuccessfulReconstructionClearsBanner:
-    @patch(
-        "core.bess.battery_system_manager.infer_intent_from_flows", return_value="IDLE"
-    )
-    @patch("core.bess.battery_system_manager.EconomicData")
-    def test_dismisses_unavailable_banner_on_success(
-        self, _economic_data, _infer_intent
-    ):
-        bsm = _make_bsm()
-        energy_data = MagicMock(
-            solar_production=1.0,
-            home_consumption=2.0,
-            battery_soe_start=10.0,
-            battery_soe_end=11.0,
-            battery_charged=0.5,
-            battery_net_change=0.5,
-        )
-        bsm.sensor_collector.collect_energy_data.return_value = energy_data
-        bsm._price_manager.get_available_prices.return_value = ([1.0] * 96, [0.5] * 96)
-        bsm._get_planned_intent_for_period = MagicMock(return_value="IDLE")
-        bsm.historical_store.get_period.return_value = MagicMock()
-
-        bsm._update_energy_data(period=10, is_first_run=False, prepare_next_day=False)
-
-        bsm._runtime_failure_tracker.dismiss_by_category.assert_any_call(
-            "HISTORICAL_DATA_UNAVAILABLE"
-        )
-        bsm._runtime_failure_tracker.record_failure_once.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to v9.4.1. When InfluxDB historical data is unavailable, the dedicated **"Incomplete Historical Data"** dashboard banner already informs the user. v9.4.1 *also* recorded the same condition in the runtime-failure tracker, so it appeared a second time in the **"Runtime Errors"** panel — which is reserved for unexpected, actionable failures. That made a benign "optimization continues normally" condition look like a hard error (red ⚠️), confusing a user who reported it from a debug log.

## Change

- `_update_energy_data` no longer calls `record_failure_once` / `dismiss_by_category` for `HISTORICAL_DATA_UNAVAILABLE`. The non-fatal `try/except` (optimization keeps running on live SOC + forecast) and the existing yellow banner are unchanged.

**No algorithm/optimizer code is touched** — only the notification path and its test.

## Testing

- `test_energy_data_collection_resilience.py` updated: missing history stays non-fatal, records no actuals, and now asserts the runtime tracker is **not** touched (3 passed)
- Fast suite: 617 passed
- `black --check .` + `ruff check .` clean
- Slow/algorithm tests delegated to CI (no optimizer changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)