### PR TITLE
docs: add GitHub Sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Something look off? The built-in AI Analyst explains every decision in plain lan
 - **InfluxDB** for historical data persistence
 - **Tibber** for power monitoring
 
-> **Want support for your inverter?** We're actively looking for testers with GivEnergy, Solis, Huawei, and other systems. [Open an issue](https://github.com/johanzander/bess-manager/issues) or join the discussion!
+> **Want support for your inverter?** We're actively looking for testers with GivEnergy, Solis, Huawei, and other systems. [Open an issue](https://github.com/johanzander/bess-manager/issues) or join the discussion! [Sponsoring](https://github.com/johanzander/bess-manager#sponsorship) helps prioritize new hardware support.
 
 ## Installation
 
@@ -81,6 +81,12 @@ Full instructions: **[Installation Guide](docs/INSTALLATION.md)**
 
 - **Issues & feature requests**: [GitHub Issues](https://github.com/johanzander/bess-manager/issues)
 - **Discussion**: [Home Assistant Community Forum](https://community.home-assistant.io/)
+
+## Sponsorship
+
+ChargeIQ is free and open source. If it's saving you money on your energy bill, consider sponsoring — it directly funds the AI tools used to build new features.
+
+[❤️ Sponsor on GitHub](https://github.com/sponsors/johanzander)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds a clean Sponsorship section at the bottom of the README linking to GitHub Sponsors
- Adds a sponsoring hint to the inverter support callout with a link to the Sponsorship section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify sponsor link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)