### PR TITLE
test(perf): cache per-scenario optimization in test_min_schedule_e2e (144→9 optimizations)

### DIFF
--- a/core/bess/tests/unit/test_min_schedule_e2e.py
+++ b/core/bess/tests/unit/test_min_schedule_e2e.py
@@ -15,6 +15,7 @@ by testing the full path with real optimizer output.
 
 import json
 import logging
+from functools import cache
 from pathlib import Path
 
 import pytest
@@ -44,13 +45,20 @@ def _load_scenario(name: str) -> dict:
         return json.load(f)
 
 
-def _run_and_build_schedule(
-    scenario: dict, current_period: int = 0
-) -> tuple[GrowattScheduleManager, list[str]]:
-    """Run optimizer on scenario and build MIN Growatt TOU schedule.
+@cache
+def _optimize_scenario(scenario_name: str):
+    """Run the DP optimizer for a scenario ONCE and cache the result.
 
-    Returns (scheduler, strategic_intents) tuple.
+    The optimization (full quarterly DP) is the only expensive step in this
+    module — every test asserts a different property of the *same* schedule. By
+    caching the result per scenario and rebuilding the cheap
+    GrowattScheduleManager fresh per test (see _run_and_build_schedule), we avoid
+    recomputing the identical optimization ~16x per scenario while preserving
+    test isolation.
+
+    Returns (OptimizationResult, BatterySettings).
     """
+    scenario = _load_scenario(scenario_name)
     battery = scenario["battery"]
     price_data = scenario["price_data"]
     base_prices = scenario["base_prices"]
@@ -87,6 +95,21 @@ def _run_and_build_schedule(
         battery_settings=battery_settings,
         period_duration_hours=period_duration_hours,
     )
+    return result, battery_settings
+
+
+def _run_and_build_schedule(
+    scenario_name: str, current_period: int = 0
+) -> tuple[GrowattScheduleManager, list[str]]:
+    """Build a MIN Growatt TOU schedule from the (cached) optimizer result.
+
+    The expensive optimization is cached by _optimize_scenario; the scheduler is
+    rebuilt fresh here so each test gets an isolated object.
+
+    Returns (scheduler, strategic_intents) tuple.
+    """
+    result, battery_settings = _optimize_scenario(scenario_name)
+    scenario = _load_scenario(scenario_name)
 
     # Convert OptimizationResult → DPSchedule (same path as battery_system_manager.py)
     strategic_intents = [pd.decision.strategic_intent for pd in result.period_data]
@@ -119,24 +142,21 @@ class TestEndToEndHardwareConstraints:
 
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_no_overlapping_intervals(self, scenario_name):
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
         assert (
             scheduler.has_no_overlapping_intervals()
         ), f"{scenario_name}: TOU intervals overlap"
 
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_chronological_order(self, scenario_name):
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
         assert (
             scheduler.intervals_are_chronologically_ordered()
         ), f"{scenario_name}: TOU intervals not in chronological order"
 
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_hardware_slot_limit(self, scenario_name):
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
         assert len(scheduler.active_tou_intervals) <= 9, (
             f"{scenario_name}: {len(scheduler.active_tou_intervals)} active intervals "
             f"exceeds 9-slot hardware limit"
@@ -144,8 +164,7 @@ class TestEndToEndHardwareConstraints:
 
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_segment_ids_in_valid_range(self, scenario_name):
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
         for seg in scheduler.active_tou_intervals:
             assert (
                 1 <= seg["segment_id"] <= 9
@@ -158,8 +177,7 @@ class TestEndToEndIntentExecution:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_charging_intents_produce_charging_config(self, scenario_name):
         """Hours with GRID_CHARGING intent must be configured for charging."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, intents = _run_and_build_schedule(scenario)
+        scheduler, intents = _run_and_build_schedule(scenario_name)
 
         # Find hours where all 4 quarterly periods are GRID_CHARGING
         for hour in range(24):
@@ -173,8 +191,7 @@ class TestEndToEndIntentExecution:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_export_intents_produce_export_config(self, scenario_name):
         """Hours with EXPORT_ARBITRAGE intent must be configured for export."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, intents = _run_and_build_schedule(scenario)
+        scheduler, intents = _run_and_build_schedule(scenario_name)
 
         for hour in range(24):
             quarter_intents = set(intents[hour * 4 : (hour + 1) * 4])
@@ -189,8 +206,7 @@ class TestEndToEndIntentExecution:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_idle_hours_use_default_mode(self, scenario_name):
         """Hours where all quarters are default-mode intents should be load_first."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, intents = _run_and_build_schedule(scenario)
+        scheduler, intents = _run_and_build_schedule(scenario_name)
 
         for hour in range(24):
             quarter_intents = set(intents[hour * 4 : (hour + 1) * 4])
@@ -210,8 +226,7 @@ class TestEndToEndChargeDischargeRates:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_grid_charging_periods_have_correct_rates(self, scenario_name):
         """GRID_CHARGING: grid_charge=True, charge_rate=100%, discharge_rate=0%."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
 
         for period in range(len(scheduler.strategic_intents)):
             settings = scheduler.get_period_settings(period)
@@ -229,8 +244,7 @@ class TestEndToEndChargeDischargeRates:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_export_arbitrage_periods_have_correct_rates(self, scenario_name):
         """EXPORT_ARBITRAGE: grid_charge=False, charge_rate=0%, discharge_rate=100%."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
 
         for period in range(len(scheduler.strategic_intents)):
             settings = scheduler.get_period_settings(period)
@@ -248,8 +262,7 @@ class TestEndToEndChargeDischargeRates:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_idle_periods_have_correct_rates(self, scenario_name):
         """IDLE: grid_charge=False, discharge_rate=0%."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
 
         for period in range(len(scheduler.strategic_intents)):
             settings = scheduler.get_period_settings(period)
@@ -264,8 +277,7 @@ class TestEndToEndChargeDischargeRates:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_solar_storage_periods_have_correct_rates(self, scenario_name):
         """SOLAR_STORAGE: grid_charge=False, charge_rate=100%, discharge_rate=0%."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
 
         for period in range(len(scheduler.strategic_intents)):
             settings = scheduler.get_period_settings(period)
@@ -283,8 +295,7 @@ class TestEndToEndChargeDischargeRates:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_load_support_periods_have_correct_rates(self, scenario_name):
         """LOAD_SUPPORT: grid_charge=False, charge_rate=0%, discharge_rate=100%."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
 
         for period in range(len(scheduler.strategic_intents)):
             settings = scheduler.get_period_settings(period)
@@ -302,8 +313,7 @@ class TestEndToEndChargeDischargeRates:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_all_periods_have_settings(self, scenario_name):
         """Every period must return valid settings via get_period_settings."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, intents = _run_and_build_schedule(scenario)
+        scheduler, intents = _run_and_build_schedule(scenario_name)
 
         for period in range(len(intents)):
             settings = scheduler.get_period_settings(period)
@@ -327,7 +337,7 @@ class TestEndToEndMidDayUpdate:
         midpoint = min(horizon // 2, 48)  # cap at period 48 (noon)
 
         for current_period in [0, midpoint]:
-            scheduler, _ = _run_and_build_schedule(scenario, current_period)
+            scheduler, _ = _run_and_build_schedule(scenario_name, current_period)
 
             assert (
                 scheduler.has_no_overlapping_intervals()
@@ -347,8 +357,7 @@ class TestEndToEndHardwareWrite:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_hardware_writes_use_valid_slot_ids(self, scenario_name):
         """All hardware writes use segment_id 1-9."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
 
         calls = []
 
@@ -383,8 +392,7 @@ class TestEndToEndHardwareWrite:
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_hardware_write_count_within_limit(self, scenario_name):
         """Never write more than 9 segments to hardware."""
-        scenario = _load_scenario(scenario_name)
-        scheduler, _ = _run_and_build_schedule(scenario)
+        scheduler, _ = _run_and_build_schedule(scenario_name)
 
         write_count = 0
 


### PR DESCRIPTION
## Why

`test_min_schedule_e2e.py` holds **144 of the ~318 slow tests** (16 assertions × 9 real-world scenarios). Each test called `_run_and_build_schedule()`, which ran a **full DP optimization every time** — but all 16 tests for a scenario only assert different properties of the *same* schedule. So the identical (expensive, quarterly) optimization was recomputed **16× per scenario**: 144 optimizations where 9 suffice.

## What

- Split out `@cache _optimize_scenario(scenario_name)` — the optimizer now runs **once per scenario (9× total)**.
- `_run_and_build_schedule` rebuilds a fresh `GrowattScheduleManager` per test, so test isolation is fully preserved.
- **No test removed, no assertion changed, no coverage lost** — this purely eliminates redundant recomputation.

These 144 weren't *duplicate tests* (each checks a distinct property); they were duplicate *computation*. The other heavy slow files (`test_cross_platform`, `test_discharge_inhibit`, `test_extended_horizon`) were audited and don't have this pattern (no per-test re-optimization; `test_extended_horizon` already uses fixtures).

## Verification

- All 16 tests for one scenario pass in **~34s** (a single optimization) vs ~16 optimizations before.
- CI's Algorithm job here will show the actual wall-clock reduction.

Test-infra only — no production code touched. Independent of the optimizer fix in #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)