### PR TITLE
fix(ci): drop pip/npm cache from issue-integrate (false failures on gated-stop runs)

### DIFF
--- a/.github/workflows/issue-integrate.yml
+++ b/.github/workflows/issue-integrate.yml
@@ -35,16 +35,17 @@ jobs:
           app-id: ${{ secrets.CLAUDE_REVIEWER_APP_ID }}
           private-key: ${{ secrets.CLAUDE_REVIEWER_PRIVATE_KEY }}
 
+      # No dependency cache here on purpose: many integrate runs legitimately
+      # stop at a human gate (lifecycle Stage 2/5) without installing anything,
+      # and setup-python/-node `cache:` post-steps ERROR when the cache dir was
+      # never created — which would mark every gated-stop run as failed.
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
 
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
The #142 smoke test of `@claude-bot integrate` surfaced this: the bot behaved perfectly (read the skills, recognised the test, stopped without shipping anything) but the **run was marked `failure`**.

Cause: `setup-python@v5` `cache: pip` (and `setup-node` `cache: npm`) post-steps **error** when the cache dir was never created — and a smoke test / any run that stops at a human gate installs no deps.

Why it matters: integrate runs **legitimately stop at human gates** (lifecycle Stage 2 = wait for user debug log, Stage 5 = wait for user confirmation) without installing anything → **every gated-stop run would falsely show red**, and that would also break Stage D's planned `workflow_run` auto-advance (it keys on success/failure).

Fix: drop the dependency caches. Real install runs work fine without them; the cache was only a speed optimisation.

## Test Plan
- [x] YAML valid
- [ ] Re-run the #142 smoke test after merge → run should now end **green**.