### PR TITLE
Fix #200: LOAD_SUPPORT discharge rate not reaching inverter on Solax Modbus

### DIFF
--- a/core/bess/solax_modbus_growatt_controller.py
+++ b/core/bess/solax_modbus_growatt_controller.py
@@ -149,8 +149,10 @@ class SolaxModbusGrowattController(GrowattMinController):
                     errors.append(str(e))
 
         # load_first uses inverter-native discharge control; touching the EMS
-        # discharge rate register (even with 0) disables discharge entirely.
-        if mode != "load_first":
+        # discharge rate register with 0 disables discharge entirely. But
+        # LOAD_SUPPORT also maps to load_first and can carry a real non-zero
+        # rate (#200) — only withhold the write when there's nothing to write.
+        if mode != "load_first" or discharge_rate != 0:
             success, error_msg = self._write_period_to_hardware(
                 controller, grid_charge, discharge_rate
             )

--- a/core/bess/tests/integration/test_cross_platform.py
+++ b/core/bess/tests/integration/test_cross_platform.py
@@ -122,10 +122,10 @@ class TestCrossPlatformHardwareWrites:
         elif _is_solax(platform_system):
             assert len(mock_controller.calls["vpp_calls"]) == 1
             assert mock_controller.calls["vpp_calls"][0] < 0
-        elif _is_solax_modbus(platform_system):
-            # LOAD_SUPPORT → load_first; inverter-native discharge, EMS register not written
-            assert mock_controller.calls["discharge_rate"] == []
         else:
+            # solax_modbus maps LOAD_SUPPORT to load_first same as the generic
+            # platforms below, but (#200) it must still write its real,
+            # non-zero discharge rate — only a genuinely zero rate is withheld.
             assert any(r > 0 for r in mock_controller.calls["discharge_rate"])
 
     def test_export_arbitrage_commands_hardware(self, platform_system, mock_controller):

--- a/core/bess/tests/unit/test_solax_modbus_growatt_single_segment.py
+++ b/core/bess/tests/unit/test_solax_modbus_growatt_single_segment.py
@@ -221,6 +221,32 @@ class TestApplyPeriod:
         assert len(mock_ha.calls["discharge_rate"]) == 0
         assert len(mock_ha.calls["grid_charge"]) == 0
 
+    def test_load_first_writes_nonzero_load_support_discharge_rate(
+        self, controller, mock_ha
+    ):
+        """LOAD_SUPPORT's real discharge rate must reach the inverter.
+
+        Regression test for #200: LOAD_SUPPORT maps to load_first, same as
+        IDLE, but unlike IDLE it can compute a non-zero discharge rate. The
+        load_first gate must only withhold zero-rate writes (see
+        test_load_first_skips_ems_discharge_write above), not this one.
+        """
+        from datetime import datetime
+
+        intents = hourly_to_quarterly({0: "LOAD_SUPPORT"})
+        schedule = make_schedule(intents)
+        controller.create_schedule(schedule, current_period=0)
+        controller._last_written_tou_mode = "load_first"
+
+        with patch("core.bess.solax_modbus_growatt_controller.time_utils") as mock_time:
+            mock_time.now.return_value = datetime(2026, 5, 20, 0, 0, 0)
+            # -2.0 kW discharge -> non-zero discharge_rate for LOAD_SUPPORT
+            grid_charge, discharge_rate = controller.compute_rates_for_period(0, -2.0)
+            assert discharge_rate > 0  # sanity: scenario must produce a rate
+            controller.apply_period(mock_ha, grid_charge, discharge_rate)
+
+        assert mock_ha.calls["discharge_rate"] == [discharge_rate]
+
 
 class TestWriteScheduleToHardware:
     """Test write_schedule_to_hardware initialises segment 1."""


### PR DESCRIPTION
## Summary
- `apply_period()` on the Solax Modbus / local-Modbus Growatt controller was silently dropping the hardware write for `LOAD_SUPPORT`'s real discharge rate under `load_first` mode
- Narrows the gate added in #166 (which correctly stops writing `discharge_rate=0`, since that disables the inverter's native self-use discharge) so it only withholds the write when there's genuinely nothing to write, not for every `load_first`-mapped intent
- Adds a regression test covering `LOAD_SUPPORT`'s non-zero rate under `load_first`

## Root cause
`apply_period()` gated the hardware write on TOU mode (`if mode != "load_first":`), but four strategic intents map to `load_first` — `IDLE`, `SOLAR_STORAGE`, `SOLAR_EXPORT`, `LOAD_SUPPORT` — and only `LOAD_SUPPORT` computes a real, non-zero action-derived discharge percentage. The other three always resolve to `discharge_rate=0`. `BATTERY_EXPORT` maps to `grid_first` and bypasses the gate entirely, which is why Grid First worked and Load First didn't (per the reporter's comment).

## Fix
Changed the condition from `if mode != "load_first":` to `if mode != "load_first" or discharge_rate != 0:` — preserves #166's protection (still skips when `discharge_rate` is genuinely `0`) while letting `LOAD_SUPPORT`'s real rate reach the inverter.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (0 errors, 0 warnings)
- [x] Live-verified against a real running mock-HA (not just the unit test's in-process mock): drove the real `HomeAssistantAPIController` + `SolaxModbusGrowattController` over actual HTTP against `scripts/mock_ha/server.py`. Before the register read `100` (stale); after applying a `LOAD_SUPPORT` period with `discharge_rate=40%`, the real `POST /api/services/number/set_value` landed and the register read `40`. Control probe: seeded the register at `77` and ran `IDLE` (`discharge_rate=0`) through the same real path — register stayed at `77`, confirming #166's protection still holds.

Closes #200