### PR TITLE
release: v9.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.6.1] - 2026-06-21
 
 ### Fixed
 
+- **LOAD_SUPPORT discharged at full rate instead of the planned pace** — The DP optimizer models partial discharge for LOAD_SUPPORT (e.g. discharge 0.4 kW and let the grid cover the rest, reserving the battery for a later expensive peak), but the inverter control layer always wrote `discharge_rate=100%`, so the battery dumped at full power and drained early. LOAD_SUPPORT now scales the inverter discharge rate from the planned battery action, mirroring EXPORT_ARBITRAGE. (Issue #147)
 - **Consumption strategy change silently dropped in setup wizard** — `POST /api/setup/complete` only entered the home settings block when `currency` or `consumption` were non-null; changing `consumptionStrategy`, `maxFuseCurrent`, `voltage`, or other home-only fields without also touching those two fields caused the change to be silently lost. Same flaw applied to the battery block (guarded by `totalCapacity` only) and electricity-price block. All three blocks now use an `any(f is not None …)` guard covering every field in the section.
 - **Consumption strategy change takes effect immediately** — Updating `consumption_strategy` via `update_settings()` now clears the stale prediction cache so the next optimization cycle fetches predictions under the new strategy, rather than waiting until the nightly `prepare_next_day` refresh at 23:55.
 - **Next-day schedule used today's solar forecast** — The `prepare_next_day` optimization built tomorrow's battery schedule from *today's* Solcast forecast instead of tomorrow's, so the plan written to the inverter could be optimized against substantially wrong solar production (e.g. 28.5 kWh today vs 64.8 kWh forecast for the next day). It now uses `get_solar_forecast_tomorrow()`, mirroring the extended-horizon path, with the same zeros fallback when tomorrow's forecast is unavailable.

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.6.0"
+version: "9.6.1"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false


### PR DESCRIPTION
Patch release bundling the bug fixes merged to `main` since v9.6.0.

## Fixed

- **LOAD_SUPPORT discharged at full rate instead of the planned pace** (#147 / #156) — The DP optimizer models partial LOAD_SUPPORT discharge (discharge a little, let grid cover the rest, reserve battery for a later peak), but the inverter control layer always wrote `discharge_rate=100%`, draining the battery early. It now scales the discharge rate from the planned battery action, mirroring EXPORT_ARBITRAGE.
- **Consumption strategy change silently dropped in setup wizard** (#158) — `POST /api/setup/complete` only saved home/battery/price blocks when specific anchor fields were non-null, so changing other fields in those sections was lost. All blocks now guard on `any(f is not None …)` across every field.
- **Consumption strategy change takes effect immediately** (#158) — `update_settings()` now clears the stale prediction cache so the next cycle uses the new strategy, instead of waiting for the nightly 23:55 refresh.
- **Next-day schedule used today's solar forecast** (#154) — `prepare_next_day` built tomorrow's plan from today's Solcast forecast; now uses `get_solar_forecast_tomorrow()` with a zeros fallback.
- **Next-day schedule ignored the real battery SOC** (#154) — `prepare_next_day` assumed minimum SOC; now seeds from the real current SOC (run fires at 23:55 when SOC ≈ tomorrow's start).

## Release checklist

- [x] Version bumped `9.6.0` → `9.6.1` (`bess_manager/config.yaml`)
- [x] CHANGELOG updated (`[9.6.1] - 2026-06-21`)
- [x] `black --check .` / `ruff check .` clean
- [ ] Full local test suite (incl. `-m slow`) — running
- [ ] CI green
- [ ] Tag `v9.6.1` + GitHub release after merge

Backend-only; no frontend changes since v9.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)