### PR TITLE
feat: inverter schedule table redesign

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1589,7 +1589,25 @@ async def get_growatt_detailed_schedule():
         # Get period groups from schedule manager (15-minute resolution)
         period_groups = []
         try:
-            raw_groups = schedule_manager.get_detailed_period_groups()
+            stored_schedule_for_today = (
+                bess_controller.system.schedule_store.get_latest_schedule()
+            )
+            today_soc_values: list[float | None] = []
+            if stored_schedule_for_today:
+                opt_result_today = stored_schedule_for_today.optimization_result
+                opt_period_today = stored_schedule_for_today.optimization_period
+                today_period_count_local = get_period_count(time_utils.today())
+                for period_idx in range(today_period_count_local):
+                    data_idx = period_idx - opt_period_today
+                    if 0 <= data_idx < len(opt_result_today.period_data):
+                        today_soc_values.append(
+                            opt_result_today.period_data[data_idx].energy.battery_soe_end
+                        )
+                    else:
+                        today_soc_values.append(None)
+            raw_groups = schedule_manager.get_detailed_period_groups(
+                soc_values=today_soc_values if today_soc_values else None
+            )
             for group in raw_groups:
                 period_groups.append(
                     {
@@ -1603,6 +1621,8 @@ async def get_growatt_detailed_schedule():
                         "charge_power_rate": group["charge_rate"],
                         "discharge_power_rate": group["discharge_rate"],
                         "grid_charge": group["grid_charge"],
+                        "total_action_kwh": group["total_action_kwh"],
+                        "soc_end_pct": group["soc_end_pct"],
                     }
                 )
         except (ValueError, KeyError, AttributeError) as e:
@@ -1623,6 +1643,7 @@ async def get_growatt_detailed_schedule():
                 )
                 tomorrow_intents: list[str] = []
                 tomorrow_actions: list[float] = []
+                tomorrow_soc_values: list[float | None] = []
                 # Standalone next-day schedule: same anchor adjustment as dashboard.
                 is_next_day_only = (
                     opt_period == 0
@@ -1643,10 +1664,14 @@ async def get_growatt_detailed_schedule():
                         pd = opt_result.period_data[data_idx]
                         tomorrow_intents.append(pd.decision.strategic_intent)
                         tomorrow_actions.append(pd.decision.battery_action or 0.0)
+                        tomorrow_soc_values.append(pd.energy.battery_soe_end)
+                    else:
+                        tomorrow_soc_values.append(None)
                 if tomorrow_intents:
                     raw_tomorrow_groups = schedule_manager.get_detailed_period_groups(
                         intents=tomorrow_intents,
                         actions=tomorrow_actions,
+                        soc_values=tomorrow_soc_values,
                     )
                     tomorrow_period_groups = []
                     for group in raw_tomorrow_groups:
@@ -1664,6 +1689,8 @@ async def get_growatt_detailed_schedule():
                                 "charge_power_rate": group["charge_rate"],
                                 "discharge_power_rate": group["discharge_rate"],
                                 "grid_charge": group["grid_charge"],
+                                "total_action_kwh": group["total_action_kwh"],
+                                "soc_end_pct": group["soc_end_pct"],
                             }
                         )
         except (AttributeError, KeyError, ValueError) as e:

--- a/backend/api.py
+++ b/backend/api.py
@@ -1621,8 +1621,14 @@ async def get_growatt_detailed_schedule():
             for group in raw_groups:
                 soc_end = group["soc_end_pct"]
                 soc_delta_kwh: float | None = None
-                if soc_end is not None and prev_soc is not None and battery_settings.total_capacity > 0:
-                    soc_delta_kwh = (soc_end - prev_soc) / 100.0 * battery_settings.total_capacity
+                if (
+                    soc_end is not None
+                    and prev_soc is not None
+                    and battery_settings.total_capacity > 0
+                ):
+                    soc_delta_kwh = (
+                        (soc_end - prev_soc) / 100.0 * battery_settings.total_capacity
+                    )
                 prev_soc = soc_end
                 period_groups.append(
                     {
@@ -1699,8 +1705,16 @@ async def get_growatt_detailed_schedule():
                     for group in raw_tomorrow_groups:
                         soc_end = group["soc_end_pct"]
                         soc_delta_kwh_tmr: float | None = None
-                        if soc_end is not None and prev_soc_tmr is not None and battery_settings.total_capacity > 0:
-                            soc_delta_kwh_tmr = (soc_end - prev_soc_tmr) / 100.0 * battery_settings.total_capacity
+                        if (
+                            soc_end is not None
+                            and prev_soc_tmr is not None
+                            and battery_settings.total_capacity > 0
+                        ):
+                            soc_delta_kwh_tmr = (
+                                (soc_end - prev_soc_tmr)
+                                / 100.0
+                                * battery_settings.total_capacity
+                            )
                         prev_soc_tmr = soc_end
                         tomorrow_period_groups.append(
                             {

--- a/backend/api.py
+++ b/backend/api.py
@@ -1461,6 +1461,7 @@ async def get_growatt_detailed_schedule():
 
     try:
         schedule_manager = bess_controller.system._inverter_controller
+        battery_settings = bess_controller.system.battery_settings
         current_hour = time_utils.now().hour
 
         # Get TOU intervals directly from schedule manager
@@ -1593,6 +1594,7 @@ async def get_growatt_detailed_schedule():
                 bess_controller.system.schedule_store.get_latest_schedule()
             )
             today_soc_values: list[float | None] = []
+            today_actions: list[float] = []
             if stored_schedule_for_today:
                 opt_result_today = stored_schedule_for_today.optimization_result
                 opt_period_today = stored_schedule_for_today.optimization_period
@@ -1600,15 +1602,28 @@ async def get_growatt_detailed_schedule():
                 for period_idx in range(today_period_count_local):
                     data_idx = period_idx - opt_period_today
                     if 0 <= data_idx < len(opt_result_today.period_data):
+                        pd_today = opt_result_today.period_data[data_idx]
+                        soe = pd_today.energy.battery_soe_end
                         today_soc_values.append(
-                            opt_result_today.period_data[data_idx].energy.battery_soe_end
+                            (soe / battery_settings.total_capacity * 100.0)
+                            if battery_settings.total_capacity > 0
+                            else None
                         )
+                        today_actions.append(pd_today.decision.battery_action or 0.0)
                     else:
                         today_soc_values.append(None)
+                        today_actions.append(0.0)
             raw_groups = schedule_manager.get_detailed_period_groups(
-                soc_values=today_soc_values if today_soc_values else None
+                actions=today_actions if today_actions else None,
+                soc_values=today_soc_values if today_soc_values else None,
             )
+            prev_soc: float | None = None
             for group in raw_groups:
+                soc_end = group["soc_end_pct"]
+                soc_delta_kwh: float | None = None
+                if soc_end is not None and prev_soc is not None and battery_settings.total_capacity > 0:
+                    soc_delta_kwh = (soc_end - prev_soc) / 100.0 * battery_settings.total_capacity
+                prev_soc = soc_end
                 period_groups.append(
                     {
                         "start_time": group["start_time"],
@@ -1622,7 +1637,8 @@ async def get_growatt_detailed_schedule():
                         "discharge_power_rate": group["discharge_rate"],
                         "grid_charge": group["grid_charge"],
                         "total_action_kwh": group["total_action_kwh"],
-                        "soc_end_pct": group["soc_end_pct"],
+                        "soc_end_pct": soc_end,
+                        "soc_delta_kwh": soc_delta_kwh,
                     }
                 )
         except (ValueError, KeyError, AttributeError) as e:
@@ -1664,7 +1680,12 @@ async def get_growatt_detailed_schedule():
                         pd = opt_result.period_data[data_idx]
                         tomorrow_intents.append(pd.decision.strategic_intent)
                         tomorrow_actions.append(pd.decision.battery_action or 0.0)
-                        tomorrow_soc_values.append(pd.energy.battery_soe_end)
+                        soe = pd.energy.battery_soe_end
+                        tomorrow_soc_values.append(
+                            (soe / battery_settings.total_capacity * 100.0)
+                            if battery_settings.total_capacity > 0
+                            else None
+                        )
                     else:
                         tomorrow_soc_values.append(None)
                 if tomorrow_intents:
@@ -1674,7 +1695,13 @@ async def get_growatt_detailed_schedule():
                         soc_values=tomorrow_soc_values,
                     )
                     tomorrow_period_groups = []
+                    prev_soc_tmr: float | None = None
                     for group in raw_tomorrow_groups:
+                        soc_end = group["soc_end_pct"]
+                        soc_delta_kwh_tmr: float | None = None
+                        if soc_end is not None and prev_soc_tmr is not None and battery_settings.total_capacity > 0:
+                            soc_delta_kwh_tmr = (soc_end - prev_soc_tmr) / 100.0 * battery_settings.total_capacity
+                        prev_soc_tmr = soc_end
                         tomorrow_period_groups.append(
                             {
                                 "start_time": group["start_time"],
@@ -1690,7 +1717,8 @@ async def get_growatt_detailed_schedule():
                                 "discharge_power_rate": group["discharge_rate"],
                                 "grid_charge": group["grid_charge"],
                                 "total_action_kwh": group["total_action_kwh"],
-                                "soc_end_pct": group["soc_end_pct"],
+                                "soc_end_pct": soc_end,
+                                "soc_delta_kwh": soc_delta_kwh_tmr,
                             }
                         )
         except (AttributeError, KeyError, ValueError) as e:

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -271,7 +271,10 @@ class InverterController(ABC):
         return self.INTENT_DESCRIPTIONS.get(intent, "Unknown intent")
 
     def get_detailed_period_groups(
-        self, intents: list[str] | None = None, actions: list[float] | None = None
+        self,
+        intents: list[str] | None = None,
+        actions: list[float] | None = None,
+        soc_values: list[float | None] | None = None,
     ) -> list[dict]:
         """Get period groups with full control parameters for display/API.
 
@@ -284,6 +287,8 @@ class InverterController(ABC):
             actions: Optional list of battery actions in kWh per period (negative=discharge).
                      If None, reads from self.current_schedule.actions. If current_schedule
                      is also None or the period is out of range, action defaults to 0.0.
+            soc_values: Optional per-period SOC end values (%). The last period's value
+                        in each group is exposed as soc_end_pct in the result.
 
         Returns:
             List of period groups with all control parameters and time strings
@@ -324,6 +329,7 @@ class InverterController(ABC):
                     "grid_charge": control["grid_charge"],
                     "charge_rate": control["charge_rate"],
                     "discharge_rate": discharge_rate,
+                    "action_kwh": action_kwh,
                 }
             )
 
@@ -340,6 +346,7 @@ class InverterController(ABC):
             ):
                 current_group["end_period"] = ps["period"]
                 current_group["count"] += 1
+                current_group["total_action_kwh"] += ps["action_kwh"]
             else:
                 if current_group is not None:
                     groups.append(current_group)
@@ -352,6 +359,7 @@ class InverterController(ABC):
                     "charge_rate": ps["charge_rate"],
                     "discharge_rate": ps["discharge_rate"],
                     "count": 1,
+                    "total_action_kwh": ps["action_kwh"],
                 }
 
         if current_group is not None:
@@ -365,6 +373,10 @@ class InverterController(ABC):
             if end_h >= 24:
                 end_h = 23
                 end_m = 59
+            end_period = group["end_period"]
+            soc_end: float | None = None
+            if soc_values is not None and end_period < len(soc_values):
+                soc_end = soc_values[end_period]
             result.append(
                 {
                     "start_time": f"{start_h:02d}:{start_m:02d}",
@@ -378,6 +390,8 @@ class InverterController(ABC):
                     "discharge_rate": group["discharge_rate"],
                     "period_count": group["count"],
                     "duration_minutes": group["count"] * 15,
+                    "total_action_kwh": group["total_action_kwh"],
+                    "soc_end_pct": soc_end,
                 }
             )
         return result

--- a/dev-run.sh
+++ b/dev-run.sh
@@ -3,7 +3,7 @@
 #
 # Container runtime: auto-detected (podman preferred, falls back to docker).
 # Override with DOCKER=docker ./dev-run.sh if needed.
-# When using podman, podman-compose must be installed: pip install podman-compose
+# When using podman, podman-compose is used from .venv (install with: pip install -r requirements-dev.txt).
 if [ -z "$DOCKER" ]; then
   if command -v podman >/dev/null 2>&1; then
     DOCKER="podman"
@@ -13,8 +13,14 @@ if [ -z "$DOCKER" ]; then
 fi
 COMPOSE="${COMPOSE:-${DOCKER} compose}"
 # podman-compose uses a different binary name; detect it automatically.
-if [ "$DOCKER" = "podman" ] && command -v podman-compose >/dev/null 2>&1; then
-  COMPOSE="podman-compose"
+# Prefer the project venv's copy so no global install is needed.
+if [ "$DOCKER" = "podman" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -x "${SCRIPT_DIR}/.venv/bin/podman-compose" ]; then
+    COMPOSE="${SCRIPT_DIR}/.venv/bin/podman-compose"
+  elif command -v podman-compose >/dev/null 2>&1; then
+    COMPOSE="podman-compose"
+  fi
 fi
 
 echo "==== BESS Manager Development Environment Setup ===="

--- a/dev-run.sh
+++ b/dev-run.sh
@@ -3,7 +3,7 @@
 #
 # Container runtime: auto-detected (podman preferred, falls back to docker).
 # Override with DOCKER=docker ./dev-run.sh if needed.
-# When using podman, podman-compose is used from .venv (install with: pip install -r requirements-dev.txt).
+# When using podman, podman-compose must be installed: pip install podman-compose
 if [ -z "$DOCKER" ]; then
   if command -v podman >/dev/null 2>&1; then
     DOCKER="podman"
@@ -13,14 +13,8 @@ if [ -z "$DOCKER" ]; then
 fi
 COMPOSE="${COMPOSE:-${DOCKER} compose}"
 # podman-compose uses a different binary name; detect it automatically.
-# Prefer the project venv's copy so no global install is needed.
-if [ "$DOCKER" = "podman" ]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [ -x "${SCRIPT_DIR}/.venv/bin/podman-compose" ]; then
-    COMPOSE="${SCRIPT_DIR}/.venv/bin/podman-compose"
-  elif command -v podman-compose >/dev/null 2>&1; then
-    COMPOSE="podman-compose"
-  fi
+if [ "$DOCKER" = "podman" ] && command -v podman-compose >/dev/null 2>&1; then
+  COMPOSE="podman-compose"
 fi
 
 echo "==== BESS Manager Development Environment Setup ===="

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -1,17 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  Battery, 
-  Zap, 
-  RefreshCw, 
-  Clock, 
-  Settings, 
+import {
+  Battery,
+  Zap,
+  RefreshCw,
+  Clock,
+  Settings,
   TrendingUp,
   Calendar,
   TrendingDown,
   CheckCircle,
   AlertTriangle,
   Home,
-  Sun
+  Sun,
+  ChevronRight
 } from 'lucide-react';
 import api from '../lib/api';
 
@@ -299,6 +300,7 @@ const InverterStatusDashboard: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const [showTomorrow, setShowTomorrow] = useState(false);
 
   // Helper function to extract values from FormattedValue objects
   const getValue = (field: any) => {
@@ -554,6 +556,14 @@ const InverterStatusDashboard: React.FC = () => {
 
   const currentPeriodGroup = getCurrentPeriodGroup();
 
+  const formatDuration = (minutes: number): string => {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hours === 0) return `${mins}min`;
+    if (mins === 0) return `${hours}h`;
+    return `${hours}h ${mins}min`;
+  };
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -711,176 +721,176 @@ const InverterStatusDashboard: React.FC = () => {
           </div>
 
           {inverterSchedule?.periodGroups && inverterSchedule.periodGroups.length > 0 ? (
-            <div className="overflow-x-auto bg-white dark:bg-gray-800 rounded-lg shadow">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-700">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                      <div className="flex items-center">
-                        <Clock className="h-4 w-4 mr-1" />
-                        Time Period
-                      </div>
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                      Duration
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                      Battery Mode
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                      Strategic Intent
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                      Power Rate
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                      Grid Charge
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-                  {inverterSchedule.periodGroups.map((group, index) => {
-                    // Check if current time falls within this period group
-                    const now = new Date();
-                    const currentMinutes = now.getHours() * 60 + now.getMinutes();
-                    const [startH, startM] = group.startTime.split(':').map(Number);
-                    const [endH, endM] = group.endTime.split(':').map(Number);
-                    const groupStartMinutes = startH * 60 + startM;
-                    const groupEndMinutes = endH * 60 + endM;
-                    const isCurrentPeriod = currentMinutes >= groupStartMinutes && currentMinutes <= groupEndMinutes;
+            <div className="space-y-4">
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+                <table className="min-w-full border-collapse">
+                  <thead>
+                    <tr>
+                      <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                        <div className="flex items-center gap-1">
+                          <Clock className="h-3.5 w-3.5" />
+                          Time Period
+                        </div>
+                      </th>
+                      <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                        Duration
+                      </th>
+                      <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                        Strategic Intent
+                      </th>
+                      <th colSpan={4} className="px-3 py-2 text-center text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-900/20">
+                        Inverter Configuration
+                      </th>
+                    </tr>
+                    <tr>
+                      <th className="px-3 py-2 text-left text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                        Mode
+                      </th>
+                      <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                        Charge %
+                      </th>
+                      <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                        Discharge %
+                      </th>
+                      <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                        Grid Charge
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white dark:bg-gray-800">
+                    {inverterSchedule.periodGroups.map((group, index) => {
+                      const now = new Date();
+                      const currentMinutes = now.getHours() * 60 + now.getMinutes();
+                      const [startH, startM] = group.startTime.split(':').map(Number);
+                      const [endH, endM] = group.endTime.split(':').map(Number);
+                      const groupStartMinutes = startH * 60 + startM;
+                      const groupEndMinutes = endH * 60 + endM;
+                      const isCurrentPeriod = currentMinutes >= groupStartMinutes && currentMinutes <= groupEndMinutes;
+                      const cell = 'px-3 py-2.5 whitespace-nowrap text-sm border border-gray-200 dark:border-gray-700';
+                      const invCell = `${cell} bg-indigo-50/20 dark:bg-indigo-900/5`;
 
-                    const formatDuration = (minutes: number): string => {
-                      const hours = Math.floor(minutes / 60);
-                      const mins = minutes % 60;
-                      if (hours === 0) return `${mins}min`;
-                      if (mins === 0) return `${hours}h`;
-                      return `${hours}h ${mins}min`;
-                    };
-
-                    return (
-                      <tr
-                        key={index}
-                        className={isCurrentPeriod ? 'bg-blue-50 dark:bg-blue-900/20' : ''}
-                      >
-                        <td className="px-4 py-4 whitespace-nowrap text-sm">
-                          <div className="flex items-center">
-                            <div className="font-medium text-gray-900 dark:text-white">
-                              {group.startTime} - {group.endTime}
-                            </div>
-                            {isCurrentPeriod && (
-                              <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 rounded">
-                                Now
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">
-                          {formatDuration(group.durationMinutes)}
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm">
-                          {getBatteryModeDisplay(group.mode)}
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm">
-                          <span className={`px-2 py-1 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
-                            {group.dominantIntent.replace(/_/g, ' ')}
-                          </span>
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm">
-                          <div className="space-y-1">
-                            {group.chargePowerRate > 0 && (
-                              <div className="text-green-600 dark:text-green-400">
-                                C: {group.chargePowerRate}%
-                              </div>
-                            )}
-                            {group.dischargePowerRate > 0 && (
-                              <div className="text-orange-600 dark:text-orange-400">
-                                D: {group.dischargePowerRate}%
-                              </div>
-                            )}
-                            {group.chargePowerRate === 0 && group.dischargePowerRate === 0 && (
-                              <div className="text-gray-500 dark:text-gray-400">-</div>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm">
-                          {group.gridCharge ? (
-                            <span className="text-green-600 dark:text-green-400 font-medium">Enabled</span>
-                          ) : (
-                            <span className="text-gray-400 dark:text-gray-500">Disabled</span>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-                {inverterSchedule.tomorrowPeriodGroups && inverterSchedule.tomorrowPeriodGroups.length > 0 && (
-                  <>
-                    <thead className="bg-indigo-50 dark:bg-indigo-900/30">
-                      <tr>
-                        <th colSpan={6} className="px-4 py-3 text-left text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider">
-                          Tomorrow&apos;s Planned Schedule
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700 opacity-75">
-                      {inverterSchedule.tomorrowPeriodGroups.map((group, index) => {
-                        const formatDuration = (minutes: number): string => {
-                          const hours = Math.floor(minutes / 60);
-                          const mins = minutes % 60;
-                          if (hours === 0) return `${mins}min`;
-                          if (mins === 0) return `${hours}h`;
-                          return `${hours}h ${mins}min`;
-                        };
-
-                        return (
-                          <tr key={`tomorrow-${index}`}>
-                            <td className="px-4 py-4 whitespace-nowrap text-sm">
-                              <div className="font-medium text-gray-900 dark:text-white">
+                      return (
+                        <tr
+                          key={index}
+                          className={isCurrentPeriod ? 'bg-blue-50 dark:bg-blue-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-700/30'}
+                        >
+                          <td className={`${cell} ${isCurrentPeriod ? 'border-l-4 border-l-blue-400' : ''}`}>
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-gray-900 dark:text-white">
                                 {group.startTime} - {group.endTime}
-                              </div>
-                            </td>
-                            <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">
-                              {formatDuration(group.durationMinutes)}
-                            </td>
-                            <td className="px-4 py-4 whitespace-nowrap text-sm">
-                              {getBatteryModeDisplay(group.mode)}
-                            </td>
-                            <td className="px-4 py-4 whitespace-nowrap text-sm">
-                              <span className={`px-2 py-1 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
-                                {group.dominantIntent.replace(/_/g, ' ')}
                               </span>
-                            </td>
-                            <td className="px-4 py-4 whitespace-nowrap text-sm">
-                              <div className="space-y-1">
-                                {group.chargePowerRate > 0 && (
-                                  <div className="text-green-600 dark:text-green-400">
-                                    C: {group.chargePowerRate}%
-                                  </div>
-                                )}
-                                {group.dischargePowerRate > 0 && (
-                                  <div className="text-orange-600 dark:text-orange-400">
-                                    D: {group.dischargePowerRate}%
-                                  </div>
-                                )}
-                                {group.chargePowerRate === 0 && group.dischargePowerRate === 0 && (
-                                  <div className="text-gray-500 dark:text-gray-400">-</div>
-                                )}
-                              </div>
-                            </td>
-                            <td className="px-4 py-4 whitespace-nowrap text-sm">
-                              {group.gridCharge ? (
-                                <span className="text-green-600 dark:text-green-400 font-medium">Enabled</span>
-                              ) : (
-                                <span className="text-gray-400 dark:text-gray-500">Disabled</span>
+                              {isCurrentPeriod && (
+                                <span className="px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 rounded">
+                                  Now
+                                </span>
                               )}
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </>
-                )}
-              </table>
+                            </div>
+                          </td>
+                          <td className={`${cell} text-gray-600 dark:text-gray-400`}>
+                            {formatDuration(group.durationMinutes)}
+                          </td>
+                          <td className={cell}>
+                            <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
+                              {group.dominantIntent.replace(/_/g, ' ')}
+                            </span>
+                          </td>
+                          <td className={invCell}>
+                            {getBatteryModeDisplay(group.mode)}
+                          </td>
+                          <td className={`${invCell} text-center`}>
+                            {group.chargePowerRate > 0 ? (
+                              <span className="text-green-600 dark:text-green-400 font-medium">{group.chargePowerRate}%</span>
+                            ) : (
+                              <span className="text-gray-300 dark:text-gray-600">—</span>
+                            )}
+                          </td>
+                          <td className={`${invCell} text-center`}>
+                            {group.dischargePowerRate > 0 ? (
+                              <span className="text-orange-500 dark:text-orange-400 font-medium">{group.dischargePowerRate}%</span>
+                            ) : (
+                              <span className="text-gray-300 dark:text-gray-600">—</span>
+                            )}
+                          </td>
+                          <td className={`${invCell} text-center`}>
+                            {group.gridCharge ? (
+                              <span className="text-green-600 dark:text-green-400 font-medium">Yes</span>
+                            ) : (
+                              <span className="text-gray-300 dark:text-gray-600">—</span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              {inverterSchedule.tomorrowPeriodGroups && inverterSchedule.tomorrowPeriodGroups.length > 0 && (
+                <div>
+                  <button
+                    onClick={() => setShowTomorrow(!showTomorrow)}
+                    className="flex items-center gap-2 text-sm font-medium text-indigo-700 dark:text-indigo-300 hover:text-indigo-900 dark:hover:text-indigo-100 transition-colors"
+                  >
+                    <ChevronRight className={`h-4 w-4 transition-transform ${showTomorrow ? 'rotate-90' : ''}`} />
+                    Tomorrow&apos;s Planned Schedule ({inverterSchedule.tomorrowPeriodGroups.length} segments)
+                  </button>
+
+                  {showTomorrow && (
+                    <div className="mt-3 overflow-x-auto rounded-lg border border-indigo-200 dark:border-indigo-800 opacity-75">
+                      <table className="min-w-full border-collapse">
+                        <tbody className="bg-white dark:bg-gray-800">
+                          {inverterSchedule.tomorrowPeriodGroups.map((group, index) => {
+                            const cell = 'px-3 py-2.5 whitespace-nowrap text-sm border border-gray-200 dark:border-gray-700';
+                            const invCell = `${cell} bg-indigo-50/20 dark:bg-indigo-900/5`;
+
+                            return (
+                              <tr key={`tomorrow-${index}`} className="hover:bg-gray-50 dark:hover:bg-gray-700/30">
+                                <td className={cell}>
+                                  <span className="font-medium text-gray-900 dark:text-white">
+                                    {group.startTime} - {group.endTime}
+                                  </span>
+                                </td>
+                                <td className={`${cell} text-gray-600 dark:text-gray-400`}>
+                                  {formatDuration(group.durationMinutes)}
+                                </td>
+                                <td className={cell}>
+                                  <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
+                                    {group.dominantIntent.replace(/_/g, ' ')}
+                                  </span>
+                                </td>
+                                <td className={invCell}>
+                                  {getBatteryModeDisplay(group.mode)}
+                                </td>
+                                <td className={`${invCell} text-center`}>
+                                  {group.chargePowerRate > 0 ? (
+                                    <span className="text-green-600 dark:text-green-400 font-medium">{group.chargePowerRate}%</span>
+                                  ) : (
+                                    <span className="text-gray-300 dark:text-gray-600">—</span>
+                                  )}
+                                </td>
+                                <td className={`${invCell} text-center`}>
+                                  {group.dischargePowerRate > 0 ? (
+                                    <span className="text-orange-500 dark:text-orange-400 font-medium">{group.dischargePowerRate}%</span>
+                                  ) : (
+                                    <span className="text-gray-300 dark:text-gray-600">—</span>
+                                  )}
+                                </td>
+                                <td className={`${invCell} text-center`}>
+                                  {group.gridCharge ? (
+                                    <span className="text-green-600 dark:text-green-400 font-medium">Yes</span>
+                                  ) : (
+                                    <span className="text-gray-300 dark:text-gray-600">—</span>
+                                  )}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           ) : (
             <div className="text-gray-500 dark:text-gray-400 text-sm">No schedule data available</div>

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -84,6 +84,7 @@ interface PeriodGroup {
   gridCharge: boolean;
   totalActionKwh?: number;
   socEndPct?: number;
+  socDeltaKwh?: number | null;
 }
 
 interface InverterSchedule {
@@ -722,39 +723,48 @@ const InverterStatusDashboard: React.FC = () => {
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Schedule Overview (15-min Resolution)</h3>
           </div>
 
-          {inverterSchedule?.periodGroups && inverterSchedule.periodGroups.length > 0 ? (
-            <div className="space-y-4">
-              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-                <table className="min-w-full border-collapse">
-                  <thead>
-                    <tr>
-                      <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
-                        <div className="flex items-center gap-1">
-                          <Clock className="h-3.5 w-3.5" />
-                          Time Period
-                        </div>
-                      </th>
-                      <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
-                        Duration
-                      </th>
-                      <th colSpan={3} className="px-3 py-2 text-center text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                        Optimization Plan
-                      </th>
+          {inverterSchedule?.periodGroups && inverterSchedule.periodGroups.length > 0 ? (() => {
+            const schedulePlatform = inverterSchedule.inverterPlatform ?? 'growatt_server_min';
+            const isTouBased = schedulePlatform !== 'solax_modbus_native';
+            const totalCols = isTouBased ? 10 : 6;
+            return (
+            <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+              <table className="min-w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th rowSpan={2} className="px-3 py-2 text-center text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                      <div className="flex items-center justify-center gap-1">
+                        <Clock className="h-3.5 w-3.5" />
+                        Time Period
+                      </div>
+                    </th>
+                    <th rowSpan={2} className="px-3 py-2 text-center text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                      Duration
+                    </th>
+                    <th colSpan={4} className="px-3 py-2 text-center text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                      Optimization Plan
+                    </th>
+                    {isTouBased && (
                       <th colSpan={4} className="px-3 py-2 text-center text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-900/20">
                         Inverter Configuration
                       </th>
-                    </tr>
-                    <tr>
-                      <th className="px-3 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                        Intent
-                      </th>
-                      <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                        Action
-                      </th>
-                      <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                        SOC
-                      </th>
-                      <th className="px-3 py-2 text-left text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                    )}
+                  </tr>
+                  <tr>
+                    <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                      Intent
+                    </th>
+                    <th className="px-3 py-2 text-center text-xs font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                      Solar
+                    </th>
+                    <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                      Grid / Discharge
+                    </th>
+                    <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                      Target SOC
+                    </th>
+                    {isTouBased && (<>
+                      <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
                         Mode
                       </th>
                       <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
@@ -766,64 +776,88 @@ const InverterStatusDashboard: React.FC = () => {
                       <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
                         Grid Charge
                       </th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white dark:bg-gray-800">
-                    {inverterSchedule.periodGroups.map((group, index) => {
-                      const now = new Date();
-                      const currentMinutes = now.getHours() * 60 + now.getMinutes();
-                      const [startH, startM] = group.startTime.split(':').map(Number);
-                      const [endH, endM] = group.endTime.split(':').map(Number);
-                      const groupStartMinutes = startH * 60 + startM;
-                      const groupEndMinutes = endH * 60 + endM;
-                      const isCurrentPeriod = currentMinutes >= groupStartMinutes && currentMinutes <= groupEndMinutes;
-                      const cell = 'px-3 py-2.5 whitespace-nowrap text-sm border border-gray-200 dark:border-gray-700';
-                      const invCell = `${cell} bg-indigo-50/20 dark:bg-indigo-900/5`;
+                    </>)}
+                  </tr>
+                </thead>
 
-                      return (
-                        <tr
-                          key={index}
-                          className={isCurrentPeriod ? 'bg-blue-50 dark:bg-blue-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-700/30'}
-                        >
-                          <td className={`${cell} ${isCurrentPeriod ? 'border-l-4 border-l-blue-400' : ''}`}>
-                            <div className="flex items-center gap-2">
-                              <span className="font-medium text-gray-900 dark:text-white">
-                                {group.startTime} - {group.endTime}
-                              </span>
-                              {isCurrentPeriod && (
-                                <span className="px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 rounded">
-                                  Now
-                                </span>
-                              )}
-                            </div>
-                          </td>
-                          <td className={`${cell} text-gray-600 dark:text-gray-400`}>
-                            {formatDuration(group.durationMinutes)}
-                          </td>
-                          <td className={cell}>
-                            <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
-                              {group.dominantIntent.replace(/_/g, ' ')}
+                {/* Today's rows */}
+                <tbody className="bg-white dark:bg-gray-800">
+                  {inverterSchedule.periodGroups.map((group, index) => {
+                    const now = new Date();
+                    const currentMinutes = now.getHours() * 60 + now.getMinutes();
+                    const [startH, startM] = group.startTime.split(':').map(Number);
+                    const [endH, endM] = group.endTime.split(':').map(Number);
+                    const groupStartMinutes = startH * 60 + startM;
+                    const groupEndMinutes = endH * 60 + endM;
+                    const isCurrentPeriod = currentMinutes >= groupStartMinutes && currentMinutes <= groupEndMinutes;
+                    const isPast = group.socEndPct == null && !isCurrentPeriod;
+                    const cell = 'px-3 py-2.5 whitespace-nowrap text-sm border border-gray-200 dark:border-gray-700';
+                    const invCell = `${cell} bg-indigo-50/20 dark:bg-indigo-900/5`;
+
+                    return (
+                      <tr
+                        key={index}
+                        className={
+                          isCurrentPeriod
+                            ? 'bg-blue-50 dark:bg-blue-900/20'
+                            : isPast
+                              ? 'opacity-40 bg-gray-50 dark:bg-gray-800/50'
+                              : 'hover:bg-gray-50 dark:hover:bg-gray-700/30'
+                        }
+                      >
+                        <td className={`${cell} text-center ${isCurrentPeriod ? 'border-l-4 border-l-blue-400' : ''}`}>
+                          <div className="flex items-center justify-center gap-2">
+                            <span className="font-medium text-gray-900 dark:text-white">
+                              {group.startTime} - {group.endTime}
                             </span>
-                          </td>
-                          <td className={`${cell} text-center`}>
-                            {group.totalActionKwh !== undefined && Math.abs(group.totalActionKwh) > 0.05 ? (
-                              <span className={group.totalActionKwh > 0 ? 'text-green-600 dark:text-green-400 font-medium' : 'text-orange-500 dark:text-orange-400 font-medium'}>
-                                {group.totalActionKwh > 0 ? '+' : ''}{group.totalActionKwh.toFixed(1)} kWh
+                            {isCurrentPeriod && (
+                              <span className="px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 rounded">
+                                Now
                               </span>
-                            ) : (
-                              <span className="text-gray-300 dark:text-gray-600">—</span>
                             )}
-                          </td>
-                          <td className={`${cell} text-center`}>
-                            {group.socEndPct !== undefined && group.socEndPct !== null ? (
-                              <span className="text-gray-700 dark:text-gray-300 font-medium">{Math.round(group.socEndPct)}%</span>
-                            ) : (
-                              <span className="text-gray-300 dark:text-gray-600">—</span>
-                            )}
-                          </td>
-                          <td className={invCell}>
-                            {getBatteryModeDisplay(group.mode)}
-                          </td>
+                          </div>
+                        </td>
+                        <td className={`${cell} text-center text-gray-600 dark:text-gray-400`}>{formatDuration(group.durationMinutes)}</td>
+                        <td className={`${cell} text-center`}>
+                          <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
+                            {group.dominantIntent.replace(/_/g, ' ')}
+                          </span>
+                        </td>
+                        {/* Solar column: SOLAR_STORAGE and passive IDLE gains */}
+                        <td className={`${cell} text-center`}>
+                          {!isPast && (group.dominantIntent === 'SOLAR_STORAGE' || group.dominantIntent === 'IDLE') &&
+                           group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                            <span className="text-amber-500 dark:text-amber-400 font-medium">
+                              +{group.socDeltaKwh.toFixed(1)} kWh
+                            </span>
+                          ) : (
+                            <span className="text-gray-300 dark:text-gray-600">—</span>
+                          )}
+                        </td>
+                        {/* Grid / Discharge column */}
+                        <td className={`${cell} text-center`}>
+                          {!isPast && group.dominantIntent === 'GRID_CHARGING' &&
+                           group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                            <span className="text-green-600 dark:text-green-400 font-medium">
+                              +{group.socDeltaKwh.toFixed(1)} kWh
+                            </span>
+                          ) : !isPast && group.totalActionKwh !== undefined && group.totalActionKwh < -0.05 ? (
+                            <span className="text-orange-500 dark:text-orange-400 font-medium">
+                              {group.totalActionKwh.toFixed(1)} kWh
+                            </span>
+                          ) : (
+                            <span className="text-gray-300 dark:text-gray-600">—</span>
+                          )}
+                        </td>
+                        <td className={`${cell} text-center`}>
+                          {group.socEndPct != null ? (
+                            <span className="text-gray-700 dark:text-gray-300 font-medium">{Math.round(group.socEndPct)}%</span>
+                          ) : (
+                            <span className="text-gray-300 dark:text-gray-600">—</span>
+                          )}
+                        </td>
+                        {isTouBased && (<>
+                          <td className={`${invCell} text-center`}>{getBatteryModeDisplay(group.mode)}</td>
                           <td className={`${invCell} text-center`}>
                             {group.chargePowerRate > 0 ? (
                               <span className="text-green-600 dark:text-green-400 font-medium">{group.chargePowerRate}%</span>
@@ -845,107 +879,81 @@ const InverterStatusDashboard: React.FC = () => {
                               <span className="text-gray-300 dark:text-gray-600">—</span>
                             )}
                           </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
+                        </>)}
+                      </tr>
+                    );
+                  })}
+                </tbody>
 
-              {inverterSchedule.tomorrowPeriodGroups && inverterSchedule.tomorrowPeriodGroups.length > 0 && (
-                <div>
-                  <button
-                    onClick={() => setShowTomorrow(!showTomorrow)}
-                    className="flex items-center gap-2 text-sm font-medium text-indigo-700 dark:text-indigo-300 hover:text-indigo-900 dark:hover:text-indigo-100 transition-colors"
-                  >
-                    <ChevronRight className={`h-4 w-4 transition-transform ${showTomorrow ? 'rotate-90' : ''}`} />
-                    Tomorrow&apos;s Planned Schedule ({inverterSchedule.tomorrowPeriodGroups.length} segments)
-                  </button>
-
-                  {showTomorrow && (
-                    <div className="mt-3 overflow-x-auto rounded-lg border border-indigo-200 dark:border-indigo-800 opacity-75">
-                      <table className="min-w-full border-collapse">
-                        <thead>
-                          <tr>
-                            <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
-                              <div className="flex items-center gap-1">
-                                <Clock className="h-3.5 w-3.5" />
-                                Time Period
-                              </div>
-                            </th>
-                            <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
-                              Duration
-                            </th>
-                            <th colSpan={3} className="px-3 py-2 text-center text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                              Optimization Plan
-                            </th>
-                            <th colSpan={4} className="px-3 py-2 text-center text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-900/20">
-                              Inverter Configuration
-                            </th>
-                          </tr>
-                          <tr>
-                            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                              Intent
-                            </th>
-                            <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                              Action
-                            </th>
-                            <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
-                              SOC
-                            </th>
-                            <th className="px-3 py-2 text-left text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
-                              Mode
-                            </th>
-                            <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
-                              Charge %
-                            </th>
-                            <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
-                              Discharge %
-                            </th>
-                            <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
-                              Grid Charge
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody className="bg-white dark:bg-gray-800">
-                          {inverterSchedule.tomorrowPeriodGroups.map((group, index) => {
-                            const cell = 'px-3 py-2.5 whitespace-nowrap text-sm border border-gray-200 dark:border-gray-700';
-                            const invCell = `${cell} bg-indigo-50/20 dark:bg-indigo-900/5`;
-
-                            return (
-                              <tr key={`tomorrow-${index}`} className="hover:bg-gray-50 dark:hover:bg-gray-700/30">
-                                <td className={cell}>
-                                  <span className="font-medium text-gray-900 dark:text-white">
-                                    {group.startTime} - {group.endTime}
+                {/* Tomorrow toggle row + rows — same table keeps columns aligned */}
+                {inverterSchedule.tomorrowPeriodGroups && inverterSchedule.tomorrowPeriodGroups.length > 0 && (
+                  <>
+                    <tbody>
+                      <tr className="bg-indigo-50 dark:bg-indigo-900/20 border-t-2 border-indigo-200 dark:border-indigo-700">
+                        <td colSpan={totalCols} className="px-3 py-2.5 border border-gray-200 dark:border-gray-700">
+                          <button
+                            onClick={() => setShowTomorrow(!showTomorrow)}
+                            className="flex items-center gap-2 text-sm font-medium text-indigo-700 dark:text-indigo-300 hover:text-indigo-900 dark:hover:text-indigo-100 transition-colors"
+                          >
+                            <ChevronRight className={`h-4 w-4 transition-transform ${showTomorrow ? 'rotate-90' : ''}`} />
+                            Tomorrow&apos;s Planned Schedule ({inverterSchedule.tomorrowPeriodGroups.length} segments)
+                          </button>
+                        </td>
+                      </tr>
+                    </tbody>
+                    {showTomorrow && (
+                      <tbody className="bg-white dark:bg-gray-800 opacity-75">
+                        {inverterSchedule.tomorrowPeriodGroups.map((group, index) => {
+                          const cell = 'px-3 py-2.5 whitespace-nowrap text-sm border border-gray-200 dark:border-gray-700';
+                          const invCell = `${cell} bg-indigo-50/20 dark:bg-indigo-900/5`;
+                          return (
+                            <tr key={`tomorrow-${index}`} className="hover:bg-gray-50 dark:hover:bg-gray-700/30">
+                              <td className={`${cell} text-center`}>
+                                <span className="font-medium text-gray-900 dark:text-white">
+                                  {group.startTime} - {group.endTime}
+                                </span>
+                              </td>
+                              <td className={`${cell} text-center text-gray-600 dark:text-gray-400`}>{formatDuration(group.durationMinutes)}</td>
+                              <td className={`${cell} text-center`}>
+                                <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
+                                  {group.dominantIntent.replace(/_/g, ' ')}
+                                </span>
+                              </td>
+                              {/* Solar column */}
+                              <td className={`${cell} text-center`}>
+                                {(group.dominantIntent === 'SOLAR_STORAGE' || group.dominantIntent === 'IDLE') &&
+                                 group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                                  <span className="text-amber-500 dark:text-amber-400 font-medium">
+                                    +{group.socDeltaKwh.toFixed(1)} kWh
                                   </span>
-                                </td>
-                                <td className={`${cell} text-gray-600 dark:text-gray-400`}>
-                                  {formatDuration(group.durationMinutes)}
-                                </td>
-                                <td className={cell}>
-                                  <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
-                                    {group.dominantIntent.replace(/_/g, ' ')}
+                                ) : (
+                                  <span className="text-gray-300 dark:text-gray-600">—</span>
+                                )}
+                              </td>
+                              {/* Grid / Discharge column */}
+                              <td className={`${cell} text-center`}>
+                                {group.dominantIntent === 'GRID_CHARGING' &&
+                                 group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                                  <span className="text-green-600 dark:text-green-400 font-medium">
+                                    +{group.socDeltaKwh.toFixed(1)} kWh
                                   </span>
-                                </td>
-                                <td className={`${cell} text-center`}>
-                                  {group.totalActionKwh !== undefined && Math.abs(group.totalActionKwh) > 0.05 ? (
-                                    <span className={group.totalActionKwh > 0 ? 'text-green-600 dark:text-green-400 font-medium' : 'text-orange-500 dark:text-orange-400 font-medium'}>
-                                      {group.totalActionKwh > 0 ? '+' : ''}{group.totalActionKwh.toFixed(1)} kWh
-                                    </span>
-                                  ) : (
-                                    <span className="text-gray-300 dark:text-gray-600">—</span>
-                                  )}
-                                </td>
-                                <td className={`${cell} text-center`}>
-                                  {group.socEndPct !== undefined && group.socEndPct !== null ? (
-                                    <span className="text-gray-700 dark:text-gray-300 font-medium">{Math.round(group.socEndPct)}%</span>
-                                  ) : (
-                                    <span className="text-gray-300 dark:text-gray-600">—</span>
-                                  )}
-                                </td>
-                                <td className={invCell}>
-                                  {getBatteryModeDisplay(group.mode)}
-                                </td>
+                                ) : group.totalActionKwh !== undefined && group.totalActionKwh < -0.05 ? (
+                                  <span className="text-orange-500 dark:text-orange-400 font-medium">
+                                    {group.totalActionKwh.toFixed(1)} kWh
+                                  </span>
+                                ) : (
+                                  <span className="text-gray-300 dark:text-gray-600">—</span>
+                                )}
+                              </td>
+                              <td className={`${cell} text-center`}>
+                                {group.socEndPct != null ? (
+                                  <span className="text-gray-700 dark:text-gray-300 font-medium">{Math.round(group.socEndPct)}%</span>
+                                ) : (
+                                  <span className="text-gray-300 dark:text-gray-600">—</span>
+                                )}
+                              </td>
+                              {isTouBased && (<>
+                                <td className={`${invCell} text-center`}>{getBatteryModeDisplay(group.mode)}</td>
                                 <td className={`${invCell} text-center`}>
                                   {group.chargePowerRate > 0 ? (
                                     <span className="text-green-600 dark:text-green-400 font-medium">{group.chargePowerRate}%</span>
@@ -967,17 +975,18 @@ const InverterStatusDashboard: React.FC = () => {
                                     <span className="text-gray-300 dark:text-gray-600">—</span>
                                   )}
                                 </td>
-                              </tr>
-                            );
-                          })}
-                        </tbody>
-                      </table>
-                    </div>
-                  )}
-                </div>
-              )}
+                              </>)}
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    )}
+                  </>
+                )}
+              </table>
             </div>
-          ) : (
+          );
+          })() : (
             <div className="text-gray-500 dark:text-gray-400 text-sm">No schedule data available</div>
           )}
         </div>

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -82,6 +82,8 @@ interface PeriodGroup {
   chargePowerRate: number;
   dischargePowerRate: number;
   gridCharge: boolean;
+  totalActionKwh?: number;
+  socEndPct?: number;
 }
 
 interface InverterSchedule {
@@ -735,14 +737,23 @@ const InverterStatusDashboard: React.FC = () => {
                       <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
                         Duration
                       </th>
-                      <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
-                        Strategic Intent
+                      <th colSpan={3} className="px-3 py-2 text-center text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                        Optimization Plan
                       </th>
                       <th colSpan={4} className="px-3 py-2 text-center text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-900/20">
                         Inverter Configuration
                       </th>
                     </tr>
                     <tr>
+                      <th className="px-3 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                        Intent
+                      </th>
+                      <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                        Action
+                      </th>
+                      <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                        SOC
+                      </th>
                       <th className="px-3 py-2 text-left text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
                         Mode
                       </th>
@@ -793,6 +804,22 @@ const InverterStatusDashboard: React.FC = () => {
                             <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
                               {group.dominantIntent.replace(/_/g, ' ')}
                             </span>
+                          </td>
+                          <td className={`${cell} text-center`}>
+                            {group.totalActionKwh !== undefined && Math.abs(group.totalActionKwh) > 0.05 ? (
+                              <span className={group.totalActionKwh > 0 ? 'text-green-600 dark:text-green-400 font-medium' : 'text-orange-500 dark:text-orange-400 font-medium'}>
+                                {group.totalActionKwh > 0 ? '+' : ''}{group.totalActionKwh.toFixed(1)} kWh
+                              </span>
+                            ) : (
+                              <span className="text-gray-300 dark:text-gray-600">—</span>
+                            )}
+                          </td>
+                          <td className={`${cell} text-center`}>
+                            {group.socEndPct !== undefined && group.socEndPct !== null ? (
+                              <span className="text-gray-700 dark:text-gray-300 font-medium">{Math.round(group.socEndPct)}%</span>
+                            ) : (
+                              <span className="text-gray-300 dark:text-gray-600">—</span>
+                            )}
                           </td>
                           <td className={invCell}>
                             {getBatteryModeDisplay(group.mode)}
@@ -849,14 +876,23 @@ const InverterStatusDashboard: React.FC = () => {
                             <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
                               Duration
                             </th>
-                            <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
-                              Strategic Intent
+                            <th colSpan={3} className="px-3 py-2 text-center text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                              Optimization Plan
                             </th>
                             <th colSpan={4} className="px-3 py-2 text-center text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-900/20">
                               Inverter Configuration
                             </th>
                           </tr>
                           <tr>
+                            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                              Intent
+                            </th>
+                            <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                              Action
+                            </th>
+                            <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+                              SOC
+                            </th>
                             <th className="px-3 py-2 text-left text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
                               Mode
                             </th>
@@ -890,6 +926,22 @@ const InverterStatusDashboard: React.FC = () => {
                                   <span className={`px-2 py-0.5 rounded text-xs font-medium ${getIntentColor(group.dominantIntent)}`}>
                                     {group.dominantIntent.replace(/_/g, ' ')}
                                   </span>
+                                </td>
+                                <td className={`${cell} text-center`}>
+                                  {group.totalActionKwh !== undefined && Math.abs(group.totalActionKwh) > 0.05 ? (
+                                    <span className={group.totalActionKwh > 0 ? 'text-green-600 dark:text-green-400 font-medium' : 'text-orange-500 dark:text-orange-400 font-medium'}>
+                                      {group.totalActionKwh > 0 ? '+' : ''}{group.totalActionKwh.toFixed(1)} kWh
+                                    </span>
+                                  ) : (
+                                    <span className="text-gray-300 dark:text-gray-600">—</span>
+                                  )}
+                                </td>
+                                <td className={`${cell} text-center`}>
+                                  {group.socEndPct !== undefined && group.socEndPct !== null ? (
+                                    <span className="text-gray-700 dark:text-gray-300 font-medium">{Math.round(group.socEndPct)}%</span>
+                                  ) : (
+                                    <span className="text-gray-300 dark:text-gray-600">—</span>
+                                  )}
                                 </td>
                                 <td className={invCell}>
                                   {getBatteryModeDisplay(group.mode)}

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -838,6 +838,39 @@ const InverterStatusDashboard: React.FC = () => {
                   {showTomorrow && (
                     <div className="mt-3 overflow-x-auto rounded-lg border border-indigo-200 dark:border-indigo-800 opacity-75">
                       <table className="min-w-full border-collapse">
+                        <thead>
+                          <tr>
+                            <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                              <div className="flex items-center gap-1">
+                                <Clock className="h-3.5 w-3.5" />
+                                Time Period
+                              </div>
+                            </th>
+                            <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                              Duration
+                            </th>
+                            <th rowSpan={2} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 align-bottom">
+                              Strategic Intent
+                            </th>
+                            <th colSpan={4} className="px-3 py-2 text-center text-xs font-semibold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50 dark:bg-indigo-900/20">
+                              Inverter Configuration
+                            </th>
+                          </tr>
+                          <tr>
+                            <th className="px-3 py-2 text-left text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                              Mode
+                            </th>
+                            <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                              Charge %
+                            </th>
+                            <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                              Discharge %
+                            </th>
+                            <th className="px-3 py-2 text-center text-xs font-semibold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider border border-gray-200 dark:border-gray-700 bg-indigo-50/70 dark:bg-indigo-900/10">
+                              Grid Charge
+                            </th>
+                          </tr>
+                        </thead>
                         <tbody className="bg-white dark:bg-gray-800">
                           {inverterSchedule.tomorrowPeriodGroups.map((group, index) => {
                             const cell = 'px-3 py-2.5 whitespace-nowrap text-sm border border-gray-200 dark:border-gray-700';

--- a/scripts/mock_ha/scenarios/synthetic-solax.json
+++ b/scripts/mock_ha/scenarios/synthetic-solax.json
@@ -40,7 +40,7 @@
       }
     },
     "inverter": {
-      "platform": "solax"
+      "platform": "solax_modbus_native"
     },
     "growatt": {
       "inverter_type": "SOLAX",


### PR DESCRIPTION
## Summary

- **New schedule table**: replaces the old hourly schedule with a 15-minute period group table split into two sections — Optimization Plan (grey) and Inverter Configuration (indigo)
- **Solar / Grid / Discharge columns**: Action column replaced with separate Solar (amber) and Grid/Discharge (green/orange) columns so the source of battery charging is immediately clear
- **SOC fixes**: `battery_soe_end` was displayed raw as %; now converted via `battery_settings.total_capacity`. Column renamed to "Target SOC"
- **Past-period greying**: rows before the optimizer's planning window are dimmed (40% opacity) with `—` for plan columns, since that data is historical/not accurate
- **Tomorrow's schedule**: collapsible toggle row inside the same `<table>` so column widths align between today and tomorrow
- **Platform gating**: Inverter Configuration columns (Mode, Charge %, Discharge %, Grid Charge) hidden for `solax_modbus_native` — VPP uses power setpoints, not TOU modes
- **Bug fixes**: `battery_settings` NameError in `get_growatt_detailed_schedule`; `today_actions` now sourced from optimizer `period_data` so GRID_CHARGING/SOLAR_STORAGE actions show correctly; `synthetic-solax.json` platform name fixed (`solax` → `solax_modbus_native`)

## Test plan

- [ ] Verify schedule table shows today + collapsible tomorrow for Growatt MIN
- [ ] Confirm Solar column shows amber values for SOLAR_STORAGE rows
- [ ] Confirm Grid/Discharge column shows green for GRID_CHARGING, orange for LOAD_SUPPORT
- [ ] Confirm Target SOC values match dashboard SOC (not raw kWh)
- [ ] Confirm pre-optimization rows (top of day) are greyed out
- [ ] Confirm Inverter Configuration columns hidden when running synthetic-solax scenario
- [ ] Run `pytest -m "not slow"` — 909 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)