### PR TITLE
Stage C: @claude-bot integrate — feature-lifecycle entry point

### DIFF
--- a/.github/workflows/issue-integrate.yml
+++ b/.github/workflows/issue-integrate.yml
@@ -1,0 +1,56 @@
+# Integration Lifecycle (gated)
+#
+# Triggered manually with `@claude-bot integrate` on a new-integration issue
+# (a new inverter platform or price provider). Drives the issue through the
+# feature-lifecycle skill, ONE stage per invocation, resuming from the PR-body
+# checklist. Re-issue `@claude-bot integrate` to advance to the next stage.
+
+name: Integration Lifecycle
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  integrate:
+    name: Integration Lifecycle
+    if: |
+      github.event.comment.user.login == github.repository_owner &&
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '@claude-bot integrate')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.CLAUDE_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_REVIEWER_PRIVATE_KEY }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          trigger_phrase: "@claude-bot integrate"
+          claude_args: "--max-turns 200 --permission-mode bypassPermissions"
+          prompt: |
+            PLACEHOLDER_PROMPT

--- a/.github/workflows/issue-integrate.yml
+++ b/.github/workflows/issue-integrate.yml
@@ -53,4 +53,58 @@ jobs:
           trigger_phrase: "@claude-bot integrate"
           claude_args: "--max-turns 200 --permission-mode bypassPermissions"
           prompt: |
-            PLACEHOLDER_PROMPT
+            You are the **Integration Lifecycle** bot for issue #${{ github.event.issue.number }} in johanzander/bess-manager.
+
+            ──────────────────────────────────────────────────────────────────
+            REQUIRED READING (read these files before acting)
+            ──────────────────────────────────────────────────────────────────
+            1. docs/agents/rules.md                       — hard constraints
+            2. docs/agents/workflow.md                    — commit/PR/release process
+            3. docs/agents/skill-architecture.md          — how the skills compose
+            4. .claude/skills/feature-lifecycle/SKILL.md  — the orchestrator you execute
+            Then read the matching IMPLEMENTATION skill (see PROCESS step 2):
+              - .claude/skills/add-inverter-platform/SKILL.md   (new inverter), or
+              - .claude/skills/add-price-provider/SKILL.md      (new price provider)
+            And the deploy skill when you reach a ship step:
+              - .claude/skills/release/SKILL.md
+
+            ──────────────────────────────────────────────────────────────────
+            PROCESS
+            ──────────────────────────────────────────────────────────────────
+            1. Get full context:
+                 gh issue view ${{ github.event.issue.number }} --json title,body,labels,comments
+               Then find any existing lifecycle PR for this issue:
+                 gh pr list --state all --search "in:body #${{ github.event.issue.number }}" --json number,title,body,isDraft,state
+
+            2. Decide feature type from the issue (a new INVERTER platform vs a
+               new PRICE PROVIDER) and read the matching implementation skill.
+
+            3. Determine the CURRENT lifecycle stage:
+               - If NO lifecycle PR exists yet → you are at Stage 1. Run the
+                 implementation skill end-to-end, mark the feature experimental,
+                 open a DRAFT PR with the feature-lifecycle checklist in the body,
+                 ship to beta via the release skill, and comment on the issue
+                 asking the user to install + report back.
+               - If a lifecycle PR exists → read its checklist. Advance ONLY to
+                 the next unchecked stage, following feature-lifecycle. If the
+                 next stage is a HUMAN GATE (Stage 2 user log, Stage 5 user
+                 confirmation) and the input isn't present yet, post a polite
+                 status/ask and STOP — do not fabricate it.
+
+            4. Update the PR-body checklist to reflect the stage you completed.
+
+            ──────────────────────────────────────────────────────────────────
+            HARD CONSTRAINTS
+            ──────────────────────────────────────────────────────────────────
+            - Follow feature-lifecycle exactly. Advance ONE stage per run.
+            - PRs are DRAFT. Never push to main. Beta vs prod remotes are owned
+              by the release skill (do not improvise remotes).
+            - NEVER claim real-world validation before the user confirms (Stage 5).
+              Keep the `experimental` marker until then.
+            - NEVER fabricate a user debug log or confirmation. Gates are human.
+            - Batch fixes — do NOT cut a beta release per fix (feature-lifecycle
+              Stage 4).
+            - Do NOT put `Closes #${{ github.event.issue.number }}` in a beta/
+              intermediate PR — only the final prod PR closes the issue.
+            - Run the local gate (pytest -m "not slow"; black/ruff; frontend build)
+              before any push.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ through CLAUDE.md. All stages run on `anthropics/claude-code-action@v1`.
 | 2. Analyze | `@claude-bot analyze` (manual) | `issue-analyze.yml` | ~$0.50–2 | Delegates to `bess-analyst` sub-agent, posts root-cause diagnosis. No code changes. |
 | 3. Fix | `@claude-bot fix` (manual) | `issue-fix.yml` | ~$1–4 | Implements minimal fix per Stage 2 plan, runs `quality-check.sh`, opens draft PR. |
 | 4. Review | `@claude-bot` on a PR (manual) | `pr-review.yml` | ~$0.50–2 | Reviews diff against rules and checklist. |
+| 5. Integrate | `@claude-bot integrate` (manual) | `issue-integrate.yml` | ~$2–10 | Drives a new inverter/provider request through the full experimental→stable lifecycle (`feature-lifecycle`), one stage per invocation. |
 
 **Why gated, not auto:** Stages 2 and 3 cost real money. The user explicitly
 triggers each one after reading the previous stage's output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,13 +141,23 @@ of `analyzed`.
 
 ## Worktree Conventions
 
-- **Default (Agent View / parallel sessions):** use native Claude Code worktrees.
-  `claude agents` and the built-in `--worktree` flag isolate each background
-  session under `.claude/worktrees/` automatically — manage them in Agent View
-  instead of separate editor windows.
-- **Legacy (separate VS Code windows):** create worktrees as sibling folders
-  (e.g. `../bess-manager-feature/`), NOT inside `.claude/worktrees/`, so each
-  opens cleanly in its own VS Code window. Only needed when not using Agent View.
+Both layouts are first-class — either way the worktree is a normal git checkout,
+so per-agent inspect / test / run (`./deploy.sh`, `pytest`, the app) works the
+same. Choose by how you want to reach an agent's work:
+
+- **Sibling folders** (e.g. `../bess-manager-feature/`) — open cleanly in their
+  own VS Code window; this is the go-to when you actively inspect code and run
+  scripts per agent. They work with Agent View too: start the background session
+  *inside* the sibling (it's a linked git worktree, so Claude won't relocate it).
+  Caveat: a sibling only appears in **unscoped** `claude agents` (or
+  `--cwd ~/GitHub`), not in the project-scoped `claude agents --cwd <repo>` view.
+- **Native `.claude/worktrees/`** (`claude agents` / `--worktree` /
+  `EnterWorktree`) — auto-created for background sessions and visible in the
+  **project-scoped** Agent View. Still a real checkout: `code
+  <repo>/.claude/worktrees/<name>` or `cd` into it to run tests/scripts.
+
+Find any session's worktree path by peeking/attaching it in Agent View, or via
+`claude agents --json` (the `cwd` field).
 
 ## Home Assistant Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,13 @@ of `analyzed`.
 
 ## Worktree Conventions
 
-- Create worktrees as sibling folders to the main repo (e.g., `../repo-feature/`), NOT inside `.claude/worktrees/`, so they open cleanly in VS Code
+- **Default (Agent View / parallel sessions):** use native Claude Code worktrees.
+  `claude agents` and the built-in `--worktree` flag isolate each background
+  session under `.claude/worktrees/` automatically — manage them in Agent View
+  instead of separate editor windows.
+- **Legacy (separate VS Code windows):** create worktrees as sibling folders
+  (e.g. `../bess-manager-feature/`), NOT inside `.claude/worktrees/`, so each
+  opens cleanly in its own VS Code window. Only needed when not using Agent View.
 
 ## Home Assistant Integration
 

--- a/docs/agents/memory/feedback_worktree_location.md
+++ b/docs/agents/memory/feedback_worktree_location.md
@@ -1,11 +1,23 @@
 ---
-name: Worktree sibling location
-description: User prefers worktrees as sibling folders, not inside .claude/worktrees/
+name: Worktree location
+description: Default to native Claude Code worktrees (Agent View / --worktree); sibling folders only for the legacy VS Code-window workflow
 type: feedback
 originSessionId: 3c427ddc-6dd1-4bc2-b841-54e3f1c0f4ba
 ---
-Create worktrees as sibling folders to the main repo (e.g. `../bess-manager-feature-name`), not inside `.claude/worktrees/`.
+**Default:** use native Claude Code worktrees. `claude agents` (Agent View) and
+the built-in `--worktree` flag isolate each background session under
+`.claude/worktrees/` automatically. Manage sessions in Agent View, not separate
+editor windows.
 
-**Why:** The `.claude/worktrees/` path is hard to find and open in VS Code. Sibling folders are easy to navigate to and open for local testing.
+**Legacy:** create worktrees as sibling folders (e.g. `../bess-manager-<name>`),
+not inside `.claude/worktrees/`, only when using the old one-window-per-worktree
+VS Code workflow.
 
-**How to apply:** Use `git worktree add ../bess-manager-<name> -b <branch>` instead of the `EnterWorktree` tool.
+**Why:** The sibling layout existed solely so worktrees opened cleanly in their
+own VS Code window. Agent View replaces window-juggling with one dashboard, so
+the native `.claude/worktrees/` location (used by `--worktree` and the
+`EnterWorktree` tool) is fine and preferred when working in Agent View.
+
+**How to apply:** Prefer `claude agents` + background sessions / `--worktree` for
+parallel work. Use `git worktree add ../bess-manager-<name> -b <branch>` only for
+the legacy VS Code-window flow.

--- a/docs/agents/memory/feedback_worktree_location.md
+++ b/docs/agents/memory/feedback_worktree_location.md
@@ -1,23 +1,31 @@
 ---
 name: Worktree location
-description: Default to native Claude Code worktrees (Agent View / --worktree); sibling folders only for the legacy VS Code-window workflow
+description: Sibling worktrees and native .claude/worktrees are both first-class; pick by VS Code-inspect/run workflow vs project-scoped Agent View
 type: feedback
 originSessionId: 3c427ddc-6dd1-4bc2-b841-54e3f1c0f4ba
 ---
-**Default:** use native Claude Code worktrees. `claude agents` (Agent View) and
-the built-in `--worktree` flag isolate each background session under
-`.claude/worktrees/` automatically. Manage sessions in Agent View, not separate
-editor windows.
+Both layouts are valid — the worktree is a normal git checkout either way, so
+per-agent inspect/test/run (`./deploy.sh`, `pytest`, the app) works the same.
 
-**Legacy:** create worktrees as sibling folders (e.g. `../bess-manager-<name>`),
-not inside `.claude/worktrees/`, only when using the old one-window-per-worktree
-VS Code workflow.
+**Sibling folders** (`../bess-manager-<name>`) — open cleanly in their own VS
+Code window; the go-to when actively inspecting/running each agent's work. They
+work with Agent View too: start the background session *inside* the sibling and
+Claude won't relocate it (it's already a linked worktree). Caveat: a sibling only
+shows in **unscoped** `claude agents` (or `--cwd ~/GitHub`), not in the
+project-scoped `claude agents --cwd <repo>` view.
 
-**Why:** The sibling layout existed solely so worktrees opened cleanly in their
-own VS Code window. Agent View replaces window-juggling with one dashboard, so
-the native `.claude/worktrees/` location (used by `--worktree` and the
-`EnterWorktree` tool) is fine and preferred when working in Agent View.
+**Native `.claude/worktrees/`** (`claude agents` / `--worktree` /
+`EnterWorktree`) — auto-created for background sessions, visible in the
+**project-scoped** Agent View. Reach it with `code <repo>/.claude/worktrees/<name>`
+or `cd`.
 
-**How to apply:** Prefer `claude agents` + background sessions / `--worktree` for
-parallel work. Use `git worktree add ../bess-manager-<name> -b <branch>` only for
-the legacy VS Code-window flow.
+**Why:** The user needs to inspect code and run scripts per agent (which is why
+sibling worktrees + VS Code were adopted). Agent View does NOT take that away —
+it's a session dashboard, not an IDE, and every session's worktree is a real
+folder. So siblings remain first-class; native is only required when you want the
+project-scoped Agent View list.
+
+**How to apply:** Default to sibling worktrees for hands-on VS Code work
+(`git worktree add ../bess-manager-<name> -b <branch>`); view Agent View unscoped
+(`claude agents`) to see them. Use native `.claude/worktrees/` when you want the
+project-scoped dashboard. Find a session's path via `claude agents --json` (`cwd`).

--- a/docs/agents/skill-architecture.md
+++ b/docs/agents/skill-architecture.md
@@ -102,6 +102,28 @@ existing controller to model on and how much is new. The architecture
 `/api/services/{domain}/{name}` layer) absorbs new inverters **additively** — no
 core refactor required.
 
+## Running the work: two tracks
+
+Agent work runs on two complementary tracks — pick by whether the work is
+unattended or hands-on. They are not competing; the interactive track is how you
+*build* the autonomous one.
+
+| | Autonomous track | Interactive track |
+|---|---|---|
+| Runtime | GitHub Actions (`claude-code-action`) | Local Claude Code |
+| Trigger | `@claude-bot integrate` on an issue | You, via Agent View (`claude agents`) |
+| Parallelism | one runner per issue (automatic) | many background sessions in Agent View |
+| Isolation | the CI checkout | native worktrees (`.claude/worktrees/`) |
+| Manage via | issues / PRs / Actions tab | the Agent View dashboard |
+| Best for | unattended, user-gated lifecycles | hands-on dev you supervise |
+
+The autonomous track is the `feature-lifecycle` pipeline described above
+(`issue-integrate.yml`). The interactive track is **Agent View** (`claude agents`,
+Claude Code v2.1.139+): dispatch parallel background sessions and triage them by
+status (Needs input / Working / Completed) instead of juggling editor windows.
+See [Worktree Conventions](../../CLAUDE.md) — native `.claude/worktrees/` is the
+default for Agent View sessions.
+
 ## Where to go next
 
 | Concern | File |

--- a/docs/agents/skill-architecture.md
+++ b/docs/agents/skill-architecture.md
@@ -46,9 +46,12 @@ prompt running on `anthropics/claude-code-action@v1`, gated on an owner
 | `issue-analyze.yml` | `@claude-bot analyze` | deep root-cause; dispatches the **`bess-analyst`** subagent |
 | `issue-fix.yml` | `@claude-bot fix` | minimal bug fix → draft PR |
 | `pr-review.yml` | `@claude-bot` on a PR | review the diff against the rules |
+| `issue-integrate.yml` | `@claude-bot integrate` | drive a new-integration issue through `feature-lifecycle`, one stage per invocation (resumes from the PR checklist) |
 
-This pipeline is built for **minimal bug fixes → one PR**. Integration work
-(multi-day, human-gated) is driven by the skill layer, not these workflows.
+The first four workflows are built for **minimal bug fixes → one PR**.
+`issue-integrate.yml` is the bridge between the GitHub pipeline and the skill
+layer: it runs `feature-lifecycle` (via read-the-file), resuming from the PR-body
+checklist, one human-gated stage at a time.
 
 ### Subagents
 

--- a/docs/agents/skill-architecture.md
+++ b/docs/agents/skill-architecture.md
@@ -113,7 +113,7 @@ unattended or hands-on. They are not competing; the interactive track is how you
 | Runtime | GitHub Actions (`claude-code-action`) | Local Claude Code |
 | Trigger | `@claude-bot integrate` on an issue | You, via Agent View (`claude agents`) |
 | Parallelism | one runner per issue (automatic) | many background sessions in Agent View |
-| Isolation | the CI checkout | native worktrees (`.claude/worktrees/`) |
+| Isolation | the CI checkout | git worktrees — sibling **or** native `.claude/worktrees/` |
 | Manage via | issues / PRs / Actions tab | the Agent View dashboard |
 | Best for | unattended, user-gated lifecycles | hands-on dev you supervise |
 
@@ -121,8 +121,10 @@ The autonomous track is the `feature-lifecycle` pipeline described above
 (`issue-integrate.yml`). The interactive track is **Agent View** (`claude agents`,
 Claude Code v2.1.139+): dispatch parallel background sessions and triage them by
 status (Needs input / Working / Completed) instead of juggling editor windows.
-See [Worktree Conventions](../../CLAUDE.md) — native `.claude/worktrees/` is the
-default for Agent View sessions.
+Agent View is a dashboard, not an IDE — each session's worktree is a real folder
+you open in VS Code or `cd` into to run tests/scripts. **Sibling and native
+worktrees are both first-class** (siblings only drop out of the *project-scoped*
+view); see [Worktree Conventions](../../CLAUDE.md).
 
 ## Where to go next
 

--- a/docs/superpowers/plans/2026-06-17-stage-c-issue-integrate-workflow.md
+++ b/docs/superpowers/plans/2026-06-17-stage-c-issue-integrate-workflow.md
@@ -1,0 +1,372 @@
+# Stage C — `issue-integrate.yml` Entry Point — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub workflow that, on owner `@claude-bot integrate`, drives a
+new-integration issue through the `feature-lifecycle` skill — resumably, one stage
+per invocation — reusing the existing `@claude-bot` pipeline conventions.
+
+**Architecture:** One new workflow `.github/workflows/issue-integrate.yml`,
+modeled on `issue-analyze.yml` / `issue-fix.yml` (owner-gated `issue_comment`
+trigger, app-token identity, `claude-code-action@v1`, inline prompt). The prompt
+uses the **read-the-file** pattern (read `.claude/skills/feature-lifecycle/SKILL.md`
+and follow it) — NOT the Skill tool — matching the existing pipeline and avoiding
+any dependency on CI skill auto-discovery. State lives in the **PR-body
+checklist**; each `@claude-bot integrate` invocation reads it and advances to the
+next human gate, then stops. Auto-advance (CI `workflow_run`) and triage routing
+are deferred to Stage D.
+
+**Tech Stack:** GitHub Actions YAML, `anthropics/claude-code-action@v1`,
+`gh` CLI, the existing `feature-lifecycle` + implementation skills (now on `main`).
+
+---
+
+## Design decisions (baked in; flag during review if you disagree)
+
+- **D-C1 — Skill usage = read-the-file.** The prompt instructs Claude to *read*
+  `.claude/skills/feature-lifecycle/SKILL.md` and the matching implementation
+  skill and follow them. No reliance on the Skill tool being surfaced in CI.
+  Rationale: `issue-fix.yml` / `issue-analyze.yml` already use this pattern; the
+  action's skill auto-discovery is undocumented/unverified.
+- **D-C2 — Resume model = manual, owner-gated.** The owner re-issues
+  `@claude-bot integrate` to advance each stage (exactly like Stages 2/3 are
+  re-triggered). Each run reads the PR checklist and advances one stage to the
+  next gate. No firing on arbitrary user comments. (Auto-advance = Stage D.)
+- **D-C3 — Feature type inferred from the issue.** The prompt determines
+  inverter vs price-provider from the issue text/labels and reads the matching
+  implementation skill (`add-inverter-platform` or `add-price-provider`).
+- **D-C4 — Identity & tokens reuse the existing secrets.**
+  `create-github-app-token` (`CLAUDE_REVIEWER_APP_ID` / `CLAUDE_REVIEWER_PRIVATE_KEY`)
+  for git/gh, `CLAUDE_CODE_OAUTH_TOKEN` for the model — identical to
+  `issue-analyze.yml`.
+- **D-C5 — No live end-to-end run in this stage.** A real lifecycle run ships a
+  beta and comments on a user's issue (cost + outward-facing). Stage C delivers
+  the workflow + validation (YAML lint, prompt review, a dry "report-only"
+  smoke invocation on a throwaway test issue). The first real run is Solis #130,
+  gated on @tatusbar.
+
+---
+
+## File Structure
+
+- Create: `.github/workflows/issue-integrate.yml` — the entry/resume workflow.
+- Modify: `docs/agents/skill-architecture.md` — add `issue-integrate.yml` to the
+  GitHub-automation table so the docs match reality.
+- Modify: `CLAUDE.md` — add the integrate stage to the Automated Agent Workflow
+  table.
+
+---
+
+## Task 1: Scaffold the workflow (trigger, gating, identity)
+
+**Files:**
+- Create: `.github/workflows/issue-integrate.yml`
+
+- [ ] **Step 1: Write the workflow header, trigger, and job gating**
+
+Create the file with the trigger + owner gating, mirroring `issue-analyze.yml`.
+The `if` also excludes PR comments (`issue.pull_request == null`) and requires
+the literal `@claude-bot integrate`:
+
+```yaml
+# Integration Lifecycle (gated)
+#
+# Triggered manually with `@claude-bot integrate` on a new-integration issue
+# (a new inverter platform or price provider). Drives the issue through the
+# feature-lifecycle skill, ONE stage per invocation, resuming from the PR-body
+# checklist. Re-issue `@claude-bot integrate` to advance to the next stage.
+
+name: Integration Lifecycle
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  integrate:
+    name: Integration Lifecycle
+    if: |
+      github.event.comment.user.login == github.repository_owner &&
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '@claude-bot integrate')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+```
+
+- [ ] **Step 2: Add the checkout + token + action steps (no prompt yet)**
+
+Append the steps block, identical in shape to `issue-analyze.yml` but with
+write-capable permissions (already set above) and a higher turn budget (the
+lifecycle does real implementation work):
+
+```yaml
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.CLAUDE_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_REVIEWER_PRIVATE_KEY }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          trigger_phrase: "@claude-bot integrate"
+          claude_args: "--max-turns 200 --permission-mode bypassPermissions"
+          prompt: |
+            PLACEHOLDER_PROMPT
+```
+
+- [ ] **Step 3: Validate YAML syntax**
+
+Run:
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/issue-integrate.yml')); print('YAML OK')"
+```
+Expected: `YAML OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+git add .github/workflows/issue-integrate.yml
+git commit -m "ci(integrate): scaffold issue-integrate workflow (trigger + identity)"
+```
+
+---
+
+## Task 2: Write the lifecycle prompt (REQUIRED READING + PROCESS + CONSTRAINTS)
+
+**Files:**
+- Modify: `.github/workflows/issue-integrate.yml` (replace `PLACEHOLDER_PROMPT`)
+
+- [ ] **Step 1: Replace `PLACEHOLDER_PROMPT` with the full prompt**
+
+Use this exact prompt body (keep the YAML block-scalar indentation under
+`prompt: |`):
+
+```
+            You are the **Integration Lifecycle** bot for issue #${{ github.event.issue.number }} in johanzander/bess-manager.
+
+            ──────────────────────────────────────────────────────────────────
+            REQUIRED READING (read these files before acting)
+            ──────────────────────────────────────────────────────────────────
+            1. docs/agents/rules.md                       — hard constraints
+            2. docs/agents/workflow.md                    — commit/PR/release process
+            3. docs/agents/skill-architecture.md          — how the skills compose
+            4. .claude/skills/feature-lifecycle/SKILL.md  — the orchestrator you execute
+            Then read the matching IMPLEMENTATION skill (see PROCESS step 2):
+              - .claude/skills/add-inverter-platform/SKILL.md   (new inverter), or
+              - .claude/skills/add-price-provider/SKILL.md      (new price provider)
+            And the deploy skill when you reach a ship step:
+              - .claude/skills/release/SKILL.md
+
+            ──────────────────────────────────────────────────────────────────
+            PROCESS
+            ──────────────────────────────────────────────────────────────────
+            1. Get full context:
+                 gh issue view ${{ github.event.issue.number }} --json title,body,labels,comments
+               Then find any existing lifecycle PR for this issue:
+                 gh pr list --state all --search "in:body #${{ github.event.issue.number }}" --json number,title,body,isDraft,state
+
+            2. Decide feature type from the issue (a new INVERTER platform vs a
+               new PRICE PROVIDER) and read the matching implementation skill.
+
+            3. Determine the CURRENT lifecycle stage:
+               - If NO lifecycle PR exists yet → you are at Stage 1. Run the
+                 implementation skill end-to-end, mark the feature experimental,
+                 open a DRAFT PR with the feature-lifecycle checklist in the body,
+                 ship to beta via the release skill, and comment on the issue
+                 asking the user to install + report back.
+               - If a lifecycle PR exists → read its checklist. Advance ONLY to
+                 the next unchecked stage, following feature-lifecycle. If the
+                 next stage is a HUMAN GATE (Stage 2 user log, Stage 5 user
+                 confirmation) and the input isn't present yet, post a polite
+                 status/ask and STOP — do not fabricate it.
+
+            4. Update the PR-body checklist to reflect the stage you completed.
+
+            ──────────────────────────────────────────────────────────────────
+            HARD CONSTRAINTS
+            ──────────────────────────────────────────────────────────────────
+            - Follow feature-lifecycle exactly. Advance ONE stage per run.
+            - PRs are DRAFT. Never push to main. Beta vs prod remotes are owned
+              by the release skill (do not improvise remotes).
+            - NEVER claim real-world validation before the user confirms (Stage 5).
+              Keep the `experimental` marker until then.
+            - NEVER fabricate a user debug log or confirmation. Gates are human.
+            - Batch fixes — do NOT cut a beta release per fix (feature-lifecycle
+              Stage 4).
+            - Do NOT put `Closes #${{ github.event.issue.number }}` in a beta/
+              intermediate PR — only the final prod PR closes the issue.
+            - Run the local gate (pytest -m "not slow"; black/ruff; frontend build)
+              before any push.
+```
+
+- [ ] **Step 2: Re-validate YAML (the prompt is the most error-prone part)**
+
+Run:
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/issue-integrate.yml')); p=d['jobs']['integrate']['steps'][-1]['with']['prompt']; print('YAML OK; prompt chars:', len(p)); assert 'feature-lifecycle/SKILL.md' in p and 'Advance ONE stage' in p"
+```
+Expected: `YAML OK; prompt chars: <n>` and no assertion error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+git add .github/workflows/issue-integrate.yml
+git commit -m "ci(integrate): add resumable feature-lifecycle prompt"
+```
+
+---
+
+## Task 3: Document the new stage
+
+**Files:**
+- Modify: `docs/agents/skill-architecture.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add the integrate row to the GitHub-automation table in skill-architecture.md**
+
+Find the table row for `pr-review.yml` and add a row directly after it:
+
+```markdown
+| `issue-integrate.yml` | `@claude-bot integrate` | drive a new-integration issue through `feature-lifecycle`, one stage per invocation (resumes from the PR checklist) |
+```
+
+Also add one sentence under that table:
+
+```markdown
+`issue-integrate.yml` is the bridge between the GitHub pipeline and the skill
+layer: it runs `feature-lifecycle` (via read-the-file), resuming from the PR-body
+checklist, one human-gated stage at a time.
+```
+
+- [ ] **Step 2: Add the integrate stage to CLAUDE.md's Automated Agent Workflow table**
+
+In `CLAUDE.md`, find the four-stage pipeline table (rows Triage/Analyze/Fix/Review)
+and add a row after Review:
+
+```markdown
+| 5. Integrate | `@claude-bot integrate` (manual) | `issue-integrate.yml` | ~$2–10 | Drives a new inverter/provider request through the full experimental→stable lifecycle (`feature-lifecycle`), one stage per invocation. |
+```
+
+- [ ] **Step 3: Verify both edits landed**
+
+Run:
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+grep -q "issue-integrate.yml" docs/agents/skill-architecture.md && echo "OK arch"
+grep -q "@claude-bot integrate" CLAUDE.md && echo "OK claude.md"
+```
+Expected: `OK arch` and `OK claude.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+git add docs/agents/skill-architecture.md CLAUDE.md
+git commit -m "docs: document the integrate lifecycle stage (issue-integrate.yml)"
+```
+
+---
+
+## Task 4: Validation + safe smoke-test plan
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Lint the workflow with actionlint if available, else YAML-only**
+
+Run:
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+if command -v actionlint >/dev/null; then actionlint .github/workflows/issue-integrate.yml && echo "actionlint OK"; else echo "actionlint not installed — YAML check only"; python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-integrate.yml')); print('YAML OK')"; fi
+```
+Expected: `actionlint OK` or `YAML OK`.
+
+- [ ] **Step 2: Confirm the gating logic matches the other workflows**
+
+Run:
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+for f in issue-analyze issue-integrate; do echo "== $f =="; grep -A4 "if: |" .github/workflows/$f.yml; done
+```
+Expected: `issue-integrate` has the same owner + non-PR gating, with
+`@claude-bot integrate` as the phrase.
+
+- [ ] **Step 3: Write the smoke-test instructions into the PR description (not a live run)**
+
+The PR for this branch MUST document how to safely first-exercise the workflow,
+because a real run ships a beta. Put this in the PR body's Test Plan:
+> - [ ] Merge, then open a **throwaway test issue** ("test: integrate smoke")
+>   and comment `@claude-bot integrate`. Confirm the run reads the skills, posts
+>   a status comment, and (since there's no real integration to build) STOPS
+>   cleanly without shipping a beta. Delete the test issue after.
+> - [ ] First real run is Solis #130, once @tatusbar picks the integration.
+
+No command to run here — this step is satisfied by including the text in Task 5's
+PR body.
+
+---
+
+## Task 5: Open the PR
+
+**Files:** none
+
+- [ ] **Step 1: Merge latest main, push, open a draft PR**
+
+```bash
+cd /Users/johanzander/GitHub/bess-manager-stage-c
+git fetch origin --quiet && git merge origin/main --no-edit
+pytest -m "not slow" -q 2>&1 | tail -5   # sanity: nothing broke (workflow-only change)
+git push -u origin feat/issue-integrate-workflow
+gh pr create --draft --base main --head feat/issue-integrate-workflow \
+  --title "Stage C: @claude-bot integrate — feature-lifecycle entry point" \
+  --body "See docs/superpowers/plans/2026-06-17-stage-c-issue-integrate-workflow.md. Adds issue-integrate.yml (owner-gated, resumable, read-the-file feature-lifecycle). No live run yet — smoke-test + first Solis run gated on #130.
+
+## Test Plan
+- [ ] Throwaway test issue + \`@claude-bot integrate\` → reads skills, posts status, stops without shipping a beta.
+- [ ] First real run = Solis #130 after @tatusbar picks the integration."
+```
+Expected: PR URL printed.
+
+- [ ] **Step 2: Report Stage C complete**
+
+State that `issue-integrate.yml` exists, is documented, YAML-valid, gated like
+the other stages, and ready for the throwaway smoke test before any real run.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Implements the grand-plan spec's **Stage C** ("issue-integrate.yml
+  entry point; `@claude-bot integrate` runs feature-lifecycle resumably; wire
+  human gates to comment triggers"). Stage D (triage routing + `workflow_run`
+  auto-advance) is explicitly out of scope (D-C2/D-C5).
+- **Placeholder scan:** `PLACEHOLDER_PROMPT` is a deliberate two-step scaffold
+  (written in Task 1, replaced in Task 2), not a plan gap. No other placeholders.
+- **Consistency:** Secret names (`CLAUDE_REVIEWER_APP_ID`,
+  `CLAUDE_REVIEWER_PRIVATE_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`), trigger phrase
+  (`@claude-bot integrate`), and file paths match `issue-analyze.yml` /
+  `issue-fix.yml` and the now-on-main skill paths, all verified before writing.


### PR DESCRIPTION
## Summary

Stage C of the autonomous inverter integration plan. Adds **`issue-integrate.yml`** — the GitHub bridge that drives a new-integration issue (inverter or price provider) through the `feature-lifecycle` skill, **one human-gated stage per invocation**, resuming from the PR-body checklist.

- Owner-gated `@claude-bot integrate` on an issue (same gating as `issue-analyze`/`issue-fix`).
- **Read-the-file** skill usage (reads `.claude/skills/feature-lifecycle/SKILL.md` + the matching implementation skill) — no dependency on CI skill auto-discovery, matching the existing pipeline.
- Manual, owner-gated resume; auto-advance (CI `workflow_run`) and triage routing are **Stage D**.
- Reuses existing identity/secrets (`CLAUDE_REVIEWER_*`, `CLAUDE_CODE_OAUTH_TOKEN`).
- Docs updated: `docs/agents/skill-architecture.md` + `CLAUDE.md` pipeline table.

Plan: `docs/superpowers/plans/2026-06-17-stage-c-issue-integrate-workflow.md`.

## Notes

- **No live run in this PR.** A real lifecycle run ships a beta + comments on a user's issue (cost + outward-facing). See the Test Plan for the safe first-exercise.

## Test Plan
- [ ] YAML valid; gating matches the other `@claude-bot` workflows (verified locally).
- [ ] Fast tests green locally (no code touched — workflow + docs only).
- [ ] After merge: open a **throwaway test issue** ("test: integrate smoke") and comment `@claude-bot integrate`. Confirm the run reads the skills, posts a status comment, and STOPS cleanly without shipping a beta (no real integration to build). Delete the test issue after.
- [ ] First real run = Solis #130, once @tatusbar picks the integration.