### PR TITLE
Fix stale health-check banner and InfluxDB placeholder-config log spam

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,6 +57,16 @@
 - All assignments and references in `decision_intelligence.py`, `sph_schedule.py`, `battery_system_manager.py`, and any API serialization
 - Frontend: any display label or type referencing `strategicIntent` / `strategic_intent`
 
+### **Minor cleanup from issue #201 (stale health-check banner) fix**
+
+**Impact**: Low | **Effort**: Low | **Dependencies**: `core/bess/influxdb_helper.py`, `backend/api.py`
+
+**Description**: A few small, non-blocking cleanups identified during code review of the #201 fix:
+
+- `get_sensor_data_batch` and `get_power_sensor_data_batch` (`core/bess/influxdb_helper.py`) each have their own copy of the `if not is_influxdb_configured(): ...` early-return guard — could be factored into a shared decorator/helper if a third call site appears.
+- `GET /api/system-health` and `POST /api/system-health/recheck` (`backend/api.py`) share the same `_require_configured_system` + health-check + `convert_keys_to_camel_case` + `HTTPException(500)` shape, differing only in whether the result is cached. Worth revisiting if a third variant is ever needed.
+- The new 5-minute health-check cron job (`backend/app.py`) also re-runs `test_influxdb_connection()` for the subset of users who *do* have InfluxDB configured (it correctly skips for everyone else). This is intentional — same cadence agreed for the dashboard banner — but worth knowing if InfluxDB load ever becomes a complaint.
+
 ### **Investigate redundant `power` gate in strategic intent detection**
 
 **Impact**: Low | **Effort**: Low | **Dependencies**: `decision_intelligence.py`, `dp_battery_algorithm.py`

--- a/backend/api.py
+++ b/backend/api.py
@@ -136,7 +136,7 @@ def _refresh_health(bess_controller) -> None:
     Failures are non-fatal — the banner will self-correct on the next poll.
     """
     try:
-        bess_controller.system._run_health_check()
+        bess_controller.system.refresh_health_check()
     except Exception as exc:
         logger.warning("Could not refresh health state after settings update: %s", exc)
 
@@ -1932,6 +1932,27 @@ async def get_system_health():
         return convert_keys_to_camel_case(error_result)
 
 
+@router.post("/api/system-health/recheck")
+async def recheck_system_health():
+    """Manually re-run health checks and refresh the cached dashboard banner state.
+
+    Unlike GET /api/system-health (which runs a fresh check but doesn't touch
+    the cache), this updates ``_cached_health_results``/``_critical_sensor_failures``
+    so the dashboard banner immediately reflects the result — for a "Recheck now"
+    button after the user fixes a sensor in Home Assistant.
+    """
+    from app import bess_controller
+
+    _require_configured_system(bess_controller)
+
+    try:
+        health_results = bess_controller.system.refresh_health_check()
+        return convert_keys_to_camel_case(health_results)
+    except Exception as e:
+        logger.error(f"Error refreshing system health: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
 @router.get("/api/dashboard-health-summary")
 async def get_dashboard_health_summary():
     """Get lightweight health summary for dashboard alert banner - only critical issues."""
@@ -3261,7 +3282,7 @@ async def setup_complete(payload: APISetupCompletePayload):
         # Re-run health check so the dashboard banner reflects the new configuration
         # instead of the stale failures recorded at startup (before sensors were set).
         try:
-            bess_controller.system._run_health_check()
+            bess_controller.system.refresh_health_check()
         except Exception as health_err:
             logger.warning("Could not re-run health check after setup: %s", health_err)
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -340,6 +340,15 @@ class BESSController:
             misfire_grace_time=30,  # Allow 30 seconds of misfire before warning
         )
 
+        # Health check refresh (every 5 minutes) — so the dashboard banner
+        # self-corrects if sensors recover after a transient failure, instead
+        # of only refreshing at startup or on the next settings save.
+        self.scheduler.add_job(
+            self.system.refresh_health_check,
+            CronTrigger(minute="*/5"),
+            misfire_grace_time=30,  # Allow 30 seconds of misfire before warning
+        )
+
         # Give BSM access to the scheduler for one-shot retry jobs
         self.system.set_scheduler(self.scheduler)
 

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -227,6 +227,31 @@ class TestSystemHealth:
 
 
 # ===========================================================================
+# POST /api/system-health/recheck
+# ===========================================================================
+
+
+class TestSystemHealthRecheck:
+    def test_returns_200_and_calls_refresh_health_check(self):
+        ctrl = _make_started_controller()
+        ctrl.system.refresh_health_check.return_value = {
+            "checks": [],
+            "system_mode": "normal",
+        }
+        sys.modules["app"].bess_controller = ctrl
+
+        resp = _client.post("/api/system-health/recheck")
+
+        assert resp.status_code == 200
+        ctrl.system.refresh_health_check.assert_called_once()
+
+    def test_unconfigured_returns_503(self):
+        sys.modules["app"].bess_controller = _unconfigured_controller()
+        resp = _client.post("/api/system-health/recheck")
+        assert resp.status_code == 503
+
+
+# ===========================================================================
 # GET /api/dashboard-health-summary
 # ===========================================================================
 

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -348,9 +348,9 @@ class TestPatchSettingsLiveUpdates:
         assert mock_controller.system.temperature_derating.enabled is True
 
     def test_health_refresh_called_after_patch(self, mock_controller):
-        """_run_health_check must be called to keep dashboard banner current."""
+        """refresh_health_check must be called to keep dashboard banner current."""
         _client.patch("/api/settings", json={"home": {"defaultHourly": 5.0}})
-        mock_controller.system._run_health_check.assert_called()
+        mock_controller.system.refresh_health_check.assert_called()
 
 
 # ===========================================================================

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -604,7 +604,7 @@ class TestSetupComplete:
 
     def test_health_check_rerun(self, complete_controller):
         _client.post("/api/setup/complete", json=_full_wizard_payload())
-        complete_controller.system._run_health_check.assert_called()
+        complete_controller.system.refresh_health_check.assert_called()
 
     def test_discovered_config_applied(self, complete_controller):
         _client.post("/api/setup/complete", json=_full_wizard_payload())

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -2710,6 +2710,16 @@ class BatterySystemManager:
             self._critical_sensor_failures = ["System Health Check"]
             return {"status": "ERROR", "checks": []}
 
+    def refresh_health_check(self) -> dict[str, Any]:
+        """Re-run the health check and update cached results/critical failures.
+
+        Public entry point for callers outside this class (the periodic
+        scheduler, a manual "recheck" endpoint) so the dashboard banner can
+        reflect current sensor state instead of only what was true at
+        startup or the last settings save.
+        """
+        return self._run_health_check()
+
     def has_critical_sensor_failures(self) -> bool:
         """Check if the system has critical sensor failures (degraded mode)."""
         return len(self._critical_sensor_failures) > 0

--- a/core/bess/influxdb_helper.py
+++ b/core/bess/influxdb_helper.py
@@ -27,7 +27,12 @@ def is_influxdb_configured() -> bool:
     except (KeyError, FileNotFoundError, json.JSONDecodeError):
         return False
 
-    if not config["url"] or not config["username"] or not config["password"]:
+    if (
+        not config["url"]
+        or not config["username"]
+        or not config["password"]
+        or not config["bucket"]
+    ):
         return False
 
     if (
@@ -394,16 +399,16 @@ def get_sensor_data_batch(sensors_list, target_date) -> dict:
         _LOGGER.warning("No sensors configured — skipping InfluxDB query")
         return {"status": "error", "message": "No sensors configured"}
 
+    if not is_influxdb_configured():
+        _LOGGER.debug("InfluxDB is not configured — skipping query")
+        return {"status": "error", "message": "InfluxDB not configured"}
+
     # Get configuration
     influxdb_config = get_influxdb_config()
     url = influxdb_config["url"]
     bucket = influxdb_config["bucket"]
     username = influxdb_config["username"]
     password = influxdb_config["password"]
-
-    if not url or not username or not password or not bucket:
-        _LOGGER.error("InfluxDB configuration is incomplete")
-        return {"status": "error", "message": "Incomplete InfluxDB configuration"}
 
     headers = {
         "Content-type": "application/vnd.flux",
@@ -723,15 +728,15 @@ def get_power_sensor_data_batch(power_sensors: list[str], target_date) -> dict:
         tzinfo=local_tz
     )
 
+    if not is_influxdb_configured():
+        _LOGGER.debug("InfluxDB is not configured — skipping query")
+        return {"status": "error", "message": "InfluxDB not configured"}
+
     influxdb_config = get_influxdb_config()
     url = influxdb_config["url"]
     bucket = influxdb_config["bucket"]
     username = influxdb_config["username"]
     password = influxdb_config["password"]
-
-    if not url or not username or not password or not bucket:
-        _LOGGER.error("InfluxDB configuration is incomplete")
-        return {"status": "error", "message": "Incomplete InfluxDB configuration"}
 
     headers = {
         "Content-type": "application/vnd.flux",

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -251,6 +251,49 @@ class TestCriticalSensorFailures:
         assert system.get_critical_sensor_failures() == ["x"]
 
 
+class TestRefreshHealthCheck:
+    """Public wrapper so callers outside BatterySystemManager (the scheduler,
+    a manual-recheck endpoint) can re-run health checks without reaching into
+    the private ``_run_health_check`` method.
+    """
+
+    def test_updates_cached_results_from_a_fresh_run(self, system):
+        system._critical_sensor_failures = ["Battery SOC"]
+        healthy_result = {
+            "status": "OK",
+            "checks": [{"name": "Battery SOC", "status": "OK", "required": True}],
+        }
+        with patch(
+            "core.bess.battery_system_manager.run_system_health_checks",
+            return_value=healthy_result,
+        ):
+            system.refresh_health_check()
+
+        assert system.get_cached_health_results() == healthy_result
+        assert not system.has_critical_sensor_failures()
+
+    def test_recovers_failures_that_are_still_present(self, system):
+        failing_result = {
+            "status": "ERROR",
+            "checks": [
+                {
+                    "name": "Battery SOC",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [],
+                }
+            ],
+        }
+        with patch(
+            "core.bess.battery_system_manager.run_system_health_checks",
+            return_value=failing_result,
+        ):
+            system.refresh_health_check()
+
+        assert system.has_critical_sensor_failures()
+        assert system.get_critical_sensor_failures() == ["Battery SOC"]
+
+
 class TestGetCurrentDailyView:
     def test_invalid_period_raises(self, system):
         with pytest.raises(SystemConfigurationError):

--- a/core/bess/tests/unit/test_influxdb_helper.py
+++ b/core/bess/tests/unit/test_influxdb_helper.py
@@ -1,0 +1,67 @@
+"""Tests for InfluxDB configuration gating in periodic data-fetch functions.
+
+Regression coverage for issue #201: get_sensor_data_batch and
+get_power_sensor_data_batch only checked for empty strings, not the shipped
+placeholder credentials, so the ~15-minute periodic job kept attempting (and
+failing) a real HTTP connection for every user who never configured InfluxDB.
+"""
+
+from datetime import date
+from unittest.mock import patch
+
+from core.bess import influxdb_helper
+
+PLACEHOLDER_CONFIG = {
+    "url": "http://homeassistant.local:8086/api/v2/query",
+    "bucket": "home_assistant/autogen",
+    "username": "your_db_username_here",
+    "password": "your_db_password_here",
+}
+
+
+class TestGetSensorDataBatchSkipsUnconfigured:
+    def test_does_not_attempt_http_request_with_placeholder_credentials(self):
+        with (
+            patch.object(
+                influxdb_helper,
+                "get_influxdb_config",
+                return_value=PLACEHOLDER_CONFIG,
+            ),
+            patch.object(influxdb_helper.requests, "post") as mock_post,
+        ):
+            result = influxdb_helper.get_sensor_data_batch(
+                ["sensor.battery_soc"], date(2026, 7, 1)
+            )
+
+        mock_post.assert_not_called()
+        assert result["status"] == "error"
+
+
+class TestGetPowerSensorDataBatchSkipsUnconfigured:
+    def test_does_not_attempt_http_request_with_placeholder_credentials(self):
+        with (
+            patch.object(
+                influxdb_helper,
+                "get_influxdb_config",
+                return_value=PLACEHOLDER_CONFIG,
+            ),
+            patch.object(influxdb_helper.requests, "post") as mock_post,
+        ):
+            result = influxdb_helper.get_power_sensor_data_batch(
+                ["sensor.solar_power"], date(2026, 7, 1)
+            )
+
+        mock_post.assert_not_called()
+        assert result["status"] == "error"
+
+
+class TestIsInfluxdbConfiguredRequiresBucket:
+    def test_returns_false_when_bucket_is_empty(self):
+        config = {
+            "url": "http://homeassistant.local:8086/api/v2/query",
+            "bucket": "",
+            "username": "real_user",
+            "password": "real_password",
+        }
+        with patch.object(influxdb_helper, "get_influxdb_config", return_value=config):
+            assert influxdb_helper.is_influxdb_configured() is False

--- a/frontend/src/components/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner.tsx
@@ -15,6 +15,8 @@ interface AlertBannerProps {
   criticalIssues: CriticalIssue[];
   totalCriticalIssues: number;
   onDismiss?: () => void;
+  onRecheck?: () => void;
+  isRechecking?: boolean;
   className?: string;
 }
 
@@ -23,6 +25,8 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
   hasWarnings,
   criticalIssues,
   onDismiss,
+  onRecheck,
+  isRechecking = false,
   className = ''
 }) => {
   const navigate = useNavigate();
@@ -124,6 +128,15 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
                 <AlertCircle className="h-3.5 w-3.5 mr-1" />
                 Report Problem
               </button>
+              {onRecheck && (
+                <button
+                  onClick={onRecheck}
+                  disabled={isRechecking}
+                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-800 dark:text-red-300 bg-red-100 dark:bg-red-800/30 hover:bg-red-200 dark:hover:bg-red-800/50 rounded-md transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isRechecking ? 'Rechecking…' : 'Recheck now'}
+                </button>
+              )}
             </div>
           </div>
 
@@ -185,6 +198,15 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
               <ExternalLink className="h-3.5 w-3.5 mr-1" />
               View Details
             </button>
+            {onRecheck && (
+              <button
+                onClick={onRecheck}
+                disabled={isRechecking}
+                className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-amber-800 dark:text-amber-300 bg-amber-100 dark:bg-amber-800/30 hover:bg-amber-200 dark:hover:bg-amber-800/50 rounded-md transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isRechecking ? 'Rechecking…' : 'Recheck now'}
+              </button>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/__tests__/AlertBanner.test.tsx
+++ b/frontend/src/components/__tests__/AlertBanner.test.tsx
@@ -1,0 +1,45 @@
+import type { ComponentProps } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import AlertBanner from '../AlertBanner'
+import { ReportProblemProvider } from '../ReportProblemContext'
+
+const renderBanner = (props: Partial<ComponentProps<typeof AlertBanner>> = {}) =>
+  render(
+    <MemoryRouter>
+      <ReportProblemProvider>
+        <AlertBanner
+          hasCriticalErrors={true}
+          hasWarnings={false}
+          criticalIssues={[{ component: 'Battery SOC', description: 'sensor unavailable', status: 'ERROR' }]}
+          totalCriticalIssues={1}
+          {...props}
+        />
+      </ReportProblemProvider>
+    </MemoryRouter>
+  )
+
+describe('AlertBanner recheck action', () => {
+  it('calls onRecheck when the Recheck now button is clicked', () => {
+    const onRecheck = vi.fn()
+    renderBanner({ onRecheck })
+
+    fireEvent.click(screen.getByRole('button', { name: /recheck now/i }))
+
+    expect(onRecheck).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render a recheck button when onRecheck is not provided', () => {
+    renderBanner()
+
+    expect(screen.queryByRole('button', { name: /recheck now/i })).not.toBeInTheDocument()
+  })
+
+  it('disables the recheck button while isRechecking is true', () => {
+    const onRecheck = vi.fn()
+    renderBanner({ onRecheck, isRechecking: true })
+
+    expect(screen.getByRole('button', { name: /rechecking/i })).toBeDisabled()
+  })
+})

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -96,6 +96,7 @@ export default function DashboardPage({
   
   const [healthSummary, setHealthSummary] = useState<HealthSummary | null>(null);
   const [dismissedBanner, setDismissedBanner] = useState(false);
+  const [isRecheckingHealth, setIsRecheckingHealth] = useState(false);
   const [demoMode, setDemoMode] = useState(false);
 
   // Runtime failures state
@@ -201,6 +202,22 @@ export default function DashboardPage({
     }
   }, [isInitialLoad, onLoadingChange, dataResolution]); // Add dependencies
 
+  // Manually re-run health checks (e.g. after fixing a sensor in Home Assistant)
+  // instead of waiting for the next periodic refresh.
+  const handleRecheckHealth = useCallback(async () => {
+    setIsRecheckingHealth(true);
+    try {
+      await api.post('/api/system-health/recheck');
+      await fetchData();
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
+      setError(`Recheck failed: ${errorMessage}`);
+      console.error('Health recheck failed:', err);
+    } finally {
+      setIsRecheckingHealth(false);
+    }
+  }, [fetchData]);
+
   useEffect(() => {
     fetchData();
     // Poll every 3s while initializing for live progress, 60s normally
@@ -240,6 +257,8 @@ export default function DashboardPage({
           criticalIssues={healthSummary.criticalIssues}
           totalCriticalIssues={healthSummary.totalCriticalIssues}
           onDismiss={handleDismissBanner}
+          onRecheck={handleRecheckHealth}
+          isRechecking={isRecheckingHealth}
         />
       )}
 


### PR DESCRIPTION
## Summary
- The dashboard health banner ("Battery Monitoring [ERROR]" / "Energy Monitoring [ERROR]") only refreshed at startup, after a settings save, or after the setup wizard — never periodically. A sensor blip at exactly one of those moments left the banner stuck showing an error indefinitely, with no way for the user to clear it short of an unrelated settings save or a restart. Added a public `refresh_health_check()` wrapper, a 5-minute scheduler job, and a manual "Recheck now" button/endpoint so the banner self-corrects.
- `get_sensor_data_batch`/`get_power_sensor_data_batch` only checked for empty-string InfluxDB config, not the shipped placeholder credentials, so the periodic sensor-collection job kept attempting real HTTP connections to the default InfluxDB URL for any user who never configured it. Both now use the existing `is_influxdb_configured()` check (which also gained a bucket-emptiness check it was missing).
- Converted two pre-existing call sites (settings-save refresh, setup-wizard completion) from the private `_run_health_check()` to the new public wrapper.

## Root cause
> **1. The "Battery Monitoring [ERROR]" / "Energy Monitoring [ERROR]" banner is stale, not live.** The dashboard alert banner is driven by a health-check result that's only recomputed when BESS Manager starts up or when you save settings — it's never rechecked automatically afterwards... This is a caching bug — the banner needs to self-correct instead of only updating on startup/settings-save.
>
> **2. Recurring "Error connecting to InfluxDB" log spam.** BESS Manager ships with a default (placeholder) InfluxDB URL, and one code path that fetches historical data every ~15 minutes doesn't check whether InfluxDB is actually configured with real credentials before trying to connect — unlike the startup path, which does check correctly.

(from the `bess-analyst` diagnosis on #201)

## Fix
- `core/bess/battery_system_manager.py`: added `refresh_health_check()` public wrapper around `_run_health_check()`.
- `backend/app.py`: new 5-minute `CronTrigger` scheduler job calling `refresh_health_check()`.
- `backend/api.py`: new `POST /api/system-health/recheck` endpoint for on-demand refresh; converted `_refresh_health()` and the setup-wizard-completion handler to use the public wrapper instead of the private method.
- `frontend/src/components/AlertBanner.tsx` + `frontend/src/pages/DashboardPage.tsx`: "Recheck now" button wired to the new endpoint.
- `core/bess/influxdb_helper.py`: `get_sensor_data_batch`/`get_power_sensor_data_batch` now call `is_influxdb_configured()` (which now also checks `bucket`) instead of an incomplete inline empty-string check.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (Black, Ruff, ESLint, TypeScript, frontend + backend tests all green — 966 backend tests, 23 frontend tests)
- [x] Live-verified via a `podman-compose` mock-HA stack with placeholder InfluxDB credentials matching the shipped defaults: confirmed zero HTTP connection attempts across startup + multiple health-check cycles (`InfluxDB is not configured — skipping...`), confirmed the 5-minute cron job re-runs the health check autonomously with no user action, and confirmed `POST /api/system-health/recheck` triggers an on-demand refresh and returns the updated state. Could not drive live execution through the exact two patched InfluxDB functions due to pre-existing, unrelated CI mock-scenario gaps (missing Nordpool config-entry-ID match and solar-forecast sensor mapping) — that gap is covered instead by direct unit tests exercising the real functions with only the HTTP layer mocked.

Closes #201