### PR TITLE
release: v9.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Dashboard hourly view returned 500** — `_aggregate_quarterly_to_hourly` was never updated when `observedIntent` was added to `APIDashboardHourlyData` in 9.6.2, so every call to `GET /api/dashboard?resolution=hourly` crashed with a missing required argument.
 - **Inverter platform badge always showed "SolaX Modbus"** — `InverterStatusDashboard.tsx` compared `platform` against legacy short strings (`growatt_min`, `growatt_sph`, `solax`) that never matched the actual API values (`growatt_server_min`, `growatt_server_sph`, etc.), so every user fell through to the else branch and saw "SolaX Modbus". String matching is updated to the current API values. (#60)
 - **Growatt SPH TOU intervals rendered "Segment #undefined"** — `GrowattSphController.build_schedule` built `tou_intervals` without `segment_id` or `is_default` fields. The frontend template assumed both were always present, causing `isDefault` to render as falsy and the segment label to show as undefined. Both fields are now included. (#60)
 - **AI Analyst returned 404 errors on deprecated model IDs** — The AI Analyst feature used `claude-sonnet-4-20250514` and `claude-opus-4-20250514`, the Claude 4.0 launch IDs from May 2025. Anthropic deprecated these IDs (retirement date June 15 2026), causing 404 errors for all users. Updated to `claude-sonnet-4-6` and `claude-opus-4-8`. (#180)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.6.3] - 2026-06-25
+
 ### Fixed
 
+- **Inverter platform badge always showed "SolaX Modbus"** — `InverterStatusDashboard.tsx` compared `platform` against legacy short strings (`growatt_min`, `growatt_sph`, `solax`) that never matched the actual API values (`growatt_server_min`, `growatt_server_sph`, etc.), so every user fell through to the else branch and saw "SolaX Modbus". String matching is updated to the current API values. (#60)
+- **Growatt SPH TOU intervals rendered "Segment #undefined"** — `GrowattSphController.build_schedule` built `tou_intervals` without `segment_id` or `is_default` fields. The frontend template assumed both were always present, causing `isDefault` to render as falsy and the segment label to show as undefined. Both fields are now included. (#60)
+- **AI Analyst returned 404 errors on deprecated model IDs** — The AI Analyst feature used `claude-sonnet-4-20250514` and `claude-opus-4-20250514`, the Claude 4.0 launch IDs from May 2025. Anthropic deprecated these IDs (retirement date June 15 2026), causing 404 errors for all users. Updated to `claude-sonnet-4-6` and `claude-opus-4-8`. (#180)
+- **EnergyFlowCards and SystemStatusCard stayed frozen between refreshes** — Both components called `useDashboardData()` without a refresh interval, so they fetched only on mount. The main dashboard page polls every 60 s but the cards remained stale. Both now pass a 60 s interval, staying in sync with the dashboard cadence. (#179)
 - **Energy Prediction health check validates active consumption strategy** — The health check was hardcoded to validate `get_estimated_consumption` (the `sensor` strategy sensor) regardless of which strategy was configured, producing false-positive warnings for users running `fixed`, `influxdb_7d_avg`, or `ha_statistics`. The check now only validates `get_estimated_consumption` when `sensor` is the active strategy; solar forecast validation is unchanged. (#160)
 - **Nord Pool HACS continental areas mapped to Norway** — The entity-id regex in `_parse_nordpool_area_from_entity_id` only matched original Nord Pool members (SE/NO/DK/FI/EE/LT/LV). HACS users with continental area codes (NL, BE, DE, DE-LU, FR, AT, PL) got `None` from the parser; the `raw.upper()` fallback produced a long string starting with "NO", so `_hints_from_nordpool_area` read the "NO" prefix and returned Norwegian krone instead of the correct currency. The regex is extended to cover all continental areas. (#171)
 - **Nord Pool Currency field always read-only in UI** — Both Nord Pool provider variants rendered the Currency input with `readOnly: true` unconditionally, preventing users from correcting a wrong auto-detected currency. The field is now editable when area or currency detection has not produced a value. (#171)

--- a/TODO.md
+++ b/TODO.md
@@ -670,6 +670,9 @@ To remove:
 3. Update `get_strategic_intent_summary()` to work directly with periods
 4. Remove the hourly aggregation methods listed above
 
+**Re-run optimization on energy prediction method change**:
+When the user changes the consumption strategy (e.g. from `sensor` to `fixed`), the optimization should re-run immediately with the new prediction method rather than waiting for the next scheduled cycle. The prediction cache should be cleared and a fresh optimization triggered in the same request that saves the new strategy.
+
 **Sensor Collector InfluxDB Usage**:
 Based on the code analysis: The function `_get_hour_readings` in SensorCollector is called by `collect_energy_data(hour)`. This is not called every hour automatically by the system; it is called when the system wants to collect and record data for a specific hour. The actual historical data for the dashboard is served from the HistoricalDataStore, which is an in-memory store populated by calls to `record_energy_data` (which uses the output of `collect_energy_data`).
 

--- a/backend/ai_chat.py
+++ b/backend/ai_chat.py
@@ -36,12 +36,8 @@ _CODEBASE_ROOT = _APP_DIR  # Docker: /app/
 if not (_CODEBASE_ROOT / "core" / "bess").exists():
     _CODEBASE_ROOT = _APP_DIR.parent  # Local dev: repo root
 
-# Domain knowledge file location.
-# In Docker: /app/agents/bess-knowledge.md  (copied from docs/agents/)
-# Local dev: <repo>/docs/agents/bess-knowledge.md
+# Domain knowledge file — mounted at the same path in dev and prod.
 _KNOWLEDGE_MD_PATH = _APP_DIR / "agents" / "bess-knowledge.md"
-if not _KNOWLEDGE_MD_PATH.exists():
-    _KNOWLEDGE_MD_PATH = _APP_DIR.parent / "docs" / "agents" / "bess-knowledge.md"
 
 # Directories the AI is allowed to read (relative to _CODEBASE_ROOT).
 _ALLOWED_DIRS = ("core/", "backend/", "docs/", "scripts/", ".claude/agents/")

--- a/backend/api.py
+++ b/backend/api.py
@@ -510,6 +510,7 @@ def _aggregate_quarterly_to_hourly(
             ),
             # Use dominant strategic intent with tie-breaking (same logic as Growatt schedule)
             strategicIntent=dominant_intent,
+            observedIntent=last_period.observedIntent,
             directSolar=sum(p.directSolar for p in quarter_periods),
         )
 

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -9,7 +9,6 @@ import sys
 from datetime import date, datetime
 from unittest.mock import MagicMock
 
-import pytest
 from api import router
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -1,0 +1,411 @@
+"""Smoke tests for dashboard and system API endpoints.
+
+Each endpoint gets two tests: 503 when unconfigured and 200 when started.
+The hourly dashboard test is a regression guard for the observedIntent bug fixed
+in _aggregate_quarterly_to_hourly.
+"""
+
+import sys
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from api import router
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.bess.daily_view_builder import DailyView
+from core.bess.models import DecisionData, EconomicData, EnergyData, PeriodData
+
+_test_app = FastAPI()
+_test_app.include_router(router)
+_client = TestClient(_test_app, raise_server_exceptions=False)
+
+
+def _make_period(period: int) -> PeriodData:
+    energy = EnergyData(
+        solar_production=0.5,
+        home_consumption=0.5,
+        battery_charged=0.0,
+        battery_discharged=0.0,
+        grid_imported=0.0,
+        grid_exported=0.0,
+        battery_soe_start=15.0,
+        battery_soe_end=15.0,
+    )
+    economic = EconomicData(
+        buy_price=1.0,
+        sell_price=0.5,
+        hourly_cost=0.5,
+        grid_only_cost=0.5,
+        solar_only_cost=0.0,
+        hourly_savings=0.0,
+    )
+    decision = DecisionData(strategic_intent="IDLE", observed_intent="IDLE")
+    return PeriodData(
+        period=period,
+        energy=energy,
+        timestamp=datetime(2025, 7, 13, period // 4, (period % 4) * 15),
+        data_source="predicted",
+        economic=economic,
+        decision=decision,
+    )
+
+
+def _make_daily_view() -> DailyView:
+    return DailyView(
+        date=date(2025, 7, 13),
+        periods=[_make_period(i) for i in range(96)],
+        total_savings=0.0,
+        actual_count=0,
+        predicted_count=96,
+    )
+
+
+def _make_started_controller() -> MagicMock:
+    ctrl = MagicMock()
+    ctrl.system.is_configured = True
+    ctrl.startup_complete = True
+
+    mock_schedule = MagicMock()
+    mock_schedule.optimization_period = 0
+    mock_schedule.optimization_result.period_data = []
+    ctrl.system.schedule_store.get_latest_schedule.return_value = mock_schedule
+
+    ctrl.system.get_current_daily_view.return_value = _make_daily_view()
+    ctrl.system.get_settings.return_value = {"battery": MagicMock(total_capacity=30.0)}
+    ctrl.system.home_settings.currency = "SEK"
+
+    sm = ctrl.system._inverter_controller
+    sm.get_strategic_intent_summary.return_value = {}
+    sm.strategic_intents = ["IDLE"] * 96
+    sm.get_period_settings.return_value = {
+        "batt_mode": "load_first",
+        "strategic_intent": "IDLE",
+        "grid_charge": False,
+        "discharge_rate": 100,
+    }
+    sm._get_intent_description.return_value = ""
+    sm.get_all_tou_segments.return_value = []
+    sm.tou_intervals = []
+
+    ctrl.ha_controller.get_battery_soc.return_value = 75.0
+    ctrl.ha_controller.get_pv_power.return_value = 0.0
+    ctrl.ha_controller.get_local_load_power.return_value = 0.0
+    ctrl.ha_controller.get_import_power.return_value = 0.0
+    ctrl.ha_controller.get_export_power.return_value = 0.0
+    ctrl.ha_controller.get_battery_charge_power.return_value = 0.0
+    ctrl.ha_controller.get_battery_discharge_power.return_value = 0.0
+    ctrl.ha_controller.get_net_battery_power.return_value = 0.0
+    ctrl.ha_controller.test_mode = False
+
+    ctrl.system.historical_store.get_today_periods.return_value = [None] * 96
+    ctrl.system.prediction_snapshot_store.get_all_snapshots_today.return_value = []
+    ctrl.system.prediction_snapshot_store.get_snapshot_at_period.return_value = None
+    ctrl.system.get_runtime_failures.return_value = []
+    ctrl.system.dismiss_runtime_failure.return_value = None
+    ctrl.system.dismiss_all_runtime_failures.return_value = 0
+    ctrl.system.has_critical_sensor_failures.return_value = False
+    ctrl.system.get_cached_health_results.return_value = {
+        "checks": [],
+        "system_mode": "normal",
+    }
+    ctrl.system.get_consumption_forecast_comparison.return_value = {
+        "actual_hourly": [None] * 24,
+        "strategies": [],
+        "active_strategy": "none",
+        "actual_hours_available": 0,
+    }
+    ctrl.settings_store.data = {}
+
+    return ctrl
+
+
+def _unconfigured_controller() -> MagicMock:
+    ctrl = MagicMock()
+    ctrl.system.is_configured = False
+    ctrl.startup_complete = True
+    return ctrl
+
+
+# ===========================================================================
+# GET /api/dashboard
+# ===========================================================================
+
+
+class TestDashboard:
+    def test_quarter_hourly_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/dashboard")
+        assert resp.status_code == 200
+
+    def test_hourly_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/dashboard?resolution=hourly")
+        assert resp.status_code == 200
+
+    def test_hourly_periods_have_strategic_and_observed_intent(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/dashboard?resolution=hourly")
+        assert resp.status_code == 200
+        periods = resp.json()["hourlyData"]
+        assert len(periods) > 0
+        assert "strategicIntent" in periods[0]
+        assert "observedIntent" in periods[0]
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/dashboard")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/decision-intelligence
+# ===========================================================================
+
+
+class TestDecisionIntelligence:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/decision-intelligence")
+        assert resp.status_code == 200
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/decision-intelligence")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/growatt/tou_settings
+# ===========================================================================
+
+
+class TestTouSettings:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/growatt/tou_settings")
+        assert resp.status_code == 200
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/growatt/tou_settings")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/growatt/strategic_intents
+# ===========================================================================
+
+
+class TestStrategicIntents:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/growatt/strategic_intents")
+        assert resp.status_code == 200
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/growatt/strategic_intents")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/system-health
+# ===========================================================================
+
+
+class TestSystemHealth:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/system-health")
+        assert resp.status_code == 200
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/system-health")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/dashboard-health-summary
+# ===========================================================================
+
+
+class TestDashboardHealthSummary:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/dashboard-health-summary")
+        assert resp.status_code == 200
+
+    def test_response_contains_has_critical_errors(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/dashboard-health-summary")
+        assert "hasCriticalErrors" in resp.json()
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/dashboard-health-summary")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/historical-data-status
+# ===========================================================================
+
+
+class TestHistoricalDataStatus:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/historical-data-status")
+        assert resp.status_code == 200
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/historical-data-status")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/prediction-analysis/snapshots
+# ===========================================================================
+
+
+class TestPredictionSnapshots:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/prediction-analysis/snapshots")
+        assert resp.status_code == 200
+
+    def test_response_contains_count(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/prediction-analysis/snapshots")
+        assert "count" in resp.json()
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/prediction-analysis/snapshots")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/prediction-analysis/timeline
+# ===========================================================================
+
+
+class TestPredictionTimeline:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/prediction-analysis/timeline")
+        assert resp.status_code == 200
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/prediction-analysis/timeline")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/prediction-analysis/comparison
+# ===========================================================================
+
+
+class TestPredictionComparison:
+    def test_missing_snapshot_returns_404(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/prediction-analysis/comparison?snapshot_period=0")
+        assert resp.status_code == 404
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/prediction-analysis/comparison?snapshot_period=0")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/prediction-analysis/snapshot-comparison
+# ===========================================================================
+
+
+class TestSnapshotComparison:
+    def test_missing_snapshot_returns_404(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get(
+            "/api/prediction-analysis/snapshot-comparison?period_a=0&period_b=10"
+        )
+        assert resp.status_code == 404
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get(
+            "/api/prediction-analysis/snapshot-comparison?period_a=0&period_b=10"
+        )
+        assert resp.status_code == 503
+
+
+# ===========================================================================
+# GET /api/consumption-forecast-comparison
+# ===========================================================================
+
+
+class TestConsumptionForecastComparison:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/consumption-forecast-comparison")
+        assert resp.status_code == 200
+
+    def test_response_contains_active_strategy(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/consumption-forecast-comparison")
+        assert "activeStrategy" in resp.json()
+
+
+# ===========================================================================
+# GET /api/export-debug-data
+# ===========================================================================
+
+
+class TestExportDebugData:
+    def test_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/export-debug-data")
+        assert resp.status_code == 200
+
+
+# ===========================================================================
+# GET /api/runtime-failures
+# POST /api/runtime-failures/{failure_id}/dismiss
+# POST /api/runtime-failures/dismiss-all
+# ===========================================================================
+
+
+class TestRuntimeFailures:
+    def test_get_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.get("/api/runtime-failures")
+        assert resp.status_code == 200
+
+    def test_get_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.get("/api/runtime-failures")
+        assert resp.status_code == 503
+
+    def test_dismiss_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.post("/api/runtime-failures/abc123/dismiss")
+        assert resp.status_code == 200
+
+    def test_dismiss_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.post("/api/runtime-failures/abc123/dismiss")
+        assert resp.status_code == 503
+
+    def test_dismiss_all_returns_200(self):
+        sys.modules["app"].bess_controller = _make_started_controller()
+        resp = _client.post("/api/runtime-failures/dismiss-all")
+        assert resp.status_code == 200
+
+    def test_dismiss_all_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.post("/api/runtime-failures/dismiss-all")
+        assert resp.status_code == 503

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.6.2"
+version: "9.6.3"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false

--- a/dev-run.sh
+++ b/dev-run.sh
@@ -1,12 +1,29 @@
 #!/bin/bash
 # Developer startup script with continuous logs
+#
+# Container runtime: auto-detected (podman preferred, falls back to docker).
+# Override with DOCKER=docker ./dev-run.sh if needed.
+# When using podman, podman-compose must be installed: pip install podman-compose
+if [ -z "$DOCKER" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    DOCKER="podman"
+  else
+    DOCKER="docker"
+  fi
+fi
+COMPOSE="${COMPOSE:-${DOCKER} compose}"
+# podman-compose uses a different binary name; detect it automatically.
+if [ "$DOCKER" = "podman" ] && command -v podman-compose >/dev/null 2>&1; then
+  COMPOSE="podman-compose"
+fi
 
 echo "==== BESS Manager Development Environment Setup ===="
+echo "Container runtime: $DOCKER"
 
 # Derive a unique project name from the directory so multiple worktrees
 # can run side-by-side without container name conflicts.
 export COMPOSE_PROJECT_NAME="bess-$(basename "$(pwd)")"
-echo "Docker Compose project: $COMPOSE_PROJECT_NAME"
+echo "Compose project: $COMPOSE_PROJECT_NAME"
 
 # Derive stable ports from the directory name so each worktree gets a
 # predictable, unique port.  The hash maps any directory name into the
@@ -19,10 +36,10 @@ if [ -z "$BESS_DEV_PORT" ]; then
 fi
 export BESS_FRONTEND_PORT="${BESS_FRONTEND_PORT:-$(( BESS_DEV_PORT + 1000 ))}"
 
-# Verify Docker is running
-if ! docker info > /dev/null 2>&1; then
-  echo "Error: Docker is not running."
-  echo "Please start Docker and try again."
+# Verify container runtime is available
+if ! $DOCKER info > /dev/null 2>&1; then
+  echo "Error: $DOCKER is not running."
+  echo "Please start $DOCKER and try again."
   exit 1
 fi
 
@@ -92,14 +109,14 @@ fi
 export TZ=${TZ:-Europe/Stockholm}
 
 echo "Stopping any existing containers for this project..."
-docker compose down --remove-orphans 2>/dev/null
+$COMPOSE down --remove-orphans 2>/dev/null
 
 # Also remove any stale container with the target name (e.g. left over
 # from a previous run or an older compose config without project naming).
 CONTAINER_NAME="${COMPOSE_PROJECT_NAME}-dev"
-if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+if $DOCKER ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
   echo "Removing stale container: $CONTAINER_NAME"
-  docker rm -f "$CONTAINER_NAME" >/dev/null
+  $DOCKER rm -f "$CONTAINER_NAME" >/dev/null
 fi
 
 # Only rebuild frontend if source files changed since last build
@@ -112,7 +129,7 @@ else
 fi
 
 echo "Building and starting development container..."
-docker compose up --build -d
+$COMPOSE up --build -d
 
 echo "Waiting for BESS to start (following logs)..."
 echo ""
@@ -127,7 +144,7 @@ print_banner() {
 trap 'print_banner; exit 0' INT
 
 # Stream logs; print the banner once BESS is fully started (Uvicorn ready).
-docker compose logs -f --no-log-prefix 2>&1 | while IFS= read -r line; do
+$COMPOSE logs -f --no-log-prefix 2>&1 | while IFS= read -r line; do
     echo "$line"
     if [[ "$line" == *"Uvicorn running on"* ]]; then
       print_banner

--- a/docker-compose.mock.yml
+++ b/docker-compose.mock.yml
@@ -12,10 +12,10 @@ services:
       - HA_TOKEN=mock_token
       - HA_TEST_MODE=false
       - BESS_HISTORICAL_SEED_FILE=${BESS_HISTORICAL_SEED_FILE:-}
-      - HA_DB_URL=${HA_DB_URL:-}
-      - HA_DB_BUCKET=${HA_DB_BUCKET:-}
-      - HA_DB_USER_NAME=${HA_DB_USER_NAME:-}
-      - HA_DB_PASSWORD=${HA_DB_PASSWORD:-}
+      - HA_DB_URL=
+      - HA_DB_BUCKET=
+      - HA_DB_USER_NAME=
+      - HA_DB_PASSWORD=
       - FAKETIME=${MOCK_TIME:-}
     depends_on:
       - mock-ha

--- a/docker-compose.mock.yml
+++ b/docker-compose.mock.yml
@@ -12,10 +12,10 @@ services:
       - HA_TOKEN=mock_token
       - HA_TEST_MODE=false
       - BESS_HISTORICAL_SEED_FILE=${BESS_HISTORICAL_SEED_FILE:-}
-      - HA_DB_URL=${HA_DB_URL:-http://nonexistent-influxdb:8086/api/v2/query}
-      - HA_DB_BUCKET=${HA_DB_BUCKET:-homeassistant/autogen}
-      - HA_DB_USER_NAME=${HA_DB_USER_NAME:-mock}
-      - HA_DB_PASSWORD=${HA_DB_PASSWORD:-mock}
+      - HA_DB_URL=${HA_DB_URL:-}
+      - HA_DB_BUCKET=${HA_DB_BUCKET:-}
+      - HA_DB_USER_NAME=${HA_DB_USER_NAME:-}
+      - HA_DB_PASSWORD=${HA_DB_PASSWORD:-}
       - FAKETIME=${MOCK_TIME:-}
     depends_on:
       - mock-ha

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./backend:/app/backend:delegated
       - ./core:/app/core:delegated
       - ./frontend/dist:/app/frontend:delegated
+      - ./docs/agents/bess-knowledge.md:/app/backend/agents/bess-knowledge.md:ro
       - ./backend/dev-options.json:/data/options.json:ro
       - ./backend/dev-bess-settings.json:/data/bess_settings.json
     environment:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -328,7 +328,7 @@ function App() {
                   <Route path="/savings" element={<SavingsAnalysisPage />} />
                   <Route path="/inverter" element={<InverterPage />} />
                   <Route path="/settings" element={<SettingsPage />} />
-                  <Route path="/system-health" element={<Navigate to="/settings" replace />} />
+                  <Route path="/system-health" element={<Navigate to="/settings?tab=system" replace />} />
                   {/* Catch-all route: redirect any unmatched paths to dashboard */}
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Activity, Battery, Download, Home, Settings, Sun, Zap } from 'lucide-react';
 import api from '../lib/api';
 import { downloadDebugBundle } from '../lib/reportProblem';
@@ -62,9 +62,12 @@ const EMPTY_INVERTER: InverterForm = { inverterPlatform: 'growatt_server_min', d
 
 const SettingsPage: React.FC = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   // ── active tab ─────────────────────────────────────────────────────────
-  const [tab, setTab] = useState<Tab>('sensors');
+  const validTabs: Tab[] = ['home', 'pricing', 'battery', 'sensors', 'system'];
+  const initialTab = searchParams.get('tab') as Tab;
+  const [tab, setTab] = useState<Tab>(validTabs.includes(initialTab) ? initialTab : 'sensors');
 
   // ── form state ─────────────────────────────────────────────────────────
   const [batteryForm, setBatteryForm] = useState<BatteryForm>(EMPTY_BATTERY);

--- a/mock-run.sh
+++ b/mock-run.sh
@@ -17,6 +17,21 @@
 
 set -euo pipefail
 
+# Container runtime: auto-detected (podman preferred, falls back to docker).
+# Override with DOCKER=docker ./mock-run.sh if needed.
+if [ -z "${DOCKER:-}" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    DOCKER="podman"
+  else
+    DOCKER="docker"
+  fi
+fi
+if [ "$DOCKER" = "podman" ] && command -v podman-compose >/dev/null 2>&1; then
+  COMPOSE="podman-compose"
+else
+  COMPOSE="${DOCKER} compose"
+fi
+
 # Derive a unique project name from the directory so multiple worktrees
 # can run side-by-side without container name conflicts.
 export COMPOSE_PROJECT_NAME="bess-mock-$(basename "$(pwd)")"
@@ -114,9 +129,9 @@ echo "==== BESS Mock Development Environment ===="
 echo "Scenario:      $SCENARIO"
 echo "Inverter type: $INVERTER_TYPE  (bess_config extracted from scenario)"
 
-# Verify Docker is running
-if ! docker info > /dev/null 2>&1; then
-  echo "Error: Docker is not running. Please start Docker and try again."
+# Verify container runtime is available
+if ! $DOCKER info > /dev/null 2>&1; then
+  echo "Error: $DOCKER is not running. Please start $DOCKER and try again."
   exit 1
 fi
 
@@ -146,13 +161,13 @@ echo "Building frontend..."
 }
 
 echo "Stopping any existing containers..."
-docker-compose \
+$COMPOSE \
   -f docker-compose.yml \
   -f docker-compose.mock.yml \
   down --remove-orphans
 
 echo "Building and starting mock environment..."
-docker-compose \
+$COMPOSE \
   -f docker-compose.yml \
   -f docker-compose.mock.yml \
   up --build -d
@@ -174,7 +189,7 @@ trap 'print_banner; exit 0' INT
 
 # Stream logs; print the banner once BESS is fully started (Uvicorn ready).
 # After the banner, continue streaming logs normally.
-docker-compose \
+$COMPOSE \
   -f docker-compose.yml \
   -f docker-compose.mock.yml \
   logs -f --no-log-prefix 2>&1 | while IFS= read -r line; do

--- a/scripts/mock_ha/scenarios/ci-wizard-nordpool-sph.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-nordpool-sph.json
@@ -235,8 +235,17 @@
       "unique_id": "SE3-current_price"
     }
   ],
-  "ac_charge_times": [],
-  "ac_discharge_times": [],
+  "ac_charge_times": {
+    "charge_power": 100,
+    "charge_stop_soc": 95,
+    "mains_enabled": false,
+    "periods": []
+  },
+  "ac_discharge_times": {
+    "discharge_power": 100,
+    "discharge_stop_soc": 15,
+    "periods": []
+  },
   "price_data": {
     "today": [
       0.55, 0.45, 0.35, 0.3, 0.28, 0.45, 0.75, 0.95,

--- a/scripts/mock_ha/server.py
+++ b/scripts/mock_ha/server.py
@@ -462,8 +462,15 @@ async def ha_websocket(ws: WebSocket) -> None:
                 "config/entity_registry/list": _entity_registry,
             }
 
-            result = _WS_HANDLERS.get(cmd_type)
-            if result is not None:
+            if cmd_type == "recorder/statistics_during_period":
+                # Return empty statistics — mock has no recorder DB.
+                # Backend gracefully handles missing statistics.
+                empty = {sid: [] for sid in msg.get("statistic_ids", [])}
+                await ws.send_json(
+                    {"id": cmd_id, "type": "result", "success": True, "result": empty}
+                )
+                logger.info("WS %-40s → empty (no recorder in mock)", cmd_type)
+            elif (result := _WS_HANDLERS.get(cmd_type)) is not None:
                 await ws.send_json(
                     {"id": cmd_id, "type": "result", "success": True, "result": result}
                 )


### PR DESCRIPTION
## [9.6.3] - 2026-06-25

### Fixed

- **Inverter platform badge always showed "SolaX Modbus"** — String matching updated to current API values (`growatt_server_min`, `growatt_server_sph`, etc.). (#60)
- **Growatt SPH TOU intervals rendered "Segment #undefined"** — `segment_id` and `is_default` fields now included in `build_schedule` output. (#60)
- **AI Analyst returned 404 errors on deprecated model IDs** — Updated from retired Claude 4.0 launch IDs to `claude-sonnet-4-6` and `claude-opus-4-8`. (#180)
- **EnergyFlowCards and SystemStatusCard stayed frozen between refreshes** — Both now poll every 60 s, in sync with the dashboard. (#179)
- **Energy Prediction health check produced false-positive warnings** — Check now only validates `get_estimated_consumption` when `sensor` is the active strategy. (#160)
- **Nord Pool HACS continental areas mapped to Norway** — Regex extended to cover NL, BE, DE, DE-LU, FR, AT, PL. (#171)
- **Nord Pool Currency field always read-only in UI** — Field is now editable when area/currency detection has not produced a value. (#171)
- **Next-day schedule timestamps stamped with today's date** — `_add_timestamps_to_period_data` now accepts a `next_day` flag to offset period indices to tomorrow's date. (#155)

### Refactored

- **Unified `prepare_next_day` and extended-horizon data paths** — Removed duplicated solar/consumption fetch logic. (#157)