### PR TITLE
feat: action-derived charge rate for GRID_CHARGING periods

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1539,7 +1539,7 @@ async def get_growatt_detailed_schedule():
                         "dischargePowerRate": hourly_settings.get(
                             "discharge_rate", 100
                         ),
-                        "chargePowerRate": 100,
+                        "chargePowerRate": hourly_settings.get("charge_rate", 100),
                         "strategic_intent": strategic_intent,
                         "intent_description": schedule_manager._get_intent_description(
                             strategic_intent

--- a/backend/tests/test_inverter_api.py
+++ b/backend/tests/test_inverter_api.py
@@ -129,3 +129,44 @@ class TestDetailedSchedule:
         for interval in intervals:
             if interval.get("enabled"):
                 assert interval["isDefault"] is False
+
+
+class TestScheduleDataChargeRate:
+    """chargePowerRate in schedule_data must reflect charge_rate from get_period_settings."""
+
+    def test_charge_power_rate_reflects_period_settings(self):
+        ctrl = _make_controller("growatt_server_min")
+        sm = ctrl.system._inverter_controller
+        sm.get_period_settings.return_value = {
+            "batt_mode": "battery_first",
+            "strategic_intent": "GRID_CHARGING",
+            "grid_charge": True,
+            "charge_rate": 25,
+            "discharge_rate": 0,
+        }
+        sys.modules["app"].bess_controller = ctrl
+        resp = _client.get("/api/growatt/detailed_schedule")
+        assert resp.status_code == 200
+        schedule = resp.json()["scheduleData"]
+        assert len(schedule) > 0
+        for entry in schedule:
+            assert (
+                entry["chargePowerRate"] == 25
+            ), f"hour {entry['hour']}: expected chargePowerRate=25, got {entry['chargePowerRate']}"
+
+    def test_charge_power_rate_defaults_to_100_when_charge_rate_absent(self):
+        ctrl = _make_controller("growatt_server_min")
+        sm = ctrl.system._inverter_controller
+        # get_period_settings returns no charge_rate key → should default to 100
+        sm.get_period_settings.return_value = {
+            "batt_mode": "load_first",
+            "strategic_intent": "IDLE",
+            "grid_charge": False,
+            "discharge_rate": 100,
+        }
+        sys.modules["app"].bess_controller = ctrl
+        resp = _client.get("/api/growatt/detailed_schedule")
+        assert resp.status_code == 200
+        schedule = resp.json()["scheduleData"]
+        for entry in schedule:
+            assert entry["chargePowerRate"] == 100

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -218,7 +218,13 @@ class InverterController(ABC):
             grid_charge, discharge_rate = self.compute_rates_for_period(
                 period, battery_action_kw
             )
-            charge_rate = self.INTENT_TO_CONTROL[intent]["charge_rate"]
+            if intent == "GRID_CHARGING" and battery_action_kw > 0.01:
+                charge_rate = min(
+                    100,
+                    max(0, round(battery_action_kw / self.max_charge_power_kw * 100)),
+                )
+            else:
+                charge_rate = self.INTENT_TO_CONTROL[intent]["charge_rate"]
         else:
             control = self.INTENT_TO_CONTROL[intent]
             grid_charge = control["grid_charge"]

--- a/core/bess/simulation/inverter_simulator.py
+++ b/core/bess/simulation/inverter_simulator.py
@@ -20,6 +20,7 @@ class ControlCommand:
     battery_mode: str  # "load_first" | "grid_first" | "battery_first"
     discharge_rate_pct: int  # 0..100
     grid_charge: bool
+    charge_rate_pct: int = 100  # 0..100; action-derived for GRID_CHARGING
 
 
 def derive_control_command(
@@ -29,26 +30,33 @@ def derive_control_command(
     reusing the production controller mappings so the simulator executes exactly
     what the real controller would write."""
     battery_mode = InverterController.INTENT_TO_MODE.get(strategic_intent, "load_first")
-    # Reuse the production intent->rates mapping (grid_charge, discharge_rate_pct).
-    grid_charge, discharge_rate_pct = _map_rates(
+    grid_charge, discharge_rate_pct, charge_rate_pct = _map_rates(
         strategic_intent, battery_action_kw, settings
     )
     return ControlCommand(
         battery_mode=battery_mode,
         discharge_rate_pct=discharge_rate_pct,
         grid_charge=grid_charge,
+        charge_rate_pct=charge_rate_pct,
     )
 
 
 def _map_rates(
     intent: str, action_kw: float, settings: BatterySettings
-) -> tuple[bool, int]:
+) -> tuple[bool, int, int]:
     """Mirror of InverterController._map_intent_to_rates without needing a live
-    controller instance (that method is an instance method bound to hardware)."""
+    controller instance. Returns (grid_charge, discharge_rate_pct, charge_rate_pct)."""
     if intent == "GRID_CHARGING":
-        return True, 0
+        if action_kw > 0.01:
+            charge_rate_pct = min(
+                100,
+                max(0, round(action_kw / settings.max_charge_power_kw * 100)),
+            )
+        else:
+            charge_rate_pct = 100
+        return True, 0, charge_rate_pct
     if intent in ("SOLAR_STORAGE", "IDLE", "SOLAR_EXPORT"):
-        return False, 0
+        return False, 0, 100
     if intent == "LOAD_SUPPORT":
         if action_kw < -0.01:
             rate = min(
@@ -57,7 +65,7 @@ def _map_rates(
             )
         else:
             rate = 0
-        return False, rate
+        return False, rate, 100
     if intent == "BATTERY_EXPORT":
         if action_kw < -0.01:
             rate = min(
@@ -66,7 +74,7 @@ def _map_rates(
             )
         else:
             rate = 0
-        return False, rate
+        return False, rate, 0
     raise ValueError(f"Unknown strategic intent: {intent}")
 
 
@@ -83,9 +91,8 @@ def mode_to_power(
     policy; check 1 (plan-faithfulness) validates/refines it."""
     if command.battery_mode == "battery_first":  # grid charging
         room = settings.max_soe_kwh - soe
-        max_charge_kwh = min(
-            settings.max_charge_power_kw * dt, room / settings.efficiency_charge
-        )
+        rate_kw = settings.max_charge_power_kw * command.charge_rate_pct / 100
+        max_charge_kwh = min(rate_kw * dt, room / settings.efficiency_charge)
         return max(0.0, max_charge_kwh) / dt
 
     if (

--- a/core/bess/tests/integration/test_schedule_management.py
+++ b/core/bess/tests/integration/test_schedule_management.py
@@ -500,3 +500,51 @@ class TestChargeRateHardwareWrite:
             "SOLAR_STORAGE must reset charge_rate to 100 — stale 0 from "
             f"LOAD_SUPPORT was not overwritten: {mock_controller.calls['charge_rate']}"
         )
+
+    def test_grid_charging_action_derived_charge_rate_with_schedule(
+        self, battery_system, mock_controller
+    ):
+        """GRID_CHARGING charge_rate must be proportional to the DP action when a
+        schedule is present — not always 100%.
+
+        Scenario: battery needs only 0.17 kWh this 15-min period (a small top-up).
+        That is 0.68 kW. With max_charge_power=15 kW the correct rate is
+        round(0.68 / 15 * 100) = 5%, not 100%.
+        """
+        from unittest.mock import MagicMock
+
+        from core.bess.dp_schedule import DPSchedule
+
+        assert battery_system._power_monitor is None
+
+        mgr = battery_system._inverter_controller
+        mgr.max_charge_power_kw = 15.0
+
+        # 96 quarter-hour periods; only period 8 (hour 2) is GRID_CHARGING
+        intents = ["IDLE"] * 96
+        for p in range(8, 12):  # hour 2: periods 8-11
+            intents[p] = "GRID_CHARGING"
+        mgr.strategic_intents = intents
+
+        # Attach a schedule with a small action at period 8:
+        # 0.17 kWh in 15 min → 0.68 kW → round(0.68 / 15 * 100) = 5
+        actions = [0.0] * 96
+        actions[8] = 0.17
+        mock_schedule = MagicMock(spec=DPSchedule)
+        mock_schedule.actions = actions
+        mgr.current_schedule = mock_schedule
+
+        mock_controller.calls["charge_rate"].clear()
+
+        with patch("core.bess.battery_system_manager.time_utils.now") as mock_now:
+            mock_now.return_value.hour = 2
+            mock_now.return_value.minute = 0
+            battery_system._apply_period_schedule(8)
+
+        assert mock_controller.calls[
+            "charge_rate"
+        ], "GRID_CHARGING must write charge_rate"
+        actual = mock_controller.calls["charge_rate"][-1]
+        assert (
+            actual == 5
+        ), f"GRID_CHARGING with 0.17 kWh action should write charge_rate=5%, got {actual}%"

--- a/core/bess/tests/unit/test_controller_coverage.py
+++ b/core/bess/tests/unit/test_controller_coverage.py
@@ -518,24 +518,33 @@ class TestSimulatorMapRates:
     def test_load_support_partial(self):
         from core.bess.simulation.inverter_simulator import _map_rates
 
-        grid_charge, rate = _map_rates("LOAD_SUPPORT", -1.5, self._settings())
+        grid_charge, rate, charge_rate = _map_rates(
+            "LOAD_SUPPORT", -1.5, self._settings()
+        )
         assert grid_charge is False
         assert rate == 10  # 1.5 / 15.0 * 100 = 10
+        assert charge_rate == 100
 
     def test_load_support_full(self):
         from core.bess.simulation.inverter_simulator import _map_rates
 
         s = self._settings()
-        grid_charge, rate = _map_rates("LOAD_SUPPORT", -s.max_discharge_power_kw, s)
+        grid_charge, rate, charge_rate = _map_rates(
+            "LOAD_SUPPORT", -s.max_discharge_power_kw, s
+        )
         assert grid_charge is False
         assert rate == 100
+        assert charge_rate == 100
 
     def test_load_support_zero(self):
         from core.bess.simulation.inverter_simulator import _map_rates
 
-        grid_charge, rate = _map_rates("LOAD_SUPPORT", 0.0, self._settings())
+        grid_charge, rate, charge_rate = _map_rates(
+            "LOAD_SUPPORT", 0.0, self._settings()
+        )
         assert grid_charge is False
         assert rate == 0
+        assert charge_rate == 100
 
 
 # ── SolaxController ──────────────────────────────────────────────────────────

--- a/core/bess/tests/unit/test_controller_coverage.py
+++ b/core/bess/tests/unit/test_controller_coverage.py
@@ -372,6 +372,49 @@ class TestGetPeriodSettings:
         result = min_ctrl.get_period_settings(0)
         assert result["discharge_rate"] == 100  # static dict fallback
 
+    def test_action_derived_charge_rate_for_grid_charging(self, min_ctrl):
+        from unittest.mock import MagicMock
+
+        min_ctrl.strategic_intents = ["GRID_CHARGING"] * 96
+        mock_schedule = MagicMock()
+        # 0.17 kWh in 15 min → 0.68 kW → round(0.68 / 15.0 * 100) = 5
+        mock_schedule.actions = [0.17] + [0.0] * 95
+        min_ctrl.current_schedule = mock_schedule
+
+        result = min_ctrl.get_period_settings(0)
+        assert result["charge_rate"] == 5
+        assert result["grid_charge"] is True
+
+    def test_grid_charging_full_rate_at_max_action(self, min_ctrl):
+        from unittest.mock import MagicMock
+
+        min_ctrl.strategic_intents = ["GRID_CHARGING"] * 96
+        mock_schedule = MagicMock()
+        # 3.75 kWh in 15 min → 15.0 kW → round(15.0 / 15.0 * 100) = 100
+        mock_schedule.actions = [3.75] + [0.0] * 95
+        min_ctrl.current_schedule = mock_schedule
+
+        result = min_ctrl.get_period_settings(0)
+        assert result["charge_rate"] == 100
+
+    def test_solar_storage_charge_rate_always_100(self, min_ctrl):
+        from unittest.mock import MagicMock
+
+        min_ctrl.strategic_intents = ["SOLAR_STORAGE"] * 96
+        mock_schedule = MagicMock()
+        mock_schedule.actions = [0.5] * 96
+        min_ctrl.current_schedule = mock_schedule
+
+        result = min_ctrl.get_period_settings(0)
+        assert result["charge_rate"] == 100
+
+    def test_grid_charging_falls_back_to_100_without_schedule(self, min_ctrl):
+        min_ctrl.strategic_intents = ["GRID_CHARGING"] * 4
+        min_ctrl.current_schedule = None
+
+        result = min_ctrl.get_period_settings(0)
+        assert result["charge_rate"] == 100
+
 
 class TestGetStrategicIntentSummary:
     def test_empty_when_no_intents(self, min_ctrl):

--- a/core/bess/tests/unit/test_inverter_simulator.py
+++ b/core/bess/tests/unit/test_inverter_simulator.py
@@ -46,6 +46,37 @@ def test_derive_command_grid_charging_enables_grid_charge():
     assert cmd.grid_charge is True
 
 
+def test_derive_command_grid_charging_scales_charge_rate():
+    """GRID_CHARGING charge_rate_pct must match the DP action, not always be 100%.
+
+    With max_charge_power=15 kW and a planned action of 0.68 kW (0.17 kWh in 15 min),
+    the correct charge_rate_pct is round(0.68 / 15 * 100) = 5, not 100.
+    This mirrors the production controller's get_period_settings() behaviour.
+    """
+    bs = make_battery_settings(max_charge_power_kw=15.0)
+    # 0.17 kWh in a 15-min period → battery_action_kw = 0.17 / 0.25 = 0.68 kW
+    cmd = derive_control_command("GRID_CHARGING", battery_action_kw=0.68, settings=bs)
+    assert cmd.battery_mode == "battery_first"
+    assert cmd.grid_charge is True
+    assert (
+        cmd.charge_rate_pct == 5
+    ), f"Expected charge_rate_pct=5 for 0.68 kW action at 15 kW max, got {cmd.charge_rate_pct}"
+
+
+def test_derive_command_grid_charging_full_action_gives_100_pct():
+    """When the planned action equals max charge power, charge_rate_pct must be 100."""
+    bs = make_battery_settings(max_charge_power_kw=15.0)
+    cmd = derive_control_command("GRID_CHARGING", battery_action_kw=15.0, settings=bs)
+    assert cmd.charge_rate_pct == 100
+
+
+def test_derive_command_solar_storage_charge_rate_is_100():
+    """SOLAR_STORAGE always uses charge_rate_pct=100 — accept solar at full rate."""
+    bs = make_battery_settings()
+    cmd = derive_control_command("SOLAR_STORAGE", battery_action_kw=0.5, settings=bs)
+    assert cmd.charge_rate_pct == 100
+
+
 # ---------------------------------------------------------------------------
 # Task 2: mode_to_power
 # ---------------------------------------------------------------------------

--- a/core/bess/tests/unit/test_min_schedule_e2e.py
+++ b/core/bess/tests/unit/test_min_schedule_e2e.py
@@ -223,7 +223,7 @@ class TestEndToEndChargeDischargeRates:
 
     @pytest.mark.parametrize("scenario_name", _get_realworld_scenarios())
     def test_grid_charging_periods_have_correct_rates(self, scenario_name):
-        """GRID_CHARGING: grid_charge=True, charge_rate=100%, discharge_rate=0%."""
+        """GRID_CHARGING: grid_charge=True, charge_rate=1..100% (action-derived), discharge_rate=0%."""
         scheduler, _ = _run_and_build_schedule(scenario_name)
 
         for period in range(len(scheduler.strategic_intents)):
@@ -233,8 +233,8 @@ class TestEndToEndChargeDischargeRates:
                     settings["grid_charge"] is True
                 ), f"{scenario_name} period {period}: GRID_CHARGING must have grid_charge=True"
                 assert (
-                    settings["charge_rate"] == 100
-                ), f"{scenario_name} period {period}: GRID_CHARGING charge_rate={settings['charge_rate']}, expected 100"
+                    0 < settings["charge_rate"] <= 100
+                ), f"{scenario_name} period {period}: GRID_CHARGING charge_rate={settings['charge_rate']}, expected 1..100"
                 assert (
                     settings["discharge_rate"] == 0
                 ), f"{scenario_name} period {period}: GRID_CHARGING discharge_rate={settings['discharge_rate']}, expected 0"

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -473,7 +473,7 @@ const InverterStatusDashboard: React.FC = () => {
       action: scheduleHour?.action || 'IDLE',
       actionColor: scheduleHour?.actionColor || 'gray',
       dischargePowerRate: scheduleHour?.dischargePowerRate || 0,
-      chargePowerRate: scheduleHour?.chargePowerRate || 100,
+      chargePowerRate: scheduleHour?.chargePowerRate ?? 100,
       gridCharge: scheduleHour?.gridCharge || false,
       batteryMode: scheduleHour?.batteryMode || 'load_first',
       // Add formatted fields from dashboard data (they ARE the FormattedValue objects)


### PR DESCRIPTION
## Summary

- **Core change:** `get_period_settings()` in `inverter_controller.py` now derives `charge_rate` from the DP algorithm's planned action for GRID_CHARGING periods — identical in structure to how `discharge_rate` is already derived. Formula: `round(battery_action_kw / max_charge_power_kw × 100)`, clamped to [0, 100].
- **Why:** Previously the system always sent 100% charge rate to the inverter during GRID_CHARGING, even for tiny top-up periods (e.g., filling the last 0.17 kWh when the battery is at 99.4%). At 100% of a 15 kW inverter, that fills in ~40 seconds and then idles. The action-derived rate sends the correct proportional command (e.g., 5%) so power draw matches what the DP planned.
- **All other intents** (SOLAR_STORAGE, IDLE, SOLAR_EXPORT) keep `charge_rate = 100` — you always want to accept solar at full rate.
- **API fix:** `chargePowerRate` in the schedule response now reads from `hourly_settings.get("charge_rate", 100)` instead of the hardcoded constant `100`.
- **Frontend fix:** `scheduleHour?.chargePowerRate ?? 100` (nullish coalescing) replaces `|| 100` so a value of `0` is no longer masked to `100`.
- The hardware write path (`adjust_charging_power()` in BSM) picks this up automatically — no BSM changes needed.

## Test plan

- [ ] 4 new unit tests in `TestGetPeriodSettings` cover: action-derived rate for small top-up (5%), full rate at max action (100%), SOLAR_STORAGE always returns 100%, fallback to 100 when no schedule
- [ ] 2 new API regression tests in `TestScheduleDataChargeRate`: `chargePowerRate` reflects `charge_rate` from `get_period_settings`; defaults to 100 when key absent — red-green verified
- [ ] Full fast suite: 915 passed, 11 skipped (up from 909 baseline, 0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)