### PR TITLE
fix: pace LOAD_SUPPORT discharge to match DP plan (issue #147)

### DIFF
--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -135,7 +135,9 @@ class InverterController(ABC):
                     100,
                     max(
                         0,
-                        int(abs(battery_action_kw) / self.max_discharge_power_kw * 100),
+                        round(
+                            abs(battery_action_kw) / self.max_discharge_power_kw * 100
+                        ),
                     ),
                 )
             else:
@@ -147,7 +149,9 @@ class InverterController(ABC):
                     100,
                     max(
                         0,
-                        int(abs(battery_action_kw) / self.max_discharge_power_kw * 100),
+                        round(
+                            abs(battery_action_kw) / self.max_discharge_power_kw * 100
+                        ),
                     ),
                 )
             else:

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -130,7 +130,17 @@ class InverterController(ABC):
         elif intent == "SOLAR_STORAGE":
             return False, 0
         elif intent == "LOAD_SUPPORT":
-            return False, 100
+            if battery_action_kw < -0.01:
+                discharge_rate = min(
+                    100,
+                    max(
+                        0,
+                        int(abs(battery_action_kw) / self.max_discharge_power_kw * 100),
+                    ),
+                )
+            else:
+                discharge_rate = 0
+            return False, discharge_rate
         elif intent == "EXPORT_ARBITRAGE":
             if battery_action_kw < -0.01:
                 discharge_rate = min(

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -120,7 +120,7 @@ class InverterController(ABC):
 
         Args:
             intent: Strategic intent string
-            battery_action_kw: Battery power in kW (used for EXPORT_ARBITRAGE scaling)
+            battery_action_kw: Battery power in kW (used for EXPORT_ARBITRAGE and LOAD_SUPPORT scaling)
 
         Returns:
             Tuple of (grid_charge, discharge_rate_percent)

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -198,13 +198,31 @@ class InverterController(ABC):
             )
 
         intent = self.strategic_intents[period]
-        control = self.INTENT_TO_CONTROL[intent]
         mode = self.INTENT_TO_MODE[intent]
 
+        if (
+            self.current_schedule is not None
+            and self.current_schedule.actions
+            and period < len(self.current_schedule.actions)
+        ):
+            battery_action_kwh = self.current_schedule.actions[period]
+            num_periods = len(self.current_schedule.actions)
+            period_duration_hours = 24.0 / num_periods
+            battery_action_kw = battery_action_kwh / period_duration_hours
+            grid_charge, discharge_rate = self.compute_rates_for_period(
+                period, battery_action_kw
+            )
+            charge_rate = self.INTENT_TO_CONTROL[intent]["charge_rate"]
+        else:
+            control = self.INTENT_TO_CONTROL[intent]
+            grid_charge = control["grid_charge"]
+            charge_rate = control["charge_rate"]
+            discharge_rate = control["discharge_rate"]
+
         return {
-            "grid_charge": control["grid_charge"],
-            "charge_rate": control["charge_rate"],
-            "discharge_rate": control["discharge_rate"],
+            "grid_charge": grid_charge,
+            "charge_rate": charge_rate,
+            "discharge_rate": discharge_rate,
             "strategic_intent": intent,
             "batt_mode": mode,
         }

--- a/core/bess/simulation/inverter_simulator.py
+++ b/core/bess/simulation/inverter_simulator.py
@@ -50,7 +50,14 @@ def _map_rates(
     if intent in ("SOLAR_STORAGE", "IDLE"):
         return False, 0
     if intent == "LOAD_SUPPORT":
-        return False, 100
+        if action_kw < -0.01:
+            rate = min(
+                100,
+                max(0, int(abs(action_kw) / settings.max_discharge_power_kw * 100)),
+            )
+        else:
+            rate = 0
+        return False, rate
     if intent == "EXPORT_ARBITRAGE":
         if action_kw < -0.01:
             rate = min(

--- a/core/bess/simulation/inverter_simulator.py
+++ b/core/bess/simulation/inverter_simulator.py
@@ -53,7 +53,7 @@ def _map_rates(
         if action_kw < -0.01:
             rate = min(
                 100,
-                max(0, int(abs(action_kw) / settings.max_discharge_power_kw * 100)),
+                max(0, round(abs(action_kw) / settings.max_discharge_power_kw * 100)),
             )
         else:
             rate = 0
@@ -61,7 +61,8 @@ def _map_rates(
     if intent == "EXPORT_ARBITRAGE":
         if action_kw < -0.01:
             rate = min(
-                100, max(0, int(abs(action_kw) / settings.max_discharge_power_kw * 100))
+                100,
+                max(0, round(abs(action_kw) / settings.max_discharge_power_kw * 100)),
             )
         else:
             rate = 0

--- a/core/bess/tests/integration/test_cross_platform.py
+++ b/core/bess/tests/integration/test_cross_platform.py
@@ -86,6 +86,7 @@ class TestCrossPlatformHardwareWrites:
     def test_discharge_commands_hardware(self, platform_system, mock_controller):
         """LOAD_SUPPORT produces a discharge command for each platform."""
         _set_intent(platform_system, PERIOD, "LOAD_SUPPORT")
+        _set_action(platform_system, PERIOD, -3.75)  # -3.75 kWh / 0.25h = -15 kW → 100%
 
         platform_system._apply_period_schedule(PERIOD)
 

--- a/core/bess/tests/integration/test_solax_integration.py
+++ b/core/bess/tests/integration/test_solax_integration.py
@@ -92,6 +92,9 @@ class TestSolaxVppCommandsPerIntent:
     def test_load_support_period_sends_negative_watts(self) -> None:
         bsm, hw = _make_bsm_solax()
         _set_intent(bsm, PERIOD, "LOAD_SUPPORT")
+        _set_action(
+            bsm, PERIOD, -3.75
+        )  # -3.75 kWh / 0.25h = -15 kW → 100% → negative VPP watts
 
         bsm._apply_period_schedule(PERIOD)
 

--- a/core/bess/tests/unit/test_controller_coverage.py
+++ b/core/bess/tests/unit/test_controller_coverage.py
@@ -424,6 +424,29 @@ class TestComputeRatesForPeriod:
         assert grid_charge is False
         assert discharge_rate == 0
 
+    def test_load_support_partial_discharge(self, min_ctrl):
+        # 1.5 kW of 15.0 kW max → 10%
+        min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+        grid_charge, discharge_rate = min_ctrl.compute_rates_for_period(
+            0, battery_action_kw=-1.5
+        )
+        assert grid_charge is False
+        assert discharge_rate == 10
+
+    def test_load_support_full_discharge(self, min_ctrl):
+        min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+        _grid_charge, discharge_rate = min_ctrl.compute_rates_for_period(
+            0, battery_action_kw=-min_ctrl.max_discharge_power_kw
+        )
+        assert discharge_rate == 100
+
+    def test_load_support_zero_action(self, min_ctrl):
+        min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+        _grid_charge, discharge_rate = min_ctrl.compute_rates_for_period(
+            0, battery_action_kw=0.0
+        )
+        assert discharge_rate == 0
+
 
 # ── SolaxController ──────────────────────────────────────────────────────────
 

--- a/core/bess/tests/unit/test_controller_coverage.py
+++ b/core/bess/tests/unit/test_controller_coverage.py
@@ -354,6 +354,24 @@ class TestGetPeriodSettings:
         with pytest.raises(ValueError):
             min_ctrl.get_period_settings(10)
 
+    def test_uses_actual_discharge_rate_when_schedule_available(self, min_ctrl):
+        from unittest.mock import MagicMock
+
+        min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+        mock_schedule = MagicMock()
+        # 96 periods, LOAD_SUPPORT action at period 0: -1.5 kWh → -6 kW → round(6/15*100)=40
+        mock_schedule.actions = [-1.5] + [0.0] * 95
+        min_ctrl.current_schedule = mock_schedule
+        result = min_ctrl.get_period_settings(0)
+        assert result["discharge_rate"] == 40
+        assert result["grid_charge"] is False
+
+    def test_falls_back_to_static_dict_when_no_schedule(self, min_ctrl):
+        min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+        min_ctrl.current_schedule = None
+        result = min_ctrl.get_period_settings(0)
+        assert result["discharge_rate"] == 100  # static dict fallback
+
 
 class TestGetStrategicIntentSummary:
     def test_empty_when_no_intents(self, min_ctrl):

--- a/core/bess/tests/unit/test_controller_coverage.py
+++ b/core/bess/tests/unit/test_controller_coverage.py
@@ -448,6 +448,35 @@ class TestComputeRatesForPeriod:
         assert discharge_rate == 0
 
 
+class TestSimulatorMapRates:
+    """_map_rates must mirror _map_intent_to_rates for every intent."""
+
+    def _settings(self):
+        return BatterySettings()
+
+    def test_load_support_partial(self):
+        from core.bess.simulation.inverter_simulator import _map_rates
+
+        grid_charge, rate = _map_rates("LOAD_SUPPORT", -1.5, self._settings())
+        assert grid_charge is False
+        assert rate == 10  # 1.5 / 15.0 * 100 = 10
+
+    def test_load_support_full(self):
+        from core.bess.simulation.inverter_simulator import _map_rates
+
+        s = self._settings()
+        grid_charge, rate = _map_rates("LOAD_SUPPORT", -s.max_discharge_power_kw, s)
+        assert grid_charge is False
+        assert rate == 100
+
+    def test_load_support_zero(self):
+        from core.bess.simulation.inverter_simulator import _map_rates
+
+        grid_charge, rate = _map_rates("LOAD_SUPPORT", 0.0, self._settings())
+        assert grid_charge is False
+        assert rate == 0
+
+
 # ── SolaxController ──────────────────────────────────────────────────────────
 
 

--- a/core/bess/tests/unit/test_discharge_inhibit.py
+++ b/core/bess/tests/unit/test_discharge_inhibit.py
@@ -62,6 +62,7 @@ class TestDischargeInhibitSuppressesDischarge:
     def test_load_support_discharges_when_inhibit_inactive(self):
         bsm, controller = _make_bsm(inhibit_active=False)
         _set_intent(bsm, PERIOD, "LOAD_SUPPORT")
+        _set_discharge_action(bsm, PERIOD, -3.75)  # -3.75 kWh / 0.25h = -15 kW → 100%
 
         bsm._apply_period_schedule(PERIOD)
 
@@ -128,6 +129,7 @@ class TestApplyDischargeInhibit:
         """Inhibit becoming active mid-period must stop discharge within 1 minute."""
         bsm, controller = _make_bsm(inhibit_active=False)
         _set_intent(bsm, PERIOD, "LOAD_SUPPORT")
+        _set_discharge_action(bsm, PERIOD, -3.75)  # -3.75 kWh / 0.25h = -15 kW → 100%
         bsm._apply_period_schedule(PERIOD)  # Sets desired=100, applied=100
         assert controller.calls["discharge_rate"][-1] == 100
 
@@ -140,6 +142,7 @@ class TestApplyDischargeInhibit:
         """Discharge must resume at the scheduled rate once inhibit clears."""
         bsm, controller = _make_bsm(inhibit_active=True)
         _set_intent(bsm, PERIOD, "LOAD_SUPPORT")
+        _set_discharge_action(bsm, PERIOD, -3.75)  # -3.75 kWh / 0.25h = -15 kW → 100%
         bsm._apply_period_schedule(PERIOD)  # Sets desired=100, applied=0 (inhibited)
 
         controller.inhibit_active = False
@@ -177,6 +180,7 @@ class TestApplyDischargeInhibit:
 
         # First period: LOAD_SUPPORT (desired=100), inhibit active → applied=0
         _set_intent(bsm, PERIOD, "LOAD_SUPPORT")
+        _set_discharge_action(bsm, PERIOD, -3.75)  # -3.75 kWh / 0.25h = -15 kW → 100%
         bsm._apply_period_schedule(PERIOD)
         assert bsm._desired_discharge_rate == 100
 

--- a/core/bess/tests/unit/test_min_schedule_e2e.py
+++ b/core/bess/tests/unit/test_min_schedule_e2e.py
@@ -256,8 +256,8 @@ class TestEndToEndChargeDischargeRates:
                     settings["charge_rate"] == 0
                 ), f"{scenario_name} period {period}: EXPORT_ARBITRAGE charge_rate={settings['charge_rate']}, expected 0"
                 assert (
-                    settings["discharge_rate"] == 100
-                ), f"{scenario_name} period {period}: EXPORT_ARBITRAGE discharge_rate={settings['discharge_rate']}, expected 100"
+                    0 <= settings["discharge_rate"] <= 100
+                )  # dynamic: rate derived from planned action, not hardcoded
 
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_idle_periods_have_correct_rates(self, scenario_name):
@@ -307,8 +307,8 @@ class TestEndToEndChargeDischargeRates:
                     settings["charge_rate"] == 0
                 ), f"{scenario_name} period {period}: LOAD_SUPPORT charge_rate={settings['charge_rate']}, expected 0"
                 assert (
-                    settings["discharge_rate"] == 100
-                ), f"{scenario_name} period {period}: LOAD_SUPPORT discharge_rate={settings['discharge_rate']}, expected 100"
+                    0 <= settings["discharge_rate"] <= 100
+                )  # dynamic: rate derived from planned action, not hardcoded
 
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_all_periods_have_settings(self, scenario_name):

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -289,20 +289,6 @@ def test_all_scenarios(scenario_name):
     planned_cost = result.economic_summary.battery_solar_cost
     gap = sim.realized_cost - planned_cost
 
-    # Known control-fidelity gap: LOAD_SUPPORT cannot pace battery discharge for
-    # home support, so deep-evening-peak high-consumption days realize worse than
-    # planned. Tracked in #147 — xfail (not silently tolerated) until fixed.
-    DISCHARGE_PACING_SCENARIOS = {
-        "synthetic_consumption_high_no_solar",
-        "synthetic_seasonal_winter",
-        "synthetic_consumption_ev_charging",
-        "historical_2025_01_12_evening_peak_no_solar",
-    }
-    if scenario_name in DISCHARGE_PACING_SCENARIOS:
-        pytest.xfail(
-            f"discharge cannot be paced for home support (R-P={gap:+.2f} SEK) — #147"
-        )
-
     tol = max(0.5, 0.01 * abs(planned_cost))
     assert abs(gap) <= tol, (
         f"{scenario_name}: realized != planned — R={sim.realized_cost:.2f}, "

--- a/docs/superpowers/plans/2026-06-20-load-support-pacing.md
+++ b/docs/superpowers/plans/2026-06-20-load-support-pacing.md
@@ -1,0 +1,298 @@
+# LOAD_SUPPORT Discharge Pacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the inverter execute LOAD_SUPPORT periods at the DP-planned discharge power instead of always dumping at 100% rate, so the plan-faithfulness simulator returns R≈P for high-consumption scenarios.
+
+**Architecture:** The fix is entirely in the real-time control translation layer. `_map_intent_to_rates` in `InverterController` and its mirror `_map_rates` in the inverter simulator both hard-code `discharge_rate=100` for LOAD_SUPPORT. Change both to scale from the planned `battery_action_kw` exactly as EXPORT_ARBITRAGE already does. The DP optimizer's reward/transition model for discharge is already correct and unchanged.
+
+**Tech Stack:** Python, pytest. No new dependencies.
+
+## Global Constraints
+
+- Never add fallbacks, silent error handling, or graceful degradation — fail explicitly per `docs/agents/rules.md`
+- `black . && ruff check --fix .` must pass before committing
+- Run `pytest -m "not slow"` (fast suite) to verify each task; the slow suite runs in CI
+- `BATTERY_MAX_CHARGE_DISCHARGE_POWER_KW = 15.0` is the default used by `BatterySettings()`
+
+---
+
+### Task 1: Scale LOAD_SUPPORT discharge_rate in the production controller
+
+The production controller (`InverterController._map_intent_to_rates`) hard-codes `discharge_rate=100` for LOAD_SUPPORT. Change it to compute the rate from `battery_action_kw`, mirroring EXPORT_ARBITRAGE.
+
+**Files:**
+- Modify: `core/bess/inverter_controller.py:116-149`
+- Test: `core/bess/tests/unit/test_controller_coverage.py:395-425`
+
+**Interfaces:**
+- Produces: `_map_intent_to_rates("LOAD_SUPPORT", battery_action_kw)` returns `(False, int)` where the int is `0..100` proportional to `abs(battery_action_kw) / max_discharge_power_kw * 100`, clamped to `[0, 100]`, truncated with `int()`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `class TestComputeRatesForPeriod` in `core/bess/tests/unit/test_controller_coverage.py` (after line 425, before the `# ── SolaxController ──` comment):
+
+```python
+def test_load_support_partial_discharge(self, min_ctrl):
+    # 1.5 kW of 15.0 kW max → 10%
+    min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+    grid_charge, discharge_rate = min_ctrl.compute_rates_for_period(
+        0, battery_action_kw=-1.5
+    )
+    assert grid_charge is False
+    assert discharge_rate == 10
+
+def test_load_support_full_discharge(self, min_ctrl):
+    min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+    _grid_charge, discharge_rate = min_ctrl.compute_rates_for_period(
+        0, battery_action_kw=-min_ctrl.max_discharge_power_kw
+    )
+    assert discharge_rate == 100
+
+def test_load_support_zero_action(self, min_ctrl):
+    min_ctrl.strategic_intents = ["LOAD_SUPPORT"] * 4
+    _grid_charge, discharge_rate = min_ctrl.compute_rates_for_period(
+        0, battery_action_kw=0.0
+    )
+    assert discharge_rate == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest core/bess/tests/unit/test_controller_coverage.py::TestComputeRatesForPeriod -v
+```
+
+Expected: 3 new tests FAIL (`assert 100 == 10`, `assert 100 == 10`, `assert 100 == 0`).
+
+- [ ] **Step 3: Implement the fix in `_map_intent_to_rates`**
+
+In `core/bess/inverter_controller.py`, replace lines 132-133:
+
+```python
+        elif intent == "LOAD_SUPPORT":
+            return False, 100
+```
+
+with:
+
+```python
+        elif intent == "LOAD_SUPPORT":
+            if battery_action_kw < -0.01:
+                discharge_rate = min(
+                    100,
+                    max(
+                        0,
+                        int(abs(battery_action_kw) / self.max_discharge_power_kw * 100),
+                    ),
+                )
+            else:
+                discharge_rate = 0
+            return False, discharge_rate
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest core/bess/tests/unit/test_controller_coverage.py::TestComputeRatesForPeriod -v
+```
+
+Expected: all 7 tests in `TestComputeRatesForPeriod` PASS.
+
+- [ ] **Step 5: Run fast suite to catch regressions**
+
+```bash
+pytest -m "not slow" -x -q
+```
+
+Expected: all fast tests PASS.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+black . && ruff check --fix .
+git add core/bess/inverter_controller.py core/bess/tests/unit/test_controller_coverage.py
+git commit -m "fix: scale LOAD_SUPPORT discharge_rate from planned action (mirrors EXPORT_ARBITRAGE)"
+```
+
+---
+
+### Task 2: Mirror the fix in the inverter simulator
+
+The simulator's `_map_rates` in `core/bess/simulation/inverter_simulator.py` must mirror `_map_intent_to_rates` exactly — it is the function the plan-faithfulness simulator uses to derive what `derive_control_command` sends. Without this change R≠P even after Task 1.
+
+**Files:**
+- Modify: `core/bess/simulation/inverter_simulator.py:43-62`
+- Test: `core/bess/tests/unit/test_controller_coverage.py` (new test class)
+
+**Interfaces:**
+- Consumes: `_map_rates(intent, action_kw, settings)` where `settings` is a `BatterySettings` instance with `.max_discharge_power_kw`
+- Produces: same `(bool, int)` tuple as `_map_intent_to_rates` for LOAD_SUPPORT
+
+- [ ] **Step 1: Write failing test**
+
+Add a new test class in `core/bess/tests/unit/test_controller_coverage.py` (after `TestComputeRatesForPeriod`, before the `# ── SolaxController ──` comment):
+
+```python
+class TestSimulatorMapRates:
+    """_map_rates must mirror _map_intent_to_rates for every intent."""
+
+    def _settings(self):
+        return BatterySettings()
+
+    def test_load_support_partial(self):
+        from core.bess.simulation.inverter_simulator import _map_rates
+        grid_charge, rate = _map_rates("LOAD_SUPPORT", -1.5, self._settings())
+        assert grid_charge is False
+        assert rate == 10  # 1.5 / 15.0 * 100 = 10
+
+    def test_load_support_full(self):
+        from core.bess.simulation.inverter_simulator import _map_rates
+        s = self._settings()
+        grid_charge, rate = _map_rates("LOAD_SUPPORT", -s.max_discharge_power_kw, s)
+        assert grid_charge is False
+        assert rate == 100
+
+    def test_load_support_zero(self):
+        from core.bess.simulation.inverter_simulator import _map_rates
+        grid_charge, rate = _map_rates("LOAD_SUPPORT", 0.0, self._settings())
+        assert grid_charge is False
+        assert rate == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest core/bess/tests/unit/test_controller_coverage.py::TestSimulatorMapRates -v
+```
+
+Expected: 3 tests FAIL (`assert 100 == 10`, etc.) — the current code returns 100 unconditionally.
+
+- [ ] **Step 3: Implement the fix in `_map_rates`**
+
+In `core/bess/simulation/inverter_simulator.py`, replace lines 52-53:
+
+```python
+    if intent == "LOAD_SUPPORT":
+        return False, 100
+```
+
+with:
+
+```python
+    if intent == "LOAD_SUPPORT":
+        if action_kw < -0.01:
+            rate = min(
+                100,
+                max(0, int(abs(action_kw) / settings.max_discharge_power_kw * 100)),
+            )
+        else:
+            rate = 0
+        return False, rate
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest core/bess/tests/unit/test_controller_coverage.py::TestSimulatorMapRates -v
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Run fast suite to catch regressions**
+
+```bash
+pytest -m "not slow" -x -q
+```
+
+Expected: all fast tests PASS.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+black . && ruff check --fix .
+git add core/bess/simulation/inverter_simulator.py core/bess/tests/unit/test_controller_coverage.py
+git commit -m "fix: mirror LOAD_SUPPORT discharge_rate scaling in inverter simulator"
+```
+
+---
+
+### Task 3: Remove xfail from the four pacing scenarios
+
+Now that R≈P holds for LOAD_SUPPORT, the four scenarios that were marked xfail in `test_scenarios.py` should pass. Remove the xfail gate and verify they do.
+
+**Files:**
+- Modify: `core/bess/tests/unit/test_scenarios.py:292-304`
+
+**Interfaces:**
+- Consumes: Task 1 + Task 2 fixes (controller + simulator both scale LOAD_SUPPORT rate)
+
+- [ ] **Step 1: Remove the xfail block**
+
+In `core/bess/tests/unit/test_scenarios.py`, delete lines 292-304 entirely (the `DISCHARGE_PACING_SCENARIOS` set and the `if scenario_name in DISCHARGE_PACING_SCENARIOS: pytest.xfail(...)` block):
+
+```python
+    # Known control-fidelity gap: LOAD_SUPPORT cannot pace battery discharge for
+    # home support, so deep-evening-peak high-consumption days realize worse than
+    # planned. Tracked in #147 — xfail (not silently tolerated) until fixed.
+    DISCHARGE_PACING_SCENARIOS = {
+        "synthetic_consumption_high_no_solar",
+        "synthetic_seasonal_winter",
+        "synthetic_consumption_ev_charging",
+        "historical_2025_01_12_evening_peak_no_solar",
+    }
+    if scenario_name in DISCHARGE_PACING_SCENARIOS:
+        pytest.xfail(
+            f"discharge cannot be paced for home support (R-P={gap:+.2f} SEK) — #147"
+        )
+```
+
+After deletion, line 292 should be the existing tolerance assertion:
+
+```python
+    tol = max(0.5, 0.01 * abs(planned_cost))
+    assert abs(gap) <= tol, (
+        f"{scenario_name}: realized != planned — R={sim.realized_cost:.2f}, "
+        f"P={planned_cost:.2f}, gap {gap:+.3f} SEK exceeds tolerance {tol:.2f}"
+    )
+```
+
+- [ ] **Step 2: Run the four previously-xfail scenarios in fast mode**
+
+These scenarios run under the fast marker (they don't invoke the slow DP optimizer — they load pre-computed scenario JSON). Run them individually to confirm they pass:
+
+```bash
+pytest core/bess/tests/unit/test_scenarios.py -k "high_no_solar or seasonal_winter or ev_charging or evening_peak_no_solar" -v
+```
+
+Expected: 4 tests PASS (not xfail-pass, not xfail-fail — genuine PASS).
+
+- [ ] **Step 3: Run the full scenario suite**
+
+```bash
+pytest core/bess/tests/unit/test_scenarios.py -v
+```
+
+Expected: all scenario tests PASS with no xfail markers remaining for pacing.
+
+- [ ] **Step 4: Run fast suite**
+
+```bash
+pytest -m "not slow" -x -q
+```
+
+Expected: all fast tests PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+black . && ruff check --fix .
+git add core/bess/tests/unit/test_scenarios.py
+git commit -m "test: remove xfail for LOAD_SUPPORT pacing scenarios — fixed by #147"
+```
+
+---
+
+## After All Tasks
+
+Open a PR against `main`. Title: `fix: pace LOAD_SUPPORT discharge to match DP plan (issue #147)`. The PR closes #147.

--- a/docs/superpowers/specs/2026-06-20-load-support-pacing-design.md
+++ b/docs/superpowers/specs/2026-06-20-load-support-pacing-design.md
@@ -1,0 +1,77 @@
+# LOAD_SUPPORT Discharge Pacing — Design Spec
+
+## Goal
+
+Make the inverter execute LOAD_SUPPORT periods at the power level the DP optimizer planned, instead of always dumping at 100% rate.
+
+## Background
+
+Issue #147. The DP optimizer correctly models partial discharge for LOAD_SUPPORT (e.g., discharge 0.4 kW, let grid cover the remaining 4.6 kW deficit, reserve battery for the expensive peak later). But `_map_intent_to_rates` always returns `discharge_rate=100` for LOAD_SUPPORT, so the inverter dumps at full rate and drains the battery early. The plan-faithfulness simulator exposes this as R−P deviations of 1–5 SEK on high-consumption days.
+
+EXPORT_ARBITRAGE already scales `discharge_rate` from the planned battery action. LOAD_SUPPORT needs the same treatment.
+
+## Architecture
+
+The Growatt MIN executes LOAD_SUPPORT as `load_first` with a per-period `discharge_rate_pct` written at runtime via `_apply_period_schedule → compute_rates_for_period → _map_intent_to_rates`. The TOU batch schedule never creates explicit slots for `load_first` (it is the inverter default). So the fix is entirely in the real-time control translation layer — no DP changes, no TOU builder changes, no new intents.
+
+Hardware validation: `discharge_rate_pct` in `load_first` mode is a power cap — 100% = full `max_discharge_power_kw`, 10% = 10% of that. Confirmed on GEN4 Modbus.
+
+## Changes
+
+### `core/bess/inverter_controller.py` — `_map_intent_to_rates`
+
+Replace the hardcoded `return False, 100` for LOAD_SUPPORT with the same scaling logic used for EXPORT_ARBITRAGE:
+
+```python
+elif intent == "LOAD_SUPPORT":
+    if battery_action_kw < -0.01:
+        discharge_rate = min(
+            100,
+            max(0, int(abs(battery_action_kw) / self.max_discharge_power_kw * 100)),
+        )
+    else:
+        discharge_rate = 0
+    return False, discharge_rate
+```
+
+### `core/bess/simulation/inverter_simulator.py` — `_map_rates`
+
+Identical change for LOAD_SUPPORT (this function mirrors the production controller):
+
+```python
+if intent == "LOAD_SUPPORT":
+    if action_kw < -0.01:
+        rate = min(100, max(0, int(abs(action_kw) / settings.max_discharge_power_kw * 100)))
+    else:
+        rate = 0
+    return False, rate
+```
+
+### `core/bess/tests/unit/test_scenarios.py`
+
+Remove `xfail` from the four scenarios currently failing due to this bug:
+- `synthetic_consumption_high_no_solar` (R−P was +4.88 SEK)
+- `synthetic_seasonal_winter` (R−P was +2.03 SEK)
+- `synthetic_consumption_ev_charging` (R−P was +2.03 SEK)
+- `historical_2025_01_12_evening_peak_no_solar` (R−P was +0.96 SEK)
+
+### `core/bess/tests/unit/test_optimization_algorithm.py` (or new file)
+
+Add unit tests for the updated `_map_intent_to_rates`:
+- LOAD_SUPPORT with `battery_action_kw = -1.5` and `max_discharge_power_kw = 6.0` → `discharge_rate = 25`
+- LOAD_SUPPORT with `battery_action_kw = -6.0` → `discharge_rate = 100`
+- LOAD_SUPPORT with `battery_action_kw = 0.0` → `discharge_rate = 0`
+
+## Why R==P Holds
+
+The simulator's `_map_rates` and the production controller's `_map_intent_to_rates` are mirrors. After this fix both compute the same `discharge_rate` from the same planned action. The simulator's `mode_to_power` for `load_first` already applies `rate_kw` as a cap: `min(deficit, rate_kw * dt, available)`. With the planned rate < deficit (which holds by construction for LOAD_SUPPORT — any period where discharge exceeds deficit would be classified as EXPORT_ARBITRAGE), the battery delivers exactly the planned amount.
+
+## Robustness
+
+Rate-limiting LOAD_SUPPORT does not under-cover home consumption: the grid always covers whatever the battery doesn't. If actual consumption exceeds the forecast, the grid picks up the extra — the battery is preserved for the expensive peak the optimizer planned for. This is strictly better than dumping now and buying expensive grid power later.
+
+## Out of Scope
+
+- `INTENT_TO_CONTROL` static dict (used only for SPH display, not for MIN hardware writes)
+- `group_periods_by_intent` base-class method (display only)
+- Any scenarios where R−P deviation is driven by forecast error rather than control faithfulness


### PR DESCRIPTION
## Summary

Fixes #147 — battery discharge for home support (LOAD_SUPPORT) was always executed at 100% rate, ignoring the power level the DP optimizer planned. The optimizer correctly models partial discharge (e.g. discharge 0.4 kW, let grid cover the remaining deficit, reserve battery for the expensive peak), but the control translation layer threw that away.

- **Root cause:** `_map_intent_to_rates` hard-coded `discharge_rate=100` for LOAD_SUPPORT. EXPORT_ARBITRAGE already scaled the rate from the planned action — LOAD_SUPPORT now does the same.
- **`round()` not `int()`:** float truncation caused ~⅓ of power levels to underdeliver by one percentage point (e.g. `0.4/6.0*100 = 6.67 → int=6`). Fixed in all four rate-scaling sites (both intents, both files).
- **Display fix:** `get_period_settings()` was reading `discharge_rate` from a static dict (always 100 for dynamic intents). It now returns the actual planned rate from the schedule when available.

## Changes

| File | What changed |
|------|-------------|
| `core/bess/inverter_controller.py` | LOAD_SUPPORT branch scales rate from `battery_action_kw`; `round()` replaces `int()` for both intents; `get_period_settings()` uses actual schedule rate |
| `core/bess/simulation/inverter_simulator.py` | Mirrors controller: LOAD_SUPPORT scaled, `round()` fix |
| `core/bess/tests/unit/test_controller_coverage.py` | 8 new unit tests (LOAD_SUPPORT partial/full/zero, simulator mirror, `get_period_settings` dynamic + fallback paths) |
| `core/bess/tests/unit/test_scenarios.py` | Removed `DISCHARGE_PACING_SCENARIOS` xfail block |
| `core/bess/tests/unit/test_min_schedule_e2e.py` | Loosened two stale `discharge_rate == 100` assertions to `0 <= x <= 100` |

## Test plan

- [ ] Fast suite green (`pytest -m "not slow"`) — 788 passed locally
- [ ] Slow suite / Algorithm job green in CI — this is where the 4 formerly-xfail scenarios run (`synthetic_consumption_high_no_solar`, `synthetic_seasonal_winter`, `synthetic_consumption_ev_charging`, `historical_2025_01_12_evening_peak_no_solar`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)