### PR TITLE
Re-land corrected #146: solar-export over-crediting fix + DP IDLE-action fix

### DIFF
--- a/core/bess/decision_intelligence.py
+++ b/core/bess/decision_intelligence.py
@@ -440,6 +440,8 @@ def classify_strategic_intent(power: float, energy_data: EnergyData) -> str:
         return "SOLAR_STORAGE"
     elif energy_data.battery_discharged > 0.01:
         return "LOAD_SUPPORT"
+    elif energy_data.grid_exported > 0.01 and energy_data.solar_to_grid > 0.01:
+        return "EXPORT_ARBITRAGE"
     return "IDLE"
 
 

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -140,6 +140,16 @@ def _discretize_state_action_space(
         POWER_STEP_KW,
     )
 
+    # Guarantee IDLE (power=0) is an available action. The arange above is
+    # offset so it never lands exactly on zero, and under the #146 binary-store
+    # semantics ("any positive power charges at max rate") the smallest positive
+    # grid power is a full-rate grid charge — not a hold. Without an explicit
+    # IDLE action the value iteration cannot represent holding the battery, so
+    # the always-achievable IDLE floor (V[t,i] >= idle_reward + V[t+1,i]) is
+    # unreachable and V collapses below it.
+    if not np.any(np.abs(power_levels) <= POWER_TOLERANCE_KW):
+        power_levels = np.sort(np.append(power_levels, 0.0))
+
     return soe_levels, power_levels
 
 

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -188,9 +188,25 @@ def _state_transition(
     the economically correct baseline: free solar energy is more valuable stored
     for later use than exported at the (typically lower) sell price.
     """
-    if power > POWER_TOLERANCE_KW:  # Charging
-        # Energy stored = power throughput x charging efficiency
-        charge_energy = power * dt * battery_settings.efficiency_charge
+    if power > POWER_TOLERANCE_KW:  # STORE disposition (+ optional grid charge)
+        surplus = max(0.0, solar_production - home_consumption)
+        room_throughput = (
+            battery_settings.max_soe_kwh - soe
+        ) / battery_settings.efficiency_charge
+        rate_throughput = battery_settings.max_charge_power_kw * dt
+        solar_to_battery = min(surplus, rate_throughput, room_throughput)
+        remaining_rate = max(
+            0.0, min(rate_throughput, room_throughput) - solar_to_battery
+        )
+        if surplus > POWER_TOLERANCE_KW:
+            grid_to_battery = 0.0  # SOLAR_STORAGE: solar only, no grid top-up
+        else:
+            grid_to_battery = (
+                remaining_rate  # GRID_CHARGING / battery_first: charge at max rate
+            )
+        charge_energy = (
+            solar_to_battery + grid_to_battery
+        ) * battery_settings.efficiency_charge
         next_soe = min(battery_settings.max_soe_kwh, soe + charge_energy)
 
     elif power < -POWER_TOLERANCE_KW:  # Discharging
@@ -200,15 +216,8 @@ def _state_transition(
         actual_discharge = min(discharge_energy, available_energy)
         next_soe = soe - actual_discharge
 
-    else:  # Hold / IDLE — passive solar charging
-        excess_solar = max(0.0, solar_production - home_consumption)
-        # Clamp to inverter max charge rate (excess_solar is kWh, limit is kW * dt = kWh)
-        max_passive_energy = battery_settings.max_charge_power_kw * dt
-        clamped_solar = min(excess_solar, max_passive_energy)
-        passive_charge = clamped_solar * battery_settings.efficiency_charge
-        available_capacity = battery_settings.max_soe_kwh - soe
-        actual_passive = min(passive_charge, available_capacity)
-        next_soe = soe + actual_passive
+    else:  # Hold / IDLE — EXPORT disposition: surplus is exported, battery holds
+        next_soe = soe
 
     # Ensure SOE stays within physical bounds
     next_soe = min(
@@ -282,17 +291,36 @@ def _compute_reward(
     # ============================================================================
     new_cost_basis = cost_basis
 
-    if power > POWER_TOLERANCE_KW:  # Active charging
-        energy_stored = power * dt * battery_settings.efficiency_charge
+    if power > POWER_TOLERANCE_KW:  # STORE disposition
+        surplus = max(0.0, solar_production - home_consumption)
+        room_throughput = (
+            battery_settings.max_soe_kwh - soe
+        ) / battery_settings.efficiency_charge
+        rate_throughput = battery_settings.max_charge_power_kw * dt
+        solar_to_battery = min(surplus, rate_throughput, room_throughput)
+        remaining_rate = max(
+            0.0, min(rate_throughput, room_throughput) - solar_to_battery
+        )
+        if surplus > POWER_TOLERANCE_KW:
+            grid_to_battery = 0.0  # SOLAR_STORAGE: solar only, no grid top-up
+        else:
+            grid_to_battery = (
+                remaining_rate  # GRID_CHARGING / battery_first: charge at max rate
+            )
+
+        energy_stored = (
+            solar_to_battery + grid_to_battery
+        ) * battery_settings.efficiency_charge
         battery_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
 
-        solar_available = max(0, solar_production - home_consumption)
-        solar_to_battery = min(solar_available, power * dt)
-        grid_to_battery = max(0, (power * dt) - solar_to_battery)
-        grid_energy_cost = grid_to_battery * current_buy_price
-        solar_opportunity_cost = solar_to_battery * current_sell_price
-        total_new_cost = grid_energy_cost + solar_opportunity_cost + battery_wear_cost
+        # genuine excess solar (above rate/room) is exported; deliberate grid top-up imported
+        surplus_exported = max(0.0, surplus - solar_to_battery)
+        grid_imported = grid_to_battery + max(0.0, home_consumption - solar_production)
+        grid_exported = surplus_exported
 
+        solar_opportunity_cost = solar_to_battery * current_sell_price
+        grid_energy_cost = grid_to_battery * current_buy_price
+        total_new_cost = grid_energy_cost + solar_opportunity_cost + battery_wear_cost
         if next_soe > battery_settings.min_soe_kwh:
             existing_cost = soe * cost_basis
             new_cost_basis = (existing_cost + total_new_cost) / next_soe
@@ -300,6 +328,13 @@ def _compute_reward(
             new_cost_basis = (
                 (total_new_cost / energy_stored) if energy_stored > 0 else cost_basis
             )
+
+        total_cost = (
+            grid_imported * current_buy_price
+            - grid_exported * current_sell_price
+            + battery_wear_cost
+        )
+        return -total_cost, new_cost_basis
 
     elif power < -POWER_TOLERANCE_KW:  # Discharging
         battery_wear_cost = 0.0
@@ -339,22 +374,11 @@ def _compute_reward(
         if effective_value_per_kwh_stored <= effective_cost_basis:
             return float("-inf"), cost_basis
 
-    else:  # IDLE — passive solar charging
-        passive_energy_stored = next_soe - soe
-        battery_wear_cost = passive_energy_stored * battery_settings.cycle_cost_per_kwh
-        # Solar opportunity cost: stored solar could have been exported at sell price
-        passive_throughput = (
-            passive_energy_stored / battery_settings.efficiency_charge
-            if passive_energy_stored > 0
-            else 0.0
-        )
-        solar_opportunity_cost = passive_throughput * current_sell_price
-
-        if passive_energy_stored > 0 and next_soe > battery_settings.min_soe_kwh:
-            existing_cost = soe * cost_basis
-            new_cost_basis = (
-                existing_cost + solar_opportunity_cost + battery_wear_cost
-            ) / next_soe
+    else:  # IDLE — EXPORT disposition: battery holds, surplus exported
+        battery_wear_cost = 0.0
+        # battery_charged/battery_discharged already 0 from _idle_battery_flows;
+        # with next_soe == soe, _idle_battery_flows returns (0.0, 0.0), so the
+        # energy_balance below exports the full surplus and credits it.
 
     # ============================================================================
     # REWARD CALCULATION
@@ -389,13 +413,28 @@ def _build_period_data(
     current_buy_price = buy_price[period]
     current_sell_price = sell_price[period]
 
-    if power > POWER_TOLERANCE_KW:  # Active charging
-        battery_charged = power * dt
+    if power > POWER_TOLERANCE_KW:  # STORE disposition (+ optional grid charge)
+        surplus = max(0.0, solar_production - home_consumption)
+        room_throughput = (
+            battery_settings.max_soe_kwh - soe
+        ) / battery_settings.efficiency_charge
+        rate_throughput = battery_settings.max_charge_power_kw * dt
+        solar_to_battery = min(surplus, rate_throughput, room_throughput)
+        remaining_rate = max(
+            0.0, min(rate_throughput, room_throughput) - solar_to_battery
+        )
+        if surplus > POWER_TOLERANCE_KW:
+            grid_to_battery = 0.0  # SOLAR_STORAGE: solar only, no grid top-up
+        else:
+            grid_to_battery = (
+                remaining_rate  # GRID_CHARGING / battery_first: charge at max rate
+            )
+        battery_charged = solar_to_battery + grid_to_battery
         battery_discharged = 0.0
     elif power < -POWER_TOLERANCE_KW:  # Active discharging
         battery_charged = 0.0
         battery_discharged = abs(power) * dt
-    else:  # IDLE — passive solar charging
+    else:  # IDLE — EXPORT disposition: battery holds, surplus exported
         battery_charged, battery_discharged = _idle_battery_flows(
             soe, next_soe, battery_settings
         )
@@ -417,19 +456,9 @@ def _build_period_data(
         battery_soe_end=next_soe,
     )
 
-    if power > POWER_TOLERANCE_KW:  # Active charging
-        energy_stored = power * dt * battery_settings.efficiency_charge
+    if power > POWER_TOLERANCE_KW:  # STORE disposition
+        energy_stored = next_soe - soe
         battery_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
-
-        expected_stored = next_soe - soe
-        if abs(energy_stored - expected_stored) > 0.01:
-            logger.warning(
-                f"Energy stored mismatch: calculated={energy_stored:.3f}, "
-                f"SOE delta={expected_stored:.3f}"
-            )
-    elif abs(power) <= POWER_TOLERANCE_KW and next_soe > soe:  # Passive solar charging
-        passive_energy_stored = next_soe - soe
-        battery_wear_cost = passive_energy_stored * battery_settings.cycle_cost_per_kwh
     else:
         battery_wear_cost = 0.0
 
@@ -1038,8 +1067,8 @@ def optimize_battery_schedule(
         f"Starting direct optimization: horizon={horizon}, initial_soe={initial_soe:.1f}, initial_cost_basis={initial_cost_basis:.3f}"
     )
 
-    # Step 1: Run DP with PeriodData storage
-    _, _, _, stored_period_data = _run_dynamic_programming(
+    # Step 1: Run DP — capture policy for continuous reconstruction
+    _, policy, _, _ = _run_dynamic_programming(
         horizon=horizon,
         buy_price=buy_price,
         sell_price=sell_price,
@@ -1054,9 +1083,14 @@ def optimize_battery_schedule(
         max_charge_power_per_period=max_charge_power_per_period,
     )
 
-    # Step 2: Extract optimal path results directly from stored DP data
+    # Step 2: Reconstruct the optimal path with continuous SoE propagation.
+    # The old approach read period_data from stored_period_data[(t, i)], which
+    # reported grid-snapped SoE values (battery_soe_end = soe_levels[next_i]).
+    # Here we carry the exact floating-point SoE forward each period so the
+    # reported trajectory matches what the simulator will produce (R == P).
     hourly_results = []
     current_soe = initial_soe
+    current_cost_basis = initial_cost_basis
     soe_levels = np.arange(
         battery_settings.min_soe_kwh,
         battery_settings.max_soe_kwh + SOE_STEP_KWH,
@@ -1064,20 +1098,57 @@ def optimize_battery_schedule(
     )
 
     for t in range(horizon):
-        # Find current state index (same logic as simulation)
+        # Map continuous SoE to the nearest grid index to look up the policy action
         i = round((current_soe - battery_settings.min_soe_kwh) / SOE_STEP_KWH)
         i = min(max(0, i), len(soe_levels) - 1)
+        action = float(policy[t, i])
 
-        # Get the PeriodData from DP results - should always exist with valid inputs
-        if (t, i) not in stored_period_data:
-            raise RuntimeError(
-                f"Missing DP result for hour {t}, state {i} (SOE={current_soe:.1f}). "
-                f"This indicates a bug in the DP algorithm or invalid inputs."
-            )
+        # Propagate SoE continuously using the exact same physics as the simulator
+        next_soe = _state_transition(
+            current_soe,
+            action,
+            battery_settings,
+            dt,
+            solar_production=solar_production[t],
+            home_consumption=home_consumption[t],
+        )
 
-        period_data = stored_period_data[(t, i)]
+        # Thread cost_basis continuously forward
+        reward, new_cost_basis = _compute_reward(
+            power=action,
+            soe=current_soe,
+            next_soe=next_soe,
+            period=t,
+            home_consumption=home_consumption[t],
+            battery_settings=battery_settings,
+            dt=dt,
+            buy_price=buy_price,
+            sell_price=sell_price,
+            solar_production=solar_production[t],
+            cost_basis=current_cost_basis,
+        )
+        # _compute_reward returns (-inf, cost_basis) for a blocked discharge; when
+        # replaying the already-chosen policy action just keep the current basis.
+        if reward == float("-inf"):
+            new_cost_basis = current_cost_basis
+
+        period_data = _build_period_data(
+            power=action,
+            soe=current_soe,
+            next_soe=next_soe,
+            period=t,
+            home_consumption=home_consumption[t],
+            battery_settings=battery_settings,
+            dt=dt,
+            buy_price=buy_price,
+            sell_price=sell_price,
+            solar_production=solar_production[t],
+            new_cost_basis=new_cost_basis,
+            currency=currency,
+        )
         hourly_results.append(period_data)
-        current_soe = period_data.energy.battery_soe_end
+        current_soe = next_soe
+        current_cost_basis = new_cost_basis
 
     # Step 3: Calculate economic summary directly from PeriodData
     total_base_cost = sum(

--- a/core/bess/simulation/inverter_simulator.py
+++ b/core/bess/simulation/inverter_simulator.py
@@ -98,8 +98,10 @@ def mode_to_power(
         )
         return -delivered_kwh / dt
 
-    # SOLAR_STORAGE / IDLE: power 0 -> _state_transition stores surplus solar passively
-    return 0.0
+    # SOLAR_STORAGE (load_first + no discharge): STORE disposition — charge all surplus.
+    # _state_transition's STORE branch caps at rate/room; no grid top-up since power*dt==surplus.
+    surplus = max(0.0, solar - home)
+    return surplus / dt
 
 
 @dataclass

--- a/core/bess/simulation/verification.py
+++ b/core/bess/simulation/verification.py
@@ -72,3 +72,43 @@ def ab_compare(
     )
     # cost delta; savings delta is the negation. Positive cost delta = modified costs more.
     return mod.realized_cost - base.realized_cost
+
+
+def realized_under_solar_error(
+    forecast_solar,
+    actual_solar,
+    buy_price,
+    sell_price,
+    home,
+    initial_soe: float,
+    settings: BatterySettings,
+    dt: float,
+) -> tuple[float, float]:
+    """Forecast-robustness harness: optimize on the *forecast* solar, then execute
+    the derived commands against the *actual* solar.
+
+    Returns ``(planned_cost_on_forecast, realized_cost_on_actual)``. With the binary
+    store/export model, bonus solar (actual > forecast) is captured or exported with
+    no phantom export booked, so realized should never be worse than the
+    forecast plan would have been on the actual day. This is the simulator-verified
+    answer to "is the schedule robust to solar forecast error?".
+    """
+    result = optimize_battery_schedule(
+        buy_price=buy_price,
+        sell_price=sell_price,
+        home_consumption=home,
+        solar_production=forecast_solar,
+        initial_soe=initial_soe,
+        battery_settings=settings,
+        period_duration_hours=dt,
+    )
+    commands = [
+        derive_control_command(
+            pd.decision.strategic_intent, pd.decision.battery_action / dt, settings
+        )
+        for pd in result.period_data
+    ]
+    sim = simulate(
+        commands, actual_solar, home, buy_price, sell_price, initial_soe, settings, dt
+    )
+    return result.economic_summary.battery_solar_cost, sim.realized_cost

--- a/core/bess/tests/helpers.py
+++ b/core/bess/tests/helpers.py
@@ -1,7 +1,10 @@
 """Shared test utilities for battery optimization tests.
 
 Reduces boilerplate across test files by providing:
-- run_scenario(): one-liner to run optimization from a scenario dict
+- run_scenario(): one-liner to run optimization from a scenario dict (plan, P)
+- run_scenario_realized(): also executes the plan through the inverter simulator,
+  returning the *realized* economics (R) so scenarios can verify the plan is
+  faithfully executable (R == P), not just that the plan claims a number.
 - Behavioral assertion helpers for strategic intents and physical constraints
 """
 
@@ -14,16 +17,13 @@ from core.bess.settings import (
     VAT_MULTIPLIER,
     BatterySettings,
 )
+from core.bess.simulation.inverter_simulator import derive_control_command, simulate
 
 
-def run_scenario(scenario: dict):
-    """Run optimization from a scenario dict (same format as JSON test data files).
-
-    Returns the OptimizationResult from optimize_battery_schedule.
-    """
+def _scenario_inputs(scenario: dict):
+    """Build optimizer inputs from a scenario dict. Shared by run_scenario and
+    run_scenario_realized so plan (P) and realized (R) use identical inputs."""
     base_prices = scenario["base_prices"]
-    home_consumption = scenario["home_consumption"]
-    solar_production = scenario["solar_production"]
     battery = scenario["battery"]
     price_data = scenario.get("price_data")
 
@@ -57,21 +57,51 @@ def run_scenario(scenario: dict):
         tax_reduction=tax_reduction,
         area="SE4",
     )
+    return {
+        "buy_price": price_manager.get_buy_prices(raw_prices=base_prices),
+        "sell_price": price_manager.get_sell_prices(raw_prices=base_prices),
+        "home_consumption": scenario["home_consumption"],
+        "solar_production": scenario["solar_production"],
+        "initial_soe": battery["initial_soe"],
+        "battery_settings": battery_settings,
+        "period_duration_hours": scenario.get("period_duration_hours", 1.0),
+    }
 
-    buy_prices = price_manager.get_buy_prices(raw_prices=base_prices)
-    sell_prices = price_manager.get_sell_prices(raw_prices=base_prices)
 
-    period_duration_hours = scenario.get("period_duration_hours", 1.0)
+def run_scenario(scenario: dict):
+    """Run optimization from a scenario dict. Returns the OptimizationResult (plan, P)."""
+    return optimize_battery_schedule(**_scenario_inputs(scenario))
 
-    return optimize_battery_schedule(
-        buy_price=buy_prices,
-        sell_price=sell_prices,
-        home_consumption=home_consumption,
-        solar_production=solar_production,
-        initial_soe=battery["initial_soe"],
-        battery_settings=battery_settings,
-        period_duration_hours=period_duration_hours,
+
+def run_scenario_realized(scenario: dict) -> tuple:
+    """Run the optimizer AND execute its plan through the inverter simulator.
+
+    Returns ``(result, realized_cost)`` where ``result.economic_summary.battery_solar_cost``
+    is the planned cost (P) and ``realized_cost`` is what the derived inverter
+    commands actually achieve (R). For an executable plan these are equal to the
+    cent; a gap is a control-fidelity finding.
+    """
+    inp = _scenario_inputs(scenario)
+    result = optimize_battery_schedule(**inp)
+    dt = inp["period_duration_hours"]
+    settings = inp["battery_settings"]
+    commands = [
+        derive_control_command(
+            pd.decision.strategic_intent, pd.decision.battery_action / dt, settings
+        )
+        for pd in result.period_data
+    ]
+    sim = simulate(
+        commands,
+        inp["solar_production"],
+        inp["home_consumption"],
+        inp["buy_price"],
+        inp["sell_price"],
+        inp["initial_soe"],
+        settings,
+        dt,
     )
+    return result, sim.realized_cost
 
 
 def get_intent_distribution(result) -> dict[str, int]:

--- a/core/bess/tests/integration/test_plan_faithfulness.py
+++ b/core/bess/tests/integration/test_plan_faithfulness.py
@@ -1,5 +1,4 @@
 # core/bess/tests/integration/test_plan_faithfulness.py
-import pytest
 
 from core.bess.simulation.verification import verify_plan_faithfulness
 from core.bess.tests.helpers import make_battery_settings
@@ -17,16 +16,6 @@ def _controlled_scenario():
     return buy, sell, solar, home
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Known control-fidelity gap: battery_first always charges at max rate, "
-        "so the per-period SoC trajectory diverges from the optimizer's planned "
-        "partial-charge split (7.4 kWh vs 10.0 kWh in P0/P1). "
-        "This is the anticipated finding the simulator exists to expose — "
-        "do NOT fix by weakening the assertion or patching mode_to_power."
-    ),
-)
 def test_realized_equals_planned_on_controlled_scenario():
     bs = make_battery_settings()
     buy, sell, solar, home = _controlled_scenario()
@@ -62,15 +51,11 @@ def test_identical_command_sequences_have_zero_delta():
     assert delta == 0.0
 
 
-def test_solar_storage_mode_stores_all_surplus_not_partial():
-    """Diagnostic for the plan-faithfulness finding (see
-    docs/investigations/simulator-plan-faithfulness-finding.md).
-
-    SOLAR_STORAGE maps to load_first, which stores ALL available surplus solar.
-    The control command carries no charge-power fraction, so the mode cannot
-    express the optimizer's planned *partial* solar storage. This is the
-    structural source of the R != P gap on solar days; it is asserted here so
-    the behaviour is pinned and the finding is visible in the suite.
+def test_solar_storage_mode_stores_all_surplus():
+    """STORE disposition: SOLAR_STORAGE → load_first stores ALL available surplus
+    solar (up to rate/room) — the binary store-all behaviour the optimizer now
+    plans against, so plan and execution agree. (Replaces the earlier diagnostic
+    that asserted the old mode_to_power==0 behaviour; see #145.)
     """
     from core.bess.simulation.inverter_simulator import (
         ControlCommand,
@@ -81,11 +66,13 @@ def test_solar_storage_mode_stores_all_surplus_not_partial():
     bs = make_battery_settings(max_charge_power_kw=10.0)
     cmd = ControlCommand("load_first", discharge_rate_pct=0, grid_charge=False)
 
-    # mode_to_power yields 0 kW (passive); _state_transition then stores surplus.
-    assert mode_to_power(cmd, solar=5.0, home=0.5, soe=5.0, settings=bs, dt=1.0) == 0.0
+    # mode_to_power now returns the surplus power (store all surplus), not 0.
+    surplus = 5.0 - 0.5
+    assert (
+        mode_to_power(cmd, solar=5.0, home=0.5, soe=5.0, settings=bs, dt=1.0)
+        == surplus / 1.0
+    )
 
-    # Over one hour with 4.5 kWh surplus, load_first stores ~all of it (efficiency
-    # adjusted), NOT a small partial amount the optimizer might have planned.
     sim = simulate(
         [cmd],
         solar_production=[5.0],
@@ -97,7 +84,87 @@ def test_solar_storage_mode_stores_all_surplus_not_partial():
         dt=1.0,
     )
     stored = sim.period_data[0].energy.battery_soe_end - 5.0
-    assert stored > 4.0, (
-        f"load_first should store ~all 4.5 kWh surplus, got {stored:.2f}; "
-        "the mode cannot express a partial charge"
+    assert (
+        stored > 4.0
+    ), f"load_first should store ~all 4.5 kWh surplus, got {stored:.2f}"
+
+
+def test_forecast_robustness_more_solar_than_planned():
+    """Task 7 / #145: optimize on a solar FORECAST, then execute against HIGHER
+    actual solar. The binary store/export model must be forecast-robust — bonus
+    solar is captured/exported, never wasted — so realized is at least as good as
+    the forecast plan (lower or equal cost)."""
+    from core.bess.simulation.verification import realized_under_solar_error
+
+    bs = make_battery_settings()
+    n = 6
+    buy = [1.0, 1.0, 2.0, 2.0, 1.0, 1.0]
+    sell = [0.8, 0.8, 1.8, 1.8, 0.9, 0.9]
+    home = [0.3] * n
+    forecast_solar = [1.0] * n
+    actual_solar = [2.0] * n  # reality beats the forecast
+
+    planned, realized = realized_under_solar_error(
+        forecast_solar=forecast_solar,
+        actual_solar=actual_solar,
+        buy_price=buy,
+        sell_price=sell,
+        home=home,
+        initial_soe=5.0,
+        settings=bs,
+        dt=1.0,
     )
+    # more actual solar than forecast → realized cost no worse than planned (bonus
+    # solar exported/stored, no phantom export booked against the forecast)
+    assert (
+        realized <= planned + 1e-6
+    ), f"forecast not robust: realized {realized} > planned {planned}"
+
+
+def test_scenarios_are_plan_faithful_realized_equals_planned():
+    """Scenarios verify R (realized), not just P (plan): executing the optimizer's
+    plan through the inverter simulator must reproduce the planned economics to
+    within the DP's SoE-grid resolution. A larger gap is a control-fidelity
+    finding (#145)."""
+    from core.bess.tests.helpers import run_scenario_realized
+
+    scenarios = {
+        "grid_charge_arbitrage": {
+            "base_prices": [0.5, 0.5, 2.0, 2.0, 1.0, 1.0],
+            "home_consumption": [0.5] * 6,
+            "solar_production": [0.0] * 6,
+            "battery": _battery(initial_soe=3.0),
+        },
+        "solar_day": {
+            "base_prices": [1.2, 1.1, 0.6, 0.6, 1.5, 1.6],
+            "home_consumption": [0.2] * 6,
+            "solar_production": [1.5, 1.8, 1.9, 1.7, 0.5, 0.0],
+            "battery": _battery(initial_soe=3.0),
+        },
+    }
+    # Tolerance reflects the DP's 0.1 kWh SoE-grid resolution: the plan trajectory
+    # is reconstructed continuously, but the policy LOOKUP still snaps SoE to the
+    # grid, leaving a sub-öre-per-period residual on solar-storage days. The
+    # structural mismodels (phantom export, store/export collisions) are gone — a
+    # gap beyond this band would be a real finding.
+    GRID_RESOLUTION_TOLERANCE = 0.10  # SEK, for these short scenarios
+    for name, sc in scenarios.items():
+        result, realized = run_scenario_realized(sc)
+        planned = result.economic_summary.battery_solar_cost
+        assert abs(realized - planned) <= GRID_RESOLUTION_TOLERANCE, (
+            f"{name}: R={realized:.4f} != P={planned:.4f} "
+            f"(gap {realized - planned:+.4f} exceeds grid-resolution tolerance)"
+        )
+
+
+def _battery(initial_soe):
+    return {
+        "max_soe_kwh": 20.0,
+        "min_soe_kwh": 2.2,
+        "max_charge_power_kw": 10.0,
+        "max_discharge_power_kw": 10.0,
+        "efficiency_charge": 0.97,
+        "efficiency_discharge": 0.95,
+        "cycle_cost_per_kwh": 0.40,
+        "initial_soe": initial_soe,
+    }

--- a/core/bess/tests/unit/data/historical_2024_08_16_high_spread_no_solar.json
+++ b/core/bess/tests/unit/data/historical_2024_08_16_high_spread_no_solar.json
@@ -90,12 +90,12 @@
     "max_discharge_power_kw": 6.0
   },
   "expected_results": {
-    "base_cost": 300.96,
-    "battery_solar_cost": 230.41,
-    "base_to_battery_solar_savings": 70.54,
-    "base_to_battery_solar_savings_pct": 23.4,
-    "total_charged": 44.8,
-    "total_discharged": 44.8
+    "base_cost": 300.95585,
+    "battery_solar_cost": 230.4346,
+    "base_to_battery_solar_savings": 70.5212,
+    "base_to_battery_solar_savings_pct": 23.4324,
+    "total_charged": 45.0,
+    "total_discharged": 45.0
   },
   "price_data": {
     "markup_rate": 0.08,
@@ -105,8 +105,13 @@
   },
   "expected_behavior": {
     "description": "High price spread without solar: should grid-charge at night lows and discharge during evening peaks",
-    "intents_present": ["GRID_CHARGING", "LOAD_SUPPORT"],
-    "intents_absent": ["SOLAR_STORAGE"],
+    "intents_present": [
+      "GRID_CHARGING",
+      "LOAD_SUPPORT"
+    ],
+    "intents_absent": [
+      "SOLAR_STORAGE"
+    ],
     "savings_positive": true,
     "constraints": {
       "soe_within_bounds": true,

--- a/core/bess/tests/unit/data/historical_2025_01_05_no_spread_no_solar.json
+++ b/core/bess/tests/unit/data/historical_2025_01_05_no_spread_no_solar.json
@@ -90,12 +90,12 @@
     "max_discharge_power_kw": 6.0
   },
   "expected_results": {
-    "base_cost": 282.79,
-    "battery_solar_cost": 282.26,
-    "base_to_battery_solar_savings": 0.53,
-    "base_to_battery_solar_savings_pct": 0.19,
-    "total_charged": 8.0,
-    "total_discharged": 7.6
+    "base_cost": 282.789,
+    "battery_solar_cost": 282.789,
+    "base_to_battery_solar_savings": 0.0,
+    "base_to_battery_solar_savings_pct": 0.0,
+    "total_charged": 0.0,
+    "total_discharged": 0.0
   },
   "price_data": {
     "markup_rate": 0.08,
@@ -106,14 +106,13 @@
   "expected_behavior": {
     "description": "Flat prices, no solar: minimal arbitrage opportunity, mostly idle with some load support",
     "intents_present": [
-      "IDLE",
-      "LOAD_SUPPORT"
+      "IDLE"
     ],
     "intents_absent": [
       "SOLAR_STORAGE",
       "EXPORT_ARBITRAGE"
     ],
-    "savings_positive": true,
+    "savings_positive": false,
     "constraints": {
       "soe_within_bounds": true,
       "power_within_limits": true

--- a/core/bess/tests/unit/data/historical_2025_01_12_evening_peak_no_solar.json
+++ b/core/bess/tests/unit/data/historical_2025_01_12_evening_peak_no_solar.json
@@ -90,12 +90,12 @@
     "max_discharge_power_kw": 6.0
   },
   "expected_results": {
-    "base_cost": 272.03,
-    "battery_solar_cost": 241.3,
-    "base_to_battery_solar_savings": 30.72,
-    "base_to_battery_solar_savings_pct": 11.29,
-    "total_charged": 26.8,
-    "total_discharged": 26.8
+    "base_cost": 272.025,
+    "battery_solar_cost": 241.1468,
+    "base_to_battery_solar_savings": 30.8783,
+    "base_to_battery_solar_savings_pct": 11.3513,
+    "total_charged": 27.0,
+    "total_discharged": 27.0
   },
   "price_data": {
     "markup_rate": 0.08,

--- a/core/bess/tests/unit/data/historical_2025_01_13_night_low_no_solar.json
+++ b/core/bess/tests/unit/data/historical_2025_01_13_night_low_no_solar.json
@@ -90,12 +90,12 @@
     "max_discharge_power_kw": 6.0
   },
   "expected_results": {
-    "base_cost": 205.63,
-    "battery_solar_cost": 202.43,
-    "base_to_battery_solar_savings": 3.2,
-    "base_to_battery_solar_savings_pct": 1.55,
-    "total_charged": 10.4,
-    "total_discharged": 10.4
+    "base_cost": 205.6275,
+    "battery_solar_cost": 202.6295,
+    "base_to_battery_solar_savings": 2.998,
+    "base_to_battery_solar_savings_pct": 1.458,
+    "total_charged": 12.0,
+    "total_discharged": 12.0
   },
   "expected_results_original": {
     "base_cost": 51.68,

--- a/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
+++ b/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
@@ -91,10 +91,10 @@
     "total_capacity": 30.0
   },
   "expected_results": {
-    "base_cost": 68.61,
-    "battery_solar_cost": -5.85,
-    "base_to_battery_solar_savings": 74.46,
-    "base_to_battery_solar_savings_pct": 108.5,
+    "base_cost": 68.613,
+    "battery_solar_cost": -5.8579,
+    "base_to_battery_solar_savings": 74.4709,
+    "base_to_battery_solar_savings_pct": 108.5376,
     "total_charged": 12.8,
     "total_discharged": 26.0
   },
@@ -106,8 +106,13 @@
   },
   "expected_behavior": {
     "description": "High solar day: should store solar and export arbitrage during peak hours, no grid charging needed",
-    "intents_present": ["SOLAR_STORAGE", "EXPORT_ARBITRAGE"],
-    "intents_absent": ["GRID_CHARGING"],
+    "intents_present": [
+      "SOLAR_STORAGE",
+      "EXPORT_ARBITRAGE"
+    ],
+    "intents_absent": [
+      "GRID_CHARGING"
+    ],
     "savings_positive": true,
     "constraints": {
       "soe_within_bounds": true,

--- a/core/bess/tests/unit/data/realworld_2026_03_24_225535.json
+++ b/core/bess/tests/unit/data/realworld_2026_03_24_225535.json
@@ -330,10 +330,12 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 129.1,
-    "battery_solar_cost": 76.0,
-    "base_to_battery_solar_savings": 53.1,
-    "base_to_battery_solar_savings_pct": 41.1
+    "base_cost": 129.10468,
+    "battery_solar_cost": 76.8378,
+    "base_to_battery_solar_savings": 52.2669,
+    "base_to_battery_solar_savings_pct": 40.4841,
+    "total_charged": 6.7,
+    "total_discharged": 22.8
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-03-24, with solar, price spread 1.07 SEK",

--- a/core/bess/tests/unit/data/realworld_2026_04_11_004719.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_11_004719.json
@@ -306,16 +306,17 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 161.6,
-    "battery_solar_cost": 94.6,
-    "base_to_battery_solar_savings": 67.0,
-    "base_to_battery_solar_savings_pct": 41.5
+    "base_cost": 161.55022,
+    "battery_solar_cost": 95.5962,
+    "base_to_battery_solar_savings": 65.9541,
+    "base_to_battery_solar_savings_pct": 40.8257,
+    "total_charged": 5.3,
+    "total_discharged": 4.9
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-11, with solar, price spread 1.57 SEK",
     "intents_present": [
       "EXPORT_ARBITRAGE",
-      "GRID_CHARGING",
       "IDLE",
       "LOAD_SUPPORT",
       "SOLAR_STORAGE"

--- a/core/bess/tests/unit/data/realworld_2026_04_19_084608.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_19_084608.json
@@ -198,26 +198,25 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 2.4,
-    "battery_solar_cost": -6.2,
-    "base_to_battery_solar_savings": 8.6,
-    "base_to_battery_solar_savings_pct": 354.4
+    "base_cost": 2.43248,
+    "battery_solar_cost": -6.518,
+    "base_to_battery_solar_savings": 8.9505,
+    "base_to_battery_solar_savings_pct": 367.9558,
+    "total_charged": 2.5,
+    "total_discharged": 8.3
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-19, with solar, price spread 0.27 SEK",
     "intents_present": [
       "EXPORT_ARBITRAGE",
       "GRID_CHARGING",
-      "IDLE",
-      "SOLAR_STORAGE"
+      "IDLE"
     ],
     "savings_positive": true,
     "constraints": {
       "soe_within_bounds": true,
       "power_within_limits": true
     },
-    "intents_absent": [
-      "LOAD_SUPPORT"
-    ]
+    "intents_absent": []
   }
 }

--- a/core/bess/tests/unit/data/realworld_2026_04_22_202249.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_22_202249.json
@@ -360,10 +360,12 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 50.8,
-    "battery_solar_cost": -36.3,
-    "base_to_battery_solar_savings": 87.1,
-    "base_to_battery_solar_savings_pct": 171.5
+    "base_cost": 50.77625,
+    "battery_solar_cost": -34.7893,
+    "base_to_battery_solar_savings": 85.5655,
+    "base_to_battery_solar_savings_pct": 168.5148,
+    "total_charged": 24.1,
+    "total_discharged": 25.7
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-22, with solar, price spread 1.04 SEK",
@@ -377,8 +379,6 @@
       "soe_within_bounds": true,
       "power_within_limits": true
     },
-    "intents_absent": [
-      "LOAD_SUPPORT"
-    ]
+    "intents_absent": []
   }
 }

--- a/core/bess/tests/unit/data/realworld_2026_04_24_090423.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_24_090423.json
@@ -207,10 +207,12 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 94.4,
-    "battery_solar_cost": 4.4,
-    "base_to_battery_solar_savings": 90.1,
-    "base_to_battery_solar_savings_pct": 95.3
+    "base_cost": 94.44272,
+    "battery_solar_cost": 1.6609,
+    "base_to_battery_solar_savings": 92.7818,
+    "base_to_battery_solar_savings_pct": 98.2414,
+    "total_charged": 3.8,
+    "total_discharged": 9.7
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-24, with solar, price spread 1.89 SEK",
@@ -218,8 +220,7 @@
       "EXPORT_ARBITRAGE",
       "GRID_CHARGING",
       "IDLE",
-      "LOAD_SUPPORT",
-      "SOLAR_STORAGE"
+      "LOAD_SUPPORT"
     ],
     "savings_positive": true,
     "constraints": {

--- a/core/bess/tests/unit/data/realworld_2026_04_27_184643.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_27_184643.json
@@ -378,10 +378,12 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 170.5,
-    "battery_solar_cost": -5.9,
-    "base_to_battery_solar_savings": 176.4,
-    "base_to_battery_solar_savings_pct": 103.5
+    "base_cost": 170.50235,
+    "battery_solar_cost": -4.918,
+    "base_to_battery_solar_savings": 175.4204,
+    "base_to_battery_solar_savings_pct": 102.8844,
+    "total_charged": 31.5,
+    "total_discharged": 47.0
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-27, with solar, price spread 2.46 SEK",

--- a/core/bess/tests/unit/data/realworld_2026_04_27_211212.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_27_211212.json
@@ -351,10 +351,12 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 111.9,
-    "battery_solar_cost": -111.8,
-    "base_to_battery_solar_savings": 223.7,
-    "base_to_battery_solar_savings_pct": 199.9
+    "base_cost": 111.94497,
+    "battery_solar_cost": -110.9842,
+    "base_to_battery_solar_savings": 222.9291,
+    "base_to_battery_solar_savings_pct": 199.1417,
+    "total_charged": 23.3,
+    "total_discharged": 26.0
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-27, with solar, price spread 2.18 SEK",

--- a/core/bess/tests/unit/data/realworld_2026_04_29_195900.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_29_195900.json
@@ -366,10 +366,12 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 86.0,
-    "battery_solar_cost": 6.6,
-    "base_to_battery_solar_savings": 79.5,
-    "base_to_battery_solar_savings_pct": 92.4
+    "base_cost": 86.03976,
+    "battery_solar_cost": 6.8718,
+    "base_to_battery_solar_savings": 79.1679,
+    "base_to_battery_solar_savings_pct": 92.0132,
+    "total_charged": 11.5,
+    "total_discharged": 13.7
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-29, with solar, price spread 2.31 SEK",
@@ -384,8 +386,6 @@
       "soe_within_bounds": true,
       "power_within_limits": true
     },
-    "intents_absent": [
-      "LOAD_SUPPORT"
-    ]
+    "intents_absent": []
   }
 }

--- a/core/bess/tests/unit/data/realworld_2026_04_29_220919.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_29_220919.json
@@ -339,10 +339,12 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 72.1,
-    "battery_solar_cost": -92.4,
-    "base_to_battery_solar_savings": 164.6,
-    "base_to_battery_solar_savings_pct": 228.1
+    "base_cost": 72.14153,
+    "battery_solar_cost": -90.7677,
+    "base_to_battery_solar_savings": 162.9093,
+    "base_to_battery_solar_savings_pct": 225.819,
+    "total_charged": 23.1,
+    "total_discharged": 34.6
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-29, with solar, price spread 1.87 SEK",

--- a/core/bess/tests/unit/data/synthetic_2024_08_16_high_spread_with_solar.json
+++ b/core/bess/tests/unit/data/synthetic_2024_08_16_high_spread_with_solar.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 127.94548,
-    "battery_solar_cost": 47.74,
-    "base_to_battery_solar_savings": 80.21,
-    "base_to_battery_solar_savings_pct": 62.69,
-    "total_charged": 48.0,
-    "total_discharged": 43.6
+    "battery_solar_cost": 60.6746,
+    "base_to_battery_solar_savings": 67.2709,
+    "base_to_battery_solar_savings_pct": 52.5778,
+    "total_charged": 43.6,
+    "total_discharged": 39.2
   },
   "expected_behavior": {
     "description": "High price spread with solar: grid-charge at lows, export arbitrage at peaks",

--- a/core/bess/tests/unit/data/synthetic_2025_01_12_evening_peak_with_solar.json
+++ b/core/bess/tests/unit/data/synthetic_2025_01_12_evening_peak_with_solar.json
@@ -96,11 +96,11 @@
     "tax_reduction": 0.0
   },
   "expected_results": {
-    "base_cost": 104.8,
-    "battery_solar_cost": 41.36,
-    "base_to_battery_solar_savings": 63.44,
-    "base_to_battery_solar_savings_pct": 60.54,
-    "total_charged": 28.0,
+    "base_cost": 104.8008,
+    "battery_solar_cost": 41.7094,
+    "base_to_battery_solar_savings": 63.0914,
+    "base_to_battery_solar_savings_pct": 60.2013,
+    "total_charged": 28.4,
     "total_discharged": 25.6
   },
   "expected_behavior": {

--- a/core/bess/tests/unit/data/synthetic_consumption_efficient.json
+++ b/core/bess/tests/unit/data/synthetic_consumption_efficient.json
@@ -97,10 +97,10 @@
   },
   "expected_results": {
     "base_cost": 30.28,
-    "battery_solar_cost": -44.13,
-    "base_to_battery_solar_savings": 74.41,
-    "base_to_battery_solar_savings_pct": 245.7,
-    "total_charged": 28.3,
+    "battery_solar_cost": -43.3337,
+    "base_to_battery_solar_savings": 73.6137,
+    "base_to_battery_solar_savings_pct": 243.1099,
+    "total_charged": 28.4,
     "total_discharged": 25.6
   },
   "expected_behavior": {

--- a/core/bess/tests/unit/data/synthetic_consumption_ev_charging.json
+++ b/core/bess/tests/unit/data/synthetic_consumption_ev_charging.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 125.21,
-    "battery_solar_cost": 74.73,
-    "base_to_battery_solar_savings": 50.48,
-    "base_to_battery_solar_savings_pct": 40.32,
-    "total_charged": 35.2,
-    "total_discharged": 32.0
+    "battery_solar_cost": 75.2756,
+    "base_to_battery_solar_savings": 49.9344,
+    "base_to_battery_solar_savings_pct": 39.8805,
+    "total_charged": 34.4,
+    "total_discharged": 31.0
   },
   "expected_behavior": {
     "description": "EV charging load: grid-charge when cheap, export arbitrage during peaks",

--- a/core/bess/tests/unit/data/synthetic_consumption_high_no_solar.json
+++ b/core/bess/tests/unit/data/synthetic_consumption_high_no_solar.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 149.98,
-    "battery_solar_cost": 128.44,
-    "base_to_battery_solar_savings": 21.54,
-    "base_to_battery_solar_savings_pct": 14.36,
-    "total_charged": 29.2,
-    "total_discharged": 26.6
+    "battery_solar_cost": 129.0347,
+    "base_to_battery_solar_savings": 20.9453,
+    "base_to_battery_solar_savings_pct": 13.9654,
+    "total_charged": 28.4,
+    "total_discharged": 25.6
   },
   "expected_behavior": {
     "description": "High consumption without solar: grid-charge off-peak, support heavy loads",

--- a/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
+++ b/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 50.31,
-    "battery_solar_cost": -31.19,
-    "base_to_battery_solar_savings": 81.5,
-    "base_to_battery_solar_savings_pct": 162.0,
-    "total_charged": 49.0,
-    "total_discharged": 44.4
+    "battery_solar_cost": -26.2761,
+    "base_to_battery_solar_savings": 76.5861,
+    "base_to_battery_solar_savings_pct": 152.2284,
+    "total_charged": 46.1,
+    "total_discharged": 41.4
   },
   "expected_behavior": {
     "description": "Negative prices: should aggressively grid-charge during negative-price hours and export during positive peaks",

--- a/core/bess/tests/unit/data/synthetic_extreme_volatility.json
+++ b/core/bess/tests/unit/data/synthetic_extreme_volatility.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 100.41,
-    "battery_solar_cost": -31.63,
-    "base_to_battery_solar_savings": 132.04,
-    "base_to_battery_solar_savings_pct": 131.5,
-    "total_charged": 48.0,
-    "total_discharged": 43.6
+    "battery_solar_cost": -28.6951,
+    "base_to_battery_solar_savings": 129.1051,
+    "base_to_battery_solar_savings_pct": 128.5779,
+    "total_charged": 48.1,
+    "total_discharged": 43.4
   },
   "expected_behavior": {
     "description": "Extreme price volatility: aggressive grid-charge at lows, export at spikes",

--- a/core/bess/tests/unit/data/synthetic_historical_2024_08_16_high_spread_with_solar.json
+++ b/core/bess/tests/unit/data/synthetic_historical_2024_08_16_high_spread_with_solar.json
@@ -37,16 +37,15 @@
   },
   "expected_results": {
     "base_cost": 2.11,
-    "battery_solar_cost": -0.67,
-    "base_to_battery_solar_savings": 2.78,
-    "base_to_battery_solar_savings_pct": 131.56,
-    "total_charged": 1.6,
-    "total_discharged": 4.0
+    "battery_solar_cost": -0.53,
+    "base_to_battery_solar_savings": 2.64,
+    "base_to_battery_solar_savings_pct": 125.1185,
+    "total_charged": 0.0,
+    "total_discharged": 2.6
   },
   "expected_behavior": {
     "description": "Short horizon high spread with solar: charge and export",
     "intents_present": [
-      "GRID_CHARGING",
       "EXPORT_ARBITRAGE"
     ],
     "savings_positive": true,

--- a/core/bess/tests/unit/data/synthetic_historical_2025_01_12_evening_peak_with_solar.json
+++ b/core/bess/tests/unit/data/synthetic_historical_2025_01_12_evening_peak_with_solar.json
@@ -37,11 +37,11 @@
   },
   "expected_results": {
     "base_cost": 2.36,
-    "battery_solar_cost": 0.52,
-    "base_to_battery_solar_savings": 1.84,
-    "base_to_battery_solar_savings_pct": 77.9661,
+    "battery_solar_cost": 0.4,
+    "base_to_battery_solar_savings": 1.96,
+    "base_to_battery_solar_savings_pct": 83.0508,
     "total_charged": 0.0,
-    "total_discharged": 2.4
+    "total_discharged": 2.5
   },
   "expected_behavior": {
     "description": "Short horizon evening peak with solar: charge and export during peak",

--- a/core/bess/tests/unit/data/synthetic_historical_2025_01_12_evening_peak_with_solar.json
+++ b/core/bess/tests/unit/data/synthetic_historical_2025_01_12_evening_peak_with_solar.json
@@ -37,11 +37,11 @@
   },
   "expected_results": {
     "base_cost": 2.36,
-    "battery_solar_cost": 0.4,
-    "base_to_battery_solar_savings": 1.96,
-    "base_to_battery_solar_savings_pct": 82.89,
-    "total_charged": 0.5,
-    "total_discharged": 2.9
+    "battery_solar_cost": 0.52,
+    "base_to_battery_solar_savings": 1.84,
+    "base_to_battery_solar_savings_pct": 77.9661,
+    "total_charged": 0.0,
+    "total_discharged": 2.4
   },
   "expected_behavior": {
     "description": "Short horizon evening peak with solar: charge and export during peak",

--- a/core/bess/tests/unit/data/synthetic_seasonal_spring.json
+++ b/core/bess/tests/unit/data/synthetic_seasonal_spring.json
@@ -97,17 +97,16 @@
   },
   "expected_results": {
     "base_cost": 67.67,
-    "battery_solar_cost": 14.64,
-    "base_to_battery_solar_savings": 53.03,
-    "base_to_battery_solar_savings_pct": 78.4,
-    "total_charged": 30.2,
-    "total_discharged": 27.6
+    "battery_solar_cost": 14.9026,
+    "base_to_battery_solar_savings": 52.7674,
+    "base_to_battery_solar_savings_pct": 77.9775,
+    "total_charged": 28.4,
+    "total_discharged": 25.6
   },
   "expected_behavior": {
     "description": "Spring day: solar storage and export arbitrage with grid charging backup",
     "intents_present": [
       "GRID_CHARGING",
-      "SOLAR_STORAGE",
       "EXPORT_ARBITRAGE"
     ],
     "savings_positive": true,

--- a/core/bess/tests/unit/data/synthetic_seasonal_summer.json
+++ b/core/bess/tests/unit/data/synthetic_seasonal_summer.json
@@ -97,9 +97,9 @@
   },
   "expected_results": {
     "base_cost": 60.9,
-    "battery_solar_cost": -14.73,
-    "base_to_battery_solar_savings": 75.63,
-    "base_to_battery_solar_savings_pct": 124.2,
+    "battery_solar_cost": -14.7116,
+    "base_to_battery_solar_savings": 75.6116,
+    "base_to_battery_solar_savings_pct": 124.1569,
     "total_charged": 28.4,
     "total_discharged": 25.6
   },

--- a/core/bess/tests/unit/data/synthetic_seasonal_winter.json
+++ b/core/bess/tests/unit/data/synthetic_seasonal_winter.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 107.11,
-    "battery_solar_cost": 56.59,
-    "base_to_battery_solar_savings": 50.52,
-    "base_to_battery_solar_savings_pct": 47.16,
-    "total_charged": 34.8,
-    "total_discharged": 31.6
+    "battery_solar_cost": 57.1756,
+    "base_to_battery_solar_savings": 49.9344,
+    "base_to_battery_solar_savings_pct": 46.6197,
+    "total_charged": 34.4,
+    "total_discharged": 31.0
   },
   "expected_behavior": {
     "description": "Winter day: no solar, grid-charge at night lows, export during peaks",

--- a/core/bess/tests/unit/test_inverter_simulator.py
+++ b/core/bess/tests/unit/test_inverter_simulator.py
@@ -55,12 +55,29 @@ def test_grid_first_discharges_to_grid_at_rate():
     assert p == -5.0
 
 
-def test_load_first_no_discharge_passively_stores_surplus_power_zero():
+def test_load_first_no_discharge_no_surplus_returns_zero():
     bs = make_battery_settings()
     cmd = ControlCommand("load_first", discharge_rate_pct=0, grid_charge=False)
-    # SOLAR_STORAGE/IDLE: power 0; _state_transition does the passive solar charge
-    p = mode_to_power(cmd, solar=1.9, home=0.2, soe=3.0, settings=bs, dt=0.25)
+    # No surplus (home >= solar): load_first holds battery, power = 0
+    p = mode_to_power(cmd, solar=0.2, home=1.9, soe=3.0, settings=bs, dt=0.25)
     assert p == 0.0
+
+
+def test_mode_to_power_load_first_stores_all_surplus():
+    """Task 4c: load_first + no discharge + surplus -> return all-surplus charge power."""
+    bs = make_battery_settings(max_charge_power_kw=10.0)
+    cmd = ControlCommand("load_first", 0, False)
+    assert (
+        mode_to_power(cmd, solar=1.6, home=0.2, soe=5.0, settings=bs, dt=0.25)
+        == (1.6 - 0.2) / 0.25
+    )
+
+
+def test_mode_to_power_grid_first_no_discharge_holds_and_exports():
+    """Task 4c: grid_first + discharge_rate 0 -> returns 0.0 (export via energy balance)."""
+    bs = make_battery_settings()
+    cmd = ControlCommand("grid_first", 0, False)
+    assert mode_to_power(cmd, solar=1.6, home=0.2, soe=5.0, settings=bs, dt=0.25) == 0.0
 
 
 def test_load_support_discharges_to_cover_home_deficit():

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -375,11 +375,33 @@ def test_defers_charging_to_cheaper_overnight_window():
         f"propagating future export value in the backward pass."
     )
 
-    # Export arbitrage must still be executed at the high-price window
-    export_intents = [p.decision.strategic_intent for p in results.period_data[77:84]]
-    assert any(i == "EXPORT_ARBITRAGE" for i in export_intents), (
-        f"Expected EXPORT_ARBITRAGE at periods 77-83 (buy=2.10 SEK). "
-        f"Got: {export_intents}"
+    # The battery must be actively used during the expensive 77-83 window
+    # (buy=2.10 SEK) to avoid those purchases — the optimizer must NOT bail to
+    # an all-IDLE schedule (the regression this test guards against: V[0] fell
+    # below the always-achievable IDLE floor and the profitability gate rejected
+    # the plan).
+    #
+    # NOTE: this previously asserted EXPORT_ARBITRAGE, which encoded the
+    # pre-#145 solar-export over-crediting model. Under the faithful binary
+    # store/export model (R == P), exporting at sell=1.44 SEK energy that was
+    # grid-charged at 1.13 SEK is a *loss* (1.13/eff_c + 0.40 cycle, delivered
+    # via /eff_d ≈ 1.65/kWh > 1.44*eff_d = 1.37/kWh). Executing the old
+    # exporting plan through the faithful simulator realizes -6.02 SEK vs
+    # grid-only, whereas covering the 2.10 SEK load from the battery
+    # (LOAD_SUPPORT) realizes +12.28 SEK. The economically correct faithful
+    # action here is to discharge to serve load, not to export.
+    window = results.period_data[77:84]
+    discharged_in_window = sum(p.energy.battery_discharged for p in window)
+    assert discharged_in_window > 0.0, (
+        f"Optimizer did not use the battery during the expensive 77-83 window "
+        f"(buy=2.10 SEK); intents={[p.decision.strategic_intent for p in window]}. "
+        f"This is the all-IDLE bail regression (V below the IDLE floor)."
+    )
+    assert results.economic_summary.grid_to_battery_solar_savings > 5.0, (
+        f"Optimization rejected to near-zero savings "
+        f"({results.economic_summary.grid_to_battery_solar_savings:.2f} SEK) — "
+        f"the profitability gate bailed to all-IDLE instead of capturing the "
+        f"price-arbitrage value."
     )
 
 

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -258,3 +258,53 @@ def test_all_scenarios(scenario_name):
         logger.info(
             f"No expected_behavior for scenario {scenario_name}, skipping behavioral validation"
         )
+
+    # ── Plan-faithfulness: R == P (#145) ──
+    # Executing the optimizer's plan through the inverter simulator must reproduce
+    # the planned economics within the DP's SoE/power-grid resolution. A larger gap
+    # is a control-fidelity finding, not just discretization.
+    from core.bess.simulation.inverter_simulator import (
+        derive_control_command,
+        simulate,
+    )
+
+    commands = [
+        derive_control_command(
+            pd.decision.strategic_intent,
+            pd.decision.battery_action / period_duration_hours,
+            battery_settings,
+        )
+        for pd in result.period_data
+    ]
+    sim = simulate(
+        commands,
+        solar_production,
+        home_consumption,
+        buy_prices,
+        sell_prices,
+        battery["initial_soe"],
+        battery_settings,
+        period_duration_hours,
+    )
+    planned_cost = result.economic_summary.battery_solar_cost
+    gap = sim.realized_cost - planned_cost
+
+    # Known control-fidelity gap: LOAD_SUPPORT cannot pace battery discharge for
+    # home support, so deep-evening-peak high-consumption days realize worse than
+    # planned. Tracked in #147 — xfail (not silently tolerated) until fixed.
+    DISCHARGE_PACING_SCENARIOS = {
+        "synthetic_consumption_high_no_solar",
+        "synthetic_seasonal_winter",
+        "synthetic_consumption_ev_charging",
+        "historical_2025_01_12_evening_peak_no_solar",
+    }
+    if scenario_name in DISCHARGE_PACING_SCENARIOS:
+        pytest.xfail(
+            f"discharge cannot be paced for home support (R-P={gap:+.2f} SEK) — #147"
+        )
+
+    tol = max(0.5, 0.01 * abs(planned_cost))
+    assert abs(gap) <= tol, (
+        f"{scenario_name}: realized != planned — R={sim.realized_cost:.2f}, "
+        f"P={planned_cost:.2f}, gap {gap:+.3f} SEK exceeds tolerance {tol:.2f}"
+    )

--- a/core/bess/tests/unit/test_surplus_disposition.py
+++ b/core/bess/tests/unit/test_surplus_disposition.py
@@ -1,0 +1,251 @@
+"""Characterization + target behaviour for binary solar-surplus disposition.
+Issue #145. Tests in the CURRENT section document today's behaviour and will be
+updated to the target behaviour in Task 2/3 (the change is intentional)."""
+
+from core.bess.dp_battery_algorithm import _compute_reward, _state_transition
+from core.bess.models import EnergyData
+from core.bess.tests.helpers import make_battery_settings
+
+DT = 0.25
+PRICES_BUY = [1.0]
+PRICES_SELL = [0.8]
+
+
+def test_idle_exports_surplus_and_holds_battery():
+    """TARGET: idle (power=0) is the EXPORT disposition — surplus is exported,
+    battery holds (does NOT passively store)."""
+    bs = make_battery_settings(max_charge_power_kw=10.0)
+    next_soe = _state_transition(
+        5.0, 0.0, bs, DT, solar_production=1.5, home_consumption=0.1
+    )
+    assert next_soe == 5.0  # battery holds; surplus exported, not stored
+
+    reward, _ = _compute_reward(
+        power=0.0,
+        soe=5.0,
+        next_soe=5.0,
+        period=0,
+        home_consumption=0.1,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=PRICES_BUY,
+        sell_price=PRICES_SELL,
+        solar_production=1.5,
+        cost_basis=bs.cycle_cost_per_kwh,
+    )
+    # surplus 1.4 kWh exported @ 0.8 → reward = +1.4*0.8 = 1.12 (cost = -1.12)
+    assert round(reward, 4) == round(1.4 * 0.8, 4)
+
+
+def test_charge_stores_all_surplus_not_a_fraction():
+    """TARGET: a charge action is the STORE disposition — it stores ALL surplus
+    (up to rate/room), exporting only genuine excess, regardless of the action's
+    magnitude. So a tiny charge action still stores all surplus."""
+    bs = make_battery_settings(max_charge_power_kw=10.0, efficiency_charge=1.0)
+    # surplus 1.4 kWh, rate_throughput = 2.5 kWh, plenty of room -> store all 1.4
+    next_soe = _state_transition(
+        5.0, 0.4, bs, DT, solar_production=1.5, home_consumption=0.1
+    )
+    assert round(next_soe - 5.0, 4) == 1.4  # stored all surplus, not 0.4*0.25
+
+    reward, _ = _compute_reward(
+        power=0.4,
+        soe=5.0,
+        next_soe=next_soe,
+        period=0,
+        home_consumption=0.1,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=PRICES_BUY,
+        sell_price=PRICES_SELL,
+        solar_production=1.5,
+        cost_basis=bs.cycle_cost_per_kwh,
+    )
+    # surplus all stored, 0 exported; only wear cost = 1.4 * cycle_cost
+    # reward = -(0 import - 0 export + 1.4*cycle_cost)
+    assert round(reward, 4) == round(-(1.4 * bs.cycle_cost_per_kwh), 4)
+
+
+def test_build_period_data_store_disposition_flows():
+    from core.bess.dp_battery_algorithm import _build_period_data, _state_transition
+
+    bs = make_battery_settings(max_charge_power_kw=10.0, efficiency_charge=1.0)
+    nxt = _state_transition(
+        5.0, 0.4, bs, DT, solar_production=1.5, home_consumption=0.1
+    )
+    pd = _build_period_data(
+        power=0.4,
+        soe=5.0,
+        next_soe=nxt,
+        period=0,
+        home_consumption=0.1,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=PRICES_BUY,
+        sell_price=PRICES_SELL,
+        solar_production=1.5,
+        new_cost_basis=bs.cycle_cost_per_kwh,
+        currency="SEK",
+    )
+    assert round(pd.energy.battery_charged, 4) == 1.4  # stored all surplus
+    assert round(pd.energy.grid_exported, 4) == 0.0  # nothing exported
+
+
+# ---------------------------------------------------------------------------
+# Task 4a: EXPORT disposition classifies as EXPORT_ARBITRAGE (not IDLE)
+# ---------------------------------------------------------------------------
+
+
+def test_idle_with_surplus_classifies_as_export_arbitrage():
+    from core.bess.decision_intelligence import classify_strategic_intent
+
+    # power 0, surplus exported, battery holds
+    ed = EnergyData(
+        solar_production=1.5,
+        home_consumption=0.1,
+        battery_charged=0.0,
+        battery_discharged=0.0,
+        grid_imported=0.0,
+        grid_exported=1.4,
+        battery_soe_start=5.0,
+        battery_soe_end=5.0,
+    )
+    assert classify_strategic_intent(0.0, ed) == "EXPORT_ARBITRAGE"
+    ed2 = EnergyData(
+        solar_production=0.1,
+        home_consumption=0.1,
+        battery_charged=0.0,
+        battery_discharged=0.0,
+        grid_imported=0.0,
+        grid_exported=0.0,
+        battery_soe_start=5.0,
+        battery_soe_end=5.0,
+    )
+    assert classify_strategic_intent(0.0, ed2) == "IDLE"
+
+
+# ---------------------------------------------------------------------------
+# Task 4b: EXPORT_ARBITRAGE maps to grid_first + hold (no discharge)
+# ---------------------------------------------------------------------------
+
+
+def test_export_arbitrage_maps_to_grid_first_hold():
+    from core.bess.inverter_controller import InverterController
+    from core.bess.simulation.inverter_simulator import derive_control_command
+
+    bs = make_battery_settings()
+    assert InverterController.INTENT_TO_MODE["EXPORT_ARBITRAGE"] == "grid_first"
+    cmd = derive_control_command("EXPORT_ARBITRAGE", battery_action_kw=0.0, settings=bs)
+    assert cmd.battery_mode == "grid_first"
+    assert cmd.grid_charge is False
+    assert cmd.discharge_rate_pct == 0
+
+
+# ---------------------------------------------------------------------------
+# Task: SOLAR_STORAGE charges from solar only — no grid top-up when surplus
+# ---------------------------------------------------------------------------
+
+
+def test_store_with_surplus_no_grid_top_up():
+    """TARGET (#145): when surplus > 0 a STORE action may NOT draw from the grid.
+
+    Scenario: solar=2.0, home=1.5 → surplus=0.5 kWh.
+    power=4.0 kW, dt=0.25 → power*dt=1.0 kWh > surplus.
+    The algorithm must store ONLY the 0.5 kWh solar surplus; grid_imported must be 0.
+    (Previously the code computed grid_to_battery = power*dt - surplus = 0.5 kWh,
+    which hardware cannot do in load_first/solar-storage mode.)
+    """
+    from core.bess.dp_battery_algorithm import _build_period_data, _state_transition
+
+    bs = make_battery_settings(max_charge_power_kw=10.0, efficiency_charge=1.0)
+    solar_production = 2.0
+    home_consumption = 1.5  # surplus = 0.5 kWh
+    power = 4.0  # power*dt = 1.0 kWh > surplus
+
+    next_soe = _state_transition(
+        5.0,
+        power,
+        bs,
+        DT,
+        solar_production=solar_production,
+        home_consumption=home_consumption,
+    )
+
+    pd = _build_period_data(
+        power=power,
+        soe=5.0,
+        next_soe=next_soe,
+        period=0,
+        home_consumption=home_consumption,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=PRICES_BUY,
+        sell_price=PRICES_SELL,
+        solar_production=solar_production,
+        new_cost_basis=bs.cycle_cost_per_kwh,
+        currency="SEK",
+    )
+
+    # Only solar surplus should be stored — no grid draw when surplus is present
+    assert (
+        pd.energy.grid_imported == 0.0
+    ), f"Expected grid_imported=0 (solar-only charging) but got {pd.energy.grid_imported}"
+    # The stored amount is exactly the solar surplus
+    assert (
+        round(pd.energy.battery_charged, 4) == 0.5
+    ), f"Expected battery_charged=0.5 (surplus only) but got {pd.energy.battery_charged}"
+
+
+# ---------------------------------------------------------------------------
+# Task: GRID_CHARGING charges at max rate (binary, mirrors solar fix)
+# ---------------------------------------------------------------------------
+
+
+def test_grid_charging_charges_at_max_rate_not_fractional():
+    """TARGET (#145): a charge action with NO solar surplus (grid-charging case)
+    must charge at MAX rate (remaining_rate = min(rate_throughput, room_throughput)),
+    NOT at the fractional power*dt that the DP planned.
+
+    Hardware: GRID_CHARGING → battery_first charges at MAX rate regardless of the
+    planned action magnitude.
+
+    Scenario: solar=0, home=0 → no surplus. power=0.4 kW (small planned action).
+    max_charge_power_kw=10, dt=0.25 → max charge = 2.5 kWh.
+    Starting at soe=2.0 with max_soe=20.0 → room=18.0, room_throughput=18.0.
+    Expected: next_soe - soe == min(10*0.25, 18.0) == 2.5, NOT 0.4*0.25 == 0.1.
+    """
+    bs = make_battery_settings(
+        total_capacity=20.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=10.0,
+        efficiency_charge=1.0,
+    )
+    soe = 2.0
+    next_soe = _state_transition(
+        soe, 0.4, bs, DT, solar_production=0.0, home_consumption=0.0
+    )
+    expected_delta = min(10.0 * DT, bs.max_soe_kwh - soe)  # 2.5 kWh (rate limited)
+    assert round(next_soe - soe, 6) == round(expected_delta, 6), (
+        f"Expected grid-charge at max rate ({expected_delta} kWh) "
+        f"but got {next_soe - soe} kWh (= power*dt = 0.4*0.25 = 0.1 kWh)"
+    )
+
+
+def test_small_surplus_at_idle_classifies_as_export_arbitrage():
+    """A power-0 period with even a SMALL exportable surplus must classify as
+    EXPORT_ARBITRAGE (grid_first), not IDLE — otherwise IDLE->load_first stores
+    it instead of exporting (#145 residual). Threshold must catch ~0.1 kWh."""
+    from core.bess.decision_intelligence import classify_strategic_intent
+
+    ed = EnergyData(
+        solar_production=0.3,
+        home_consumption=0.2,
+        battery_charged=0.0,
+        battery_discharged=0.0,
+        grid_imported=0.0,
+        grid_exported=0.1,
+        battery_soe_start=5.0,
+        battery_soe_end=5.0,
+    )
+    assert classify_strategic_intent(0.0, ed) == "EXPORT_ARBITRAGE"

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -175,10 +175,78 @@ python scripts/mock_ha/scenarios/from_debug_log.py <debug-log-file.md>
 After applying the fix and running mock HA, check `http://localhost:8123/mock/service_log`
 to see what TOU segments BESS sent to the inverter. Compare with expected behavior.
 
+## Plan-Faithfulness Simulator (`R == P`) — verify what the hardware *actually does*
+
+**The single most valuable verification tool in this codebase.** Every savings
+number the optimizer reports is a *plan* (`P`) — computed from the chosen battery
+*actions*. But the inverter is driven by coarse *modes* (`grid_first` /
+`load_first` / `battery_first` + charge/discharge rates), and a mode is a
+**policy**, not a power setpoint. So the plan can claim things the hardware can't
+deliver. Plan-only tests (`run_scenario`, scenario `expected_results`) cannot see
+this gap.
+
+The simulator (`core/bess/simulation/`) closes the loop: it takes the control
+commands derived from a plan and computes the **realized** economics (`R`) of
+executing them. The invariant is:
+
+> **`R == P`** — executing the optimizer's plan through the inverter must
+> reproduce the planned economics (to within the DP's SoE/power-grid resolution).
+> A larger gap is a real control-fidelity bug, not noise.
+
+This is *pure simulation* (no hardware, no mock-HA), so it runs in unit tests.
+
+### Core API (`core/bess/simulation/`)
+
+```python
+from core.bess.simulation.inverter_simulator import (
+    derive_control_command,  # plan period (intent + power) -> ControlCommand
+    simulate,                # execute commands on conditions -> realized PeriodData + cost
+)
+from core.bess.simulation.verification import (
+    verify_plan_faithfulness,   # optimize -> derive -> simulate -> (P, R, per-period deltas)
+    ab_compare,                 # realized-cost delta between two command sequences (exact)
+    realized_under_solar_error, # optimize on FORECAST solar, execute on ACTUAL solar (robustness)
+)
+```
+
+In **scenario tests**, use the helper `run_scenario_realized(scenario)` (in
+`tests/helpers.py`) — it returns `(result, realized_cost)` so you can assert
+`R == P` alongside the normal plan checks. `test_scenarios.py` does this for every
+scenario.
+
+### When to use it — REQUIRED for any optimizer or control change
+
+If you touch the **DP** (`dp_battery_algorithm.py`), the **intent classification**
+(`decision_intelligence.py`), or the **control mapping** (`inverter_controller.py`),
+you MUST verify `R == P` still holds — a passing plan-only test means nothing if
+the plan isn't executable. Add/keep an `R == P` assertion for the affected
+scenarios.
+
+### What it has already caught (why it exists)
+
+- **Phantom solar-export over-crediting** (#145): the optimizer booked export of
+  surplus a `load_first` "store" period actually stores → ~8–16% inflated savings
+  on sunny days. Invisible to plan-only tests.
+- **Discharge can't be paced for home support** (#147): `LOAD_SUPPORT` dumps the
+  battery greedily on deep evening peaks → realizes ~3–4% worse than planned.
+
+### Known gaps and `xfail`
+
+A real, unfixed `R != P` gap should be **`xfail`'d with a tracking issue** (so it
+stays visible), never hidden under a loose tolerance. See the
+`DISCHARGE_PACING_SCENARIOS` set in `test_scenarios.py` (→ #147). The grid-resolution
+residual (`max(0.5 SEK, 1% of |P|)` in `test_scenarios.py`) is the *only* tolerance
+— it reflects the DP's 0.1 kWh SoE grid, not a fudge factor.
+
 ## Test Data
 
 JSON scenario fixtures live in `core/bess/tests/unit/data/`.
 Name them descriptively: `high_solar_export.json`, `ev_charging_overnight.json`.
+
+Scenarios may carry `expected_results` (plan economics) and `expected_behavior`
+(intent presence/absence, `savings_positive`). When the optimizer legitimately
+changes behavior, regenerate these **from the optimizer** (store `expected_results`
+at ≥4 decimals to avoid 1-dp rounding-boundary flips) rather than hand-editing.
 
 ## Red Flags
 

--- a/docs/superpowers/plans/2026-06-19-binary-solar-surplus.md
+++ b/docs/superpowers/plans/2026-06-19-binary-solar-surplus.md
@@ -1,0 +1,508 @@
+# Binary Solar-Surplus Handling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the optimizer model solar surplus as a binary per-period disposition — **STORE** all surplus (charge action) or **EXPORT/hold** all surplus (idle action) — and credit grid export per disposition, so its plan is faithfully executable and it stops booking phantom export revenue.
+
+**Architecture:** Change two branches of the DP's per-period model — **idle** stops passively storing surplus and instead exports it (battery holds); **charge** stores *all* available surplus (up to rate/capacity) rather than a fractional `power·dt`, with any `power·dt` beyond surplus coming from grid (deliberate grid-charging preserved). Discharge is unchanged. Verified by the simulator (PR #144): `R == P` on same-solar, and `realized(new) ≥ realized(old)` on more-solar-than-planned.
+
+**Tech Stack:** Python 3, pytest, NumPy. Changes confined to `core/bess/dp_battery_algorithm.py` (`_state_transition`, `_compute_reward`, `_build_period_data`); verification reuses `core/bess/simulation/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-binary-solar-surplus-design.md` · **Issue:** #145
+
+---
+
+## Conventions (read before any task)
+
+- `surplus = max(0, solar - home)` (kWh in the period).
+- `room_throughput = (max_soe_kwh - soe) / efficiency_charge` (max solar throughput that fits).
+- `rate_throughput = max_charge_power_kw * dt` (max charge throughput this period).
+- **STORE** (charge action, `power > POWER_TOLERANCE_KW`): solar stored (throughput) =
+  `min(surplus, rate_throughput, room_throughput)`; grid-charged (throughput) =
+  `max(0, min(power*dt, room_throughput) - solar_to_battery)`; surplus exported =
+  `max(0, surplus - solar_to_battery)` (genuine excess only).
+- **EXPORT/hold** (idle, `|power| <= POWER_TOLERANCE_KW`): nothing stored; `next_soe = soe`;
+  surplus fully exported.
+- **DISCHARGE** (`power < -POWER_TOLERANCE_KW`): unchanged.
+
+Run tests from repo root `/Users/johanzander/GitHub/bess-manager`. Lint with `black . && ruff check --fix .` before each commit. Stage only the files each task touches; never `git add -A`, never stage `.claude/`.
+
+---
+
+### Task 1: Characterize current behavior (lock the baseline before changing it)
+
+**Files:**
+- Test: `core/bess/tests/unit/test_surplus_disposition.py` (create)
+
+- [ ] **Step 1: Write characterization tests of CURRENT behavior**
+
+```python
+# core/bess/tests/unit/test_surplus_disposition.py
+"""Characterization + target behaviour for binary solar-surplus disposition.
+Issue #145. Tests in the CURRENT section document today's behaviour and will be
+updated to the target behaviour in Task 2/3 (the change is intentional)."""
+from core.bess.dp_battery_algorithm import _state_transition, _compute_reward
+from core.bess.tests.helpers import make_battery_settings
+
+DT = 0.25
+PRICES_BUY = [1.0]
+PRICES_SELL = [0.8]
+
+
+def test_current_idle_passively_stores_surplus():
+    """CURRENT: idle (power=0) stores surplus solar (to be changed in Task 2)."""
+    bs = make_battery_settings(max_charge_power_kw=10.0)
+    # surplus = 1.5 - 0.1 = 1.4 kWh; idle currently stores it
+    next_soe = _state_transition(5.0, 0.0, bs, DT, solar_production=1.5, home_consumption=0.1)
+    assert next_soe > 5.0  # battery charged passively (current behaviour)
+```
+
+- [ ] **Step 2: Run — confirm it passes (documents current behaviour)**
+
+Run: `pytest core/bess/tests/unit/test_surplus_disposition.py -v`
+Expected: PASS (this is current behaviour).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/bess/tests/unit/test_surplus_disposition.py
+git commit -m "test(dp): characterize current solar-surplus disposition (#145)"
+```
+
+---
+
+### Task 2: EXPORT disposition — idle exports surplus instead of storing it
+
+**Files:**
+- Modify: `core/bess/dp_battery_algorithm.py` (`_state_transition` idle branch; `_compute_reward` idle branch)
+- Test: `core/bess/tests/unit/test_surplus_disposition.py`
+
+- [ ] **Step 1: Replace the characterization test with the TARGET behaviour (failing)**
+
+Replace `test_current_idle_passively_stores_surplus` with:
+
+```python
+def test_idle_exports_surplus_and_holds_battery():
+    """TARGET: idle (power=0) is the EXPORT disposition — surplus is exported,
+    battery holds (does NOT passively store)."""
+    bs = make_battery_settings(max_charge_power_kw=10.0)
+    next_soe = _state_transition(5.0, 0.0, bs, DT, solar_production=1.5, home_consumption=0.1)
+    assert next_soe == 5.0  # battery holds; surplus exported, not stored
+
+    reward, _ = _compute_reward(
+        power=0.0, soe=5.0, next_soe=5.0, period=0, home_consumption=0.1,
+        battery_settings=bs, dt=DT, buy_price=PRICES_BUY, sell_price=PRICES_SELL,
+        solar_production=1.5, cost_basis=bs.cycle_cost_per_kwh,
+    )
+    # surplus 1.4 kWh exported @ 0.8 → reward = +1.4*0.8 = 1.12 (cost = -1.12)
+    assert round(reward, 4) == round(1.4 * 0.8, 4)
+```
+
+- [ ] **Step 2: Run — confirm it fails**
+
+Run: `pytest core/bess/tests/unit/test_surplus_disposition.py::test_idle_exports_surplus_and_holds_battery -v`
+Expected: FAIL (currently idle stores surplus → next_soe > 5.0).
+
+- [ ] **Step 3: Implement — idle exports surplus**
+
+In `_state_transition`, the `else:  # Hold / IDLE` branch — replace the passive-charging body so idle holds:
+
+```python
+    else:  # Hold / IDLE — EXPORT disposition: surplus is exported, battery holds
+        next_soe = soe
+```
+
+In `_compute_reward`, the `else:  # IDLE` branch — replace passive-charging flows so surplus exports and no wear/opportunity cost is booked:
+
+```python
+    else:  # IDLE — EXPORT disposition: battery holds, surplus exported
+        battery_wear_cost = 0.0
+        # battery_charged/battery_discharged already 0 from _idle_battery_flows;
+        # with next_soe == soe, _idle_battery_flows returns (0.0, 0.0), so the
+        # energy_balance below exports the full surplus and credits it.
+```
+
+(Confirm `_idle_battery_flows(soe, soe, settings)` returns `(0.0, 0.0)` — it does, since `passive_energy_stored = next_soe - soe = 0`.)
+
+- [ ] **Step 4: Run — confirm it passes**
+
+Run: `pytest core/bess/tests/unit/test_surplus_disposition.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/bess/dp_battery_algorithm.py core/bess/tests/unit/test_surplus_disposition.py
+git commit -m "feat(dp): idle is EXPORT disposition — exports surplus, holds battery (#145)"
+```
+
+---
+
+### Task 3: STORE disposition — charge stores ALL surplus (not a fraction)
+
+**Files:**
+- Modify: `core/bess/dp_battery_algorithm.py` (`_state_transition` charge branch; `_compute_reward` charge branch)
+- Test: `core/bess/tests/unit/test_surplus_disposition.py`
+
+- [ ] **Step 1: Write the failing target test**
+
+```python
+def test_charge_stores_all_surplus_not_a_fraction():
+    """TARGET: a charge action is the STORE disposition — it stores ALL surplus
+    (up to rate/room), exporting only genuine excess, regardless of the action's
+    magnitude. So a tiny charge action still stores all surplus."""
+    bs = make_battery_settings(max_charge_power_kw=10.0, efficiency_charge=1.0)
+    # surplus 1.4 kWh, rate_throughput = 2.5 kWh, plenty of room -> store all 1.4
+    next_soe = _state_transition(5.0, 0.4, bs, DT, solar_production=1.5, home_consumption=0.1)
+    assert round(next_soe - 5.0, 4) == 1.4  # stored all surplus, not 0.4*0.25
+
+    reward, _ = _compute_reward(
+        power=0.4, soe=5.0, next_soe=next_soe, period=0, home_consumption=0.1,
+        battery_settings=bs, dt=DT, buy_price=PRICES_BUY, sell_price=PRICES_SELL,
+        solar_production=1.5, cost_basis=bs.cycle_cost_per_kwh,
+    )
+    # surplus all stored, 0 exported; only wear cost = 1.4 * cycle_cost
+    # reward = -(0 import - 0 export + 1.4*cycle_cost)
+    assert round(reward, 4) == round(-(1.4 * bs.cycle_cost_per_kwh), 4)
+```
+
+- [ ] **Step 2: Run — confirm it fails**
+
+Run: `pytest core/bess/tests/unit/test_surplus_disposition.py::test_charge_stores_all_surplus_not_a_fraction -v`
+Expected: FAIL (currently charges 0.4*0.25=0.1, exports the rest).
+
+- [ ] **Step 3: Implement — charge stores all surplus + optional grid top-up**
+
+In `_state_transition`, the charging branch (`if power > POWER_TOLERANCE_KW:`) — replace so it stores all surplus up to rate/room, plus any grid top-up the action requests beyond surplus:
+
+```python
+    if power > POWER_TOLERANCE_KW:  # STORE disposition (+ optional grid charge)
+        surplus = max(0.0, solar_production - home_consumption)
+        room_throughput = (battery_settings.max_soe_kwh - soe) / battery_settings.efficiency_charge
+        rate_throughput = battery_settings.max_charge_power_kw * dt
+        solar_to_battery = min(surplus, rate_throughput, room_throughput)
+        remaining_rate = max(0.0, min(rate_throughput, room_throughput) - solar_to_battery)
+        grid_to_battery = min(max(0.0, power * dt - surplus), remaining_rate)
+        charge_energy = (solar_to_battery + grid_to_battery) * battery_settings.efficiency_charge
+        next_soe = min(battery_settings.max_soe_kwh, soe + charge_energy)
+```
+
+In `_compute_reward`, the charging branch (`if power > POWER_TOLERANCE_KW:`) — recompute flows from the STORE disposition (store all surplus; export only the genuine excess; grid import only the deliberate top-up):
+
+```python
+    if power > POWER_TOLERANCE_KW:  # STORE disposition
+        surplus = max(0.0, solar_production - home_consumption)
+        room_throughput = (battery_settings.max_soe_kwh - soe) / battery_settings.efficiency_charge
+        rate_throughput = battery_settings.max_charge_power_kw * dt
+        solar_to_battery = min(surplus, rate_throughput, room_throughput)
+        remaining_rate = max(0.0, min(rate_throughput, room_throughput) - solar_to_battery)
+        grid_to_battery = min(max(0.0, power * dt - surplus), remaining_rate)
+
+        energy_stored = (solar_to_battery + grid_to_battery) * battery_settings.efficiency_charge
+        battery_wear_cost = energy_stored * battery_settings.cycle_cost_per_kwh
+
+        # genuine excess solar (above rate/room) is exported; deliberate grid top-up imported
+        surplus_exported = max(0.0, surplus - solar_to_battery)
+        grid_imported = grid_to_battery + max(0.0, home_consumption - solar_production)
+        grid_exported = surplus_exported
+
+        solar_opportunity_cost = solar_to_battery * current_sell_price
+        grid_energy_cost = grid_to_battery * current_buy_price
+        total_new_cost = grid_energy_cost + solar_opportunity_cost + battery_wear_cost
+        if next_soe > battery_settings.min_soe_kwh:
+            existing_cost = soe * cost_basis
+            new_cost_basis = (existing_cost + total_new_cost) / next_soe
+        else:
+            new_cost_basis = (total_new_cost / energy_stored) if energy_stored > 0 else cost_basis
+
+        total_cost = grid_imported * current_buy_price - grid_exported * current_sell_price + battery_wear_cost
+        return -total_cost, new_cost_basis
+```
+
+> Note: this branch now computes its own `grid_imported`/`grid_exported` and returns directly, replacing the shared energy-balance block for the charge case. Leave the discharge branch and the (now EXPORT) idle branch to fall through to the shared `total_cost` block as before. Verify the function still returns correctly for all three branches after the edit.
+
+- [ ] **Step 4: Run — confirm it passes**
+
+Run: `pytest core/bess/tests/unit/test_surplus_disposition.py -v`
+Expected: PASS (all disposition tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/bess/dp_battery_algorithm.py core/bess/tests/unit/test_surplus_disposition.py
+git commit -m "feat(dp): charge is STORE disposition — stores all surplus, exports only excess (#145)"
+```
+
+---
+
+### Task 4: Mirror the disposition flows in `_build_period_data`
+
+**Files:**
+- Modify: `core/bess/dp_battery_algorithm.py` (`_build_period_data`)
+- Test: `core/bess/tests/unit/test_surplus_disposition.py`
+
+- [ ] **Step 1: Write failing test asserting PeriodData flows match the disposition**
+
+```python
+def test_build_period_data_store_disposition_flows():
+    from core.bess.dp_battery_algorithm import _build_period_data, _state_transition
+    bs = make_battery_settings(max_charge_power_kw=10.0, efficiency_charge=1.0)
+    nxt = _state_transition(5.0, 0.4, bs, DT, solar_production=1.5, home_consumption=0.1)
+    pd = _build_period_data(
+        power=0.4, soe=5.0, next_soe=nxt, period=0, home_consumption=0.1,
+        battery_settings=bs, dt=DT, buy_price=PRICES_BUY, sell_price=PRICES_SELL,
+        solar_production=1.5, new_cost_basis=bs.cycle_cost_per_kwh, currency="SEK",
+    )
+    assert round(pd.energy.battery_charged, 4) == 1.4  # stored all surplus
+    assert round(pd.energy.grid_exported, 4) == 0.0    # nothing exported
+```
+
+- [ ] **Step 2: Run — confirm it fails**
+
+Run: `pytest core/bess/tests/unit/test_surplus_disposition.py::test_build_period_data_store_disposition_flows -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement — apply the same STORE/EXPORT flow logic in `_build_period_data`**
+
+Mirror the Task 2/3 flow computation in `_build_period_data`: for `power > POWER_TOLERANCE_KW` compute `battery_charged = solar_to_battery + grid_to_battery` (store-all) and `grid_exported = max(0, surplus - solar_to_battery)`; for the idle branch set `battery_charged = 0` and export the surplus (`next_soe == soe`). Use the identical formulas from the Conventions block so `_build_period_data` and `_compute_reward` agree exactly.
+
+- [ ] **Step 4: Run — confirm it passes**
+
+Run: `pytest core/bess/tests/unit/test_surplus_disposition.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/bess/dp_battery_algorithm.py core/bess/tests/unit/test_surplus_disposition.py
+git commit -m "feat(dp): mirror STORE/EXPORT disposition flows in _build_period_data (#145)"
+```
+
+---
+
+### Task 5: Re-baseline the existing suite (intentional savings shifts)
+
+**Files:**
+- Modify: any unit/integration tests asserting specific savings/intents that change.
+
+- [ ] **Step 1: Run the fast suite, capture failures**
+
+Run: `pytest -m "not slow" -q`
+Expected: some assertions on specific savings numbers / intent distributions now differ (savings drop to the truthful figure where phantom export was removed; some SOLAR_STORAGE periods become IDLE/EXPORT).
+
+- [ ] **Step 2: For each failure, verify the new value is correct, then update the expectation**
+
+For every failing assertion, hand-verify the new number reflects the disposition model (no phantom export), then update the expected value with a comment referencing #145. Do NOT loosen assertions; update them to the correct new values.
+
+- [ ] **Step 3: Run the slow suite, re-baseline likewise**
+
+Run: `pytest -m slow -q` and repeat Step 2 for slow-suite failures (algorithm/scenario tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -- core/bess/tests
+git commit -m "test: re-baseline savings/intent expectations for binary surplus model (#145)"
+```
+
+---
+
+### Task 6: Verify with the simulator — `R == P` (same solar)
+
+**Files:**
+- Modify: `core/bess/tests/integration/test_plan_faithfulness.py` (flip the xfail)
+
+- [ ] **Step 1: Remove the `@pytest.mark.xfail` from `test_realized_equals_planned_on_controlled_scenario`**
+
+The controlled-scenario `R == P` test should now PASS, because the plan only contains mode-expressible actions. Delete the `xfail` decorator.
+
+- [ ] **Step 2: Run — confirm it passes**
+
+Run: `pytest core/bess/tests/integration/test_plan_faithfulness.py -v`
+Expected: PASS (no more xfail).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/bess/tests/integration/test_plan_faithfulness.py
+git commit -m "test(sim): plan-faithfulness now holds (R==P) under binary surplus model (#145)"
+```
+
+---
+
+### Task 7: Forecast-robustness harness + A/B gate (more solar than planned)
+
+**Files:**
+- Modify: `core/bess/simulation/verification.py` (add `ab_under_solar_error`)
+- Test: `core/bess/tests/integration/test_plan_faithfulness.py`
+
+- [ ] **Step 1: Write failing test for the forecast-error A/B**
+
+```python
+def test_more_solar_than_planned_is_forecast_robust():
+    """Optimize with forecast solar, execute against higher actual solar. New
+    (binary) model must not lose realized savings vs simply storing the bonus."""
+    from core.bess.simulation.verification import realized_under_solar_error
+    bs = make_battery_settings()
+    n = 6
+    buy = [1.0, 1.0, 2.0, 2.0, 1.0, 1.0]
+    sell = [0.8, 0.8, 1.8, 1.8, 0.9, 0.9]
+    forecast_solar = [1.0] * n
+    actual_solar = [2.0] * n  # reality beats forecast
+    home = [0.3] * n
+    realized = realized_under_solar_error(
+        forecast_solar=forecast_solar, actual_solar=actual_solar,
+        buy=buy, sell=sell, home=home, initial_soe=5.0, settings=bs, dt=1.0,
+    )
+    # bonus solar is captured/exported, never wasted: realized should be finite and
+    # at least as good as the planned-on-forecast cost (more solar => more value).
+    assert realized is not None
+```
+
+- [ ] **Step 2: Run — confirm it fails (function missing)**
+
+Run: `pytest core/bess/tests/integration/test_plan_faithfulness.py::test_more_solar_than_planned_is_forecast_robust -v`
+Expected: FAIL (`ImportError`).
+
+- [ ] **Step 3: Implement `realized_under_solar_error`**
+
+```python
+def realized_under_solar_error(
+    forecast_solar, actual_solar, buy, sell, home, initial_soe, settings, dt,
+):
+    """Optimize on forecast solar; execute the derived commands against actual solar."""
+    from core.bess.dp_battery_algorithm import optimize_battery_schedule
+    from core.bess.simulation.inverter_simulator import derive_control_command, simulate
+    res = optimize_battery_schedule(
+        buy_price=buy, sell_price=sell, home_consumption=home,
+        solar_production=forecast_solar, initial_soe=initial_soe,
+        battery_settings=settings, period_duration_hours=dt,
+    )
+    cmds = [
+        derive_control_command(pd.decision.strategic_intent, pd.decision.battery_action / dt, settings)
+        for pd in res.period_data
+    ]
+    sim = simulate(cmds, actual_solar, home, buy, sell, initial_soe, settings, dt)
+    return sim.realized_cost
+```
+
+- [ ] **Step 4: Run — confirm it passes**
+
+Run: `pytest core/bess/tests/integration/test_plan_faithfulness.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/bess/simulation/verification.py core/bess/tests/integration/test_plan_faithfulness.py
+git commit -m "test(sim): forecast-error harness (optimize on forecast, execute on actual) (#145)"
+```
+
+---
+
+### Task 8: Full gate + reproduction-day measurement
+
+- [ ] **Step 1: Full suites green**
+
+Run: `pytest -m "not slow" -q` then `pytest -m slow -q`. Expected: all green.
+
+- [ ] **Step 2: Re-measure the reproduction day (manual check, not committed)**
+
+Reconstruct the reproduction-day inputs and run `verify_plan_faithfulness` (as in the finding doc). Expected: the prior +5.39 SEK gap collapses toward ~0 (`R ≈ P`). Record the number in the PR.
+
+- [ ] **Step 3: Lint + commit any formatting**
+
+Run: `black . && ruff check --fix .`
+```bash
+git add -A -- core/bess
+git commit -m "style: format binary-surplus changes (#145)" || echo "nothing to format"
+```
+
+- [ ] **Step 4: Update the finding doc + PR with the result and the realized(new) ≥ realized(old) outcome.**
+
+---
+
+## Self-Review
+
+**Spec coverage:** STORE disposition → Task 3; EXPORT disposition → Task 2; export credited per disposition → Tasks 2–4; forecast-robustness → Task 7; `R==P` → Task 6; hard merge condition `realized(new) ≥ realized(old)` → Tasks 7–8 (record + gate); supersedes #141 → verified by the dither disappearing in re-baseline (Task 5) and the reproduction-day measurement (Task 8).
+
+**Placeholder scan:** none — each code step shows the actual edit. Task 5 is intentionally data-driven (re-baseline) but constrained ("verify new value correct, do not loosen").
+
+**Type consistency:** `realized_under_solar_error` returns a float (realized cost); `derive_control_command(intent, action_kw, settings)` and `simulate(...)` signatures match PR #144. The Conventions formulas are reused verbatim in `_state_transition`, `_compute_reward`, and `_build_period_data` so the three agree.
+
+**Open risk to watch during execution:** the STORE branch decouples `next_soe` from the action magnitude (stores all surplus). Confirm the DP's `next_i = round((next_soe - min)/SOE_STEP)` indexing still lands on a valid grid state for all charge actions (it should — `next_soe` is clamped to `[min, max]`), and that collapsing many charge power-levels to the same `next_soe` doesn't break action selection (it only makes some actions redundant). If the slow suite reveals a deeper coupling, stop and escalate before forcing fixes.
+
+---
+
+## Plan extension: control vocabulary (added 2026-06-19 after Tasks 1–4)
+
+The DP change (Tasks 1–4) is not yet executable: `IDLE` (now = export/hold) and
+`SOLAR_STORAGE` (now = store) both map to the identical command (`load_first`,
+charge 100%, discharge 0), which physically **stores** surplus. The export
+disposition must route to `grid_first`. These tasks (**4a–4c**) must complete
+**before** Tasks 6–8 (the `R==P` and financial gates). Confirmed mode behaviour:
+`load_first` stores surplus until full, then exports the overflow; `grid_first`
+exports (and discharges battery for export); only `grid_first` exports while the
+battery is not full.
+
+### Task 4a: route the EXPORT disposition through `EXPORT_ARBITRAGE`/grid_first
+
+**Files:** `core/bess/decision_intelligence.py` (`classify_strategic_intent`); test in `core/bess/tests/unit/test_surplus_disposition.py`.
+
+- [ ] **Failing test:** a power≈0 period with exportable surplus classifies as `EXPORT_ARBITRAGE` (not `IDLE`); a power≈0 period with no surplus stays `IDLE`.
+
+```python
+def test_idle_with_surplus_classifies_as_export_arbitrage():
+    from core.bess.decision_intelligence import classify_strategic_intent
+    from core.bess.models import EnergyData
+    # power 0, surplus exported, battery holds
+    ed = EnergyData(solar_production=1.5, home_consumption=0.1, battery_charged=0.0,
+                    battery_discharged=0.0, grid_imported=0.0, grid_exported=1.4,
+                    battery_soe_start=5.0, battery_soe_end=5.0)
+    assert classify_strategic_intent(0.0, ed) == "EXPORT_ARBITRAGE"
+    ed2 = EnergyData(solar_production=0.1, home_consumption=0.1, battery_charged=0.0,
+                     battery_discharged=0.0, grid_imported=0.0, grid_exported=0.0,
+                     battery_soe_start=5.0, battery_soe_end=5.0)
+    assert classify_strategic_intent(0.0, ed2) == "IDLE"
+```
+
+- [ ] **Implement:** in the power≈0 fallthrough of `classify_strategic_intent`, add — *before* the existing IDLE return — a branch: if `energy_data.grid_exported > 0.1 and energy_data.solar_to_grid > 0.1` (exporting surplus solar, battery not charging) → return `"EXPORT_ARBITRAGE"`. Keep the existing `battery_charged>0.01 → SOLAR_STORAGE` / `battery_discharged>0.01 → LOAD_SUPPORT` branches; final fallthrough stays `IDLE`.
+- [ ] Run the test (pass), commit: `feat(dp): power-0 surplus export classifies as EXPORT_ARBITRAGE/grid_first (#145)`.
+
+### Task 4b: confirm control mapping routes export to grid_first
+
+**Files:** `core/bess/inverter_controller.py` (verify only).
+
+- [ ] Confirm `INTENT_TO_MODE["EXPORT_ARBITRAGE"] == "grid_first"` and that `_map_intent_to_rates("EXPORT_ARBITRAGE", action_kw≈0)` returns `(grid_charge=False, discharge_rate=0)` — i.e. grid_first + no battery discharge = "export surplus, hold battery." No code change expected; add a short behavioural test asserting this if one doesn't exist. Commit if changed.
+
+### Task 4c: make the simulator's `mode_to_power` faithful to the two dispositions
+
+**Files:** `core/bess/simulation/inverter_simulator.py` (`mode_to_power`); test in `core/bess/tests/unit/test_inverter_simulator.py`.
+
+- [ ] **Failing tests:**
+  - `load_first` + discharge 0 with surplus → returns a charge power that stores **all** surplus (so `_state_transition`'s STORE branch charges it): `mode_to_power(load_first,0) for solar 1.6/home 0.2 → (1.6-0.2)/dt`.
+  - `grid_first` + discharge 0 → returns `0.0` (export surplus via energy balance, battery holds).
+  - `load_first` + discharge 0 with **no** surplus → `0.0` (hold).
+
+```python
+def test_mode_to_power_load_first_stores_all_surplus():
+    bs = make_battery_settings(max_charge_power_kw=10.0)
+    cmd = ControlCommand("load_first", 0, False)
+    assert mode_to_power(cmd, solar=1.6, home=0.2, soe=5.0, settings=bs, dt=0.25) == (1.6 - 0.2) / 0.25
+
+def test_mode_to_power_grid_first_no_discharge_holds_and_exports():
+    bs = make_battery_settings()
+    cmd = ControlCommand("grid_first", 0, False)
+    assert mode_to_power(cmd, solar=1.6, home=0.2, soe=5.0, settings=bs, dt=0.25) == 0.0
+```
+
+- [ ] **Implement:** update `mode_to_power` so the `load_first` store branch (discharge_rate 0) returns `max(0, solar - home) / dt` (store all surplus solar; `_state_transition`'s STORE branch caps at rate/room and adds no grid top-up since `power*dt == surplus`), returning `0.0` when there's no surplus. `grid_first` and `load_first`+discharge branches unchanged in intent (grid_first with discharge 0 returns 0.0 → holds and exports surplus via the energy balance).
+- [ ] Run the simulator unit tests (pass), commit: `feat(sim): mode_to_power models load_first store-all vs grid_first export (#145)`.
+
+### Acceptance for the extension
+
+After 4a–4c, re-run the reproduction-day `verify_plan_faithfulness`: the gap should
+collapse toward **`R ≈ P`** (from +4.07 SEK). If it does not, **stop and report the
+residual per-period deltas** — do not force it; it means another disposition is still
+mismodelled. Only once `R == P` holds do Tasks 6–8 (xfail flip, forecast A/B, full
+gate incl. `realized(new) ≥ realized(old)`) make sense.

--- a/docs/superpowers/specs/2026-06-19-binary-solar-surplus-design.md
+++ b/docs/superpowers/specs/2026-06-19-binary-solar-surplus-design.md
@@ -1,0 +1,120 @@
+# Design: binary solar-surplus handling (store-all vs export-all)
+
+**Date:** 2026-06-19
+**Issue:** #145
+**Depends on:** the closed-loop savings simulator (PR #144) — used as the acceptance gate.
+**Supersedes:** #141 (the intent-dither hysteresis) if the dither dissolves.
+
+## Problem
+
+The optimizer over-credits solar export. Its reward model computes grid export from
+an energy balance using the *planned* (possibly fractional) battery charge, and
+credits export of the remainder. But the control applies a fixed `charge_rate =
+100%` in storage periods, so the battery charges *all* available surplus up to its
+rate — the "export the rest" the optimizer booked never happens. On the
+reproduction day this is an **11.85% plan-vs-realized savings gap**, concentrated
+in `SOLAR_STORAGE` periods (see #145 and the simulator finding doc).
+
+## Why not the obvious "scale charge_rate to planned charge"
+
+Two reasons (both decisive):
+
+1. **Solar is a forecast.** Encoding a planned charge power into `charge_rate`
+   chases noise — actual solar deviates more than the fractional amounts involved.
+2. **`charge_rate = 100%` in storage periods is intentional and correct.** If the
+   plan is "store, no export" and actual solar exceeds the forecast, the best
+   outcome is to store the bonus, not export it. Scaling `charge_rate` down to the
+   forecast would throw the bonus away.
+
+## The model: a binary per-period choice for solar surplus
+
+Each period, surplus solar (`solar − home − battery_charged_from_solar`) is handled
+one of two ways, and the optimizer credits accordingly:
+
+- **STORE** → `load_first`, `charge_rate = 100%`: store as much surplus as
+  physically possible (`min(surplus, max_charge_rate, room)`); `load_first` exports
+  only the genuine excess (above rate / when full). The optimizer credits **only
+  that genuine excess** as export — never a planned fractional export.
+- **EXPORT** → `grid_first`, `charge_rate = 0`: store nothing from solar; export all
+  surplus; the battery may additionally discharge to grid (arbitrage). The optimizer
+  credits the full surplus (plus any battery-to-grid) as export.
+
+A single period is never "store a little **and** export a little" — that split is
+what no real mode can deliver and is the source of the bug.
+
+**Forecast-robustness falls out for free:** STORE periods stay at 100%, so whatever
+actual solar arrives is captured (bonus = upside), and because the optimizer books
+*no* phantom export in STORE periods, forecast error cannot create a fake-revenue
+gap. EXPORT periods export whatever actual solar arrives (bonus = extra revenue).
+
+Grid charging (`GRID_CHARGING` / `battery_first`, buying cheap grid energy) and
+battery discharge for home/grid remain as today — those are already faithfully
+controllable (discharge power is encoded via `discharge_rate`).
+
+## DP design (the substantive change — to finalize in the plan)
+
+The per-period decision must expose the STORE-vs-EXPORT disposition for surplus, and
+the reward/flow model must compute flows + export credit from it.
+
+**Recommended approach — disposition-aware flow model, minimal action-space change:**
+Keep the existing power-level action enumeration, but reinterpret a *charging*
+action as the **STORE disposition** (store all surplus up to rate; its exact
+magnitude no longer matters) and a *non-charging* action in the presence of surplus
+as the **EXPORT disposition**. Then in `_compute_reward` / `_state_transition`:
+- STORE: `battery_charged = min(surplus, max_charge_rate·dt, room)`; surplus export =
+  `max(0, surplus − battery_charged)`; credit that export only.
+- EXPORT: `battery_charged_from_solar = 0`; surplus export = full surplus; battery
+  may discharge to grid per the (encoded) discharge action; credit accordingly.
+
+This collapses the charge side to effectively one "store-all" action, which is the
+point — it removes the fractional charges that drive both the over-crediting and the
+dither.
+
+**Alternative considered:** add an explicit per-period boolean disposition to the
+state/action tuple. Cleaner conceptually but a larger DP refactor; defer unless the
+recommended approach proves awkward.
+
+Either way: **export must be credited per disposition, not from a
+disposition-agnostic energy balance.**
+
+## Acceptance gate (the validation loop this enables)
+
+1. **Implement** the change in the optimizer.
+2. **Existing suite green** — `pytest -m "not slow"` and `-m slow`; no economic
+   regression on planned-case scenarios (savings may *shift* to the correct lower
+   number where phantom export is removed — that is expected and must be reviewed,
+   not asserted unchanged).
+3. **Simulator, same solar:** `verify_plan_faithfulness` gives **`R == P`** (cent-exact)
+   on representative scenarios incl. the reproduction day — the plan is now faithfully
+   executable.
+4. **Simulator, more solar than planned:** a new harness optimizes with *forecast*
+   solar and simulates with *higher actual* solar; assert the new implementation is
+   **forecast-robust** (STORE captures the bonus with no phantom export; realized ≥
+   planned), and A/B it against the old implementation to quantify the improvement.
+   (`simulate()` already takes its own `solar_production`, so this only needs a
+   harness that decouples forecast from actual.)
+
+**Hard merge condition (financial safety):** ship **only if
+`realized(new) ≥ realized(old)`** across the scenario set (same-solar *and*
+more-solar-than-planned). The change must never reduce *realized* savings — the
+reported (planned) savings dropping to the truthful, executable figure is expected
+and is **not** a regression; a drop in *realized* savings **is**, and blocks merge.
+This is the simulator-verified answer to "could the binary model cost money?" — it
+cannot ship if it does.
+
+## Relationship to #141
+
+This addresses the **economic** root cause. If, as expected, binary dispositions
+remove the morning fractional charges, the mode-dither dissolves and #141 (the
+cosmetic hysteresis) becomes unnecessary — close it. If any cosmetic flicker
+remains, it is then a genuinely separate, low-priority display concern.
+
+## Open questions for the plan
+
+1. Final action-space representation (recommended disposition-aware reinterpretation
+   vs explicit boolean disposition).
+2. Does `load_first` export excess **immediately** at the inverter, or only when the
+   battery is full? (Confirmed: it exports excess — modes are priority orders. The
+   flow model uses `export = max(0, surplus − stored)`.)
+3. Terminal value and cost-basis interaction (expected unaffected; verify).
+4. Whether grid-charge amount remains continuous (deliberate purchase) — expected yes.


### PR DESCRIPTION
## What this is

Re-lands #146 (which was reverted in #151 to keep `main` green) **with the regression fixed**. Two commits:
1. Re-apply #146 (binary store/export — the #145 solar-export over-crediting fix + faithful control vocabulary + R==P simulator wiring).
2. **The fix:** guarantee an IDLE (power=0) action exists in the DP action set.

## The regression #146 had (now fixed)

#146's "any positive power charges at max rate" turned the smallest positive power level — previously a near-negligible hold — into a full-rate grid charge. That left the DP with **no way to represent holding the battery**, so the value function dropped below the always-achievable all-IDLE floor and the profitability gate bailed to an all-IDLE schedule. This broke no-solar price arbitrage (`test_defers_charging_to_cheaper_overnight_window`).

Fix: ensure `power=0` is in the discretized action set. `V[0,start]` restored (−130.2 → −91.3), zero IDLE-floor violations. The #145 over-crediting fix and R==P are preserved.

## Test correction (reviewed + approved)

That regression test's `EXPORT_ARBITRAGE` assertion was economically stale — it encoded the pre-#145 over-crediting model. Under the faithful model, exporting grid-charged energy at that price spread is a *loss* (the old "export" plan realizes −6 SEK; serving load from the battery realizes +12 SEK). The assertion now checks the faithful-correct behaviour: the battery is used to serve load in the expensive window and the day saves money. Still guards the original bug (fails if the optimizer bails to all-IDLE).

## Gating

Diagnosed and fixed via a dedicated debugging agent; design reviewed and approved. Full slow suite must be green here (CI Merge gate) before merge, and this lands only on explicit approval. Does **not** tag/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)