### PR TITLE
fix: extend Nordpool area hints to continental areas (NL/BE/DE/FR/AT/PL)

### DIFF
--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -2200,6 +2200,13 @@ class HomeAssistantAPIController:
         "LT": ("EUR", 1.21),
         "LV": ("EUR", 1.21),
         "GB": ("GBP", 1.0),
+        # Continental Nord Pool day-ahead areas (post-expansion):
+        "NL": ("EUR", 1.21),
+        "BE": ("EUR", 1.21),
+        "DE": ("EUR", 1.19),
+        "FR": ("EUR", 1.20),
+        "AT": ("EUR", 1.20),
+        "PL": ("PLN", 1.23),
     }
 
     def _hints_from_nordpool_area(self, area: str | None) -> dict:

--- a/core/bess/tests/unit/test_discovery_hints.py
+++ b/core/bess/tests/unit/test_discovery_hints.py
@@ -60,6 +60,32 @@ class TestHintsFromNordpoolArea:
         hints = self.ctrl._hints_from_nordpool_area("GB")
         assert hints == {"currency": "GBP", "vat_multiplier": 1.0}
 
+    def test_nl_area_returns_eur_21vat(self):
+        hints = self.ctrl._hints_from_nordpool_area("NL")
+        assert hints == {"currency": "EUR", "vat_multiplier": 1.21}
+
+    def test_be_area_returns_eur_21vat(self):
+        hints = self.ctrl._hints_from_nordpool_area("BE")
+        assert hints == {"currency": "EUR", "vat_multiplier": 1.21}
+
+    def test_de_lu_area_returns_eur_19vat(self):
+        # Nord Pool publishes the German bidding zone as "DE-LU"; the prefix
+        # parser must take the first two characters and map to DE.
+        hints = self.ctrl._hints_from_nordpool_area("DE-LU")
+        assert hints == {"currency": "EUR", "vat_multiplier": 1.19}
+
+    def test_fr_area_returns_eur_20vat(self):
+        hints = self.ctrl._hints_from_nordpool_area("FR")
+        assert hints == {"currency": "EUR", "vat_multiplier": 1.20}
+
+    def test_at_area_returns_eur_20vat(self):
+        hints = self.ctrl._hints_from_nordpool_area("AT")
+        assert hints == {"currency": "EUR", "vat_multiplier": 1.20}
+
+    def test_pl_area_returns_pln_23vat(self):
+        hints = self.ctrl._hints_from_nordpool_area("PL")
+        assert hints == {"currency": "PLN", "vat_multiplier": 1.23}
+
     def test_unknown_area_returns_empty(self):
         hints = self.ctrl._hints_from_nordpool_area("XX99")
         assert hints == {}


### PR DESCRIPTION
## Summary

- Extends `_AREA_HINTS` in `ha_api_controller.py` with the post-expansion Nord Pool day-ahead areas: NL/BE/DE/FR/AT (EUR) and PL (PLN), with their standard VAT rates.
- Adds 6 regression tests in `test_discovery_hints.py`, including one for `DE-LU` (covered by the existing `area[:2]` prefix slice).

Closes #163.

## Why

Without these entries, `_hints_from_nordpool_area()` returns `{}` for any continental area, the discover endpoint skips the currency update, and the bootstrap `SEK` default from `config.yaml` stays in place. The Settings → Electricity Pricing UI then locks Currency to SEK because the field is `readOnly` behind "Auto-detected…", so the user has no way to correct it. See #163 for the full root-cause writeup.

## Scope note

This PR is backend-only. The UI fallback (let the user edit Currency when auto-detect resolves to blank/unknown) is mentioned in #163 as a follow-up; I left it out here to keep the change minimal.

## Test plan

- [x] `pytest core/bess/tests/unit/test_discovery_hints.py` — 37 passed locally
- [ ] Verify on real install: NL Nordpool area now persists EUR through setup wizard