### PR TITLE
docs: add After Merge cleanup step to implement-issue skill

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -137,6 +137,38 @@ Closes #<n>
   the spec (if any); the plan is execution scaffolding that only drifts once
   the code is the source of truth. Never commit a plan doc into the PR.
 
+## After Merge
+
+A **separate, later invocation** — often a different session, sometimes days
+later once CI is green and the user has reviewed. Not part of the numbered
+flow above, which stops at draft-PR-open per the Step 10 constraints.
+
+1. Confirm the merge:
+
+   ```bash
+   gh pr view <n> --json state,mergedAt,mergeCommit
+   ```
+
+   `state == "MERGED"` is authoritative — that's the standard signal, no need
+   to separately diff branch content against `main`. Squash merges break
+   `git branch -d`'s normal ancestry check (the branch's commits never become
+   reachable from `main`), so force-delete below is expected, not a sign
+   something's wrong.
+
+2. Remove the worktree — via `ExitWorktree action=remove discard_changes=true`
+   if the session is still in it, or `git worktree remove <path>` from the
+   main repo root for a `.worktrees/`-created one.
+
+3. Force-delete the local branch and prune stale remote refs:
+
+   ```bash
+   git branch -D <branch-name>
+   git fetch origin --prune
+   ```
+
+   GitHub auto-deletes the remote branch on merge by default; `--prune` just
+   clears the now-stale local tracking ref.
+
 ## Rationalizations — Reality
 
 | Excuse | Reality |


### PR DESCRIPTION
## Summary
- The `implement-issue` skill's numbered flow stops at draft-PR-open (`finishing-a-development-branch` Option 2 deliberately leaves the worktree alive for PR iteration), so there was no documented procedure for closing out a merged branch/worktree in a later session.
- Adds an `## After Merge` section: confirm merge via `gh pr view --json state,mergedAt,mergeCommit`, remove the worktree, force-delete the local branch, and `fetch --prune`.
- Documents the one non-obvious gotcha: squash merges break `git branch -d`'s ancestry check (the branch's commits never become reachable from `main`), so force-delete after confirming `MERGED` state is expected, not a sign something's wrong — no need to separately diff branch content against `main`.

## Test plan
- [x] Docs-only change, no code paths affected