### PR TITLE
fix: GRID_CHARGING throttled to ~1% due to DP tie-break reporting wrong action magnitude

### DIFF
--- a/core/bess/decision_intelligence.py
+++ b/core/bess/decision_intelligence.py
@@ -447,6 +447,7 @@ def classify_strategic_intent(power: float, energy_data: EnergyData) -> str:
 
 def create_decision_data(
     power: float,
+    battery_action_kwh: float,
     energy_data: EnergyData,
     hour: int,
     cost_basis: float,
@@ -456,7 +457,6 @@ def create_decision_data(
     battery_wear_cost: float,
     buy_price: float,
     sell_price: float,
-    dt: float,
     currency: str,
 ) -> DecisionData:
     """
@@ -468,6 +468,9 @@ def create_decision_data(
 
     Args:
         power: Battery power action (+ charge, - discharge) in kW
+        battery_action_kwh: Reported planned energy action in kWh for this period.
+            Caller-derived, since only the caller knows whether `power` is the
+            physically achieved action or merely a DP test value.
         energy_data: Complete energy flow data
         hour: Current hour (0-23)
         cost_basis: Cost basis of stored energy per kWh
@@ -477,7 +480,6 @@ def create_decision_data(
         battery_wear_cost: Battery degradation cost
         buy_price: Current electricity purchase price per kWh
         sell_price: Current electricity sale price per kWh
-        dt: Period duration in hours (e.g., 0.25 for quarterly, 1.0 for hourly)
         currency: Currency code for display in economic chain explanations
 
     Returns:
@@ -531,8 +533,6 @@ def create_decision_data(
         future_target_hours = [hour]
 
     # Create DecisionData with only fields we can implement
-    # Convert power (kW) to energy (kWh) for consistency with other period data
-    battery_action_kwh = power * dt
     return DecisionData(
         strategic_intent=strategic_intent,
         battery_action=battery_action_kwh,

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -448,13 +448,19 @@ def _build_period_data(
         grid_to_battery = remaining_rate  # solar fills first, grid tops up the rest
         battery_charged = solar_to_battery + grid_to_battery
         battery_discharged = 0.0
+        # STORE physics are binary (any positive power charges at rate_throughput),
+        # so the DP's tie-break can report an arbitrary small `power`. Use the
+        # achieved throughput instead — see #203.
+        battery_action_kwh = battery_charged
     elif power < -POWER_TOLERANCE_KW:  # Active discharging
         battery_charged = 0.0
         battery_discharged = abs(power) * dt
+        battery_action_kwh = power * dt
     else:  # IDLE — EXPORT disposition: battery holds, surplus exported
         battery_charged, battery_discharged = _idle_battery_flows(
             soe, next_soe, battery_settings
         )
+        battery_action_kwh = power * dt
 
     energy_balance = (
         solar_production + battery_discharged - home_consumption - battery_charged
@@ -483,6 +489,7 @@ def _build_period_data(
 
     decision_data = create_decision_data(
         power=power,
+        battery_action_kwh=battery_action_kwh,
         energy_data=energy_data,
         hour=period,
         cost_basis=new_cost_basis,
@@ -492,7 +499,6 @@ def _build_period_data(
         battery_wear_cost=battery_wear_cost,
         buy_price=current_buy_price,
         sell_price=current_sell_price,
-        dt=dt,
         currency=currency,
     )
 

--- a/core/bess/tests/unit/test_surplus_disposition.py
+++ b/core/bess/tests/unit/test_surplus_disposition.py
@@ -290,6 +290,60 @@ def test_grid_charging_charges_at_max_rate_not_fractional():
     )
 
 
+def test_grid_charging_action_reports_achieved_throughput_not_tied_power():
+    """Regression for #203: decision.battery_action must reflect the achieved
+    charge throughput, not the arbitrary tested `power` that won the DP's
+    tie-break among physically-identical positive STORE levels.
+
+    _state_transition's STORE physics are binary (see
+    test_grid_charging_charges_at_max_rate_not_fractional above): any positive
+    power charges at the same max rate_throughput. The real DP's power_levels
+    are iterated ascending with a strict `>` update, so the smallest positive
+    level (POWER_STEP_KW = 0.2 kW) always wins as best_action — but that tiny
+    tested value must not leak into decision.battery_action, since it drives
+    the inverter's charge_rate register via get_period_settings().
+
+    Scenario mirrors test_grid_charging_charges_at_max_rate_not_fractional:
+    no solar, power=0.2 kW (the smallest positive power_level). Expected
+    battery_action = 2.5 kWh (max-rate achieved charge), not 0.2*0.25=0.05 kWh.
+    """
+    from core.bess.dp_battery_algorithm import _build_period_data, _state_transition
+
+    bs = make_battery_settings(
+        total_capacity=20.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=10.0,
+        efficiency_charge=1.0,
+    )
+    soe = 2.0
+    tied_power = 0.2  # smallest positive power_level — always wins the DP tie-break
+    next_soe = _state_transition(
+        soe, tied_power, bs, DT, solar_production=0.0, home_consumption=0.0
+    )
+    pd = _build_period_data(
+        power=tied_power,
+        soe=soe,
+        next_soe=next_soe,
+        period=0,
+        home_consumption=0.0,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=PRICES_BUY,
+        sell_price=PRICES_SELL,
+        solar_production=0.0,
+        new_cost_basis=bs.cycle_cost_per_kwh,
+        currency="SEK",
+    )
+    expected_action = min(bs.max_charge_power_kw * DT, bs.max_soe_kwh - soe)  # 2.5 kWh
+    assert round(pd.decision.battery_action, 4) == round(expected_action, 4), (
+        f"Expected battery_action={expected_action} (achieved max-rate charge) "
+        f"but got {pd.decision.battery_action:.4f} "
+        f"(leaked tested power={tied_power}*{DT}={tied_power * DT})"
+    )
+    assert pd.decision.strategic_intent == "GRID_CHARGING"
+
+
 def test_small_solar_surplus_at_idle_classifies_as_solar_export():
     """A power-0 period with solar surplus classifies as SOLAR_EXPORT (load_first).
     grid_first is only for active battery discharge — idle periods must use


### PR DESCRIPTION
## Summary

- `_build_period_data`'s STORE branch charges at a fixed `rate_throughput` regardless of the tested `power`'s magnitude — every positive power level is physically identical. The DP's ascending-order + strict-`>` tie-break therefore always kept the smallest positive `power_level` (0.2 kW) as `best_action`, and `create_decision_data` reported that raw `power * dt` as `decision.battery_action` instead of the actually achieved charge.
- That leaked value drove `inverter_controller.get_period_settings()`'s `charge_rate` formula, silently throttling `GRID_CHARGING` hardware charging to ~1% instead of the planned rate — live since PR #191 merged 2026-06-27.
- Fix: `_build_period_data` now computes `battery_action_kwh` from the achieved throughput (`battery_charged`) for the STORE branch, and passes it into `create_decision_data` instead of letting that function re-derive `power * dt` internally. DISCHARGE and IDLE reporting are unchanged — they were not affected by the tie, so scope is kept to exactly the reported bug.

## Root cause analysis

Full analysis (confirmed against source, with complete blast-radius trace) available on the issue: #203

## Test plan

- [x] New regression test `test_grid_charging_action_reports_achieved_throughput_not_tied_power` in `core/bess/tests/unit/test_surplus_disposition.py` — reproduces the exact tie-break scenario (0.2 kW tested power), fails before the fix (`0.05` vs expected `2.5` kWh), passes after
- [x] Full fast suite (`pytest -m "not slow"`): 930 passed, 0 failed
- [x] Slow/algorithm tests for affected areas (`test_optimization_algorithm.py`, `test_terminal_value.py`, `test_scenarios.py`, `test_action_threshold.py`): 40 passed, 0 failed
- [x] `black` / `ruff` clean

Fixes #203

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>