### PR TITLE
release: v9.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.8.1] - 2026-06-28
+
+### Changed
+
+- **Debug export now leads with a "Key Findings" section** — the debug bundle opens with an auto-generated digest that surfaces cross-run schedule disagreements (a slot scheduled differently across re-optimization runs) and a deduplicated rollup of today's log anomalies (network/connectivity, data gaps, restarts, runtime errors), grouped by category and source. Raw logs and the full schedule JSON are moved to the bottom, and the health check is captioned as a point-in-time snapshot so its "OK" is not mistaken for "nothing went wrong today." The in-app AI chat uses the same digest instead of the raw log dump. This makes root-causing optimizer decisions and runtime failures much faster. (#198)
+
 ## [9.8.0] - 2026-06-27
 
 ### Added

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "9.8.0"
+version: "9.8.1"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false


### PR DESCRIPTION
## v9.8.1

### Changed
- **Debug export now leads with a "Key Findings" section** — the bundle opens with an auto-generated digest surfacing cross-run schedule disagreements and a deduplicated rollup of today's log anomalies (network / data-gap / restart / runtime-error), grouped by category and source. Raw logs and full schedule JSON moved to the bottom; health check captioned point-in-time. The in-app AI chat uses the same digest. (#198)

Ships the work merged in #198 (bess-analyst economics expertise + Key Findings debug digest).

Local gate: 929 fast + 44 scenario pytest, 20 vitest, tsc clean, black/ruff clean. Slow algorithm suite covered by CI (no optimizer logic changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)