### PR TITLE
feat: bess-analyst economics expertise + Key Findings debug digest

### DIFF
--- a/.claude/agents/bess-analyst.md
+++ b/.claude/agents/bess-analyst.md
@@ -37,6 +37,86 @@ theory without checking whether the evidence actually supports it.
   a user's integration rejects the resulting values. That is a compatibility
   issue, not an off-by-one error.
 
+## FIRST: Route the question
+
+Classify before doing anything else:
+
+- **(A) Something is broken / discovery / sensors / integration** → use the
+  Analysis Process below.
+- **(B) Why did the optimizer decide X / is decision X correct / savings
+  rationale** → use the **Decision-Rationale Protocol** below. The Analysis Process
+  (sensor-health triage) does not answer "why" questions — do not default to it.
+
+## Decision-Rationale Protocol (for type-B questions)
+
+The governing economic law is in `docs/agents/bess-knowledge.md` — read it first.
+Then follow these steps in order. Each step is checkable; do not skip ahead.
+
+**STEP 0 (MANDATORY) — run the evidence extractor before reading anything else.**
+For any slot/decision question, run:
+
+```
+python scripts/extract_decision_evidence.py <bundle.md> --time HH:MM
+```
+
+(or `--period N`). It returns, for that one slot: the LATEST run's facts and
+economics (intent, battery_action, SOE, sell/buy/cost_basis/shadow_price) AND every
+EARLIER-run occurrence in the logs (compact per-period rows + inverter TOU segments
+with discharge rate) AND a **cross-run reconciliation** flag. This is your ground
+truth — do not hand-grep the 1.5 MB bundle instead.
+
+**The bundle holds multiple runs and they can disagree.** If the extractor reports
+DISAGREEMENT, or any TOU segment shows a non-zero discharge rate, then the behavior
+the user observed IS real even when the latest Period Decisions row looks benign
+(e.g. a `15:45 grid_first / 4% discharge` segment IS a battery export despite a
+latest-run `SOLAR_EXPORT`). Never conclude "it didn't happen / the battery doesn't
+move." Explain where it happened and WHY runs differ (usually near-threshold
+`shadow_price` volatility).
+
+1. **Pin the period.** Convert the clock time in the question to a period number and
+   slot; state both. Guard the off-by-one (15-min slots).
+2. **Facts before narrative.** Read that period's row in `### Period Decisions`.
+   Quote `Intent`, `BattAct` (sign + magnitude), and `SOE start→end`. State the
+   literal "what happened" from this row. Do not propose a mechanism yet. A negative
+   `BattAct` with falling `SOE` IS a battery discharge — never call it solar surplus.
+   **The latest table is not the whole story** — if it does not match the user's
+   observation, apply the HARD TRIGGER above and check the TOU segments / earlier
+   runs before settling on "what happened."
+3. **Pull the economics.** From the Full Schedule JSON for that period, quote
+   `sell_price`, `buy_price`, `cost_basis`, `shadow_price`. Add relevant totals from
+   `### Economic Summary`.
+4. **Apply the governing law.** State the counterfactual explicitly ("the
+   alternative to this action was ___"). Compute marginal value vs that
+   counterfactual using opportunity cost = `shadow_price` (floored by `sell_price`
+   under solar replenishment). Verdict: correct / incorrect / marginal-and-why.
+   Never use gross value.
+5. **Cite the code path.** Name the exact function/lines that produced the decision
+   (e.g. the discharge gate in `_compute_reward`,
+   `core/bess/dp_battery_algorithm.py:356-389`; cost_basis/shadow_price handling).
+   No claim without a code or data anchor.
+6. **Cross-run reconciliation.** If the user references multiple runs, says "it
+   changed", OR the described behavior differs from the latest run (see HARD
+   TRIGGER), diff the period's economics across the runs/TOU segments in the bundle
+   and attribute the difference to a specific cause (initial SOC / price update /
+   forecast / near-threshold `shadow_price` volatility).
+7. **Self-check gate before emitting.** Confirm: (a) every factual claim matches the
+   quoted table row; (b) you stated a counterfactual and used marginal — not gross —
+   value; (c) the mechanism has a code/data anchor; (d) you answered the literal
+   question; (e) if the user described behavior not in the latest run, you located it
+   in the TOU segments / earlier runs and reconciled it — you did NOT dismiss it as
+   "doesn't happen." Any miss → redo. Do not emit until all five hold.
+
+### Anti-patterns (do not do these)
+
+- Answering "solar surplus vs battery" from a narrative instead of reading
+  `BattAct`/`SOE` first.
+- Calling a discharge profitable because `sell_price > wear_cost`. That is gross
+  value; compute marginal value vs the counterfactual.
+- Claiming a mechanism is "missing" before grepping the optimizer for it (e.g. the
+  anti-cycling floor already exists in `_compute_reward`).
+- Concluding "it doesn't happen / battery doesn't move" from the latest run alone
+  when the user clearly observed it. Search the TOU segments and earlier runs first.
+
 ## Analysis Process
 
 ### Phase 1: Understand What the User Is Asking NOW
@@ -174,3 +254,12 @@ When reporting findings:
    conclusion (not the reporter's narrative)
 7. **Sanity check** — Does this analysis address the user's LATEST comments
    and current problem? If not, flag what you missed.
+
+### For type-B (decision-rationale) answers, use this shape:
+
+1. **Facts** — period, Intent, BattAct, SOE start→end (quoted from the table).
+2. **Economics** — sell/buy/cost_basis/shadow_price for the period.
+3. **Counterfactual & verdict** — the stated alternative, the marginal value vs it,
+   and correct / incorrect / marginal.
+4. **Code anchor** — the function/lines that produced the decision.
+5. **Cross-run note** — only if the user referenced multiple runs.

--- a/.claude/agents/bess-analyst.md
+++ b/.claude/agents/bess-analyst.md
@@ -92,7 +92,7 @@ move." Explain where it happened and WHY runs differ (usually near-threshold
    Never use gross value.
 5. **Cite the code path.** Name the exact function/lines that produced the decision
    (e.g. the discharge gate in `_compute_reward`,
-   `core/bess/dp_battery_algorithm.py:356-389`; cost_basis/shadow_price handling).
+   `core/bess/dp_battery_algorithm.py:361-394`; cost_basis/shadow_price handling).
    No claim without a code or data anchor.
 6. **Cross-run reconciliation.** If the user references multiple runs, says "it
    changed", OR the described behavior differs from the latest run (see HARD

--- a/backend/ai_chat.py
+++ b/backend/ai_chat.py
@@ -748,7 +748,7 @@ class AIAnalystService:
             if export.key_findings:
                 from core.bess.debug_report_formatter import DebugReportFormatter
 
-                sections.append(DebugReportFormatter()._format_key_findings(export))
+                sections.append(DebugReportFormatter().format_key_findings(export))
 
             # System info (tiny)
             sections.append(

--- a/backend/ai_chat.py
+++ b/backend/ai_chat.py
@@ -744,6 +744,12 @@ class AIAnalystService:
 
             sections = []
 
+            # Key findings — prepend at start so the model sees them first.
+            if export.key_findings:
+                from core.bess.debug_report_formatter import DebugReportFormatter
+
+                sections.append(DebugReportFormatter()._format_key_findings(export))
+
             # System info (tiny)
             sections.append(
                 f"## System\nVersion: {export.bess_version}, "
@@ -886,23 +892,9 @@ class AIAnalystService:
                     )
                 sections.append("\n".join(rows))
 
-            # Logs — key events only, capped
-            if (
-                export.todays_log_content
-                and "not found" not in export.todays_log_content.lower()
-            ):
-                log_lines = export.todays_log_content.split("\n")
-                # Cap at 200 lines to stay within budget.
-                if len(log_lines) > 200:
-                    log_lines = log_lines[-200:]
-                    sections.append(
-                        f"## Logs (last 200 of {len(export.todays_log_content.splitlines())} lines)\n"
-                        f"```\n{chr(10).join(log_lines)}\n```"
-                    )
-                else:
-                    sections.append(
-                        f"## Logs ({len(log_lines)} lines)\n```\n{chr(10).join(log_lines)}\n```"
-                    )
+            # Raw log dump intentionally excluded from chat context.
+            # Key findings (above) surface the relevant anomalies in a
+            # structured, token-efficient form.
 
             markdown = "\n\n".join(sections)
 
@@ -916,7 +908,7 @@ class AIAnalystService:
             summary = (
                 f"Loaded: {period_count} historical periods, "
                 f"{schedule_count} schedule(s), "
-                f"health, settings, logs "
+                f"health, settings, key findings "
                 f"({len(markdown) // 1000}KB)"
             )
 

--- a/backend/tests/test_ai_chat.py
+++ b/backend/tests/test_ai_chat.py
@@ -1,8 +1,9 @@
 """Tests for AIAnalystService — the in-app AI chat backend.
 
 Covers: service init, status reporting, session lifecycle, message trimming,
-session expiry, SSE formatting, system prompt loading, and tool execution
-(read_file, search_code, list_files) including path sandboxing.
+session expiry, SSE formatting, system prompt loading, tool execution
+(read_file, search_code, list_files) including path sandboxing, and the
+_gather_context method (key findings inclusion, raw log exclusion).
 """
 
 import asyncio
@@ -456,3 +457,86 @@ class TestTrimMessagesWithTools:
         assert len(session.messages) == 2
         assert session.messages[0]["content"] == "question 1"
         assert session.messages[1]["content"] == "Here is the answer."
+
+
+# ---------------------------------------------------------------------------
+# _gather_context — key findings and log exclusion
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_export(key_findings=None, log_content="") -> MagicMock:
+    """Return a minimal MagicMock DebugDataExport with explicit field values."""
+    export = MagicMock()
+    export.bess_version = "9.9.0-test"
+    export.system_uptime_hours = 12.0
+    export.timezone = "Europe/Brussels"
+    export.health_check_results = {"checks": []}
+    export.battery_settings = {}
+    export.price_settings = {}
+    export.home_settings = {}
+    export.price_data = None
+    export.entity_snapshot = {}
+    export.inverter_tou_segments = []
+    export.historical_periods = []
+    export.schedules = []
+    export.snapshots = []
+    export.todays_log_content = log_content
+    export.key_findings = key_findings if key_findings is not None else {}
+    return export
+
+
+class TestGatherContext:
+    """Tests for _gather_context focusing on key findings and log handling."""
+
+    def test_key_findings_heading_present_in_context(self):
+        """Key findings section appears at the start of context."""
+        service = _make_service()
+        fake_export = _make_fake_export(key_findings={"clean": True})
+
+        with patch("core.bess.debug_data_exporter.DebugDataAggregator") as mock_agg:
+            mock_agg.return_value.aggregate_all_data.return_value = fake_export
+            ctx, _summary = service._gather_context(MagicMock())
+
+        assert "Key Findings" in ctx
+
+    def test_raw_log_dump_excluded_from_context(self):
+        """Raw todays_log_content is NOT included in the chat context."""
+        service = _make_service()
+        distinctive_log_body = "RAWLOG_SENTINEL_abc123\n" * 5
+        fake_export = _make_fake_export(
+            key_findings={"clean": True},
+            log_content=distinctive_log_body,
+        )
+
+        with patch("core.bess.debug_data_exporter.DebugDataAggregator") as mock_agg:
+            mock_agg.return_value.aggregate_all_data.return_value = fake_export
+            ctx, _summary = service._gather_context(MagicMock())
+
+        assert "RAWLOG_SENTINEL_abc123" not in ctx
+
+    def test_key_findings_appears_before_system_section(self):
+        """Key findings block precedes the System section in context."""
+        service = _make_service()
+        fake_export = _make_fake_export(key_findings={"clean": True})
+
+        with patch("core.bess.debug_data_exporter.DebugDataAggregator") as mock_agg:
+            mock_agg.return_value.aggregate_all_data.return_value = fake_export
+            ctx, _summary = service._gather_context(MagicMock())
+
+        findings_pos = ctx.find("Key Findings")
+        system_pos = ctx.find("## System")
+        assert findings_pos != -1
+        assert system_pos != -1
+        assert findings_pos < system_pos
+
+    def test_summary_mentions_key_findings_not_logs(self):
+        """Summary string references key findings, not raw logs."""
+        service = _make_service()
+        fake_export = _make_fake_export(key_findings={"clean": True})
+
+        with patch("core.bess.debug_data_exporter.DebugDataAggregator") as mock_agg:
+            mock_agg.return_value.aggregate_all_data.return_value = fake_export
+            _ctx, summary = service._gather_context(MagicMock())
+
+        assert "key findings" in summary
+        assert "logs" not in summary

--- a/core/bess/debug_data_exporter.py
+++ b/core/bess/debug_data_exporter.py
@@ -56,6 +56,7 @@ from typing import Any
 
 from . import time_utils
 from .battery_system_manager import BatterySystemManager
+from .debug_findings import build_key_findings
 from .health_check import run_system_health_checks
 
 logger = logging.getLogger(__name__)
@@ -294,6 +295,7 @@ class DebugDataExport:
     todays_log_content: str
     log_file_info: dict
     ha_ws_discovery: dict = field(default_factory=dict)
+    key_findings: dict = field(default_factory=dict)
     compact: bool = True
 
 
@@ -354,7 +356,7 @@ class DebugDataAggregator:
         """
         logger.info("Starting debug data aggregation (compact=%s)", compact)
 
-        return DebugDataExport(
+        export = DebugDataExport(
             export_timestamp=datetime.now().astimezone().isoformat(),
             timezone=self._get_timezone(),
             bess_version=self._get_version(),
@@ -380,6 +382,10 @@ class DebugDataAggregator:
             ha_ws_discovery=self._serialize_ha_ws_discovery(),
             compact=compact,
         )
+        export.key_findings = build_key_findings(
+            export.schedules, export.todays_log_content
+        )
+        return export
 
     def _get_version(self) -> str:
         """Get BESS Manager version.

--- a/core/bess/debug_findings.py
+++ b/core/bess/debug_findings.py
@@ -73,3 +73,56 @@ def summarize_log_anomalies(log_content: str) -> list[LogAnomaly]:
             existing.first_ts = min(existing.first_ts, ts)
             existing.last_ts = max(existing.last_ts, ts)
     return sorted(agg.values(), key=lambda a: a.count, reverse=True)
+
+
+@dataclass
+class SlotDisagreement:
+    period: int
+    time: str
+    occurrences: list[tuple[str, str, float]]  # (timestamp, intent, battery_action)
+    intents: list[str]
+
+
+def _period_to_time(period: int) -> str:
+    return f"{period // 4:02d}:{(period % 4) * 15:02d}"
+
+
+def reconcile_schedules(schedules: list[dict]) -> list[SlotDisagreement]:
+    """Flag slots whose strategic_intent differs across today's runs."""
+    by_period: dict[int, list[tuple[str, str, float]]] = {}
+    for sched in schedules:
+        ts = sched.get("timestamp", "")
+        result = sched.get("optimization_result") or {}
+        for pd in result.get("period_data", []):
+            period = pd.get("period")
+            dec = pd.get("decision") or {}
+            intent = dec.get("strategic_intent")
+            action = dec.get("battery_action") or 0.0
+            if period is None or intent is None:
+                continue
+            by_period.setdefault(period, []).append((ts, intent, action))
+
+    out = []
+    for period in sorted(by_period):
+        occ = by_period[period]
+        intents = sorted({intent for _, intent, _ in occ})
+        if len(intents) > 1:
+            out.append(
+                SlotDisagreement(
+                    period=period,
+                    time=_period_to_time(period),
+                    occurrences=occ,
+                    intents=intents,
+                )
+            )
+    return out
+
+
+def build_key_findings(schedules: list[dict], log_content: str) -> dict:
+    disagreements = reconcile_schedules(schedules)
+    anomalies = summarize_log_anomalies(log_content)
+    return {
+        "disagreements": disagreements,
+        "anomalies": anomalies,
+        "clean": not disagreements and not anomalies,
+    }

--- a/core/bess/debug_findings.py
+++ b/core/bess/debug_findings.py
@@ -1,0 +1,75 @@
+"""Pre-digested findings for the debug bundle / AI-chat context.
+
+Pure functions over already-collected data: the log text and the serialized
+schedules. No I/O. Two consumers render the result (the markdown formatter and the
+AI-chat context builder) so the logic lives here once.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# A categorized, deduplicated log finding.
+@dataclass
+class LogAnomaly:
+    category: str
+    source: str  # "module:line"
+    count: int
+    first_ts: str
+    last_ts: str
+    sample: str
+
+
+_LOG_LINE_RE = re.compile(r"^(\S+ \S+) \| (\w+) \| ([\w.]+:\d+) - (.*)$")
+
+# (category, compiled message/source matcher). First match wins; order matters.
+_CATEGORY_RULES = [
+    (
+        "network",
+        re.compile(
+            r"Max retries|Connection error|Failed to establish a new connection"
+            r"|Failed to load batch data"
+        ),
+    ),
+    (
+        "data_gap",
+        re.compile(r"Historical data unavailable|No InfluxDB data|missing period"),
+    ),
+    (
+        "restart",
+        re.compile(r"Starting BESS Manager|BESS Manager started|Application startup"),
+    ),
+]
+
+
+def _categorize(level: str, message: str) -> str | None:
+    for category, matcher in _CATEGORY_RULES:
+        if matcher.search(message):
+            return category
+    if level == "ERROR":
+        return "runtime_error"
+    return None  # uncategorized WARNING/INFO — not actionable, ignore
+
+
+def summarize_log_anomalies(log_content: str) -> list[LogAnomaly]:
+    """Categorize + deduplicate actionable log lines by (category, source)."""
+    agg: dict[tuple[str, str], LogAnomaly] = {}
+    for line in log_content.splitlines():
+        m = _LOG_LINE_RE.match(line)
+        if not m:
+            continue
+        ts, level, source, message = m.groups()
+        category = _categorize(level, message)
+        if category is None:
+            continue
+        key = (category, source)
+        existing = agg.get(key)
+        if existing is None:
+            agg[key] = LogAnomaly(category, source, 1, ts, ts, message.strip())
+        else:
+            existing.count += 1
+            existing.first_ts = min(existing.first_ts, ts)
+            existing.last_ts = max(existing.last_ts, ts)
+    return sorted(agg.values(), key=lambda a: a.count, reverse=True)

--- a/core/bess/debug_report_formatter.py
+++ b/core/bess/debug_report_formatter.py
@@ -463,7 +463,7 @@ Findings (top) and System Logs (bottom).*
             return summary_text
 
         # Compact: render the latest schedule as a markdown table.
-        # The full JSON still lives in the collapsible for deeper digs.
+        # The full JSON is rendered at the bottom by _format_raw_schedule_json.
         schedule = export.schedules[0]
         opt_period = schedule.get("optimization_period", "?")
         opt_result = schedule.get("optimization_result", {})

--- a/core/bess/debug_report_formatter.py
+++ b/core/bess/debug_report_formatter.py
@@ -28,7 +28,7 @@ class DebugReportFormatter:
         try:
             sections = [
                 self._format_header(export),
-                self._format_key_findings(export),
+                self.format_key_findings(export),
                 self._format_system_info(export),
                 self._format_health_status(export),
                 self._format_settings(export),
@@ -62,7 +62,7 @@ class DebugReportFormatter:
 
 **BESS Version**: {export.bess_version}"""
 
-    def _format_key_findings(self, export: DebugDataExport) -> str:
+    def format_key_findings(self, export: DebugDataExport) -> str:
         kf = export.key_findings or {}
         lines = ["## ⚠️ Key Findings (auto-generated — read first)"]
         if kf.get("clean", False) or (

--- a/core/bess/debug_report_formatter.py
+++ b/core/bess/debug_report_formatter.py
@@ -28,6 +28,7 @@ class DebugReportFormatter:
         try:
             sections = [
                 self._format_header(export),
+                self._format_key_findings(export),
                 self._format_system_info(export),
                 self._format_health_status(export),
                 self._format_settings(export),
@@ -39,6 +40,7 @@ class DebugReportFormatter:
                 self._format_schedules(export),
                 self._format_snapshots(export),
                 self._format_logs(export),
+                self._format_raw_schedule_json(export),
             ]
             return "\n\n".join(sections)
         except Exception as e:
@@ -59,6 +61,35 @@ class DebugReportFormatter:
 **Export Date**: {export.export_timestamp}
 
 **BESS Version**: {export.bess_version}"""
+
+    def _format_key_findings(self, export: DebugDataExport) -> str:
+        kf = export.key_findings or {}
+        lines = ["## ⚠️ Key Findings (auto-generated — read first)"]
+        if kf.get("clean", False) or (
+            not kf.get("disagreements") and not kf.get("anomalies")
+        ):
+            lines.append("\nNo cross-run disagreements or log anomalies detected.")
+            return "\n".join(lines)
+
+        disagreements = kf.get("disagreements", [])
+        if disagreements:
+            lines.append("\n### Cross-run schedule disagreements")
+            for d in disagreements:
+                lines.append(
+                    f"- Period {d.period} ({d.time}): {', '.join(d.intents)} "
+                    f"across {len(d.occurrences)} runs — explain WHY runs differ; "
+                    f"do NOT conclude it didn't happen."
+                )
+
+        anomalies = kf.get("anomalies", [])
+        if anomalies:
+            lines.append("\n### Today's log anomalies (deduplicated)")
+            for a in anomalies:
+                lines.append(
+                    f"- [{a.category}] {a.source} ×{a.count} "  # noqa: RUF001
+                    f"({a.first_ts} → {a.last_ts}): {a.sample}"
+                )
+        return "\n".join(lines)
 
     def _format_system_info(self, export: DebugDataExport) -> str:
         """Format system information section.
@@ -111,7 +142,10 @@ class DebugReportFormatter:
             overall_status = "UNKNOWN"
         critical_count = error_count
 
-        summary = f"""## System Health Status
+        summary = f"""## System Health Status (point-in-time snapshot at export)
+
+*This reflects health at export time only. For problems earlier today, see Key
+Findings (top) and System Logs (bottom).*
 
 **Overall Status**: {overall_status}
 
@@ -426,16 +460,7 @@ class DebugReportFormatter:
 **Last Optimization**: {last}"""
 
         if not export.compact or not export.schedules:
-            details = f"""
-<details>
-<summary>Full Schedule Data ({total} schedules - click to expand)</summary>
-
-```json
-{self._format_json(export.schedules)}
-```
-
-</details>"""
-            return summary_text + details
+            return summary_text
 
         # Compact: render the latest schedule as a markdown table.
         # The full JSON still lives in the collapsible for deeper digs.
@@ -491,21 +516,7 @@ class DebugReportFormatter:
 
         table = "\n".join(rows)
 
-        details = f"""
-<details>
-<summary>Full Schedule JSON (for deep debugging)</summary>
-
-```json
-{self._format_json(export.schedules)}
-```
-
-</details>"""
-
-        return (
-            summary_text
-            + f"\n\n{econ_block}\n\n### Period Decisions\n\n{table}"
-            + details
-        )
+        return summary_text + f"\n\n{econ_block}\n\n### Period Decisions\n\n{table}"
 
     def _format_snapshots(self, export: DebugDataExport) -> str:
         """Format prediction snapshots section with summary.
@@ -618,6 +629,18 @@ class DebugReportFormatter:
 </details>"""
 
         return summary + details
+
+    def _format_raw_schedule_json(self, export: DebugDataExport) -> str:
+        return f"""## Raw Schedule JSON (deep debugging)
+
+<details>
+<summary>Full Schedule JSON (all runs)</summary>
+
+```json
+{self._format_json(export.schedules)}
+```
+
+</details>"""
 
     def _format_json(self, data: Any) -> str:
         """Format data as indented JSON.

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -267,11 +267,16 @@ def _compute_reward(
     - Grid costs applied to energy throughput (what you draw from grid)
     - Cost basis includes BOTH grid costs AND cycle costs for profitability analysis
 
-    PROFITABILITY CHECK:
-    - For any discharge, calculate the value of the discharged energy
-    - Value = max(avoiding grid purchases, grid export revenue)
-    - Discharge only profitable if this value > cost_basis
-    - Must account for discharge efficiency losses
+    PROFITABILITY CHECK (opportunity-cost floor):
+    - A discharge is worthwhile only if its value beats the opportunity cost of
+      the stored kWh — not its sunk cost basis and not zero.
+    - Value = max(avoided grid purchase, grid export revenue), after discharge
+      efficiency.
+    - The effective floor is raised to sell_price whenever upcoming solar will
+      replenish the discharged capacity (replenishment): the kWh could be exported
+      later, so sell_price is its true replacement cost. Since
+      sell_price * efficiency_discharge < sell_price, marginal round-trip and
+      refill trades are correctly blocked.
 
     Example for stored energy costing 2.61/kWh:
     - If buy_price = 2.58, sell_price = 1.81

--- a/core/bess/tests/unit/test_debug_findings.py
+++ b/core/bess/tests/unit/test_debug_findings.py
@@ -1,0 +1,32 @@
+from core.bess.debug_findings import summarize_log_anomalies
+
+SAMPLE_LOG = """2026-06-28 00:16:00 | WARNING | core.bess.battery_system_manager:1439 - Historical data unavailable for period 0 (00:00): No InfluxDB data available
+2026-06-28 00:31:00 | WARNING | core.bess.battery_system_manager:1439 - Historical data unavailable for period 1 (00:15): No InfluxDB data available
+2026-06-28 10:31:00 | ERROR | core.bess.influxdb_helper:519 - Error connecting to InfluxDB: HTTPConnectionPool: Max retries exceeded
+2026-06-28 11:31:00 | ERROR | core.bess.influxdb_helper:519 - Error connecting to InfluxDB: HTTPConnectionPool: Max retries exceeded
+2026-06-28 09:00:00 | INFO | core.bess.app:12 - nothing interesting here
+"""
+
+
+def test_summarize_dedups_by_category_and_source():
+    out = summarize_log_anomalies(SAMPLE_LOG)
+    by_source = {a.source: a for a in out}
+
+    data_gap = by_source["core.bess.battery_system_manager:1439"]
+    assert data_gap.category == "data_gap"
+    assert data_gap.count == 2
+    assert data_gap.first_ts == "2026-06-28 00:16:00"
+    assert data_gap.last_ts == "2026-06-28 00:31:00"
+
+    network = by_source["core.bess.influxdb_helper:519"]
+    assert network.category == "network"
+    assert network.count == 2
+
+
+def test_summarize_ignores_uncategorized_info_lines():
+    out = summarize_log_anomalies(SAMPLE_LOG)
+    assert all("app:12" not in a.source for a in out)
+
+
+def test_summarize_empty_log_returns_empty():
+    assert summarize_log_anomalies("") == []

--- a/core/bess/tests/unit/test_debug_findings.py
+++ b/core/bess/tests/unit/test_debug_findings.py
@@ -1,4 +1,8 @@
-from core.bess.debug_findings import summarize_log_anomalies
+from core.bess.debug_findings import (
+    build_key_findings,
+    reconcile_schedules,
+    summarize_log_anomalies,
+)
 
 SAMPLE_LOG = """2026-06-28 00:16:00 | WARNING | core.bess.battery_system_manager:1439 - Historical data unavailable for period 0 (00:00): No InfluxDB data available
 2026-06-28 00:31:00 | WARNING | core.bess.battery_system_manager:1439 - Historical data unavailable for period 1 (00:15): No InfluxDB data available
@@ -30,3 +34,49 @@ def test_summarize_ignores_uncategorized_info_lines():
 
 def test_summarize_empty_log_returns_empty():
     assert summarize_log_anomalies("") == []
+
+
+def _sched(ts, period, intent, action):
+    return {
+        "timestamp": ts,
+        "optimization_result": {
+            "period_data": [
+                {
+                    "period": period,
+                    "decision": {
+                        "strategic_intent": intent,
+                        "battery_action": action,
+                    },
+                }
+            ]
+        },
+    }
+
+
+def test_reconcile_flags_intent_disagreement_on_same_slot():
+    schedules = [
+        _sched("2026-06-28 10:31:00", 63, "BATTERY_EXPORT", -0.1),
+        _sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0),
+    ]
+    out = reconcile_schedules(schedules)
+    assert len(out) == 1
+    d = out[0]
+    assert d.period == 63
+    assert d.time == "15:45"
+    assert set(d.intents) == {"BATTERY_EXPORT", "SOLAR_EXPORT"}
+
+
+def test_reconcile_no_disagreement_when_all_runs_agree():
+    schedules = [
+        _sched("2026-06-28 10:31:00", 63, "SOLAR_EXPORT", -0.0),
+        _sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0),
+    ]
+    assert reconcile_schedules(schedules) == []
+
+
+def test_build_key_findings_clean_when_nothing_notable():
+    schedules = [_sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0)]
+    result = build_key_findings(schedules, "")
+    assert result["clean"] is True
+    assert result["disagreements"] == []
+    assert result["anomalies"] == []

--- a/core/bess/tests/unit/test_debug_findings.py
+++ b/core/bess/tests/unit/test_debug_findings.py
@@ -80,3 +80,18 @@ def test_build_key_findings_clean_when_nothing_notable():
     assert result["clean"] is True
     assert result["disagreements"] == []
     assert result["anomalies"] == []
+
+
+def test_build_key_findings_surfaces_the_15_45_case():
+    schedules = [
+        _sched("2026-06-28 10:31:00", 63, "BATTERY_EXPORT", -0.1),
+        _sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0),
+    ]
+    log = (
+        "2026-06-28 10:31:00 | ERROR | core.bess.influxdb_helper:519 - "
+        "Error connecting to InfluxDB: Max retries exceeded\n"
+    )
+    result = build_key_findings(schedules, log)
+    assert result["clean"] is False
+    assert result["disagreements"][0].time == "15:45"
+    assert result["anomalies"][0].category == "network"

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -105,7 +105,7 @@ which must still clear the wear cost. A 6 öre differential against a 40 öre we
 cost is a loss, not a 6 öre gain.
 
 **Reconciliation with the code:** `_compute_reward`
-(`core/bess/dp_battery_algorithm.py:356-389`) implements this as an anti-cycling
+(`core/bess/dp_battery_algorithm.py:361-394`) implements this as an anti-cycling
 floor — for a discharge it raises the effective floor to `sell_price` whenever solar
 will replenish the discharged capacity, so `sell × efficiency_discharge < sell ≤
 floor` blocks the trade. The function's older docstring phrasing ("value >

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -78,6 +78,71 @@ period's shadow price is stored on its decision data and is used at apply time
 for the SOLAR_EXPORT discharge gate (below).
 
 
+## The Governing Economic Law (read this first)
+
+Every battery action is judged by its **marginal net value against the next-best
+alternative for that same slot** — never by its gross value, and never against
+"do nothing = 0".
+
+The opportunity cost of a stored kWh is its **forward-looking `shadow_price`** (the
+DP's value-to-go slope), floored by `sell_price` when upcoming solar will replenish
+the battery for free. It is **not** the sunk `cost_basis`, and **not** zero.
+
+Operational forms of the one law:
+
+- **Discharge to grid** is worthwhile only if
+  `sell_price × efficiency_discharge > opportunity_cost_of_stored_kWh`.
+- **Discharge to cover home load** is worthwhile only if it beats the cheapest
+  alternative for that kWh (usually a future avoided import at a higher buy price).
+- **Charge** is worthwhile only if the stored kWh's future value exceeds what it
+  cost to store it (grid/solar cost + wear).
+
+The classic error this prevents: treating `sell_price > wear_cost` as "profitable".
+That compares gross sale value to wear and ignores the counterfactual. If the real
+alternative is "let solar keep charging one more slot and export one slot earlier",
+the value captured is only the **differential** in sell price between the two slots,
+which must still clear the wear cost. A 6 öre differential against a 40 öre wear
+cost is a loss, not a 6 öre gain.
+
+**Reconciliation with the code:** `_compute_reward`
+(`core/bess/dp_battery_algorithm.py:356-389`) implements this as an anti-cycling
+floor — for a discharge it raises the effective floor to `sell_price` whenever solar
+will replenish the discharged capacity, so `sell × efficiency_discharge < sell ≤
+floor` blocks the trade. The function's older docstring phrasing ("value >
+cost_basis") describes that floor's implementation, not the user-facing law above.
+
+### Facts vs Economics — where each lives in a debug bundle
+
+Answer "what happened" and "why" from different parts of the bundle, in that order:
+
+- **Facts (what happened):** `## Optimization Schedules → ### Period Decisions`
+  table. Columns: `Intent | Observed | BattAct | SOE start→end | BuyPrice |
+  Savings`. A negative `BattAct` with a falling `SOE` is a battery discharge — read
+  this before proposing any mechanism. Solar-only export shows `BattAct ≈ 0`.
+- **Economics (why):** the Full Schedule JSON `<details>` block — `sell_price`,
+  `buy_price`, `cost_basis`, `shadow_price` per period — plus `### Economic Summary`.
+- **Period ↔ clock time:** slots are 15 minutes. Map the question's clock time to a
+  period number and confirm it. Watch the off-by-one: the price shown for 15:45 is
+  the 15:45 slot's price, not 16:00's.
+
+### Illustrative: applying the law (method demo, not a lookup)
+
+*Illustrative only — the method generalizes to any period. Do not pattern-match the
+scenario; reproduce the reasoning steps.*
+
+A battery discharges a small amount to grid in a slot where `sell = 0.46`,
+`wear = 0.40`.
+
+- **Wrong (gross):** `0.46 > 0.40 → +6 öre, profitable.`
+- **Right (marginal):** the alternative is to let solar charge one more slot and
+  export one slot earlier, so only the sell-price *differential* (~0.06) is gained,
+  against 0.40 wear ⇒ ≈ `−0.34 SEK/kWh`, a loss. Equivalently: `shadow_price` (e.g.
+  0.876) and `cost_basis` (e.g. 0.62) both exceed `sell 0.46`, so the stored kWh is
+  worth more kept than exported ⇒ do not discharge.
+- If different optimization runs disagree on such a near-threshold slot, the cause
+  is `shadow_price` sensitivity across re-optimizations, not a missing mechanism.
+
+
 ## Strategic Intents
 
 Every 15-minute slot gets a strategic intent based on the energy flows the
@@ -156,11 +221,9 @@ The optimizer works with buy and sell prices derived from spot prices:
 
 For Octopus Energy (UK), prices are already final — no markup/VAT applied.
 
-A discharge is profitable when:
-    sell_price (or avoided buy_price) > cost_basis + cycle_cost
-
-Where cost_basis is the price at which the energy was originally stored
-(tracked via FIFO), and cycle_cost is the battery wear cost per kWh.
+For when a discharge is worthwhile, see **The Governing Economic Law** above —
+gross `sell_price` vs `cycle_cost` is *not* the test; marginal value vs the
+counterfactual is.
 
 
 ## Energy Flow Decomposition

--- a/docs/superpowers/plans/2026-06-28-bess-analyst-decision-rationale.md
+++ b/docs/superpowers/plans/2026-06-28-bess-analyst-decision-rationale.md
@@ -1,0 +1,362 @@
+# BESS Analyst Decision-Rationale Expertise — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `bess-analyst` agent answer optimization-rationale questions
+correctly and completely on the first invocation, by fixing the economics
+knowledge it relies on and giving it a mandatory evidence-first reasoning protocol.
+
+**Architecture:** Documentation + agent-prompt changes only, in three layers:
+(1) rewrite the economics in the shared knowledge doc to one governing
+opportunity-cost law; (2) add a routing step + ordered Decision-Rationale Protocol
+to the agent file; (3) correct contradictory in-code docstrings so code and docs
+agree. No optimizer behavior changes.
+
+**Tech Stack:** Markdown (knowledge doc, agent file), Python docstrings/comments
+(`core/bess/`). No new dependencies.
+
+## Global Constraints
+
+- **No behavior change to the optimizer.** Part 4 edits are comment/docstring-only.
+  Do not alter any computation in `core/bess/`.
+- **One governing law, stated verbatim** everywhere economics are described: *an
+  action's value is its marginal net value vs the next-best alternative; the
+  opportunity cost of a stored kWh is its forward-looking `shadow_price` (floored by
+  `sell_price` under solar replenishment), never the sunk `cost_basis`, never zero.*
+- **No canonical scenario library, no CI fixture.** The single illustrative example
+  must be labelled non-canonical. Validation is a manual agent re-run.
+- Run `./scripts/quality-check.sh` before any commit that touches `core/bess/`
+  (per repo convention — Black formatting is the most common CI failure).
+- Spec: `docs/superpowers/specs/2026-06-28-bess-analyst-decision-rationale-design.md`.
+
+---
+
+## File Structure
+
+- `docs/agents/bess-knowledge.md` — economics section rewritten (Task 1). Shared by
+  the in-app AI chat and the analyst agent.
+- `.claude/agents/bess-analyst.md` — routing step, Decision-Rationale Protocol,
+  anti-patterns, output template (Task 2).
+- `core/bess/dp_battery_algorithm.py` — docstring/comment corrections (Task 3).
+- Other `core/bess/` files (`decision_intelligence.py`, `models.py`) — comment-only
+  corrections if the grep in Task 3 finds the naive framing.
+
+---
+
+### Task 1: Rewrite the economics in the knowledge doc
+
+**Files:**
+- Modify: `docs/agents/bess-knowledge.md` (delete lines 159-163; add governing-law
+  section, facts-vs-economics map, illustrative example)
+
+**Interfaces:**
+- Produces: the canonical wording of the governing law that Task 2 (agent protocol)
+  and Task 3 (code docstrings) must match verbatim.
+
+- [ ] **Step 1: Delete the contradictory naive formula.**
+
+Remove this block (currently `bess-knowledge.md:159-163`):
+
+```
+A discharge is profitable when:
+    sell_price (or avoided buy_price) > cost_basis + cycle_cost
+
+Where cost_basis is the price at which the energy was originally stored
+(tracked via FIFO), and cycle_cost is the battery wear cost per kWh.
+```
+
+- [ ] **Step 2: Add the governing-law section.**
+
+Insert a new section immediately after `## The Dynamic Programming Algorithm`
+(before `## Strategic Intents`):
+
+```markdown
+## The Governing Economic Law (read this first)
+
+Every battery action is judged by its **marginal net value against the next-best
+alternative for that same slot** — never by its gross value, and never against
+"do nothing = 0".
+
+The opportunity cost of a stored kWh is its **forward-looking `shadow_price`** (the
+DP's value-to-go slope), floored by `sell_price` when upcoming solar will replenish
+the battery for free. It is **not** the sunk `cost_basis`, and **not** zero.
+
+Operational forms of the one law:
+
+- **Discharge to grid** is worthwhile only if
+  `sell_price × efficiency_discharge > opportunity_cost_of_stored_kWh`.
+- **Discharge to cover home load** is worthwhile only if it beats the cheapest
+  alternative for that kWh (usually a future avoided import at a higher buy price).
+- **Charge** is worthwhile only if the stored kWh's future value exceeds what it
+  cost to store it (grid/solar cost + wear).
+
+The classic error this prevents: treating `sell_price > wear_cost` as "profitable".
+That compares gross sale value to wear and ignores the counterfactual. If the real
+alternative is "let solar keep charging one more slot and export one slot earlier",
+the value captured is only the **differential** in sell price between the two slots,
+which must still clear the wear cost. A 6 öre differential against a 40 öre wear
+cost is a loss, not a 6 öre gain.
+
+**Reconciliation with the code:** `_compute_reward`
+(`core/bess/dp_battery_algorithm.py:356-389`) implements this as an anti-cycling
+floor — for a discharge it raises the effective floor to `sell_price` whenever solar
+will replenish the discharged capacity, so `sell × efficiency_discharge < sell ≤
+floor` blocks the trade. The function's older docstring phrasing ("value >
+cost_basis") describes that floor's implementation, not the user-facing law above.
+```
+
+- [ ] **Step 3: Add the facts-vs-economics bundle map.**
+
+Append this subsection to the new section (or directly after it):
+
+```markdown
+### Facts vs Economics — where each lives in a debug bundle
+
+Answer "what happened" and "why" from different parts of the bundle, in that order:
+
+- **Facts (what happened):** `## Optimization Schedules → ### Period Decisions`
+  table. Columns: `Intent | Observed | BattAct | SOE start→end | BuyPrice |
+  Savings`. A negative `BattAct` with a falling `SOE` is a battery discharge — read
+  this before proposing any mechanism. Solar-only export shows `BattAct ≈ 0`.
+- **Economics (why):** the Full Schedule JSON `<details>` block — `sell_price`,
+  `buy_price`, `cost_basis`, `shadow_price` per period — plus `### Economic Summary`.
+- **Period ↔ clock time:** slots are 15 minutes. Map the question's clock time to a
+  period number and confirm it. Watch the off-by-one: the price shown for 15:45 is
+  the 15:45 slot's price, not 16:00's.
+```
+
+- [ ] **Step 4: Add the single illustrative example.**
+
+Append:
+
+```markdown
+### Illustrative: applying the law (method demo, not a lookup)
+
+*Illustrative only — the method generalizes to any period. Do not pattern-match the
+scenario; reproduce the reasoning steps.*
+
+A battery discharges a small amount to grid in a slot where `sell = 0.46`,
+`wear = 0.40`.
+
+- **Wrong (gross):** `0.46 > 0.40 → +6 öre, profitable.`
+- **Right (marginal):** the alternative is to let solar charge one more slot and
+  export one slot earlier, so only the sell-price *differential* (~0.06) is gained,
+  against 0.40 wear ⇒ ≈ `−0.34 SEK/kWh`, a loss. Equivalently: `shadow_price` (e.g.
+  0.876) and `cost_basis` (e.g. 0.62) both exceed `sell 0.46`, so the stored kWh is
+  worth more kept than exported ⇒ do not discharge.
+- If different optimization runs disagree on such a near-threshold slot, the cause
+  is `shadow_price` sensitivity across re-optimizations, not a missing mechanism.
+```
+
+- [ ] **Step 5: Verify the doc is internally consistent.**
+
+Run: `grep -n "profitable when\|cost_basis + cycle_cost\|shadow_price\|Governing Economic Law" docs/agents/bess-knowledge.md`
+Expected: the deleted naive formula no longer appears; the governing-law section and
+shadow_price references are present.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add docs/agents/bess-knowledge.md
+git commit -m "docs: state one governing opportunity-cost law in bess-knowledge"
+```
+
+---
+
+### Task 2: Add the Decision-Rationale Protocol to the agent
+
+**Files:**
+- Modify: `.claude/agents/bess-analyst.md` (add routing step before "Analysis
+  Process"; add protocol, anti-patterns, output template)
+
+**Interfaces:**
+- Consumes: the governing-law wording from Task 1 (reference it, do not restate a
+  different version).
+
+- [ ] **Step 1: Add a question-routing step.**
+
+Insert immediately before `## Analysis Process`:
+
+```markdown
+## FIRST: Route the question
+
+Classify before doing anything else:
+
+- **(A) Something is broken / discovery / sensors / integration** → use the
+  Analysis Process below.
+- **(B) Why did the optimizer decide X / is decision X correct / savings
+  rationale** → use the **Decision-Rationale Protocol** below. The Analysis Process
+  (sensor-health triage) does not answer "why" questions — do not default to it.
+```
+
+- [ ] **Step 2: Add the Decision-Rationale Protocol.**
+
+Insert after the routing step:
+
+```markdown
+## Decision-Rationale Protocol (for type-B questions)
+
+The governing economic law is in `docs/agents/bess-knowledge.md` — read it first.
+Then follow these steps in order. Each step is checkable; do not skip ahead.
+
+1. **Pin the period.** Convert the clock time in the question to a period number and
+   slot; state both. Guard the off-by-one (15-min slots).
+2. **Facts before narrative.** Read that period's row in `### Period Decisions`.
+   Quote `Intent`, `BattAct` (sign + magnitude), and `SOE start→end`. Answer the
+   literal "what happened" (battery discharge vs solar surplus) from this row
+   alone. Do not propose a mechanism yet. A negative `BattAct` with falling `SOE`
+   IS a battery discharge — never call it solar surplus.
+3. **Pull the economics.** From the Full Schedule JSON for that period, quote
+   `sell_price`, `buy_price`, `cost_basis`, `shadow_price`. Add relevant totals from
+   `### Economic Summary`.
+4. **Apply the governing law.** State the counterfactual explicitly ("the
+   alternative to this action was ___"). Compute marginal value vs that
+   counterfactual using opportunity cost = `shadow_price` (floored by `sell_price`
+   under solar replenishment). Verdict: correct / incorrect / marginal-and-why.
+   Never use gross value.
+5. **Cite the code path.** Name the exact function/lines that produced the decision
+   (e.g. the discharge gate in `_compute_reward`,
+   `core/bess/dp_battery_algorithm.py:356-389`; cost_basis/shadow_price handling).
+   No claim without a code or data anchor.
+6. **Cross-run reconciliation.** If the user references multiple runs or "it
+   changed", diff the period's economics across the runs in the bundle and attribute
+   the change to a specific input delta (initial SOC / price update / forecast).
+7. **Self-check gate before emitting.** Confirm: (a) every factual claim matches the
+   quoted table row; (b) you stated a counterfactual and used marginal — not gross —
+   value; (c) the mechanism has a code/data anchor; (d) you answered the literal
+   question. Any miss → redo. Do not emit until all four hold.
+
+### Anti-patterns (do not do these)
+
+- Answering "solar surplus vs battery" from a narrative instead of reading
+  `BattAct`/`SOE` first.
+- Calling a discharge profitable because `sell_price > wear_cost`. That is gross
+  value; compute marginal value vs the counterfactual.
+- Claiming a mechanism is "missing" before grepping the optimizer for it (e.g. the
+  anti-cycling floor already exists in `_compute_reward`).
+```
+
+- [ ] **Step 3: Add the decision-rationale output template.**
+
+Append to the `## Output Format` section:
+
+```markdown
+### For type-B (decision-rationale) answers, use this shape:
+
+1. **Facts** — period, Intent, BattAct, SOE start→end (quoted from the table).
+2. **Economics** — sell/buy/cost_basis/shadow_price for the period.
+3. **Counterfactual & verdict** — the stated alternative, the marginal value vs it,
+   and correct / incorrect / marginal.
+4. **Code anchor** — the function/lines that produced the decision.
+5. **Cross-run note** — only if the user referenced multiple runs.
+```
+
+- [ ] **Step 4: Verify the agent file.**
+
+Run: `grep -n "Route the question\|Decision-Rationale Protocol\|Anti-patterns\|Counterfactual" .claude/agents/bess-analyst.md`
+Expected: routing step, protocol, anti-patterns, and output template all present.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add .claude/agents/bess-analyst.md
+git commit -m "docs: add evidence-first decision-rationale protocol to bess-analyst"
+```
+
+---
+
+### Task 3: Correct contradictory in-code documentation
+
+**Files:**
+- Modify: `core/bess/dp_battery_algorithm.py` (docstring/comments only)
+- Modify (if grep hits): `core/bess/decision_intelligence.py`, `core/bess/models.py`
+
+**Interfaces:**
+- Consumes: the governing-law wording from Task 1.
+
+- [ ] **Step 1: Find all naive-framing docstrings/comments.**
+
+Run: `grep -rn "profitable if\|value > cost_basis\|sell_price > cost_basis\|profitability" core/bess/dp_battery_algorithm.py core/bess/decision_intelligence.py core/bess/models.py`
+Expected: hits in the `_compute_reward` docstring (~lines 262-284) and possibly the
+module docstring (~lines 19-50). Note every hit before editing.
+
+- [ ] **Step 2: Reword the `_compute_reward` docstring.**
+
+In `core/bess/dp_battery_algorithm.py`, replace the `PROFITABILITY CHECK` paragraph
+of the `_compute_reward` docstring so it describes the opportunity-cost floor the
+code actually applies. New text:
+
+```
+    PROFITABILITY CHECK (opportunity-cost floor):
+    - A discharge is worthwhile only if its value beats the opportunity cost of
+      the stored kWh — not its sunk cost basis and not zero.
+    - Value = max(avoided grid purchase, grid export revenue), after discharge
+      efficiency.
+    - The effective floor is raised to sell_price whenever upcoming solar will
+      replenish the discharged capacity (replenishment): the kWh could be exported
+      later, so sell_price is its true replacement cost. Since
+      sell_price * efficiency_discharge < sell_price, marginal round-trip and
+      refill trades are correctly blocked.
+```
+
+Keep the numeric example below it; it is still valid.
+
+- [ ] **Step 3: Reconcile the module docstring and inline comments.**
+
+Read the module docstring (~lines 19-50) and the inline anti-cycling comments
+(~lines 361-375). Where wording implies gross value or `cost_basis`-only reasoning,
+adjust it to match the governing law. Do not change any code or numbers.
+
+- [ ] **Step 4: Fix any other files flagged by Step 1.**
+
+For each hit in `decision_intelligence.py` / `models.py`, correct comment/docstring
+wording to match the governing law. Comment-only; no logic changes.
+
+- [ ] **Step 5: Verify no behavior changed.**
+
+Run: `git diff --stat core/bess/` (confirm only the intended files changed) and
+`./scripts/quality-check.sh`
+Expected: quality check passes; diff shows comment/docstring lines only.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add core/bess/
+git commit -m "docs: align optimizer docstrings with the governing opportunity-cost law"
+```
+
+---
+
+### Task 4: Validate via manual agent re-run
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Re-invoke the analyst on a representative bundle.**
+
+Using a real debug bundle (e.g. `bess-debug-2026-06-28-113159.md` referenced in
+`docs/dialogue.txt`, or any current bundle), invoke the `bess-analyst` agent with
+the original question from `docs/dialogue.txt` (the 15:45 battery-export question).
+
+- [ ] **Step 2: Confirm first-attempt correctness, no pushback.**
+
+The answer must, on the first attempt:
+1. identify a battery discharge (negative `BattAct`, falling `SOE`), not solar surplus;
+2. reject the gross "6 öre" framing and give the marginal verdict
+   (`shadow_price > sell_price` ⇒ discharging is a loss);
+3. cite `_compute_reward`;
+4. name cross-run `shadow_price` volatility as the real issue.
+
+If it fails any point, capture which step of the protocol was skipped and refine the
+relevant doc/agent wording (Tasks 1-2), then re-run. This is a judgement check on
+representative cases, not a pinned regression test.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Part 1 → Task 1; Parts 2 & 3 → Task 2; Part 4 → Task 3;
+  Validation → Task 4. All spec sections covered.
+- **Placeholder scan:** no TBD/TODO; every doc edit shows the actual text to insert.
+- **Consistency:** the governing-law wording is authored once in Task 1 and
+  referenced (not re-forked) by Tasks 2 and 3; the `_compute_reward:356-389` anchor
+  is used identically in the knowledge doc, the agent protocol, and the validation.

--- a/docs/superpowers/plans/2026-06-28-debug-bundle-key-findings.md
+++ b/docs/superpowers/plans/2026-06-28-debug-bundle-key-findings.md
@@ -1,0 +1,578 @@
+# Debug Bundle Key-Findings Section — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface pre-digested conclusions (cross-run schedule disagreements + a
+deduplicated log-anomaly rollup) at the TOP of the debug bundle and the AI-chat
+context, and demote raw logs/JSON to the bottom — so agents and the in-app chat stop
+anchoring on the latest run and the green health snapshot.
+
+**Architecture:** One new data-layer module `core/bess/debug_findings.py` computes
+findings from structured schedule data (`export.schedules`, already all runs) and the
+log text (`export.todays_log_content`). Two thin renderers consume it:
+`debug_report_formatter.py` (markdown bundle) and `backend/ai_chat.py` (chat context).
+No optimizer behavior changes.
+
+**Tech Stack:** Python 3 (stdlib only — `dataclasses`, `re`), pytest. No new deps.
+
+## Global Constraints
+
+- **No optimizer behavior change.** This plan only adds reporting/aggregation.
+- **Findings are derived, deduplicated data** — group by `(category, module:line)`;
+  never emit raw per-line counts (220 "restart" hits are one repeated warning).
+- **Log anomalies come from `export.todays_log_content`**, NOT the runtime failure
+  tracker (unreliable, not exported).
+- **Cross-run reconciliation comes from `export.schedules`** — the exporter already
+  serializes ALL of today's runs there via `get_all_schedules_today()` + `asdict`.
+- **Always-on, self-suppressing:** the Key Findings section renders every time; when
+  there is nothing notable it says so explicitly ("No anomalies… detected").
+- Run `.venv/bin/pytest -m "not slow"` and `./scripts/quality-check.sh` before any
+  commit (Black formatting is the most common CI failure).
+- Spec: `docs/superpowers/specs/2026-06-28-bess-analyst-decision-rationale-design.md`
+  (Part 5).
+
+---
+
+## File Structure
+
+- `core/bess/debug_findings.py` — NEW. Dataclasses + `summarize_log_anomalies`,
+  `reconcile_schedules`, `build_key_findings`. Pure functions, no I/O.
+- `core/bess/tests/unit/test_debug_findings.py` — NEW. Unit tests for the above.
+- `core/bess/debug_data_exporter.py` — add `key_findings` field to `DebugDataExport`
+  and populate it in `aggregate_all_data`.
+- `core/bess/debug_report_formatter.py` — render `_format_key_findings` first;
+  caption the health snapshot; move full schedule JSON to the bottom.
+- `backend/ai_chat.py` — include findings text in `_gather_context`; exclude raw log
+  dump.
+
+---
+
+### Task 1: Log-anomaly aggregation (`debug_findings.py`)
+
+**Files:**
+- Create: `core/bess/debug_findings.py`
+- Test: `core/bess/tests/unit/test_debug_findings.py`
+
+**Interfaces:**
+- Produces:
+  - `@dataclass LogAnomaly(category: str, source: str, count: int, first_ts: str,
+    last_ts: str, sample: str)`
+  - `summarize_log_anomalies(log_content: str) -> list[LogAnomaly]`
+
+- [ ] **Step 1: Write the failing test.**
+
+```python
+# core/bess/tests/unit/test_debug_findings.py
+from core.bess.debug_findings import LogAnomaly, summarize_log_anomalies
+
+SAMPLE_LOG = """2026-06-28 00:16:00 | WARNING | core.bess.battery_system_manager:1439 - Historical data unavailable for period 0 (00:00): No InfluxDB data available
+2026-06-28 00:31:00 | WARNING | core.bess.battery_system_manager:1439 - Historical data unavailable for period 1 (00:15): No InfluxDB data available
+2026-06-28 10:31:00 | ERROR | core.bess.influxdb_helper:519 - Error connecting to InfluxDB: HTTPConnectionPool: Max retries exceeded
+2026-06-28 11:31:00 | ERROR | core.bess.influxdb_helper:519 - Error connecting to InfluxDB: HTTPConnectionPool: Max retries exceeded
+2026-06-28 09:00:00 | INFO | core.bess.app:12 - nothing interesting here
+"""
+
+
+def test_summarize_dedups_by_category_and_source():
+    out = summarize_log_anomalies(SAMPLE_LOG)
+    by_source = {a.source: a for a in out}
+
+    data_gap = by_source["core.bess.battery_system_manager:1439"]
+    assert data_gap.category == "data_gap"
+    assert data_gap.count == 2
+    assert data_gap.first_ts == "2026-06-28 00:16:00"
+    assert data_gap.last_ts == "2026-06-28 00:31:00"
+
+    network = by_source["core.bess.influxdb_helper:519"]
+    assert network.category == "network"
+    assert network.count == 2
+
+
+def test_summarize_ignores_uncategorized_info_lines():
+    out = summarize_log_anomalies(SAMPLE_LOG)
+    assert all("app:12" not in a.source for a in out)
+
+
+def test_summarize_empty_log_returns_empty():
+    assert summarize_log_anomalies("") == []
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_debug_findings.py -q`
+Expected: FAIL — `ModuleNotFoundError: core.bess.debug_findings`.
+
+- [ ] **Step 3: Implement the minimal code.**
+
+```python
+# core/bess/debug_findings.py
+"""Pre-digested findings for the debug bundle / AI-chat context.
+
+Pure functions over already-collected data: the log text and the serialized
+schedules. No I/O. Two consumers render the result (the markdown formatter and the
+AI-chat context builder) so the logic lives here once.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# A categorized, deduplicated log finding.
+@dataclass
+class LogAnomaly:
+    category: str
+    source: str  # "module:line"
+    count: int
+    first_ts: str
+    last_ts: str
+    sample: str
+
+
+_LOG_LINE_RE = re.compile(r"^(\S+ \S+) \| (\w+) \| ([\w.]+:\d+) - (.*)$")
+
+# (category, compiled message/source matcher). First match wins; order matters.
+_CATEGORY_RULES = [
+    ("network", re.compile(
+        r"Max retries|Connection error|Failed to establish a new connection"
+        r"|Failed to load batch data")),
+    ("data_gap", re.compile(
+        r"Historical data unavailable|No InfluxDB data|missing period")),
+    ("restart", re.compile(
+        r"Starting BESS Manager|BESS Manager started|Application startup")),
+]
+
+
+def _categorize(level: str, message: str) -> str | None:
+    for category, matcher in _CATEGORY_RULES:
+        if matcher.search(message):
+            return category
+    if level == "ERROR":
+        return "runtime_error"
+    return None  # uncategorized WARNING/INFO — not actionable, ignore
+
+
+def summarize_log_anomalies(log_content: str) -> list[LogAnomaly]:
+    """Categorize + deduplicate actionable log lines by (category, source)."""
+    agg: dict[tuple[str, str], LogAnomaly] = {}
+    for line in log_content.splitlines():
+        m = _LOG_LINE_RE.match(line)
+        if not m:
+            continue
+        ts, level, source, message = m.groups()
+        category = _categorize(level, message)
+        if category is None:
+            continue
+        key = (category, source)
+        existing = agg.get(key)
+        if existing is None:
+            agg[key] = LogAnomaly(category, source, 1, ts, ts, message.strip())
+        else:
+            existing.count += 1
+            existing.first_ts = min(existing.first_ts, ts)
+            existing.last_ts = max(existing.last_ts, ts)
+    return sorted(agg.values(), key=lambda a: a.count, reverse=True)
+```
+
+- [ ] **Step 4: Run the tests.**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_debug_findings.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add core/bess/debug_findings.py core/bess/tests/unit/test_debug_findings.py
+git commit -m "feat: deduplicated log-anomaly aggregation for debug findings"
+```
+
+---
+
+### Task 2: Cross-run reconciliation + `build_key_findings`
+
+**Files:**
+- Modify: `core/bess/debug_findings.py`
+- Modify: `core/bess/tests/unit/test_debug_findings.py`
+
+**Interfaces:**
+- Consumes: `LogAnomaly`, `summarize_log_anomalies` (Task 1).
+- Produces:
+  - `@dataclass SlotDisagreement(period: int, time: str,
+    occurrences: list[tuple[str, str, float]], intents: list[str])`
+    where each occurrence is `(schedule_timestamp, strategic_intent, battery_action)`.
+  - `reconcile_schedules(schedules: list[dict]) -> list[SlotDisagreement]`
+  - `build_key_findings(schedules: list[dict], log_content: str) -> dict`
+    returning `{"disagreements": [...], "anomalies": [...], "clean": bool}`.
+
+`schedules` is `export.schedules`: a list of dicts, each
+`{"timestamp": str, "optimization_result": {"period_data": [
+{"period": int, "decision": {"strategic_intent": str, "battery_action": float}}, ...]}}`.
+
+- [ ] **Step 1: Write the failing test.**
+
+```python
+from core.bess.debug_findings import (
+    SlotDisagreement,
+    build_key_findings,
+    reconcile_schedules,
+)
+
+
+def _sched(ts, period, intent, action):
+    return {
+        "timestamp": ts,
+        "optimization_result": {
+            "period_data": [
+                {"period": period, "decision": {
+                    "strategic_intent": intent, "battery_action": action}}
+            ]
+        },
+    }
+
+
+def test_reconcile_flags_intent_disagreement_on_same_slot():
+    schedules = [
+        _sched("2026-06-28 10:31:00", 63, "BATTERY_EXPORT", -0.1),
+        _sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0),
+    ]
+    out = reconcile_schedules(schedules)
+    assert len(out) == 1
+    d = out[0]
+    assert d.period == 63
+    assert d.time == "15:45"
+    assert set(d.intents) == {"BATTERY_EXPORT", "SOLAR_EXPORT"}
+
+
+def test_reconcile_no_disagreement_when_all_runs_agree():
+    schedules = [
+        _sched("2026-06-28 10:31:00", 63, "SOLAR_EXPORT", -0.0),
+        _sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0),
+    ]
+    assert reconcile_schedules(schedules) == []
+
+
+def test_build_key_findings_clean_when_nothing_notable():
+    schedules = [_sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0)]
+    result = build_key_findings(schedules, "")
+    assert result["clean"] is True
+    assert result["disagreements"] == []
+    assert result["anomalies"] == []
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_debug_findings.py -q`
+Expected: FAIL — `ImportError: cannot import name 'reconcile_schedules'`.
+
+- [ ] **Step 3: Implement.**
+
+```python
+# add to core/bess/debug_findings.py
+
+@dataclass
+class SlotDisagreement:
+    period: int
+    time: str
+    occurrences: list[tuple[str, str, float]]  # (timestamp, intent, battery_action)
+    intents: list[str]
+
+
+def _period_to_time(period: int) -> str:
+    return f"{period // 4:02d}:{(period % 4) * 15:02d}"
+
+
+def reconcile_schedules(schedules: list[dict]) -> list[SlotDisagreement]:
+    """Flag slots whose strategic_intent differs across today's runs."""
+    by_period: dict[int, list[tuple[str, str, float]]] = {}
+    for sched in schedules:
+        ts = sched.get("timestamp", "")
+        result = sched.get("optimization_result") or {}
+        for pd in result.get("period_data", []):
+            period = pd.get("period")
+            dec = pd.get("decision") or {}
+            intent = dec.get("strategic_intent")
+            action = dec.get("battery_action") or 0.0
+            if period is None or intent is None:
+                continue
+            by_period.setdefault(period, []).append((ts, intent, action))
+
+    out = []
+    for period in sorted(by_period):
+        occ = by_period[period]
+        intents = sorted({intent for _, intent, _ in occ})
+        if len(intents) > 1:
+            out.append(
+                SlotDisagreement(
+                    period=period,
+                    time=_period_to_time(period),
+                    occurrences=occ,
+                    intents=intents,
+                )
+            )
+    return out
+
+
+def build_key_findings(schedules: list[dict], log_content: str) -> dict:
+    disagreements = reconcile_schedules(schedules)
+    anomalies = summarize_log_anomalies(log_content)
+    return {
+        "disagreements": disagreements,
+        "anomalies": anomalies,
+        "clean": not disagreements and not anomalies,
+    }
+```
+
+- [ ] **Step 4: Run the tests.**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_debug_findings.py -q`
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add core/bess/debug_findings.py core/bess/tests/unit/test_debug_findings.py
+git commit -m "feat: cross-run schedule reconciliation + build_key_findings"
+```
+
+---
+
+### Task 3: Populate `key_findings` in the exporter
+
+**Files:**
+- Modify: `core/bess/debug_data_exporter.py` (`DebugDataExport` dataclass ~line 287;
+  `aggregate_all_data` ~line 374)
+- Test: `core/bess/tests/unit/test_debug_findings.py` (one integration-style test)
+
+**Interfaces:**
+- Consumes: `build_key_findings` (Task 2).
+- Produces: `DebugDataExport.key_findings: dict` populated from `self.schedules`
+  (serialized runs) and `self.todays_log_content`.
+
+- [ ] **Step 1: Add the field.** In `DebugDataExport` (after `ha_ws_discovery`), add:
+
+```python
+    key_findings: dict = field(default_factory=dict)
+```
+
+- [ ] **Step 2: Populate it in `aggregate_all_data`.** After the `DebugDataExport(...)`
+  instance is built (it needs `schedules` and `todays_log_content` already set),
+  compute and attach findings. Locate the `return DebugDataExport(...)` /
+  construction in `aggregate_all_data` and set `key_findings` from the same inputs:
+
+```python
+from .debug_findings import build_key_findings  # top-of-file import
+
+# where the export object is assembled (it already has schedules + todays_log_content):
+export.key_findings = build_key_findings(export.schedules, export.todays_log_content)
+return export
+```
+
+If `aggregate_all_data` constructs and returns in one expression, assign to a local
+`export` first, then set `export.key_findings`, then return it.
+
+- [ ] **Step 3: Write the test.**
+
+```python
+def test_build_key_findings_surfaces_the_15_45_case():
+    schedules = [
+        _sched("2026-06-28 10:31:00", 63, "BATTERY_EXPORT", -0.1),
+        _sched("2026-06-28 11:31:00", 63, "SOLAR_EXPORT", -0.0),
+    ]
+    log = (
+        "2026-06-28 10:31:00 | ERROR | core.bess.influxdb_helper:519 - "
+        "Error connecting to InfluxDB: Max retries exceeded\n"
+    )
+    result = build_key_findings(schedules, log)
+    assert result["clean"] is False
+    assert result["disagreements"][0].time == "15:45"
+    assert result["anomalies"][0].category == "network"
+```
+
+- [ ] **Step 4: Run the tests + quality gate.**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_debug_findings.py -q && ./scripts/quality-check.sh`
+Expected: tests pass; quality gate green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add core/bess/debug_data_exporter.py core/bess/tests/unit/test_debug_findings.py
+git commit -m "feat: attach key_findings to DebugDataExport"
+```
+
+---
+
+### Task 4: Render Key Findings at the top; demote raw data
+
+**Files:**
+- Modify: `core/bess/debug_report_formatter.py` (`format_report` ~line 19;
+  `_format_health_status` ~line 86; `_format_schedules` ~line 400)
+
+**Interfaces:**
+- Consumes: `export.key_findings` (Task 3).
+
+- [ ] **Step 1: Add `_format_key_findings`.**
+
+```python
+    def _format_key_findings(self, export: DebugDataExport) -> str:
+        kf = export.key_findings or {}
+        lines = ["## ⚠️ Key Findings (auto-generated — read first)"]
+        if kf.get("clean", False) or (not kf.get("disagreements") and not kf.get("anomalies")):
+            lines.append("\nNo cross-run disagreements or log anomalies detected.")
+            return "\n".join(lines)
+
+        disagreements = kf.get("disagreements", [])
+        if disagreements:
+            lines.append("\n### Cross-run schedule disagreements")
+            for d in disagreements:
+                lines.append(
+                    f"- Period {d.period} ({d.time}): {', '.join(d.intents)} "
+                    f"across {len(d.occurrences)} runs — explain WHY runs differ; "
+                    f"do NOT conclude it didn't happen."
+                )
+
+        anomalies = kf.get("anomalies", [])
+        if anomalies:
+            lines.append("\n### Today's log anomalies (deduplicated)")
+            for a in anomalies:
+                lines.append(
+                    f"- [{a.category}] {a.source} ×{a.count} "
+                    f"({a.first_ts} → {a.last_ts}): {a.sample}"
+                )
+        return "\n".join(lines)
+```
+
+- [ ] **Step 2: Put it first in `format_report`.** In the section list assembled by
+  `format_report` (~line 30), insert `self._format_key_findings(export)` immediately
+  after `self._format_header(export)`.
+
+- [ ] **Step 3: Caption the health snapshot as point-in-time.** In
+  `_format_health_status`, change the heading line `## System Health Status` to:
+
+```python
+        summary = f"""## System Health Status (point-in-time snapshot at export)
+
+*This reflects health at export time only. For problems earlier today, see Key
+Findings (top) and System Logs (bottom).*
+"""
+```
+
+(keep the rest of the method unchanged).
+
+- [ ] **Step 4: Move the full schedule JSON to the bottom.** In `_format_schedules`,
+  remove the `details` (`<details>Full Schedule JSON…`) block from its return value
+  (return only `summary_text + econ_block + Period Decisions table`). Add a new
+  `_format_raw_schedule_json(export)` method that returns that `<details>` block, and
+  append it LAST in `format_report` (after `_format_logs`).
+
+```python
+    def _format_raw_schedule_json(self, export: DebugDataExport) -> str:
+        return f"""## Raw Schedule JSON (deep debugging)
+
+<details>
+<summary>Full Schedule JSON (all runs)</summary>
+
+```json
+{self._format_json(export.schedules)}
+```
+
+</details>"""
+```
+
+- [ ] **Step 5: Test the rendering end to end.**
+
+Run:
+```bash
+.venv/bin/python -c "
+from core.bess.debug_report_formatter import DebugReportFormatter
+from core.bess.debug_data_exporter import DebugDataExport
+from core.bess.debug_findings import build_key_findings
+sched=[{'timestamp':'2026-06-28 10:31:00','optimization_result':{'period_data':[{'period':63,'decision':{'strategic_intent':'BATTERY_EXPORT','battery_action':-0.1}}]}},
+       {'timestamp':'2026-06-28 11:31:00','optimization_result':{'period_data':[{'period':63,'decision':{'strategic_intent':'SOLAR_EXPORT','battery_action':-0.0}}]}}]
+kf=build_key_findings(sched,'2026-06-28 10:31:00 | ERROR | core.bess.influxdb_helper:519 - Max retries exceeded')
+print('Period 63' in DebugReportFormatter()._format_key_findings(type('E',(),{'key_findings':kf})()))
+"
+```
+Expected: `True`.
+
+- [ ] **Step 6: Quality gate + commit.**
+
+```bash
+./scripts/quality-check.sh
+git add core/bess/debug_report_formatter.py
+git commit -m "feat: render Key Findings at top, demote raw logs/JSON to bottom"
+```
+
+---
+
+### Task 5: Include findings in AI-chat context; drop the raw log dump
+
+**Files:**
+- Modify: `backend/ai_chat.py` (`_gather_context` ~line 725)
+- Test: `backend/tests/test_ai_chat.py`
+
+**Interfaces:**
+- Consumes: `export.key_findings` (Task 3).
+
+- [ ] **Step 1: Read `_gather_context`** to see how it builds the context string from
+  the export (it already calls the exporter). Identify where the log content is added.
+
+- [ ] **Step 2: Prepend findings, exclude raw logs.** In `_gather_context`, render the
+  key findings (reuse the formatter's `_format_key_findings`, or format inline) at the
+  START of the context, and ensure the raw `todays_log_content` dump is NOT included
+  (the findings replace it for the chat path).
+
+- [ ] **Step 3: Add a test** asserting the gathered context contains the Key Findings
+  heading and does NOT contain the full raw log body. Follow the existing patterns in
+  `backend/tests/test_ai_chat.py` for constructing a fake system_manager/export.
+
+- [ ] **Step 4: Run tests.**
+
+Run: `.venv/bin/pytest backend/tests/test_ai_chat.py -q`
+Expected: pass.
+
+- [ ] **Step 5: Quality gate + commit.**
+
+```bash
+./scripts/quality-check.sh
+git add backend/ai_chat.py backend/tests/test_ai_chat.py
+git commit -m "feat: surface key findings in AI-chat context, drop raw log dump"
+```
+
+---
+
+### Task 6: Validate end to end
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Run the full fast suite.**
+
+Run: `.venv/bin/pytest -m "not slow" -q`
+Expected: green.
+
+- [ ] **Step 2: Re-invoke the analyst** on `docs/bess-debug-2026-06-28-113159.md`
+  with the original `docs/dialogue.txt` question (regenerate the bundle if needed so
+  it has the new top section). Confirm, on the FIRST attempt, the agent:
+  1. Reads the Key Findings section and reports the 15:45 BATTERY_EXPORT vs
+     SOLAR_EXPORT disagreement without being prompted.
+  2. Flags the InfluxDB-outage anomaly rather than reporting "system OK".
+  3. Gives the marginal `shadow_price > sell` loss verdict and cites `_compute_reward`.
+
+- [ ] **Step 3: If it still anchors,** the gap is renderer prominence/wording, not
+  data — adjust `_format_key_findings` phrasing and re-run. Do not add optimizer logic.
+
+---
+
+## Self-Review
+
+- **Spec coverage (Part 5):** Key Findings section → Tasks 1-4; log rollup (dedup) →
+  Task 1; reconciliation → Task 2; exporter wiring → Task 3; bundle restructure +
+  health caption → Task 4; AI-chat parity + token reduction → Task 5; validation →
+  Task 6.
+- **Placeholder scan:** all code steps show real code; tests have real assertions.
+  Task 5 steps 1-3 describe inspection-then-edit because `_gather_context`'s exact
+  body must be read first; the assertions to add are specified.
+- **Type consistency:** `LogAnomaly` / `SlotDisagreement` field names and the
+  `build_key_findings` dict keys (`disagreements`, `anomalies`, `clean`) are used
+  identically across Tasks 2-5; `export.schedules` shape is the same one the exporter
+  already produces (`asdict` of `StoredSchedule`).

--- a/docs/superpowers/plans/2026-06-28-debug-bundle-key-findings.md
+++ b/docs/superpowers/plans/2026-06-28-debug-bundle-key-findings.md
@@ -40,7 +40,7 @@ No optimizer behavior changes.
 - `core/bess/tests/unit/test_debug_findings.py` — NEW. Unit tests for the above.
 - `core/bess/debug_data_exporter.py` — add `key_findings` field to `DebugDataExport`
   and populate it in `aggregate_all_data`.
-- `core/bess/debug_report_formatter.py` — render `_format_key_findings` first;
+- `core/bess/debug_report_formatter.py` — render `format_key_findings` first;
   caption the health snapshot; move full schedule JSON to the bottom.
 - `backend/ai_chat.py` — include findings text in `_gather_context`; exclude raw log
   dump.
@@ -411,10 +411,10 @@ git commit -m "feat: attach key_findings to DebugDataExport"
 **Interfaces:**
 - Consumes: `export.key_findings` (Task 3).
 
-- [ ] **Step 1: Add `_format_key_findings`.**
+- [ ] **Step 1: Add `format_key_findings`.**
 
 ```python
-    def _format_key_findings(self, export: DebugDataExport) -> str:
+    def format_key_findings(self, export: DebugDataExport) -> str:
         kf = export.key_findings or {}
         lines = ["## ⚠️ Key Findings (auto-generated — read first)"]
         if kf.get("clean", False) or (not kf.get("disagreements") and not kf.get("anomalies")):
@@ -443,7 +443,7 @@ git commit -m "feat: attach key_findings to DebugDataExport"
 ```
 
 - [ ] **Step 2: Put it first in `format_report`.** In the section list assembled by
-  `format_report` (~line 30), insert `self._format_key_findings(export)` immediately
+  `format_report` (~line 30), insert `self.format_key_findings(export)` immediately
   after `self._format_header(export)`.
 
 - [ ] **Step 3: Caption the health snapshot as point-in-time.** In
@@ -490,7 +490,7 @@ from core.bess.debug_findings import build_key_findings
 sched=[{'timestamp':'2026-06-28 10:31:00','optimization_result':{'period_data':[{'period':63,'decision':{'strategic_intent':'BATTERY_EXPORT','battery_action':-0.1}}]}},
        {'timestamp':'2026-06-28 11:31:00','optimization_result':{'period_data':[{'period':63,'decision':{'strategic_intent':'SOLAR_EXPORT','battery_action':-0.0}}]}}]
 kf=build_key_findings(sched,'2026-06-28 10:31:00 | ERROR | core.bess.influxdb_helper:519 - Max retries exceeded')
-print('Period 63' in DebugReportFormatter()._format_key_findings(type('E',(),{'key_findings':kf})()))
+print('Period 63' in DebugReportFormatter().format_key_findings(type('E',(),{'key_findings':kf})()))
 "
 ```
 Expected: `True`.
@@ -518,7 +518,7 @@ git commit -m "feat: render Key Findings at top, demote raw logs/JSON to bottom"
   the export (it already calls the exporter). Identify where the log content is added.
 
 - [ ] **Step 2: Prepend findings, exclude raw logs.** In `_gather_context`, render the
-  key findings (reuse the formatter's `_format_key_findings`, or format inline) at the
+  key findings (reuse the formatter's `format_key_findings`, or format inline) at the
   START of the context, and ensure the raw `todays_log_content` dump is NOT included
   (the findings replace it for the chat path).
 
@@ -559,7 +559,7 @@ Expected: green.
   3. Gives the marginal `shadow_price > sell` loss verdict and cites `_compute_reward`.
 
 - [ ] **Step 3: If it still anchors,** the gap is renderer prominence/wording, not
-  data — adjust `_format_key_findings` phrasing and re-run. Do not add optimizer logic.
+  data — adjust `format_key_findings` phrasing and re-run. Do not add optimizer logic.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-28-bess-analyst-decision-rationale-design.md
+++ b/docs/superpowers/specs/2026-06-28-bess-analyst-decision-rationale-design.md
@@ -1,0 +1,245 @@
+# BESS Analyst — Decision-Rationale Expertise (Design Spec)
+
+**Date:** 2026-06-28
+**Status:** Approved design, pre-implementation
+**Goal:** Make the `bess-analyst` agent a first-attempt, zero-pushback authority on
+the optimization algorithm and the economics of price arbitrage.
+
+## Problem
+
+A real dialogue (`docs/dialogue.txt`) shows the analyst failing a single
+optimization-rationale question through three escalating errors. The user had to
+push back repeatedly; the agent only reached the correct answer after being
+corrected step by step. The standard this spec targets is the opposite:
+**invoke once, get a correct, complete, authoritative answer, no pushback.**
+
+### Root causes (evidenced)
+
+1. **Narrated over the evidence.** The user asked why the battery sold to grid at
+   15:45. The agent answered "it's solar surplus, not the battery." But the debug
+   bundle's `### Period Decisions` table already showed `BattAct -0.1`,
+   `SOE` dropping, and `Intent = BATTERY_EXPORT` for that period — the agent even
+   quoted that exact row in its *second* answer. The decisive fact was present and
+   unread on attempt #1.
+
+2. **Gross-value fallacy.** Once it accepted the discharge, it reasoned
+   `sell_price 0.46 > wear 0.40 → +6 öre, marginally profitable`. This evaluates
+   the action against *doing nothing*. The true counterfactual was "let solar keep
+   charging one more slot, start solar-export one slot earlier," whose value is the
+   *differential* sell price minus wear: `0.46 − 0.40 − 0.40 = −0.34 SEK/kWh` — a
+   loss. The user had to derive this.
+
+3. **Did not know its own code.** The optimizer already implements this opportunity
+   cost. `_compute_reward` (`core/bess/dp_battery_algorithm.py:356-389`) raises the
+   discharge floor to `sell_price` when solar will replenish the battery, so
+   `sell × eff_discharge < sell ≤ floor` ⇒ discharge blocked. The agent claimed the
+   mechanism was *missing* and proposed building it (issue #196), when the real,
+   legitimate finding is near-threshold `shadow_price` volatility across
+   re-optimization runs.
+
+### Meta-cause: the knowledge doc itself is contradictory
+
+`docs/agents/bess-knowledge.md` contains **both**:
+
+- the correct forward-looking framing (lines 69–147: shadow price = opportunity
+  value, explicitly *not* the sunk cost basis), buried as a sub-detail of the
+  narrow SOLAR_EXPORT gate; and
+- a naive contradictory rule (lines 159–163: *"A discharge is profitable when
+  sell_price > cost_basis + cycle_cost"*), echoed in the `_compute_reward`
+  docstring.
+
+The analyst reached for the simple, wrong one. The correct law is never stated as
+**the** governing principle for evaluating *any* action.
+
+### The two-layer shape of the failure
+
+The debug bundle (`core/bess/debug_report_formatter.py`) separates exactly the two
+things the agent conflated:
+
+- **Fact layer** — `## Optimization Schedules → ### Period Decisions` table:
+  `Intent | Observed | BattAct | SOE start→end | BuyPrice | Savings`. Answers
+  *"what happened"* (battery vs solar) from one row.
+- **Economic layer** — Full Schedule JSON `<details>` block: `sell_price`,
+  `buy_price`, `cost_basis`, `shadow_price`; plus `### Economic Summary`. Answers
+  *"why"*.
+
+Both were available on attempt #1.
+
+## Non-Goals
+
+- No canonical/lookup scenario library. There are hundreds of cases; the *law* and
+  the *protocol* must generalize, not a memorized example.
+- No CI fixture / automated regression test tied to one debug bundle. Validation is
+  manual: after the changes, re-run the same question + log against the new
+  agent/knowledge and judge the output. (Both the user and the implementer do this.)
+- No changes to the optimizer's behavior. This spec changes *documentation and the
+  agent's reasoning protocol only*. (Issue #196's shadow-price-volatility fix is a
+  separate piece of work.)
+
+## Approved Approach: Layered Decision-Rationale Playbook
+
+Two coordinated changes plus a small output template. Scope covers the **shared**
+knowledge doc (so the in-app AI chat benefits too) and the **analyst agent file**
+(reasoning discipline, which belongs in the agent and must fire on attempt #1).
+
+### Part 1 — Rewrite the economics in `docs/agents/bess-knowledge.md`
+
+State **one governing law** up front, before any action-specific detail:
+
+> **Every battery action is judged by its *marginal* net value against the
+> next-best alternative for that same slot — never gross value, never against
+> "do nothing = 0."**
+> The opportunity cost of a stored kWh is its forward-looking `shadow_price` (the
+> DP's value-to-go slope), floored by `sell_price` when solar will replenish it. It
+> is **not** the sunk `cost_basis`, and **not** zero. A discharge to grid is
+> worthwhile only if `sell_price × efficiency_discharge >` that opportunity cost.
+
+Changes:
+
+1. **Delete** the naive formula at `bess-knowledge.md:159-163`. Replace with the
+   governing law above and the per-action operational forms (charge / discharge /
+   hold) derived from it.
+2. **Add a note** that `_compute_reward`'s "value > cost_basis" docstring describes
+   the *implementation's* anti-cycling floor (which already raises the floor to
+   `sell_price`, `dp_battery_algorithm.py:376-389`), not the user-facing economic
+   law — so the two are reconciled, not contradictory.
+3. **Add a "Facts vs Economics — where each lives in a debug bundle" subsection:**
+   - Facts → `### Period Decisions` table (Intent, BattAct sign+magnitude, SOE
+     start→end).
+   - Economics → Full Schedule JSON `<details>` (sell/buy/cost_basis/shadow_price)
+     + `### Economic Summary`.
+   - Period ↔ clock-time mapping (15-min slots), with an explicit **off-by-one
+     warning** (the dialogue's "15:45 vs 16:00 price" slip).
+4. **One short illustrative example** of the reasoning *shape* — clearly labelled
+   *"illustrative; the method generalizes to any period — do not pattern-match the
+   scenario."* It shows: wrong framing (`sell > wear → profit`) vs right framing
+   (state the counterfactual → marginal value → `shadow_price` vs `sell`). Its job
+   is to make the abstract gross-vs-marginal law transfer to the model, not to be a
+   lookup case.
+
+### Part 2 — Add a Decision-Rationale Protocol to `.claude/agents/bess-analyst.md`
+
+The current process is built for "something is broken / discovery / sensor"
+questions and has **no** path for "why did the optimizer decide X." Add:
+
+**A routing step at the top:**
+- (A) Broken / discovery / sensors / integration → existing process.
+- (B) Why did the optimizer decide X / is decision X correct / savings rationale →
+  Decision-Rationale Protocol below.
+
+**The Decision-Rationale Protocol (mandatory, ordered, each step checkable):**
+
+1. **Pin the period.** Convert the clock time in the question to period number +
+   slot; state both; guard the off-by-one.
+2. **Facts before narrative.** Read that period's `### Period Decisions` row; quote
+   Intent, BattAct (sign + magnitude), SOE start→end; answer the literal "what
+   happened" (battery vs solar) from this row *alone*. No mechanism yet.
+3. **Pull economics.** Quote sell/buy/cost_basis/shadow_price from Full Schedule
+   JSON for that period + relevant `### Economic Summary` totals.
+4. **Apply the governing law.** State the counterfactual explicitly ("the
+   alternative to this action was ___"), compute marginal value vs it using
+   opportunity cost = `shadow_price` (floored by `sell_price` under solar
+   replenishment); verdict: correct / incorrect / marginal-and-why.
+5. **Cite the code path.** Name the exact function/lines that produced the decision
+   (`_compute_reward` discharge gate `dp_battery_algorithm.py:356-389`;
+   cost_basis/shadow_price). No claim without a code or data anchor.
+6. **Cross-run reconciliation.** If the user references multiple runs or "it
+   changed," diff the period's economics across the runs in the bundle and attribute
+   the change to a specific input delta (initial SOC / price update / forecast).
+7. **Self-check gate before emitting.** Verify: (a) every factual claim matches the
+   quoted row; (b) a counterfactual was stated and marginal — not gross — value was
+   used; (c) the mechanism has a code/data anchor; (d) the literal question is
+   answered. Any miss → redo, do not emit.
+
+**Anti-pattern list (verbatim from the dialogue failures):**
+- Don't answer "solar surplus vs battery" from a narrative — read BattAct/SOE first.
+- Never call a discharge profitable because `sell_price > wear_cost`. That's gross
+  value; compute marginal value vs the counterfactual.
+- Never claim a mechanism is "missing" before grepping the optimizer for it (e.g.,
+  the anti-cycling floor already exists).
+
+### Part 3 — Output template
+
+Add a "Decision rationale" output format mirroring the protocol so answers are
+auditable: **Facts → Economics → Counterfactual & verdict → Code anchor →
+(cross-run note).**
+
+### Part 4 — Correct contradictory in-code documentation
+
+Comment/docstring-only changes, **no behavior change**. The implementation must
+audit in-code documentation that states the economics and correct any that carry
+the naive gross-value framing so code and docs agree on the one governing law:
+
+- `_compute_reward` docstring (`core/bess/dp_battery_algorithm.py`, ~lines 262-284):
+  the "PROFITABILITY CHECK … Discharge only profitable if this value > cost_basis"
+  text. Reword to describe the opportunity-cost floor the code actually applies
+  (floor raised to `sell_price` under replenishment, `dp_battery_algorithm.py:376-389`).
+- The module-level docstring's profitability/threshold description (~lines 19-50)
+  and the inline anti-cycling comments — confirm they match the governing law;
+  correct any wording that implies gross value or `cost_basis`-only reasoning.
+- Grep the rest of `core/bess/` (`decision_intelligence.py`, `models.py`) for the
+  same framing in comments/docstrings and fix wording where it contradicts the law.
+
+These are documentation corrections only — do not alter any computation.
+
+## Files Touched
+
+- `docs/agents/bess-knowledge.md` — rewrite economics section (Part 1).
+- `.claude/agents/bess-analyst.md` — routing step, protocol, anti-patterns, output
+  template (Parts 2 & 3).
+- `core/bess/dp_battery_algorithm.py` — docstring/comment corrections only (Part 4).
+- Any other `core/bess/` file whose comments/docstrings carry the naive framing
+  (Part 4) — comment-only.
+
+## Part 5 — Surface conclusions at the top of the debug bundle (added after validation)
+
+Validation runs proved the knowledge/protocol fixes are necessary but not
+sufficient: a Sonnet agent reliably anchors on the *latest* run and on the green
+health snapshot, ignoring contradicting evidence buried in the raw logs — even an
+explicit "STEP 0 MANDATORY" tool instruction. The durable fix is **structural**:
+pre-digest the conclusions and put them first; demote raw data to the bottom.
+
+**Restructure the bundle and the AI-chat context into three tiers:**
+
+1. **Top — always-on `Key Findings` section** (auto-generated, conclusion-phrased):
+   - **Cross-run schedule reconciliation:** per-slot disagreements computed from
+     `schedule_store.get_all_schedules_today()` (already serialized into
+     `export.schedules` as all runs). Phrased imperatively ("DISAGREEMENT @ 15:45:
+     earlier runs BATTERY_EXPORT, latest SOLAR_EXPORT — explain why; do not conclude
+     it didn't happen").
+   - **Today's log-anomaly rollup:** parsed from `export.todays_log_content`,
+     **categorized and deduplicated** by `(category, module:line)` — categories:
+     network/connectivity, data gaps (skipped periods / missing actuals), restarts,
+     runtime errors. Each entry = category · deduped count · first→last timestamp ·
+     one sample. Raw counts over-count (e.g. 220 "restart" hits are one repeated
+     warning string), so dedup is required. Derived from logs, NOT the runtime
+     failure tracker (which isn't exported and is unreliable).
+   - Self-suppressing: shows "No anomalies or disagreements detected" when clean.
+   - The existing health snapshot stays but is captioned **point-in-time** so its
+     green "OK" is never read as "nothing went wrong today."
+
+2. **Middle — structured reference** (settings, latest schedule, economics, entity
+   snapshot): unchanged, read on demand.
+
+3. **Bottom — raw data for deep digging** (`## System Logs`, full schedule JSON
+   `<details>`): moved to the end.
+
+**Shared computation, two renderers** (no duplicated logic): a new
+`core/bess/debug_findings.py` produces the findings from structured data + log text;
+`debug_report_formatter.py` renders the markdown section; `backend/ai_chat.py`
+`_gather_context` includes the same findings and **excludes the raw log dump**
+(fewer tokens, better answers). The standalone `scripts/extract_decision_evidence.py`
+remains a manual CLI.
+
+## Validation
+
+Manual, by re-invoking the agent (no baked fixture). After the changes, run the
+original `docs/dialogue.txt` question against a representative debug bundle and
+confirm the agent, on the **first attempt**, without pushback:
+1. identifies a battery discharge (BattAct negative, SOE drop), not solar surplus;
+2. rejects the gross "6 öre" framing and gives the marginal verdict
+   (`shadow_price > sell_price` ⇒ a loss to discharge);
+3. cites `_compute_reward`;
+4. names cross-run shadow-price volatility as the real issue.
+
+This is a judgement check on representative cases, not a pinned regression test.

--- a/scripts/extract_decision_evidence.py
+++ b/scripts/extract_decision_evidence.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Extract all decision evidence for a single slot from a BESS debug bundle.
+
+A debug bundle holds the SAME slot in several places, and they can disagree:
+
+- the LATEST optimization run, as a `### Period Decisions` markdown table and a
+  structured "Full Schedule JSON" block (the reliable source for economics:
+  sell_price / buy_price / cost_basis / shadow_price); and
+- EARLIER runs, only as box-drawing tables dumped in `## System Logs` — compact
+  per-period rows (`║ 63 ║ … BATTERY_EXPORT`) and inverter TOU schedule blocks
+  (`║ 15:45-15:59 ║ … 4%`).
+
+The analyst's recurring failure is reading only the latest run and concluding "it
+didn't happen" when an earlier run scheduled the very action the user asked about.
+This script gathers every occurrence of one slot across all those sources and flags
+cross-run disagreement, so the agent cannot miss it.
+
+Usage:
+    python scripts/extract_decision_evidence.py <bundle.md> --time 15:45
+    python scripts/extract_decision_evidence.py <bundle.md> --period 63
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+INTENTS = {
+    "GRID_CHARGING",
+    "SOLAR_STORAGE",
+    "LOAD_SUPPORT",
+    "BATTERY_EXPORT",
+    "SOLAR_EXPORT",
+    "IDLE",
+}
+
+BOX = "║"  # ║ column separator used in log tables
+PRICE_RE = re.compile(r"^\d+\.\d+/\d+\.\d+$")
+TIMERANGE_RE = re.compile(r"^(\d{2}):(\d{2})-(\d{2}):(\d{2})$")
+
+
+def period_to_time(period: int) -> str:
+    return f"{period // 4:02d}:{(period % 4) * 15:02d}"
+
+
+def time_to_period(t: str) -> int:
+    h, m = (int(x) for x in t.split(":"))
+    return h * 4 + m // 15
+
+
+def minutes(t: str) -> int:
+    h, m = (int(x) for x in t.split(":"))
+    return h * 60 + m
+
+
+def _cells(line: str) -> list[str]:
+    return [c.strip() for c in line.split(BOX)]
+
+
+def parse_period_decisions(text: str, period: int) -> dict | None:
+    """The latest run's `### Period Decisions` markdown table row for `period`."""
+    in_table = False
+    for line in text.splitlines():
+        if line.strip().startswith("### Period Decisions"):
+            in_table = True
+            continue
+        if in_table:
+            if line.startswith("|"):
+                cols = [c.strip() for c in line.strip().strip("|").split("|")]
+                if len(cols) >= 8 and cols[0].isdigit() and int(cols[0]) == period:
+                    return {
+                        "period": int(cols[0]),
+                        "time": cols[1],
+                        "intent": cols[2],
+                        "observed": cols[3],
+                        "battery_action": cols[4],
+                        "soe": cols[5],
+                        "buy_price": cols[6],
+                        "savings": cols[7],
+                    }
+            elif line.strip().startswith("##"):
+                break
+    return None
+
+
+def parse_compact_rows(text: str, period: int) -> list[dict]:
+    """Box-drawing per-period rows from log dumps of earlier runs.
+
+    Example: ║ 63 ║ 1.06/0.46 ║ ... ║ -0.1 ║ BATTERY_EXPORT ║ ...
+    """
+    rows = []
+    for ln, line in enumerate(text.splitlines(), 1):
+        if BOX not in line:
+            continue
+        cells = [c for c in _cells(line) if c != ""]
+        if not cells or not cells[0].isdigit() or int(cells[0]) != period:
+            continue
+        intent_idx = next((i for i, c in enumerate(cells) if c in INTENTS), None)
+        if intent_idx is None:
+            continue  # not a per-period decision row
+        price = next((c for c in cells if PRICE_RE.match(c)), None)
+        batt = cells[intent_idx - 1] if intent_idx >= 1 else None
+        rows.append(
+            {
+                "line": ln,
+                "intent": cells[intent_idx],
+                "battery_action": batt,
+                "buy_sell": price,
+            }
+        )
+    return rows
+
+
+def parse_tou_rows(text: str, target_min: int) -> list[dict]:
+    """Inverter TOU schedule rows (box-drawing) whose window covers the slot.
+
+    Example: ║ 15:45-15:59 ║ 15min ║ BATTERY_EXPORT ║ grid_first ║ False ║ 0% ║ 4% ║
+    """
+    rows = []
+    for ln, line in enumerate(text.splitlines(), 1):
+        if BOX not in line:
+            continue
+        cells = _cells(line)
+        cells = [c for c in cells if c != ""]
+        if len(cells) < 4:
+            continue
+        m = TIMERANGE_RE.match(cells[0])
+        if not m:
+            continue
+        start = int(m.group(1)) * 60 + int(m.group(2))
+        end = int(m.group(3)) * 60 + int(m.group(4))
+        if not (start <= target_min <= end):
+            continue
+        intent = next((c for c in cells if c in INTENTS), None)
+        mode = next(
+            (c for c in cells if c in {"load_first", "grid_first", "battery_first"}),
+            None,
+        )
+        pcts = [c for c in cells if c.endswith("%")]
+        rows.append(
+            {
+                "line": ln,
+                "window": cells[0],
+                "intent": intent,
+                "mode": mode,
+                "charge_pct": pcts[0] if len(pcts) >= 1 else None,
+                "discharge_pct": pcts[1] if len(pcts) >= 2 else None,
+            }
+        )
+    return rows
+
+
+def parse_json_economics(text: str, period: int) -> list[dict]:
+    """Per-period economics from every ```json block that contains the period."""
+    results = []
+    for block in re.findall(r"```json\n(.*?)\n```", text, re.DOTALL):
+        try:
+            data = json.loads(block)
+        except (ValueError, json.JSONDecodeError):
+            continue
+        for entry in _find_period_entries(data, period):
+            econ = entry.get("economic", {})
+            dec = entry.get("decision", {})
+            results.append(
+                {
+                    "intent": dec.get("strategic_intent"),
+                    "battery_action": dec.get("battery_action"),
+                    "sell_price": econ.get("sell_price"),
+                    "buy_price": econ.get("buy_price"),
+                    "cost_basis": dec.get("cost_basis"),
+                    "shadow_price": dec.get("shadow_price"),
+                    "battery_to_grid": entry.get("energy", {}).get("battery_to_grid"),
+                    "soe_start": entry.get("energy", {}).get("battery_soe_start"),
+                    "soe_end": entry.get("energy", {}).get("battery_soe_end"),
+                }
+            )
+    return results
+
+
+def _find_period_entries(node, period: int):
+    """Recursively yield dicts that look like a period entry for `period`."""
+    if isinstance(node, dict):
+        if node.get("period") == period and ("decision" in node or "economic" in node):
+            yield node
+        for v in node.values():
+            yield from _find_period_entries(v, period)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _find_period_entries(v, period)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("bundle", help="path to the debug bundle .md file")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--time", help="slot clock time, e.g. 15:45")
+    g.add_argument("--period", type=int, help="period number, e.g. 63")
+    args = ap.parse_args()
+
+    if args.period is not None:
+        period = args.period
+        time = period_to_time(period)
+    else:
+        time = args.time
+        period = time_to_period(time)
+
+    with open(args.bundle, encoding="utf-8") as f:
+        text = f.read()
+
+    pd_row = parse_period_decisions(text, period)
+    econ = parse_json_economics(text, period)
+    compact = parse_compact_rows(text, period)
+    tou = parse_tou_rows(text, minutes(time))
+
+    out = []
+    out.append(f"# Decision evidence for period {period} ({time})\n")
+
+    out.append("## Latest run — facts (Period Decisions table)")
+    if pd_row:
+        out.append(
+            f"- intent={pd_row['intent']}  battery_action={pd_row['battery_action']}"
+            f"  SOE={pd_row['soe']}  buy={pd_row['buy_price']}"
+        )
+    else:
+        out.append("- (not found)")
+
+    out.append("\n## Latest run — economics (Full Schedule JSON)")
+    if econ:
+        for e in econ:
+            out.append(
+                f"- intent={e['intent']}  sell={e['sell_price']}  buy={e['buy_price']}"
+                f"  cost_basis={e['cost_basis']}  shadow_price={e['shadow_price']}"
+                f"  battery_to_grid={e['battery_to_grid']}"
+                f"  SOE={e['soe_start']}→{e['soe_end']}"
+            )
+    else:
+        out.append("- (not found)")
+
+    out.append("\n## Earlier runs — compact per-period rows (log dumps)")
+    if compact:
+        for r in compact:
+            out.append(
+                f"- line {r['line']}: intent={r['intent']}"
+                f"  battery_action={r['battery_action']}  buy/sell={r['buy_sell']}"
+            )
+    else:
+        out.append("- (none)")
+
+    out.append("\n## Earlier runs — inverter TOU schedule segments covering this slot")
+    if tou:
+        for r in tou:
+            out.append(
+                f"- line {r['line']}: {r['window']}  intent={r['intent']}"
+                f"  mode={r['mode']}  charge={r['charge_pct']}"
+                f"  discharge={r['discharge_pct']}"
+            )
+    else:
+        out.append("- (none)")
+
+    # Disagreement flag — the whole point of the script.
+    intents_seen = set()
+    if pd_row:
+        intents_seen.add(pd_row["intent"])
+    for e in econ:
+        if e["intent"]:
+            intents_seen.add(e["intent"])
+    for r in compact:
+        intents_seen.add(r["intent"])
+    for r in tou:
+        if r["intent"]:
+            intents_seen.add(r["intent"])
+    discharge_in_tou = any(
+        r["discharge_pct"] and r["discharge_pct"] != "0%" for r in tou
+    )
+
+    out.append("\n## Cross-run reconciliation")
+    if len(intents_seen) > 1:
+        out.append(
+            f"- DISAGREEMENT: this slot appears with different intents across "
+            f"sources: {sorted(intents_seen)}."
+        )
+        out.append(
+            "  Do NOT answer from the latest run alone — explain WHY runs differ "
+            "(near-threshold shadow_price volatility is the usual cause) and which "
+            "plan actually executes."
+        )
+    else:
+        out.append(f"- All sources agree: intent={sorted(intents_seen) or '(none)'}.")
+    if discharge_in_tou:
+        out.append(
+            "- An inverter TOU segment for this slot has a NON-ZERO discharge rate: "
+            "the battery WAS scheduled to export here in at least one run, even if "
+            "the latest Period Decisions row shows no discharge."
+        )
+
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The `bess-analyst` agent repeatedly got optimization-rationale questions wrong on
the first attempt — anchoring on the latest run and the green health snapshot,
ignoring contradicting evidence buried in the logs, and reasoning with gross sale
value instead of marginal/opportunity cost. This branch fixes both the *knowledge*
and the *structure* that let it fail.

## What

**1. Make the analyst an expert (docs + agent prompt + CLI)**
- `docs/agents/bess-knowledge.md`: one **governing economic law** — an action's value
  is marginal vs the next-best counterfactual; opportunity cost of a stored kWh is its
  forward-looking `shadow_price`, never the sunk `cost_basis`, never zero. Deleted the
  contradictory gross-value formula.
- `.claude/agents/bess-analyst.md`: an evidence-first **decision-rationale protocol**
  (pin period → facts before narrative → economics → counterfactual → cite code →
  cross-run reconcile → self-check), plus anti-patterns drawn from real failures.
- `core/bess/dp_battery_algorithm.py`: `_compute_reward` docstring aligned with the
  law. **Docstring-only — no optimizer logic change.**
- `scripts/extract_decision_evidence.py`: deterministic CLI that pulls one slot's
  facts + economics from all runs and flags cross-run disagreement.

**2. Always-on "Key Findings" digest in debug bundles + AI-chat**
- `core/bess/debug_findings.py`: deduplicated log-anomaly rollup (network / data-gap /
  restart / runtime-error, grouped by `category·source`) + cross-run schedule
  reconciliation from `export.schedules`.
- Wired into `DebugDataExport`; rendered at the **top** of the bundle, with raw logs
  and full schedule JSON demoted to the **bottom** and the health snapshot captioned
  *point-in-time*.
- `backend/ai_chat.py`: includes the findings, drops the raw log dump (fewer tokens,
  better answers).

## Validation

- Fast suite green (929 passed / 11 skipped). New unit tests for `debug_findings`,
  the exporter wiring, the formatter, and the AI-chat context.
- The agent fix was verified by re-running `bess-analyst` against the real bundle: fed
  the extractor output, it produced the correct marginal-loss verdict on the first
  attempt (and surfaced a candidate `_compute_reward` gate edge-case — see #196).
- **Pending:** end-to-end validation of the in-product Key Findings section against a
  freshly *regenerated* bundle from a running add-on.

## Notes

- Related to #196 (near-threshold BATTERY_EXPORT flip) — investigation only; this PR
  does **not** close it and changes no optimizer behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
