### PR TITLE
fix: next-day schedule uses tomorrow's solar forecast and real SOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - **Next-day schedule used today's solar forecast** — The `prepare_next_day` optimization built tomorrow's battery schedule from *today's* Solcast forecast instead of tomorrow's, so the plan written to the inverter could be optimized against substantially wrong solar production (e.g. 28.5 kWh today vs 64.8 kWh forecast for the next day). It now uses `get_solar_forecast_tomorrow()`, mirroring the extended-horizon path, with the same zeros fallback when tomorrow's forecast is unavailable.
+- **Next-day schedule ignored the real battery SOC** — The `prepare_next_day` run (cron at 23:55, when current SOC is known and ≈ tomorrow's starting SOC) discarded the actual SOC and assumed minimum SOC. On any night the battery wasn't actually empty, tomorrow's plan started from a wrong state and under-used stored energy. It now seeds the next-day plan from the real current SOC, matching the regular optimization path.
 
 ## [9.6.0] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Next-day schedule used today's solar forecast** — The `prepare_next_day` optimization built tomorrow's battery schedule from *today's* Solcast forecast instead of tomorrow's, so the plan written to the inverter could be optimized against substantially wrong solar production (e.g. 28.5 kWh today vs 64.8 kWh forecast for the next day). It now uses `get_solar_forecast_tomorrow()`, mirroring the extended-horizon path, with the same zeros fallback when tomorrow's forecast is unavailable.
+
 ## [9.6.0] - 2026-06-20
 
 ### Fixed

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1537,9 +1537,10 @@ class BatterySystemManager:
             consumption_data = consumption_predictions
             solar_data = solar_predictions
 
-            # Initialize all periods with minimal SOC for next day
-            initial_soe = self.battery_settings.min_soe_kwh
-            combined_soe = [initial_soe] * period_count
+            # Seed the next-day plan from the real current SOC. This runs at
+            # 23:55, so current SOC is ~= tomorrow's starting SOC; assuming min
+            # SOC here would discard energy actually in the battery.
+            combined_soe = [current_soe] * period_count
 
             optimization_period = 0
 

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1522,7 +1522,17 @@ class BatterySystemManager:
                 if self._consumption_predictions
                 else self._get_consumption_forecast()
             )
-            solar_predictions = self.controller.get_solar_forecast()
+            # The next-day schedule must be built from tomorrow's solar forecast,
+            # not today's. Mirror the extended-horizon branch's zeros fallback when
+            # tomorrow's forecast is unavailable.
+            try:
+                solar_predictions = self.controller.get_solar_forecast_tomorrow()
+            except SystemConfigurationError:
+                tomorrow_date = date.today() + timedelta(days=1)
+                solar_predictions = [0.0] * get_period_count(tomorrow_date)
+                logger.info(
+                    "Tomorrow's solar forecast unavailable, using zeros for next-day schedule"
+                )
 
             consumption_data = consumption_predictions
             solar_data = solar_predictions

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -233,6 +233,29 @@ class TestGatherOptimizationDataExtended:
         # Solar must come from the tomorrow forecast, not today's
         assert all(v == 2.0 for v in data["full_solar"])
 
+    def test_prepare_next_day_starts_from_real_soc(self):
+        """Next-day plan must seed initial SOE from the real current SOC.
+
+        Regression: the prepare_next_day run (cron at 23:55, when current SOC is
+        known and ~= tomorrow's starting SOC) discarded current_soc and assumed
+        min SOC, so any night the battery wasn't actually empty the next-day plan
+        started from a wrong state.
+        """
+        controller = MockHomeAssistantController()
+        source = MockSource([0.5] * 96)
+        system = _make_system(source, controller)
+
+        result = system._gather_optimization_data(
+            period=0, current_soc=50.0, prepare_next_day=True, period_count=96
+        )
+
+        assert result is not None
+        _, data = result
+        expected_soe = 50.0 / 100.0 * system.battery_settings.total_capacity
+        # Must reflect real SOC, not min_soe_kwh
+        assert expected_soe != system.battery_settings.min_soe_kwh
+        assert data["combined_soe"][0] == expected_soe
+
     def test_prepare_next_day_solar_falls_back_to_zeros_on_error(self):
         """If tomorrow's solar forecast is unavailable, next-day uses zeros."""
         from core.bess.exceptions import SystemConfigurationError

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -211,6 +211,51 @@ class TestGatherOptimizationDataExtended:
         _, data = result
         assert len(data["full_consumption"]) == 96
 
+    def test_prepare_next_day_uses_tomorrow_solar_forecast(self):
+        """prepare_next_day must build the schedule from TOMORROW's solar forecast.
+
+        Regression: the next-day schedule was built with today's solar forecast,
+        which under-/over-forecasts tomorrow's production and distorts the plan.
+        """
+        controller = MockHomeAssistantController()
+        controller.solar_forecast = [1.0] * 96  # today
+        controller.solar_forecast_tomorrow = [2.0] * 96  # tomorrow
+        source = MockSource([0.5] * 96)
+        system = _make_system(source, controller)
+
+        result = system._gather_optimization_data(
+            period=0, current_soc=50.0, prepare_next_day=True, period_count=96
+        )
+
+        assert result is not None
+        _, data = result
+        assert len(data["full_solar"]) == 96
+        # Solar must come from the tomorrow forecast, not today's
+        assert all(v == 2.0 for v in data["full_solar"])
+
+    def test_prepare_next_day_solar_falls_back_to_zeros_on_error(self):
+        """If tomorrow's solar forecast is unavailable, next-day uses zeros."""
+        from core.bess.exceptions import SystemConfigurationError
+
+        controller = MockHomeAssistantController()
+        controller.solar_forecast = [1.0] * 96
+        source = MockSource([0.5] * 96)
+        system = _make_system(source, controller)
+
+        with patch.object(
+            controller,
+            "get_solar_forecast_tomorrow",
+            side_effect=SystemConfigurationError("Not configured"),
+        ):
+            result = system._gather_optimization_data(
+                period=0, current_soc=50.0, prepare_next_day=True, period_count=96
+            )
+
+        assert result is not None
+        _, data = result
+        assert len(data["full_solar"]) == 96
+        assert all(v == 0.0 for v in data["full_solar"])
+
 
 class TestCalculateTerminalValue:
     """Test _calculate_terminal_value() method."""


### PR DESCRIPTION
Two independent correctness bugs in the `prepare_next_day` branch of `BatterySystemManager._gather_optimization_data` (`core/bess/battery_system_manager.py`). Both are in the dedicated next-day pass that runs from cron at **23:55** (`backend/app.py:323`) to pre-compute tomorrow's schedule. The parallel "today / extended-horizon" branch already handles both correctly — this branch had drifted.

Found while analyzing debug bundle `bess-debug-2026-06-20-235905.md` (v9.6.0).

## Bug 1 — used today's solar forecast for tomorrow

`solar_predictions = self.controller.get_solar_forecast()` returns **today's** Solcast (`solar_forecast_today`). Evidence from the bundle: the next-day schedule's `solar_production` summed to **28.52 kWh** (= `solcast...forecast_today`) while the actual next-day forecast `solcast...forecast_tomorrow` was **64.85 kWh**. The plan was optimized against ~half the real expected solar, distorting store-vs-export decisions all day.

**Fix:** use `get_solar_forecast_tomorrow()`, mirroring the extended-horizon path, with the same zeros fallback on `SystemConfigurationError`.

## Bug 2 — ignored the real battery SOC

The next-day branch discarded `current_soc` (already passed into the method) and seeded every period with `min_soe_kwh`. Since the run fires at 23:55, current SOC ≈ tomorrow's starting SOC. Evidence: the bundle's health check shows `battery_soc = 28%` (~5.6 kWh on a 20 kWh pack) at 23:59, but the next-day schedule's `initial_soe` was **2.2 kWh** (min) — ignoring ~3.4 kWh of real stored energy. The assumption "the evening plan drains to min by midnight" silently fails whenever it doesn't (paused system, manual charge, conservative/failed evening plan).

**Fix:** seed `combined_soe` from `current_soe`, matching the regular branch.

## Tests (TDD — each watched fail first)

- `test_prepare_next_day_uses_tomorrow_solar_forecast`
- `test_prepare_next_day_solar_falls_back_to_zeros_on_error`
- `test_prepare_next_day_starts_from_real_soc`

Verification: `test_extended_horizon.py` 16 passed; fast suite **780 passed, 0 failed**; prepare_next_day integration suites **78 passed, 1 skipped**; `black`/`ruff` clean.

## Related (filed separately, out of scope here)

- #155 — next-day schedule period timestamps stamped with today's date (cosmetic; indices are correct).
- Follow-up issue — unify the two optimization paths so "one branch updated, the other forgotten" can't recur (this PR fixed two instances of exactly that drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)