### PR TITLE
fix: Nord Pool HACS continental areas + currency field read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - **Energy Prediction health check validates active consumption strategy** — The health check was hardcoded to validate `get_estimated_consumption` (the `sensor` strategy sensor) regardless of which strategy was configured, producing false-positive warnings for users running `fixed`, `influxdb_7d_avg`, or `ha_statistics`. The check now only validates `get_estimated_consumption` when `sensor` is the active strategy; solar forecast validation is unchanged. (#160)
+- **Nord Pool HACS continental areas mapped to Norway** — The entity-id regex in `_parse_nordpool_area_from_entity_id` only matched original Nord Pool members (SE/NO/DK/FI/EE/LT/LV). HACS users with continental area codes (NL, BE, DE, DE-LU, FR, AT, PL) got `None` from the parser; the `raw.upper()` fallback produced a long string starting with "NO", so `_hints_from_nordpool_area` read the "NO" prefix and returned Norwegian krone instead of the correct currency. The regex is extended to cover all continental areas. (#171)
+- **Nord Pool Currency field always read-only in UI** — Both Nord Pool provider variants rendered the Currency input with `readOnly: true` unconditionally, preventing users from correcting a wrong auto-detected currency. The field is now editable when area or currency detection has not produced a value. (#171)
 
 ## [9.6.2] - 2026-06-24
 

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -2358,9 +2358,12 @@ class HomeAssistantAPIController:
         - sensor.nordpool_kwh_se4_sek_2_10_025 -> SE4  (custom integration)
         - sensor.nordpool_kwh_no1_nok_3_10_025 -> NO1  (custom integration)
         - sensor.nord_pool_se3_current_price    -> SE3  (official HA)
+        - sensor.nordpool_kwh_nl_eur_2_10_025  -> NL   (HACS continental)
+        - nordpool_kwh_de-lu_eur_2_10_025      -> DE-LU (HACS DE-LU zone)
         """
         match = re.search(
-            r"(?:^|_)(se[1-4]|no[1-5]|dk[12]|fi|ee|lt|lv)(?:_|$)", entity_id
+            r"(?:^|_)(se[1-4]|no[1-5]|dk[12]|fi|ee|lt|lv|nl|be|de(?:-lu)?|fr|at|pl)(?:_|$)",
+            entity_id,
         )
         if match:
             return match.group(1).upper()

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -2355,14 +2355,15 @@ class HomeAssistantAPIController:
         """Parse Nordpool area code from an entity_id.
 
         Examples:
-        - sensor.nordpool_kwh_se4_sek_2_10_025 -> SE4  (custom integration)
-        - sensor.nordpool_kwh_no1_nok_3_10_025 -> NO1  (custom integration)
-        - sensor.nord_pool_se3_current_price    -> SE3  (official HA)
-        - sensor.nordpool_kwh_nl_eur_2_10_025  -> NL   (HACS continental)
-        - nordpool_kwh_de-lu_eur_2_10_025      -> DE-LU (HACS DE-LU zone)
+        - sensor.nordpool_kwh_se4_sek_2_10_025   -> SE4   (custom integration)
+        - sensor.nordpool_kwh_no1_nok_3_10_025   -> NO1   (custom integration)
+        - sensor.nord_pool_se3_current_price      -> SE3   (official HA)
+        - sensor.nordpool_kwh_nl_eur_2_10_025    -> NL    (HACS continental)
+        - sensor.nordpool_kwh_de_lu_eur_2_10_025 -> DE_LU (HACS DE-LU, HA slug)
+        - nordpool_kwh_de-lu_eur_2_10_025        -> DE-LU (device registry identifier)
         """
         match = re.search(
-            r"(?:^|_)(se[1-4]|no[1-5]|dk[12]|fi|ee|lt|lv|nl|be|de(?:-lu)?|fr|at|pl)(?:_|$)",
+            r"(?:^|_)(se[1-4]|no[1-5]|dk[12]|fi|ee|lt|lv|nl|be|de(?:[-_]lu)?|fr|at|pl)(?:_|$)",
             entity_id,
         )
         if match:

--- a/core/bess/tests/unit/test_discovery_hints.py
+++ b/core/bess/tests/unit/test_discovery_hints.py
@@ -323,6 +323,62 @@ class TestDiscoverHaMetadataNordpoolArea:
         result = self.ctrl.discover_ha_metadata(None)
         assert result["nordpool_area"] == "NO1"
 
+    def test_hacs_nl_identifier_not_aliased_to_norway(self, monkeypatch):
+        """Issue #171: HACS 'nordpool_kwh_nl_eur_2_10_025' must give NL, not NO."""
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_nl_eur_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "NL"
+
+    def test_hacs_be_identifier_normalised(self, monkeypatch):
+        """Issue #171: HACS 'nordpool_kwh_be_eur_2_10_025' → 'BE'."""
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_be_eur_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "BE"
+
+    def test_hacs_de_identifier_normalised(self, monkeypatch):
+        """Issue #171: HACS 'nordpool_kwh_de_eur_2_10_025' → 'DE'."""
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_de_eur_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "DE"
+
+    def test_hacs_de_lu_identifier_normalised(self, monkeypatch):
+        """Issue #171: HACS 'nordpool_kwh_de-lu_eur_2_10_025' → 'DE-LU'."""
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_de-lu_eur_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "DE-LU"
+
+    def test_hacs_fr_identifier_normalised(self, monkeypatch):
+        """Issue #171: HACS 'nordpool_kwh_fr_eur_2_10_025' → 'FR'."""
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_fr_eur_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "FR"
+
+    def test_hacs_at_identifier_normalised(self, monkeypatch):
+        """Issue #171: HACS 'nordpool_kwh_at_eur_2_10_025' → 'AT'."""
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_at_eur_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "AT"
+
+    def test_hacs_pl_identifier_normalised(self, monkeypatch):
+        """Issue #171: HACS 'nordpool_kwh_pl_pln_2_10_025' → 'PL'."""
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_pl_pln_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "PL"
+
     def test_non_matching_config_entry_ignored(self, monkeypatch):
         """Devices for a different config entry are not used."""
         entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}

--- a/core/bess/tests/unit/test_discovery_hints.py
+++ b/core/bess/tests/unit/test_discovery_hints.py
@@ -355,6 +355,19 @@ class TestDiscoverHaMetadataNordpoolArea:
         result = self.ctrl.discover_ha_metadata(None)
         assert result["nordpool_area"] == "DE-LU"
 
+    def test_hacs_de_lu_underscore_entity_id_normalised(self, monkeypatch):
+        """Issue #171: HA slugifies DE-LU to 'de_lu', so entity IDs use underscore.
+
+        'nordpool_kwh_de_lu_eur_2_10_025' must be parsed to 'DE_LU', not 'DE'
+        (which would leave '_lu_eur_...' unmatched) and must not fall back to
+        raw.upper() which would alias to 'NO' (Norway) via the 2-char prefix.
+        """
+        entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}
+        devices = [self._nordpool_device("nordpool_kwh_de_lu_eur_2_10_025")]
+        monkeypatch.setattr(self.ctrl, "_ws_query", self._ws_stub([entry], devices))
+        result = self.ctrl.discover_ha_metadata(None)
+        assert result["nordpool_area"] == "DE_LU"
+
     def test_hacs_fr_identifier_normalised(self, monkeypatch):
         """Issue #171: HACS 'nordpool_kwh_fr_eur_2_10_025' → 'FR'."""
         entry = {"domain": "nordpool", "state": "loaded", "entry_id": "abc"}

--- a/frontend/src/components/settings/PricingFormSection.tsx
+++ b/frontend/src/components/settings/PricingFormSection.tsx
@@ -57,7 +57,7 @@ export function PricingFormSection({ form, onChange }: Props) {
               {txtInput('Price Area', form.area, () => {}, 'Auto-detected…', { readOnly: true })}
               {txtInput('Currency', form.currency,
                 v => onChange({ ...form, currency: v }), 'Auto-detected…',
-                { readOnly: !!(form.area && form.currency) })}
+                { readOnly: !!(form.area && form.area.length <= 5 && form.currency) })}
             </div>
           </div>
         )}
@@ -70,7 +70,7 @@ export function PricingFormSection({ form, onChange }: Props) {
               {txtInput('Price Area', form.area, () => {}, 'Auto-detected…', { readOnly: true })}
               {txtInput('Currency', form.currency,
                 v => onChange({ ...form, currency: v }), 'Auto-detected…',
-                { readOnly: !!(form.area && form.currency) })}
+                { readOnly: !!(form.area && form.area.length <= 5 && form.currency) })}
             </div>
           </div>
         )}

--- a/frontend/src/components/settings/PricingFormSection.tsx
+++ b/frontend/src/components/settings/PricingFormSection.tsx
@@ -55,7 +55,9 @@ export function PricingFormSection({ form, onChange }: Props) {
               v => onChange({ ...form, nordpoolConfigEntryId: v }), 'Auto-detected…')}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {txtInput('Price Area', form.area, () => {}, 'Auto-detected…', { readOnly: true })}
-              {txtInput('Currency', form.currency, () => {}, 'Auto-detected…', { readOnly: true })}
+              {txtInput('Currency', form.currency,
+                v => onChange({ ...form, currency: v }), 'Auto-detected…',
+                { readOnly: !!(form.area && form.currency) })}
             </div>
           </div>
         )}
@@ -66,7 +68,9 @@ export function PricingFormSection({ form, onChange }: Props) {
               v => onChange({ ...form, nordpoolEntity: v }), 'sensor.nordpool_…')}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {txtInput('Price Area', form.area, () => {}, 'Auto-detected…', { readOnly: true })}
-              {txtInput('Currency', form.currency, () => {}, 'Auto-detected…', { readOnly: true })}
+              {txtInput('Currency', form.currency,
+                v => onChange({ ...form, currency: v }), 'Auto-detected…',
+                { readOnly: !!(form.area && form.currency) })}
             </div>
           </div>
         )}


### PR DESCRIPTION
Fixes #171

## What changed

- **Backend** (`core/bess/ha_api_controller.py`): Extend the regex in `_parse_nordpool_area_from_entity_id` to match continental Nord Pool area codes (NL, BE, DE, DE-LU, FR, AT, PL). HACS entity IDs like `nordpool_kwh_nl_eur_2_10_025` were not matched, so the `raw.upper()` fallback produced `"NORDPOOL_KWH_NL_EUR_2_10_025"` — whose two-character prefix `"NO"` caused `_hints_from_nordpool_area` to return Norwegian krone (NOK) instead of EUR.

- **Frontend** (`frontend/src/components/settings/PricingFormSection.tsx`): Remove unconditional `readOnly: true` from the Currency field in both Nord Pool variants. The field is now editable when area or currency have not been populated by discovery (`!(form.area && form.currency)`), so users can correct a wrong or missing currency without re-running auto-detect.

- **Tests** (`core/bess/tests/unit/test_discovery_hints.py`): 7 new tests in `TestDiscoverHaMetadataNordpoolArea` cover HACS-style identifiers for each continental area code, verifying the regression described in #171 (NL must not map to Norway).

## Test plan

- [ ] All 812 fast tests pass (`pytest -m "not slow"`)
- [ ] `_parse_nordpool_area_from_entity_id("nordpool_kwh_nl_eur_2_10_025")` → `"NL"` (not `None`)
- [ ] Discovery sets EUR currency (not NOK) for NL/BE/DE/FR/AT/PL HACS users
- [ ] Currency field is editable when area detection has not run; locked when both area and currency are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)