### PR TITLE
fix: allow grid charging during solar surplus when price is cheaper

### DIFF
--- a/core/bess/decision_intelligence.py
+++ b/core/bess/decision_intelligence.py
@@ -433,7 +433,7 @@ def classify_strategic_intent(power: float, energy_data: EnergyData) -> str:
             return "BATTERY_EXPORT"
         return "LOAD_SUPPORT"
     elif power > _POWER_THRESHOLD_KW:  # Charging
-        if energy_data.grid_to_battery > energy_data.solar_to_battery:
+        if energy_data.grid_to_battery > 0.01:
             return "GRID_CHARGING"
         return "SOLAR_STORAGE"
     elif energy_data.battery_charged > 0.01:

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -215,12 +215,7 @@ def _state_transition(
         remaining_rate = max(
             0.0, min(rate_throughput, room_throughput) - solar_to_battery
         )
-        if surplus > POWER_TOLERANCE_KW:
-            grid_to_battery = 0.0  # SOLAR_STORAGE: solar only, no grid top-up
-        else:
-            grid_to_battery = (
-                remaining_rate  # GRID_CHARGING / battery_first: charge at max rate
-            )
+        grid_to_battery = remaining_rate  # solar fills first, grid tops up the rest
         charge_energy = (
             solar_to_battery + grid_to_battery
         ) * battery_settings.efficiency_charge
@@ -325,12 +320,7 @@ def _compute_reward(
         remaining_rate = max(
             0.0, min(rate_throughput, room_throughput) - solar_to_battery
         )
-        if surplus > POWER_TOLERANCE_KW:
-            grid_to_battery = 0.0  # SOLAR_STORAGE: solar only, no grid top-up
-        else:
-            grid_to_battery = (
-                remaining_rate  # GRID_CHARGING / battery_first: charge at max rate
-            )
+        grid_to_battery = remaining_rate  # solar fills first, grid tops up the rest
 
         energy_stored = (
             solar_to_battery + grid_to_battery
@@ -450,12 +440,7 @@ def _build_period_data(
         remaining_rate = max(
             0.0, min(rate_throughput, room_throughput) - solar_to_battery
         )
-        if surplus > POWER_TOLERANCE_KW:
-            grid_to_battery = 0.0  # SOLAR_STORAGE: solar only, no grid top-up
-        else:
-            grid_to_battery = (
-                remaining_rate  # GRID_CHARGING / battery_first: charge at max rate
-            )
+        grid_to_battery = remaining_rate  # solar fills first, grid tops up the rest
         battery_charged = solar_to_battery + grid_to_battery
         battery_discharged = 0.0
     elif power < -POWER_TOLERANCE_KW:  # Active discharging

--- a/core/bess/simulation/inverter_simulator.py
+++ b/core/bess/simulation/inverter_simulator.py
@@ -106,10 +106,10 @@ def mode_to_power(
         )
         return -delivered_kwh / dt
 
-    # SOLAR_STORAGE (load_first + no discharge): STORE disposition — charge all surplus.
-    # _state_transition's STORE branch caps at rate/room; no grid top-up since power*dt==surplus.
-    surplus = max(0.0, solar - home)
-    return surplus / dt
+    # IDLE/SOLAR_STORAGE (load_first + no discharge): passive solar charging.
+    # Return 0.0 so _state_transition uses its IDLE branch (power=0), which charges
+    # from solar surplus passively — never drawing from grid (load_first hardware).
+    return 0.0
 
 
 @dataclass

--- a/core/bess/tests/integration/test_plan_faithfulness.py
+++ b/core/bess/tests/integration/test_plan_faithfulness.py
@@ -52,10 +52,14 @@ def test_identical_command_sequences_have_zero_delta():
 
 
 def test_solar_storage_mode_stores_all_surplus():
-    """STORE disposition: SOLAR_STORAGE → load_first stores ALL available surplus
-    solar (up to rate/room) — the binary store-all behaviour the optimizer now
-    plans against, so plan and execution agree. (Replaces the earlier diagnostic
-    that asserted the old mode_to_power==0 behaviour; see #145.)
+    """IDLE/SOLAR_STORAGE: load_first + no discharge stores surplus via passive charging.
+
+    After the grid-charging-during-surplus fix, mode_to_power returns 0.0 for
+    load_first + no discharge (regardless of surplus). _state_transition's IDLE branch
+    then performs passive solar charging (solar fills battery, no grid draw). The old
+    code returned surplus/dt which went through the STORE branch; that used to be
+    equivalent (grid_to_battery was gated to 0), but after removing the surplus gate
+    the STORE branch would add grid top-up — incorrect for load_first hardware.
     """
     from core.bess.simulation.inverter_simulator import (
         ControlCommand,
@@ -66,12 +70,8 @@ def test_solar_storage_mode_stores_all_surplus():
     bs = make_battery_settings(max_charge_power_kw=10.0)
     cmd = ControlCommand("load_first", discharge_rate_pct=0, grid_charge=False)
 
-    # mode_to_power now returns the surplus power (store all surplus), not 0.
-    surplus = 5.0 - 0.5
-    assert (
-        mode_to_power(cmd, solar=5.0, home=0.5, soe=5.0, settings=bs, dt=1.0)
-        == surplus / 1.0
-    )
+    # mode_to_power returns 0.0; _state_transition IDLE branch does the solar charging.
+    assert mode_to_power(cmd, solar=5.0, home=0.5, soe=5.0, settings=bs, dt=1.0) == 0.0
 
     sim = simulate(
         [cmd],
@@ -86,7 +86,7 @@ def test_solar_storage_mode_stores_all_surplus():
     stored = sim.period_data[0].energy.battery_soe_end - 5.0
     assert (
         stored > 4.0
-    ), f"load_first should store ~all 4.5 kWh surplus, got {stored:.2f}"
+    ), f"load_first should store ~all 4.5 kWh surplus via IDLE passive charging, got {stored:.2f}"
 
 
 def test_forecast_robustness_more_solar_than_planned():

--- a/core/bess/tests/unit/data/realworld_2026_04_11_004719.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_11_004719.json
@@ -307,11 +307,11 @@
   },
   "expected_results": {
     "base_cost": 161.5502,
-    "battery_solar_cost": 96.1246,
-    "base_to_battery_solar_savings": 65.4256,
-    "base_to_battery_solar_savings_pct": 40.4986,
-    "total_charged": 5.3,
-    "total_discharged": 4.9
+    "battery_solar_cost": 96.6414,
+    "base_to_battery_solar_savings": 64.9088,
+    "base_to_battery_solar_savings_pct": 40.1787,
+    "total_charged": 24.7423,
+    "total_discharged": 22.8000
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-11, with solar, price spread 1.57 SEK",

--- a/core/bess/tests/unit/data/realworld_2026_04_29_220919.json
+++ b/core/bess/tests/unit/data/realworld_2026_04_29_220919.json
@@ -340,11 +340,11 @@
   },
   "expected_results": {
     "base_cost": 72.1415,
-    "battery_solar_cost": -76.8465,
-    "base_to_battery_solar_savings": 148.988,
-    "base_to_battery_solar_savings_pct": 206.5218,
-    "total_charged": 23.1,
-    "total_discharged": 34.6
+    "battery_solar_cost": -76.8840,
+    "base_to_battery_solar_savings": 149.0255,
+    "base_to_battery_solar_savings_pct": 206.5738,
+    "total_charged": 10.7162,
+    "total_discharged": 23.1500
   },
   "expected_behavior": {
     "description": "Real-world debug log from 2026-04-29, with solar, price spread 1.87 SEK",

--- a/core/bess/tests/unit/data/synthetic_2024_08_16_high_spread_with_solar.json
+++ b/core/bess/tests/unit/data/synthetic_2024_08_16_high_spread_with_solar.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 127.9455,
-    "battery_solar_cost": 60.6746,
-    "base_to_battery_solar_savings": 67.2709,
-    "base_to_battery_solar_savings_pct": 52.5778,
-    "total_charged": 43.6,
-    "total_discharged": 39.2
+    "battery_solar_cost": 48.1466,
+    "base_to_battery_solar_savings": 79.7988,
+    "base_to_battery_solar_savings_pct": 62.3694,
+    "total_charged": 46.3712,
+    "total_discharged": 41.8000
   },
   "expected_behavior": {
     "description": "High price spread with solar: grid-charge at lows, export arbitrage at peaks",

--- a/core/bess/tests/unit/data/synthetic_consumption_efficient.json
+++ b/core/bess/tests/unit/data/synthetic_consumption_efficient.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 30.28,
-    "battery_solar_cost": -43.3337,
-    "base_to_battery_solar_savings": 73.6137,
-    "base_to_battery_solar_savings_pct": 243.1099,
-    "total_charged": 28.4,
-    "total_discharged": 25.6
+    "battery_solar_cost": -44.0916,
+    "base_to_battery_solar_savings": 74.3716,
+    "base_to_battery_solar_savings_pct": 245.6129,
+    "total_charged": 28.4211,
+    "total_discharged": 25.6000
   },
   "expected_behavior": {
     "description": "Efficient consumption with solar: store solar and export during high prices",

--- a/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
+++ b/core/bess/tests/unit/data/synthetic_extreme_negative_prices.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 50.31,
-    "battery_solar_cost": -26.5367,
-    "base_to_battery_solar_savings": 76.8467,
-    "base_to_battery_solar_savings_pct": 152.7464,
-    "total_charged": 46.1,
-    "total_discharged": 41.4
+    "battery_solar_cost": -30.3945,
+    "base_to_battery_solar_savings": 80.7045,
+    "base_to_battery_solar_savings_pct": 160.4144,
+    "total_charged": 48.3657,
+    "total_discharged": 43.6000
   },
   "expected_behavior": {
     "description": "Negative prices: should aggressively grid-charge during negative-price hours and export during positive peaks",

--- a/core/bess/tests/unit/data/synthetic_extreme_volatility.json
+++ b/core/bess/tests/unit/data/synthetic_extreme_volatility.json
@@ -97,11 +97,11 @@
   },
   "expected_results": {
     "base_cost": 100.41,
-    "battery_solar_cost": -28.9225,
-    "base_to_battery_solar_savings": 129.3325,
-    "base_to_battery_solar_savings_pct": 128.8044,
-    "total_charged": 48.1,
-    "total_discharged": 43.4
+    "battery_solar_cost": -31.3290,
+    "base_to_battery_solar_savings": 131.7390,
+    "base_to_battery_solar_savings_pct": 131.2011,
+    "total_charged": 48.3657,
+    "total_discharged": 43.6000
   },
   "expected_behavior": {
     "description": "Extreme price volatility: aggressive grid-charge at lows, export at spikes",

--- a/core/bess/tests/unit/test_idle_solar_charging.py
+++ b/core/bess/tests/unit/test_idle_solar_charging.py
@@ -256,9 +256,16 @@ def test_solar_storage_preferred_over_idle_when_profitable():
                 f"SOE={pd.energy.battery_soe_start:.1f}→{pd.energy.battery_soe_end:.1f}"
             )
 
-    # Count how many high-solar periods chose SOLAR_STORAGE vs IDLE
-    solar_storage_count = sum(
-        1 for _, intent, _, _ in solar_periods_with_excess if intent == "SOLAR_STORAGE"
+    # Count how many high-solar periods chose an active charging intent vs IDLE.
+    # After the 2026-06-27 surplus gate fix, solar-hour STORE actions get grid_to_battery > 0
+    # (solar rarely saturates the 5 kW max charge rate) and are classified as GRID_CHARGING.
+    # That is correct: buy=0.08 GBP during solar hours is cheap enough to top up from grid
+    # alongside free solar. The original bug (issue #73) was being IDLE during solar, not
+    # the presence of grid top-up.
+    charging_during_solar = sum(
+        1
+        for _, intent, _, _ in solar_periods_with_excess
+        if intent in ("SOLAR_STORAGE", "GRID_CHARGING")
     )
     idle_count = sum(
         1 for _, intent, _, _ in solar_periods_with_excess if intent == "IDLE"
@@ -271,25 +278,21 @@ def test_solar_storage_preferred_over_idle_when_profitable():
 
     logger.info(
         f"High-solar periods: {len(solar_periods_with_excess)} total, "
-        f"{solar_storage_count} SOLAR_STORAGE, {idle_count} IDLE"
+        f"{charging_during_solar} charging (SOLAR_STORAGE or GRID_CHARGING), {idle_count} IDLE"
     )
     logger.info(f"GRID_CHARGING periods: {grid_charging_count}")
 
-    # The optimizer should choose SOLAR_STORAGE for at least some high-solar
-    # periods rather than leaving the battery idle and grid-charging later.
-    # With sell=0.12 and evening buy=0.20-0.35, storing free solar is clearly
-    # more valuable than exporting it.
-    assert solar_storage_count > 0, (
+    # The optimizer must actively charge during high-solar periods (SOLAR_STORAGE or
+    # GRID_CHARGING), not leave the battery idle and export cheap solar at 0.12 GBP
+    # when evening prices reach 0.20-0.35 GBP.
+    assert charging_during_solar > 0, (
         f"Optimizer chose IDLE for all {len(solar_periods_with_excess)} high-solar "
-        f"periods and scheduled {grid_charging_count} GRID_CHARGING periods. "
-        f"Free solar storage should be preferred over grid export at 0.12 GBP "
+        f"periods. Free solar storage should be preferred over grid export at 0.12 GBP "
         f"when evening prices reach 0.20-0.35 GBP."
     )
 
-    # If the optimizer correctly stores solar, it should NOT need grid charging
-    # (or need very little) since solar can fill the battery for free.
-    assert grid_charging_count == 0, (
-        f"Optimizer scheduled {grid_charging_count} GRID_CHARGING periods despite "
-        f"abundant free solar available for storage. Grid charging should be "
-        f"unnecessary with this solar forecast."
+    # No high-solar period should be wasted as IDLE when storage is profitable.
+    assert idle_count == 0, (
+        f"Optimizer left {idle_count} high-solar periods as IDLE. "
+        f"Free solar storage should be preferred over exporting at sell=0.12 GBP."
     )

--- a/core/bess/tests/unit/test_inverter_simulator.py
+++ b/core/bess/tests/unit/test_inverter_simulator.py
@@ -69,14 +69,17 @@ def test_load_first_no_discharge_no_surplus_returns_zero():
     assert p == 0.0
 
 
-def test_mode_to_power_load_first_stores_all_surplus():
-    """Task 4c: load_first + no discharge + surplus -> return all-surplus charge power."""
+def test_mode_to_power_load_first_surplus_returns_zero():
+    """load_first + no discharge + surplus -> return 0.0 (IDLE branch).
+
+    The old code returned surplus/dt here, which coincidentally matched IDLE when
+    grid_to_battery was gated to 0. After removing the surplus gate in dp_battery_algorithm,
+    mode_to_power must return 0.0 so _state_transition uses the IDLE branch (passive solar
+    charging, no grid draw) instead of the STORE branch (which now adds grid top-up).
+    """
     bs = make_battery_settings(max_charge_power_kw=10.0)
     cmd = ControlCommand("load_first", 0, False)
-    assert (
-        mode_to_power(cmd, solar=1.6, home=0.2, soe=5.0, settings=bs, dt=0.25)
-        == (1.6 - 0.2) / 0.25
-    )
+    assert mode_to_power(cmd, solar=1.6, home=0.2, soe=5.0, settings=bs, dt=0.25) == 0.0
 
 
 def test_mode_to_power_grid_first_no_discharge_holds_and_exports():

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -444,7 +444,7 @@ def test_grid_charges_during_solar_surplus_when_price_is_cheaper():
     """
     settings = BatterySettings(
         total_capacity=20.0,
-        min_soc=10.0,   # min_soe = 2.0 kWh
+        min_soc=10.0,  # min_soe = 2.0 kWh
         max_soc=100.0,  # max_soe = 20.0 kWh
         max_charge_power_kw=10.0,
         max_discharge_power_kw=10.0,
@@ -459,10 +459,10 @@ def test_grid_charges_during_solar_surplus_when_price_is_cheaper():
     #                   buy=1.76 SEK — EXPENSIVE, was the first grid-charge slot before fix
     # Period 2 (18:00): expensive peak (buy=3.50) — discharge opportunity
     # Period 3 (19:00): idle (buy=1.20)
-    solar =       [0.9958, 0.7076, 0.0,  0.0]
-    consumption = [0.8300, 0.9250, 2.0,  1.0]
-    buy_price =   [1.01,   1.76,   3.50, 1.20]
-    sell_price =  [0.50,   0.70,   1.60, 0.60]
+    solar = [0.9958, 0.7076, 0.0, 0.0]
+    consumption = [0.8300, 0.9250, 2.0, 1.0]
+    buy_price = [1.01, 1.76, 3.50, 1.20]
+    sell_price = [0.50, 0.70, 1.60, 0.60]
 
     results = optimize_battery_schedule(
         buy_price=buy_price,

--- a/core/bess/tests/unit/test_optimization_algorithm.py
+++ b/core/bess/tests/unit/test_optimization_algorithm.py
@@ -431,3 +431,61 @@ def test_strategy_data_structure():
         assert hour_data.decision.strategic_intent is not None
         assert hour_data.decision.battery_action is not None
         assert hour_data.decision.cost_basis >= 0
+
+
+def test_grid_charges_during_solar_surplus_when_price_is_cheaper():
+    """Regression: optimizer must grid-charge during hours with small solar surplus
+    when grid prices are cheaper than the next available no-surplus window.
+
+    Root cause (2026-06-27): _state_transition forced grid_to_battery=0 whenever
+    solar surplus > POWER_TOLERANCE_KW. This blocked grid charging at 16:00 (1.01
+    SEK/kWh, small surplus) and forced it to 17:00 (1.76 SEK/kWh, no surplus).
+    Fix: always set grid_to_battery = remaining_rate (solar fills first, grid tops up).
+    """
+    settings = BatterySettings(
+        total_capacity=20.0,
+        min_soc=10.0,   # min_soe = 2.0 kWh
+        max_soc=100.0,  # max_soe = 20.0 kWh
+        max_charge_power_kw=10.0,
+        max_discharge_power_kw=10.0,
+        efficiency_charge=0.97,
+        efficiency_discharge=0.95,
+        cycle_cost_per_kwh=0.10,
+    )
+    # 4 periods at 15-min resolution, from the 2026-06-27 debug report:
+    # Period 0 (16:00): solar=0.9958 kWh, consumption=0.8300 kWh → surplus=0.1658 kWh
+    #                   buy=1.01 SEK — CHEAP, surplus blocks grid charging in old code
+    # Period 1 (17:00): solar=0.7076 kWh, consumption=0.9250 kWh → no surplus
+    #                   buy=1.76 SEK — EXPENSIVE, was the first grid-charge slot before fix
+    # Period 2 (18:00): expensive peak (buy=3.50) — discharge opportunity
+    # Period 3 (19:00): idle (buy=1.20)
+    solar =       [0.9958, 0.7076, 0.0,  0.0]
+    consumption = [0.8300, 0.9250, 2.0,  1.0]
+    buy_price =   [1.01,   1.76,   3.50, 1.20]
+    sell_price =  [0.50,   0.70,   1.60, 0.60]
+
+    results = optimize_battery_schedule(
+        buy_price=buy_price,
+        sell_price=sell_price,
+        home_consumption=consumption,
+        solar_production=solar,
+        initial_soe=2.0,  # start at min SOE — empty battery
+        battery_settings=settings,
+        period_duration_hours=0.25,
+    )
+
+    p0 = results.period_data[0]
+
+    # After the fix: grid actively charges at period 0 (cheap price, small surplus).
+    # Before the fix: grid_to_battery was forced to 0 because surplus > POWER_TOLERANCE_KW.
+    assert p0.energy.grid_to_battery > 0.0, (
+        f"Period 0 (1.01 SEK/kWh): expected grid-to-battery > 0 but got "
+        f"grid_to_battery={p0.energy.grid_to_battery:.4f}. "
+        f"Intent={p0.decision.strategic_intent}. "
+        f"The surplus gate (grid_to_battery=0 when surplus>0) is still active."
+    )
+    assert p0.decision.strategic_intent == "GRID_CHARGING", (
+        f"Period 0 should be GRID_CHARGING (grid participates), "
+        f"got {p0.decision.strategic_intent}. "
+        f"grid_to_battery={p0.energy.grid_to_battery:.4f}"
+    )

--- a/core/bess/tests/unit/test_surplus_disposition.py
+++ b/core/bess/tests/unit/test_surplus_disposition.py
@@ -67,16 +67,25 @@ def test_idle_exports_when_battery_full():
     assert round(reward, 4) == round(1.4 * 0.8, 4)
 
 
-def test_charge_stores_all_surplus_not_a_fraction():
-    """TARGET: a charge action is the STORE disposition — it stores ALL surplus
-    (up to rate/room), exporting only genuine excess, regardless of the action's
-    magnitude. So a tiny charge action still stores all surplus."""
+def test_store_action_charges_at_max_rate_solar_plus_grid():
+    """TARGET: a STORE action charges at MAX rate — solar fills first, grid tops up.
+
+    Renamed from test_charge_stores_all_surplus_not_a_fraction after the 2026-06-27
+    fix that allows simultaneous solar+grid charging during surplus hours.
+
+    Scenario: solar=1.5, home=0.1 → surplus=1.4 kWh. rate_throughput=2.5 kWh.
+    Solar covers 1.4 kWh; grid covers the remaining 1.1 kWh.
+    power magnitude (0.4) is still ignored — any positive power = STORE at max rate.
+    """
     bs = make_battery_settings(max_charge_power_kw=10.0, efficiency_charge=1.0)
-    # surplus 1.4 kWh, rate_throughput = 2.5 kWh, plenty of room -> store all 1.4
     next_soe = _state_transition(
         5.0, 0.4, bs, DT, solar_production=1.5, home_consumption=0.1
     )
-    assert round(next_soe - 5.0, 4) == 1.4  # stored all surplus, not 0.4*0.25
+    # Solar covers 1.4 kWh, grid covers 1.1 kWh → total = 2.5 kWh stored (rate-limited)
+    assert round(next_soe - 5.0, 4) == 2.5, (
+        f"Expected STORE at max rate (2.5 kWh = solar 1.4 + grid 1.1) "
+        f"but got {next_soe - 5.0:.4f} kWh"
+    )
 
     reward, _ = _compute_reward(
         power=0.4,
@@ -91,9 +100,12 @@ def test_charge_stores_all_surplus_not_a_fraction():
         solar_production=1.5,
         cost_basis=bs.cycle_cost_per_kwh,
     )
-    # surplus all stored, 0 exported; only wear cost = 1.4 * cycle_cost
-    # reward = -(0 import - 0 export + 1.4*cycle_cost)
-    assert round(reward, 4) == round(-(1.4 * bs.cycle_cost_per_kwh), 4)
+    # grid_to_battery=1.1 kWh at buy_price=1.0; wear=2.5*cycle_cost; export=0
+    # total_cost = 1.1*1.0 + 2.5*cycle_cost_per_kwh
+    expected_cost = 1.1 * PRICES_BUY[0] + 2.5 * bs.cycle_cost_per_kwh
+    assert round(reward, 4) == round(-expected_cost, 4), (
+        f"Expected reward={-expected_cost:.4f} but got {reward:.4f}"
+    )
 
 
 def test_build_period_data_store_disposition_flows():
@@ -117,8 +129,16 @@ def test_build_period_data_store_disposition_flows():
         new_cost_basis=bs.cycle_cost_per_kwh,
         currency="SEK",
     )
-    assert round(pd.energy.battery_charged, 4) == 1.4  # stored all surplus
-    assert round(pd.energy.grid_exported, 4) == 0.0  # nothing exported
+    # After fix: solar covers 1.4 kWh, grid covers 1.1 kWh → max rate 2.5 kWh stored
+    assert round(pd.energy.battery_charged, 4) == 2.5, (
+        f"Expected battery_charged=2.5 (solar 1.4 + grid 1.1) but got {pd.energy.battery_charged:.4f}"
+    )
+    assert round(pd.energy.grid_exported, 4) == 0.0, (
+        f"Expected grid_exported=0 but got {pd.energy.grid_exported:.4f}"
+    )
+    assert round(pd.energy.grid_imported, 4) == 1.1, (
+        f"Expected grid_imported=1.1 (grid top-up) but got {pd.energy.grid_imported:.4f}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -176,21 +196,24 @@ def test_battery_export_maps_to_grid_first_hold():
 # ---------------------------------------------------------------------------
 
 
-def test_store_with_surplus_no_grid_top_up():
-    """TARGET (#145): when surplus > 0 a STORE action may NOT draw from the grid.
+def test_store_with_surplus_draws_grid_to_fill_remaining_rate():
+    """After 2026-06-27 fix: STORE action during solar surplus charges at MAX rate.
+    Solar fills first; grid covers remaining capacity up to max charge rate.
 
-    Scenario: solar=2.0, home=1.5 → surplus=0.5 kWh.
-    power=4.0 kW, dt=0.25 → power*dt=1.0 kWh > surplus.
-    The algorithm must store ONLY the 0.5 kWh solar surplus; grid_imported must be 0.
-    (Previously the code computed grid_to_battery = power*dt - surplus = 0.5 kWh,
-    which hardware cannot do in load_first/solar-storage mode.)
+    This replaced test_store_with_surplus_no_grid_top_up which encoded the old
+    SOLAR_STORAGE-only constraint (grid_to_battery=0 when surplus>0). The old
+    constraint prevented the optimizer from using cheap solar-surplus hours for
+    grid arbitrage, causing it to charge at more expensive no-surplus hours.
+
+    Scenario: solar=2.0, home=1.5 → surplus=0.5 kWh. rate_throughput=2.5 kWh.
+    Solar covers 0.5 kWh; grid draws 2.0 kWh; total charged = 2.5 kWh.
     """
     from core.bess.dp_battery_algorithm import _build_period_data, _state_transition
 
     bs = make_battery_settings(max_charge_power_kw=10.0, efficiency_charge=1.0)
     solar_production = 2.0
     home_consumption = 1.5  # surplus = 0.5 kWh
-    power = 4.0  # power*dt = 1.0 kWh > surplus
+    power = 4.0  # any positive value → STORE at max rate
 
     next_soe = _state_transition(
         5.0,
@@ -199,6 +222,12 @@ def test_store_with_surplus_no_grid_top_up():
         DT,
         solar_production=solar_production,
         home_consumption=home_consumption,
+    )
+
+    # After fix: solar 0.5 + grid 2.0 = 2.5 kWh total (rate-limited)
+    assert round(next_soe - 5.0, 4) == 2.5, (
+        f"Expected STORE at max rate (2.5 kWh) but got {next_soe - 5.0:.4f}. "
+        f"Surplus gate may still be blocking grid charging."
     )
 
     pd = _build_period_data(
@@ -216,14 +245,13 @@ def test_store_with_surplus_no_grid_top_up():
         currency="SEK",
     )
 
-    # Only solar surplus should be stored — no grid draw when surplus is present
-    assert (
-        pd.energy.grid_imported == 0.0
-    ), f"Expected grid_imported=0 (solar-only charging) but got {pd.energy.grid_imported}"
-    # The stored amount is exactly the solar surplus
-    assert (
-        round(pd.energy.battery_charged, 4) == 0.5
-    ), f"Expected battery_charged=0.5 (surplus only) but got {pd.energy.battery_charged}"
+    # Grid draws 2.0 kWh to top up the remaining capacity after solar
+    assert round(pd.energy.grid_imported, 4) == 2.0, (
+        f"Expected grid_imported=2.0 (grid top-up) but got {pd.energy.grid_imported:.4f}"
+    )
+    assert round(pd.energy.battery_charged, 4) == 2.5, (
+        f"Expected battery_charged=2.5 but got {pd.energy.battery_charged:.4f}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/core/bess/tests/unit/test_surplus_disposition.py
+++ b/core/bess/tests/unit/test_surplus_disposition.py
@@ -103,9 +103,9 @@ def test_store_action_charges_at_max_rate_solar_plus_grid():
     # grid_to_battery=1.1 kWh at buy_price=1.0; wear=2.5*cycle_cost; export=0
     # total_cost = 1.1*1.0 + 2.5*cycle_cost_per_kwh
     expected_cost = 1.1 * PRICES_BUY[0] + 2.5 * bs.cycle_cost_per_kwh
-    assert round(reward, 4) == round(-expected_cost, 4), (
-        f"Expected reward={-expected_cost:.4f} but got {reward:.4f}"
-    )
+    assert round(reward, 4) == round(
+        -expected_cost, 4
+    ), f"Expected reward={-expected_cost:.4f} but got {reward:.4f}"
 
 
 def test_build_period_data_store_disposition_flows():
@@ -130,15 +130,15 @@ def test_build_period_data_store_disposition_flows():
         currency="SEK",
     )
     # After fix: solar covers 1.4 kWh, grid covers 1.1 kWh → max rate 2.5 kWh stored
-    assert round(pd.energy.battery_charged, 4) == 2.5, (
-        f"Expected battery_charged=2.5 (solar 1.4 + grid 1.1) but got {pd.energy.battery_charged:.4f}"
-    )
-    assert round(pd.energy.grid_exported, 4) == 0.0, (
-        f"Expected grid_exported=0 but got {pd.energy.grid_exported:.4f}"
-    )
-    assert round(pd.energy.grid_imported, 4) == 1.1, (
-        f"Expected grid_imported=1.1 (grid top-up) but got {pd.energy.grid_imported:.4f}"
-    )
+    assert (
+        round(pd.energy.battery_charged, 4) == 2.5
+    ), f"Expected battery_charged=2.5 (solar 1.4 + grid 1.1) but got {pd.energy.battery_charged:.4f}"
+    assert (
+        round(pd.energy.grid_exported, 4) == 0.0
+    ), f"Expected grid_exported=0 but got {pd.energy.grid_exported:.4f}"
+    assert (
+        round(pd.energy.grid_imported, 4) == 1.1
+    ), f"Expected grid_imported=1.1 (grid top-up) but got {pd.energy.grid_imported:.4f}"
 
 
 # ---------------------------------------------------------------------------
@@ -246,12 +246,12 @@ def test_store_with_surplus_draws_grid_to_fill_remaining_rate():
     )
 
     # Grid draws 2.0 kWh to top up the remaining capacity after solar
-    assert round(pd.energy.grid_imported, 4) == 2.0, (
-        f"Expected grid_imported=2.0 (grid top-up) but got {pd.energy.grid_imported:.4f}"
-    )
-    assert round(pd.energy.battery_charged, 4) == 2.5, (
-        f"Expected battery_charged=2.5 but got {pd.energy.battery_charged:.4f}"
-    )
+    assert (
+        round(pd.energy.grid_imported, 4) == 2.0
+    ), f"Expected grid_imported=2.0 (grid top-up) but got {pd.energy.grid_imported:.4f}"
+    assert (
+        round(pd.energy.battery_charged, 4) == 2.5
+    ), f"Expected battery_charged=2.5 but got {pd.energy.battery_charged:.4f}"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git


### PR DESCRIPTION
## Summary

- **Root cause**: `dp_battery_algorithm.py` had a surplus gate (`if surplus > POWER_TOLERANCE_KW: grid_to_battery = 0.0`) in three functions (`_state_transition`, `_compute_reward`, `_build_period_data`). Whenever solar production exceeded home consumption, the optimizer was forbidden from grid-charging — even at much cheaper prices.
- **Fix**: Remove the gate. Solar fills the battery first; grid tops up the remaining capacity to max charge rate. Real example: hour 16 at 1.01 SEK/kWh was skipped in favour of hour 17 at 1.76 SEK/kWh; now hour 16 is used correctly.
- Two companion fixes were needed to keep plan faithfulness (R == P):
  - `inverter_simulator.mode_to_power`: was returning `surplus/dt` for `load_first`/no-discharge, which after removing the gate triggered STORE+grid charging — wrong for load_first hardware. Now returns `0.0` (passive solar IDLE).
  - `classify_strategic_intent`: threshold changed from `grid > solar` to `grid > 0.01`. A period with solar=3.2 kWh and grid=2.8 kWh was classified SOLAR_STORAGE → load_first (passive only), silently dropping the grid top-up in the simulator. Now any grid contribution → GRID_CHARGING → battery_first.

## Test plan

- [x] New regression test: `test_grid_charges_during_solar_surplus_when_price_is_cheaper` (red before fix, green after)
- [x] 3 surplus disposition tests updated for new behaviour (TDD, committed before production fix)
- [x] 20 targeted tests pass (plan faithfulness, inverter simulator, regression)
- [x] 909 fast tests pass, 0 failures
- [x] 26 scenario tests pass (including `synthetic_extreme_negative_prices` which had a 7.57 SEK R≠P gap before the classify fix)
- [ ] Full slow suite (~325 tests) running locally / in CI

## Savings improvement on scenario baselines

| Scenario | Before | After | Delta |
|----------|--------|-------|-------|
| `synthetic_2024_08_16_high_spread_with_solar` | 67.27 SEK | 79.80 SEK | **+12.5** |
| `synthetic_extreme_negative_prices` | 76.85 SEK | 80.70 SEK | **+3.86** |
| `synthetic_extreme_volatility` | 129.33 SEK | 131.74 SEK | **+2.41** |
| `synthetic_consumption_efficient` | 73.61 SEK | 74.37 SEK | **+0.76** |
| `realworld_2026_04_29_220919` | 148.99 SEK | 149.03 SEK | +0.04 |
| `realworld_2026_04_11_004719` | 65.43 SEK | 64.91 SEK | -0.52 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)