### PR TITLE
fix: auto-refresh dashboard cards every 60s

### DIFF
--- a/frontend/src/components/EnergyFlowCards.tsx
+++ b/frontend/src/components/EnergyFlowCards.tsx
@@ -131,7 +131,7 @@ interface EnergyFlowCardsProps {
 }
 
 const EnergyFlowCards: React.FC<EnergyFlowCardsProps> = ({ className = "" }) => {
-  const { data: apiData, loading: isLoading, error } = useDashboardData();
+  const { data: apiData, loading: isLoading, error } = useDashboardData(undefined, 'quarter-hourly', 60000);
 
   if (isLoading) {
     return (

--- a/frontend/src/components/SystemStatusCard.tsx
+++ b/frontend/src/components/SystemStatusCard.tsx
@@ -133,8 +133,10 @@ interface SystemStatusCardProps {
 }
 
 
+const DASHBOARD_REFRESH_MS = 60000;
+
 const SystemStatusCard: React.FC<SystemStatusCardProps> = ({ className = "", systemMode }) => {
-  const { data: dashboardData, loading: dashboardLoading, error: dashboardError } = useDashboardData();
+  const { data: dashboardData, loading: dashboardLoading, error: dashboardError } = useDashboardData(undefined, 'quarter-hourly', DASHBOARD_REFRESH_MS);
   const [inverterData, setInverterData] = useState<any>(null);
   const [inverterLoading, setInverterLoading] = useState(true);
   const [inverterError, setInverterError] = useState<string | null>(null);
@@ -156,6 +158,8 @@ const SystemStatusCard: React.FC<SystemStatusCardProps> = ({ className = "", sys
     };
 
     fetchInverterData();
+    const interval = setInterval(fetchInverterData, DASHBOARD_REFRESH_MS);
+    return () => clearInterval(interval);
   }, []);
 
   const statusData = useMemo(() => {

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -15,10 +15,12 @@ interface UseDashboardDataResult {
  *
  * @param date - Optional date filter
  * @param resolution - Data resolution: 'hourly' (24 periods) or 'quarter-hourly' (96 periods). Defaults to 'quarter-hourly'.
+ * @param refreshInterval - Auto-refresh interval in ms. 0 = no auto-refresh (default).
  */
 export const useDashboardData = (
   date?: string,
-  resolution: DataResolution = 'quarter-hourly'
+  resolution: DataResolution = 'quarter-hourly',
+  refreshInterval: number = 0
 ): UseDashboardDataResult => {
   const [data, setData] = useState<DashboardResponse | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -41,7 +43,11 @@ export const useDashboardData = (
 
   useEffect(() => {
     fetchData();
-  }, [fetchData]);
+    if (refreshInterval > 0) {
+      const interval = setInterval(fetchData, refreshInterval);
+      return () => clearInterval(interval);
+    }
+  }, [fetchData, refreshInterval]);
 
   const refetch = useCallback(() => {
     fetchData();


### PR DESCRIPTION
## Summary

- `useDashboardData` hook now accepts an optional `refreshInterval` parameter (default `0` = no auto-refresh)
- `EnergyFlowCards` and `SystemStatusCard` pass `60000` ms so they re-fetch in sync with the dashboard's own polling cadence
- `SystemStatusCard`'s inverter status fetch (`/api/growatt/inverter_status`) also now polls every 60 s

**Root cause:** `DashboardPage` has its own `setInterval` loop that updates `lastUpdate` and the charts every 60 s, but both sub-components called `useDashboardData()` without an interval, so they fetched only on mount and stayed frozen until a full page reload.

Reported by Frank in #126.

## Test plan

- [ ] `npm run test` — all 20 frontend tests pass
- [ ] `.venv/bin/pytest -m "not slow"` — 805 backend tests pass
- [ ] Manual: open Dashboard, wait >60 s, confirm Battery SOC and System Status cards update without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)