### PR TITLE
fix: anti-cycling discharge gate over-values stored energy in solar surplus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Anti-cycling discharge gate no longer over-values stored energy during solar surplus** — When solar already covers all home load for a period, `_compute_reward`'s discharge profitability check no longer credits the discharge with `avoid_purchase_value` (there is no grid purchase to displace when solar covers the load). This closed a leak that let marginal, unprofitable ~0.1 kWh `BATTERY_EXPORT` discharges slip past the `-inf` anti-cycling floor in solar-surplus periods with a full battery. (#204)
+
 ## [9.8.1] - 2026-06-28
 
 ### Changed

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -361,7 +361,16 @@ def _compute_reward(
         # Profitability check: only discharge if value exceeds cost basis
         avoid_purchase_value = current_buy_price * battery_settings.efficiency_discharge
         export_value = current_sell_price * battery_settings.efficiency_discharge
-        effective_value_per_kwh_stored = max(avoid_purchase_value, export_value)
+
+        # If solar already covers all home load this period, there is no grid
+        # purchase for the discharge to displace — its only realizable value is
+        # the export price. Including avoid_purchase_value here would credit the
+        # discharge for a purchase that was never going to happen.
+        excess_solar = max(0.0, solar_production - home_consumption)
+        if excess_solar > POWER_TOLERANCE_KW:
+            effective_value_per_kwh_stored = export_value
+        else:
+            effective_value_per_kwh_stored = max(avoid_purchase_value, export_value)
 
         # Anti-cycling: use sell_price as cost basis floor to prevent wasteful
         # charge/discharge cycling.  Stored energy has an opportunity cost —
@@ -382,7 +391,6 @@ def _compute_reward(
         if current_sell_price > current_buy_price:
             effective_cost_basis = max(effective_cost_basis, current_sell_price)
         else:
-            excess_solar = max(0.0, solar_production - home_consumption)
             capacity_after_discharge = battery_settings.max_soe_kwh - next_soe
             if (
                 excess_solar > POWER_TOLERANCE_KW

--- a/core/bess/simulation/verification.py
+++ b/core/bess/simulation/verification.py
@@ -1,5 +1,7 @@
 """Verification harnesses: plan-faithfulness (R == P) and A/B economic gate."""
 
+import statistics
+
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.settings import BatterySettings
 from core.bess.simulation.inverter_simulator import (
@@ -92,7 +94,18 @@ def realized_under_solar_error(
     no phantom export booked, so realized should never be worse than the
     forecast plan would have been on the actual day. This is the simulator-verified
     answer to "is the schedule robust to solar forecast error?".
+
+    Both figures are credited for usable energy left in the battery at horizon end
+    (mirroring BatterySystemManager._calculate_terminal_value's median-buy-price
+    valuation), otherwise a run that legitimately stores more bonus solar than the
+    forecast run — real value carried past the horizon, not waste — looks like a
+    loss purely from the horizon cutoff.
     """
+    terminal_value_per_kwh = max(
+        0.0,
+        statistics.median(buy_price) * settings.efficiency_discharge
+        - settings.cycle_cost_per_kwh,
+    )
     result = optimize_battery_schedule(
         buy_price=buy_price,
         sell_price=sell_price,
@@ -101,6 +114,7 @@ def realized_under_solar_error(
         initial_soe=initial_soe,
         battery_settings=settings,
         period_duration_hours=dt,
+        terminal_value_per_kwh=terminal_value_per_kwh,
     )
     commands = [
         derive_control_command(
@@ -111,4 +125,16 @@ def realized_under_solar_error(
     sim = simulate(
         commands, actual_solar, home, buy_price, sell_price, initial_soe, settings, dt
     )
-    return result.economic_summary.battery_solar_cost, sim.realized_cost
+
+    planned_usable = max(
+        0.0, result.period_data[-1].energy.battery_soe_end - settings.min_soe_kwh
+    )
+    realized_usable = max(
+        0.0, sim.period_data[-1].energy.battery_soe_end - settings.min_soe_kwh
+    )
+    planned_cost = (
+        result.economic_summary.battery_solar_cost
+        - terminal_value_per_kwh * planned_usable
+    )
+    realized_cost = sim.realized_cost - terminal_value_per_kwh * realized_usable
+    return planned_cost, realized_cost

--- a/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
+++ b/core/bess/tests/unit/data/historical_2025_06_02_high_solar_export.json
@@ -92,11 +92,11 @@
   },
   "expected_results": {
     "base_cost": 68.613,
-    "battery_solar_cost": -5.7875,
-    "base_to_battery_solar_savings": 74.4005,
-    "base_to_battery_solar_savings_pct": 108.435,
-    "total_charged": 12.8,
-    "total_discharged": 26.0
+    "battery_solar_cost": -5.6755,
+    "base_to_battery_solar_savings": 74.2885,
+    "base_to_battery_solar_savings_pct": 108.2717,
+    "total_charged": 13.5,
+    "total_discharged": 26.6
   },
   "price_data": {
     "markup_rate": 0.08,

--- a/core/bess/tests/unit/test_solar_export_discharge_gate.py
+++ b/core/bess/tests/unit/test_solar_export_discharge_gate.py
@@ -48,17 +48,21 @@ def _solar_export_periods(result):
 
 @pytest.mark.slow
 def test_solar_export_covers_dip_when_buy_exceeds_export():
-    """Normal prices (buy > sell). During SOLAR_EXPORT the battery is full and
-    exporting surplus, so the marginal stored kWh is only worth the export floor
-    (the ongoing surplus refills it — the replenishment effect). The DP shadow
-    price therefore equals roughly the sell price, well below buy*eff_d, so the
-    gate ALLOWS discharge (100): covering an intra-period dip from the battery is
-    cheaper than buying it from grid, because solar refills the battery for free.
+    """Normal prices (buy comfortably above shadow). During SOLAR_EXPORT the
+    battery is full and exporting surplus. Discharging opens up room that the
+    ongoing surplus refills — but that refill is not free: every period spent
+    below full incurs the passive-charging cycle cost the full battery avoids.
+    So the marginal stored kWh is worth the export floor *plus* that forced
+    replenishment cost (issue #204 fixed the anti-cycling gate that used to let
+    the DP dodge this cost via unprofitable marginal discharges — see
+    docs/superpowers/specs/2026-06-27-solar-export-discharge-rate-design.md).
+    The gate still ALLOWS discharge (100) here because buy*eff_d clears even
+    this higher, more accurate shadow price.
     """
     bs = make_battery_settings(efficiency_discharge=0.95)
     eff_d = bs.efficiency_discharge
 
-    buy = [0.5] * 8 + [5.0] * 8
+    buy = [1.0] * 8 + [5.0] * 8
     sell = [0.3] * 16
     solar = [4.0] * 8 + [0.0] * 8
     consumption = [0.5] * 8 + [2.0] * 8
@@ -77,10 +81,11 @@ def test_solar_export_covers_dip_when_buy_exceeds_export():
     for t in periods:
         shadow = result.period_data[t].decision.shadow_price
         assert shadow > 0.0, f"period {t}: shadow_price not populated"
-        # replenishment floor: stored energy worth ~the export price, not the peak
+        # replenishment floor: export price plus the forced recharge's cycle cost,
+        # not sell price alone (see docstring)
         assert shadow == pytest.approx(
-            sell[t], abs=0.05
-        ), f"period {t}: shadow {shadow:.3f} should be ~sell {sell[t]:.3f}"
+            0.7093, abs=0.01
+        ), f"period {t}: shadow {shadow:.4f} should be ~0.7093 (sell + cycle cost)"
         assert shadow < buy[t] * eff_d
         assert solar_export_discharge_rate(buy[t], shadow, eff_d) == 100
 

--- a/core/bess/tests/unit/test_surplus_disposition.py
+++ b/core/bess/tests/unit/test_surplus_disposition.py
@@ -330,3 +330,123 @@ def test_battery_export_active_discharge_still_grid_first():
     assert cmd.battery_mode == "grid_first"
     assert cmd.discharge_rate_pct == 50
     assert cmd.grid_charge is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #204: anti-cycling discharge gate over-values stored energy when
+# solar already covers all home load (no grid purchase to displace)
+# ---------------------------------------------------------------------------
+
+
+def test_discharge_blocked_when_solar_covers_load_and_action_matches_bug_report():
+    """Reproduces issue #204 period 63 exactly: solar covers all home load,
+    battery full, buy_price > sell_price. avoid_purchase_value wrongly lets a
+    marginal 0.1 kWh discharge through the -inf anti-cycling gate because
+    there is no grid purchase to actually avoid this period."""
+    bs = make_battery_settings()
+    buy_price = [1.0568]
+    sell_price = [0.46126]
+    cost_basis = 0.6219
+    soe = bs.max_soe_kwh  # battery full
+    power = -0.4  # discharge power that yields the reported 0.1 kWh action
+
+    next_soe = _state_transition(
+        soe, power, bs, DT, solar_production=0.893, home_consumption=0.155
+    )
+
+    reward, _ = _compute_reward(
+        power=power,
+        soe=soe,
+        next_soe=next_soe,
+        period=0,
+        home_consumption=0.155,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=buy_price,
+        sell_price=sell_price,
+        solar_production=0.893,
+        cost_basis=cost_basis,
+    )
+    assert reward == float("-inf"), (
+        f"Expected discharge blocked (no grid purchase to displace, "
+        f"export_value=0.438 < cost_basis=0.622) but got reward={reward}"
+    )
+
+
+def test_discharge_blocked_at_smaller_action_size_below_capacity_threshold():
+    """Same solar-covers-load scenario as above but with a smaller discharge
+    action (0.05 kWh) whose capacity_after_discharge falls below SOE_STEP_KWH.
+    The fix must gate on excess_solar alone, not on capacity_after_discharge —
+    otherwise this smaller action slips through even after fixing the
+    reported 0.1 kWh case."""
+    bs = make_battery_settings()
+    buy_price = [1.0568]
+    sell_price = [0.46126]
+    cost_basis = 0.6219
+    soe = bs.max_soe_kwh
+    power = -0.2  # half the reported action size
+
+    next_soe = _state_transition(
+        soe, power, bs, DT, solar_production=0.893, home_consumption=0.155
+    )
+    capacity_after_discharge = bs.max_soe_kwh - next_soe
+    assert (
+        capacity_after_discharge < 0.1
+    )  # confirms this is the smaller-action edge case
+
+    reward, _ = _compute_reward(
+        power=power,
+        soe=soe,
+        next_soe=next_soe,
+        period=0,
+        home_consumption=0.155,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=buy_price,
+        sell_price=sell_price,
+        solar_production=0.893,
+        cost_basis=cost_basis,
+    )
+    assert reward == float(
+        "-inf"
+    ), f"Expected discharge blocked even at smaller action size but got reward={reward}"
+
+
+def test_discharge_not_blocked_when_solar_does_not_cover_load():
+    """Regression guard: when solar does NOT cover home load, there IS a real
+    grid purchase to avoid, so avoid_purchase_value must remain in the max()
+    and a genuinely profitable discharge must not be blocked."""
+    bs = make_battery_settings()
+    buy_price = [1.0568]
+    sell_price = [0.46126]
+    cost_basis = 0.5  # below avoid_purchase_value, discharge is profitable
+    soe = bs.max_soe_kwh
+    power = -0.4
+    solar_production = 0.1
+    home_consumption = 1.0  # exceeds solar, no excess solar
+
+    next_soe = _state_transition(
+        soe,
+        power,
+        bs,
+        DT,
+        solar_production=solar_production,
+        home_consumption=home_consumption,
+    )
+
+    reward, _ = _compute_reward(
+        power=power,
+        soe=soe,
+        next_soe=next_soe,
+        period=0,
+        home_consumption=home_consumption,
+        battery_settings=bs,
+        dt=DT,
+        buy_price=buy_price,
+        sell_price=sell_price,
+        solar_production=solar_production,
+        cost_basis=cost_basis,
+    )
+    assert reward != float(
+        "-inf"
+    ), "Expected discharge NOT blocked (real grid purchase avoided) but got -inf"

--- a/docs/superpowers/specs/2026-06-27-solar-export-discharge-rate-design.md
+++ b/docs/superpowers/specs/2026-06-27-solar-export-discharge-rate-design.md
@@ -128,24 +128,42 @@ invisible to the simulator. So:
 
 ## What the shadow price turns out to be during SOLAR_EXPORT
 
-A SOLAR_EXPORT period is, by definition, a **full battery actively exporting
-surplus**. So the marginal stored kWh is *replenishable for free* from the
-ongoing surplus — its opportunity value is just the **export floor (sell
-price)**, not the future peak. The DP shadow price confirms this empirically
-(`shadow ≈ sell` for every SOLAR_EXPORT period). Consequences:
+**Updated 2026-07-03 (issue #204):** the anti-cycling discharge gate in
+`_compute_reward` used to let the DP take marginal, unprofitable discharges
+during solar-surplus periods (crediting them with `avoid_purchase_value` even
+when there was no grid purchase to displace). Fixing #204 closed that leak —
+and it turns out the empirical `shadow ≈ sell` result below was partly an
+artifact of it: the buggy discharge path let the DP dodge the wear cost of the
+forced passive-solar recharge that a not-quite-full battery incurs every period
+during a surplus. With the gate fixed, that recharge cost is no longer
+avoidable, and the shadow price correctly rises to include it. The reasoning
+that follows is updated accordingly; the mechanism (backward-difference on `V`)
+is unchanged.
 
-- **Normal prices** (`buy·eff_d > sell`): gate → **100**. Covering an
-  intra-period dip from the battery beats buying from grid, because the surplus
-  refills the battery. This is the common case.
+A SOLAR_EXPORT period is, by definition, a **full battery actively exporting
+surplus**. The marginal stored kWh is replenishable from the ongoing surplus,
+but that refill is not free: every period spent below full pays the passive-
+charging cycle cost (`cycle_cost_per_kwh`) that a full battery avoids. So the
+marginal stored kWh's opportunity value is the **export floor (sell price)
+plus that forced-replenishment cycle cost**, not sell price alone. Consequences:
+
+- **Normal prices, buy comfortably above the (now higher) shadow price**: gate
+  → **100**. Covering an intra-period dip from the battery still beats buying
+  from grid.
+- **Buy price too close to sell** (shadow price, inflated by cycle cost, now
+  exceeds `buy·eff_d`): gate → **0**, even though `buy > sell`. The
+  replenishment cost eats the spread that used to make covering the dip
+  worthwhile.
 - **Inverted prices** (`sell ≥ buy·eff_d` — export premium, negative buy):
   gate → **0**. The energy is worth more exported than the cheap grid import it
   would displace; export it and buy the dip from grid.
 
-So in practice the gate is 100 except under export-premium / negative-price
-conditions. A hardcoded `discharge_rate=100` would be *wrong* in those inverted
-cases — which is why the shadow price (not a constant) is required. The
-reserve-for-peak behaviour shows up at LOAD_SUPPORT/discharge periods, where the
-gate does not apply.
+The gate is no longer "100 except under export-premium conditions" — it now
+also depends on `buy` clearing the cycle-cost-inclusive shadow price, not just
+`buy > sell`. The shadow price (not a constant, and not a bare sell-price
+proxy) is required precisely because that threshold moves with `cycle_cost_per_kwh`
+and the price levels. The reserve-for-peak behaviour shows up at
+LOAD_SUPPORT/discharge periods, where the gate does not apply.
 
 ## Tests
 


### PR DESCRIPTION
## Summary

- `_compute_reward`'s discharge profitability check took `max(avoid_purchase_value, export_value)` unconditionally, crediting discharges with the avoided-purchase price even in periods where solar already covers all home load — i.e. there is no grid purchase to actually displace. This let marginal, unprofitable ~0.1 kWh `BATTERY_EXPORT` discharges slip past the `-inf` anti-cycling gate whenever `buy_price > sell_price` (the normal case).
- Fix: exclude `avoid_purchase_value` from the max whenever `excess_solar > POWER_TOLERANCE_KW`, decoupled from the existing `capacity_after_discharge` check (which answers a different question — room to reabsorb *future* solar — not whether there's a purchase to avoid *this* period). Reusing the compound condition (as the issue's initial proposal suggested) would have left the leak open for discharge actions too small to open up that capacity — confirmed via `bess-analyst` review before implementation.
- Reproduces and blocks the exact case from issue #204 (period 63, 2026-06-28 bundle): `effective_value_per_kwh_stored` drops from `1.004` (wrongly using `avoid_purchase_value`) to `0.438` (`export_value` only), correctly gating below `cost_basis=0.622`.

### Downstream fallout (also fixed here)

Fixing the gate correctly removes a bug that a few other tests were unknowingly relying on:

- **`test_scenarios[historical_2025_06_02_high_solar_export]`**: `expected_results` fixture was pinned to the old (buggy) economics. Regenerated from the optimizer per `docs/agents/testing.md` convention (0.15% cost delta, ≥4 decimal precision).
- **`test_solar_export_covers_dip_when_buy_exceeds_export`**: the SOLAR_EXPORT intra-period dip-gate's `shadow_price` now correctly includes the cycle cost of forced solar-replenishment (~0.71 vs the old ~0.3 ≈ sell price), since the DP can no longer dodge that cost via the now-blocked marginal discharges. Updated the test's buy price so it still exercises the `gate=100` path under the corrected economics, and corrected the design doc's now-inaccurate "replenishment is free" claim (`docs/superpowers/specs/2026-06-27-solar-export-discharge-rate-design.md`).
- **`test_forecast_robustness_more_solar_than_planned`**: exposed that `realized_under_solar_error` never credited terminal SoE value — previously masked because the #204 bug drained the battery via bogus exports before horizon end. The corrected DP legitimately stores bonus solar without discharging, so more actual solar than forecast means more stored (real) value left uncredited at the horizon cutoff. Added the same median-buy-price terminal valuation `battery_system_manager._calculate_terminal_value` already uses in production, applied symmetrically to both planned and realized costs.

Supersedes #196 (closed in favor of #204, which pinpointed the actual root cause).

Fixes #204

## Test plan

- [x] New regression tests in `test_surplus_disposition.py`: reproduces the exact documented bug (period 63 numbers), a smaller-action edge case proving the fix isn't scoped too narrowly to the reported action size, and a non-regression guard for the legitimate "real purchase to avoid" case (all written test-first, watched RED before the fix, GREEN after).
- [x] Full fast suite: 932 passed, 11 skipped
- [x] Full slow suite (algorithm/integration, ~11.5 min): 326 passed, 3 skipped
- [x] `black` / `ruff` clean on all changed files
- [x] Independent root-cause verification via `bess-analyst` sub-agent before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)