### PR TITLE
release: v9.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.6.3] - 2026-06-25
+
 ### Fixed
 
+- **Dashboard cards frozen until page reload** — `EnergyFlowCards` and `SystemStatusCard` called `useDashboardData()` with no refresh interval, so Battery SOC, inverter status, and energy flow values only fetched on mount and stayed stale. Both cards now poll every 60 s, matching the dashboard's own update cadence. (#126)
 - **Energy Prediction health check validates active consumption strategy** — The health check was hardcoded to validate `get_estimated_consumption` (the `sensor` strategy sensor) regardless of which strategy was configured, producing false-positive warnings for users running `fixed`, `influxdb_7d_avg`, or `ha_statistics`. The check now only validates `get_estimated_consumption` when `sensor` is the active strategy; solar forecast validation is unchanged. (#160)
 - **Nord Pool HACS continental areas mapped to Norway** — The entity-id regex in `_parse_nordpool_area_from_entity_id` only matched original Nord Pool members (SE/NO/DK/FI/EE/LT/LV). HACS users with continental area codes (NL, BE, DE, DE-LU, FR, AT, PL) got `None` from the parser; the `raw.upper()` fallback produced a long string starting with "NO", so `_hints_from_nordpool_area` read the "NO" prefix and returned Norwegian krone instead of the correct currency. The regex is extended to cover all continental areas. (#171)
 - **Nord Pool Currency field always read-only in UI** — Both Nord Pool provider variants rendered the Currency input with `readOnly: true` unconditionally, preventing users from correcting a wrong auto-detected currency. The field is now editable when area or currency detection has not produced a value. (#171)

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.6.2"
+version: "9.6.3"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false


### PR DESCRIPTION
## v9.6.3

### Fixed

- **Dashboard cards frozen until page reload** — `EnergyFlowCards` and `SystemStatusCard` now poll every 60 s, matching the dashboard's own update cadence. (#126)
- **Energy Prediction health check validates active consumption strategy** — No longer hardcoded to the `sensor` strategy; validates whatever strategy is configured. (#160)
- **Nord Pool HACS continental areas mapped to Norway** — Extended regex to cover NL, BE, DE, DE-LU, FR, AT, PL. (#171)
- **Nord Pool Currency field always read-only in UI** — Now editable when area/currency detection did not return a valid hint. (#171)
- **Next-day schedule timestamps stamped with today's date** — `prepare_next_day` path now generates timestamps with tomorrow's date. (#155)

### Refactored

- **Unified `prepare_next_day` and extended-horizon data paths** — Single shared fetch stage for tomorrow's solar/consumption/prices; eliminates the duplicated-fix failure mode. (#157)

🤖 Generated with [Claude Code](https://claude.com/claude-code)