### PR TITLE
Fix: detect Solcast via entity registry unique_id instead of entity_id

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -2979,7 +2979,7 @@ async def run_setup_discovery():
                 sensors[phase_key] = entity_id
 
         # Discover optional integration sensors (Solcast, Weather, EV, etc.)
-        optional_sensors = ha.discover_optional_sensors(states)
+        optional_sensors = ha.discover_optional_sensors(states, registry)
         for key, entity_id in optional_sensors.items():
             if key not in sensors:
                 sensors[key] = entity_id

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -675,11 +675,11 @@ def _make_discover_controller(store_data: dict) -> MagicMock:
 class TestDiscoverLocaleDefaults:
     """POST /api/setup/discover — locale-appropriate defaults (#113)."""
 
-    def _run_discover(self, ctrl, integrations):
+    def _run_discover(self, ctrl, integrations, registry=None):
         """Helper: mock HA calls and POST /api/setup/discover."""
         ha = ctrl.ha_controller
         ha.discover_integrations.return_value = (integrations, [])
-        ha.fetch_entity_registry.return_value = []
+        ha.fetch_entity_registry.return_value = [] if registry is None else registry
         ha.discover_sensors_from_registry.return_value = ({}, None)
         ha.discover_current_sensors.return_value = {}
         ha.discover_optional_sensors.return_value = {}
@@ -821,6 +821,47 @@ class TestDiscoverLocaleDefaults:
 
         assert store["home"]["currency"] == original_currency
         assert store["electricity_price"]["vat_multiplier"] == original_vat
+
+    def test_discover_optional_sensors_receives_entity_registry(self):
+        """discover_optional_sensors must receive the entity registry (#218).
+
+        The registry is already fetched in this endpoint for Octopus
+        discovery; without passing it through, Solcast detection falls back
+        to fragile entity_id substring matching that breaks on non-English
+        HA locales.
+        """
+        store = deepcopy(_PRE_EXISTING_STORE)
+        ctrl = _make_discover_controller(store)
+        integrations = {
+            "growatt_found": False,
+            "device_sn": None,
+            "growatt_device_id": None,
+            "solax_found": False,
+            "nordpool_found": False,
+            "nordpool_area": None,
+            "nordpool_custom_area": None,
+            "nordpool_custom_entity": None,
+            "nordpool_config_entry_id": None,
+            "octopus_found": False,
+            "detected_inverter_platforms": [],
+            "detected_phase_count": None,
+            "currency": None,
+            "vat_multiplier": None,
+        }
+        registry = [
+            {
+                "entity_id": "sensor.solpanel_prognos_idag",
+                "platform": "solcast_solar",
+                "unique_id": "abc_total_kwh_forecast_today",
+            }
+        ]
+
+        resp = self._run_discover(ctrl, integrations, registry=registry)
+
+        assert resp.status_code == 200
+        ctrl.ha_controller.discover_optional_sensors.assert_called_once_with(
+            [], registry
+        )
 
 
 # ===========================================================================

--- a/core/bess/debug_data_exporter.py
+++ b/core/bess/debug_data_exporter.py
@@ -104,13 +104,21 @@ _ENTITY_REGISTRY_DOMAINS = frozenset(
         "nordpool",
         "octopus_energy",
         "entsoe",
+        "solcast_solar",
     }
 )
 
 # Keywords matched against entity_id and unique_id to capture entities
 # that belong to BESS-relevant integrations even if they register under
 # an unexpected platform name.
-_ENTITY_REGISTRY_KEYWORDS = ("growatt", "solax", "nordpool", "octopus", "entsoe")
+_ENTITY_REGISTRY_KEYWORDS = (
+    "growatt",
+    "solax",
+    "nordpool",
+    "octopus",
+    "entsoe",
+    "solcast",
+)
 
 # Entity registry fields that are useful for debugging discovery and
 # sensor mapping. unique_id is redacted (last-4) since it often contains

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -650,6 +650,11 @@ class HomeAssistantAPIController:
         "charger_use_mode": "solax_charger_use_mode",
     }
 
+    SOLCAST_SUFFIX_MAP: ClassVar[dict[str, str]] = {
+        "total_kwh_forecast_today": "solar_forecast_today",
+        "total_kwh_forecast_tomorrow": "solar_forecast_tomorrow",
+    }
+
     def resolve_sensor_for_influxdb(self, sensor_key: str) -> str | None:
         """Resolve sensor key to entity ID formatted for InfluxDB (without 'sensor.' prefix).
 
@@ -2457,12 +2462,6 @@ class HomeAssistantAPIController:
 
         Returns (sensor_key, entity_id) if matched, None otherwise.
         """
-        if "solcast" in lower_id and "peak" not in lower_id:
-            if "forecast_today" in lower_id:
-                return "solar_forecast_today", entity_id
-            if "forecast_tomorrow" in lower_id:
-                return "solar_forecast_tomorrow", entity_id
-
         if entity_id.startswith("weather."):
             return "weather_entity", entity_id
 
@@ -2577,22 +2576,29 @@ class HomeAssistantAPIController:
 
         return None
 
-    def discover_optional_sensors(self, states: list[dict]) -> dict[str, str]:
-        """Discover optional integration sensors from entity states.
+    def discover_optional_sensors(
+        self, states: list[dict], entity_registry: list[dict] | None = None
+    ) -> dict[str, str]:
+        """Discover optional integration sensors.
 
-        Scans all entity states for sensors belonging to optional integrations:
-        - Solcast solar forecast (forecast_today / forecast_tomorrow)
-        - Weather entity for temperature derating
-        - 48h average grid import (consumption forecast)
-        - Discharge inhibit binary sensor
+        Uses the entity registry (unique_id) for Solcast detection and entity
+        states for weather, consumption forecast, and discharge inhibit
+        sensors.
 
         Args:
             states: List of state dicts from /api/states
+            entity_registry: Entity registry list (for Solcast detection).
 
         Returns:
             dict mapping sensor_key -> entity_id for detected optional sensors
         """
         result: dict[str, str] = {}
+
+        if entity_registry is not None:
+            solcast = self._map_registry_entities(
+                entity_registry, ["solcast_solar"], self.SOLCAST_SUFFIX_MAP
+            )
+            result.update(solcast)
 
         for state in states:
             entity_id = str(state.get("entity_id", ""))

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -1384,3 +1384,50 @@ class TestFrontendSensorKeysMatchBackend:
                 f"{sorted(undeclared)}. Either add them to the frontend "
                 f"sensorDefinitions.ts or to BACKEND_ONLY_KEYS with a reason."
             )
+
+
+# ---------------------------------------------------------------------------
+# Solcast entity-registry discovery (#218): unique_id matching instead of
+# entity_id substrings, so detection survives non-English HA locale renames.
+# ---------------------------------------------------------------------------
+
+
+class TestSolcastEntityRegistryDiscovery:
+    def test_detects_solcast_via_unique_id_with_localized_entity_id(self):
+        """A renamed (non-English) entity_id must still be found via unique_id."""
+        controller = _make_controller()
+        registry = [
+            _entity(
+                "sensor.solpanel_prognos_idag",
+                "solcast_solar",
+                "abc123_total_kwh_forecast_today",
+            ),
+            _entity(
+                "sensor.solpanel_prognos_imorgon",
+                "solcast_solar",
+                "abc123_total_kwh_forecast_tomorrow",
+            ),
+        ]
+
+        result = controller.discover_optional_sensors([], registry)
+
+        assert result["solar_forecast_today"] == "sensor.solpanel_prognos_idag"
+        assert result["solar_forecast_tomorrow"] == "sensor.solpanel_prognos_imorgon"
+
+    def test_no_solcast_detection_without_entity_registry(self):
+        """English-locale entity_id substrings alone no longer detect Solcast.
+
+        Registry-based unique_id matching is the only path now (matches the
+        beta reference implementation) — states-only substring matching was
+        removed because it broke on non-English HA installs.
+        """
+        controller = _make_controller()
+        states = [
+            {"entity_id": "sensor.solcast_pv_forecast_forecast_today"},
+            {"entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow"},
+        ]
+
+        result = controller.discover_optional_sensors(states, None)
+
+        assert "solar_forecast_today" not in result
+        assert "solar_forecast_tomorrow" not in result

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -527,7 +527,7 @@ After discovery, the system derives additional configuration hints:
 
 Beyond core inverter and price sensors, discovery also detects:
 
-- **Solcast solar forecast**: Entities matching `solcast_solar` platform with `forecast_today` / `forecast_tomorrow` in the entity ID
+- **Solcast solar forecast**: Entity registry entries on the `solcast_solar` platform, matched by `unique_id` suffix (robust against non-English HA locale renaming of the entity ID)
 - **Weather**: Entities in the `weather.*` domain, preferring `weather.home` when multiple exist
 - **Phase currents**: `current_l1`, `current_l2`, `current_l3`
 - **EV charging inhibit**: Binary sensors ending with `_charging` or `_is_charging`

--- a/scripts/mock_ha/scenarios/ci-wizard-full.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-full.json
@@ -294,6 +294,22 @@
       "platform": "growatt_server",
       "config_entry_id": "mock_growatt_config_entry",
       "unique_id": "MOCK_SN-ac_charge"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_today",
+      "unique_id": "total_kwh_forecast_today",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Today",
+      "disabled_by": null,
+      "hidden_by": null
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow",
+      "unique_id": "total_kwh_forecast_tomorrow",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Tomorrow",
+      "disabled_by": null,
+      "hidden_by": null
     }
   ],
   "time_segments": [],

--- a/scripts/mock_ha/scenarios/ci-wizard-nordpool-hacs.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-nordpool-hacs.json
@@ -255,6 +255,22 @@
       "platform": "growatt_server",
       "config_entry_id": "mock_growatt_config_entry",
       "unique_id": "MOCK_SN-ac_charge"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_today",
+      "unique_id": "total_kwh_forecast_today",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Today",
+      "disabled_by": null,
+      "hidden_by": null
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow",
+      "unique_id": "total_kwh_forecast_tomorrow",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Tomorrow",
+      "disabled_by": null,
+      "hidden_by": null
     }
   ],
   "time_segments": [],

--- a/scripts/mock_ha/scenarios/synthetic-both.json
+++ b/scripts/mock_ha/scenarios/synthetic-both.json
@@ -667,13 +667,19 @@
     },
     {
       "entity_id": "sensor.solcast_pv_forecast_forecast_today",
+      "unique_id": "total_kwh_forecast_today",
       "platform": "solcast_solar",
-      "unique_id": "sensor_solcast_pv_forecast_forecast_today"
+      "original_name": "Forecast Today",
+      "disabled_by": null,
+      "hidden_by": null
     },
     {
       "entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow",
+      "unique_id": "total_kwh_forecast_tomorrow",
       "platform": "solcast_solar",
-      "unique_id": "sensor_solcast_pv_forecast_forecast_tomorrow"
+      "original_name": "Forecast Tomorrow",
+      "disabled_by": null,
+      "hidden_by": null
     },
     {
       "entity_id": "sensor.current_l1",

--- a/scripts/mock_ha/scenarios/synthetic-growatt-sph.json
+++ b/scripts/mock_ha/scenarios/synthetic-growatt-sph.json
@@ -2950,5 +2950,23 @@
     "discharge_stop_soc": 15,
     "periods": []
   },
-  "inverter_platform": "growatt_server_sph"
+  "inverter_platform": "growatt_server_sph",
+  "entity_registry": [
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_today",
+      "unique_id": "total_kwh_forecast_today",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Today",
+      "disabled_by": null,
+      "hidden_by": null
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow",
+      "unique_id": "total_kwh_forecast_tomorrow",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Tomorrow",
+      "disabled_by": null,
+      "hidden_by": null
+    }
+  ]
 }

--- a/scripts/mock_ha/scenarios/synthetic-solax.json
+++ b/scripts/mock_ha/scenarios/synthetic-solax.json
@@ -2946,5 +2946,23 @@
     }
   ],
   "time_segments": [],
-  "inverter_platform": "solax_modbus_native"
+  "inverter_platform": "solax_modbus_native",
+  "entity_registry": [
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_today",
+      "unique_id": "total_kwh_forecast_today",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Today",
+      "disabled_by": null,
+      "hidden_by": null
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow",
+      "unique_id": "total_kwh_forecast_tomorrow",
+      "platform": "solcast_solar",
+      "original_name": "Forecast Tomorrow",
+      "disabled_by": null,
+      "hidden_by": null
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Solcast solar-forecast sensors are now detected via entity-registry `unique_id` matching instead of fragile `entity_id` substring matching, so detection survives non-English HA locale renaming.
- This fix was already shipped on beta but never wired up on `main` (the only call site never passed the entity registry through), and it's the only actionable item from #218 that applies to `main` today.

## Root cause
From #218 item 3: beta added entity-registry-based Solcast detection (`SOLCAST_SUFFIX_MAP`, `discover_optional_sensors(states, entity_registry=...)`) but the only call site in `backend/api.py`'s discovery endpoint never passed the registry through, so it was dead code there too. On `main`, the entity-registry detection didn't exist at all — only the substring-matching path (`"solcast" in lower_id` / `"forecast_today" in lower_id`), which breaks when HA translates entity names to the user's locale.

Items 1 and 2 from #218 (`spot_multiplier` port, and the setup wizard's `_PRICE_MAP` gap) depend on fields that don't exist on `main` yet — split out to #221.

## Fix
- Add `SOLCAST_SUFFIX_MAP` mapping `unique_id` suffixes to BESS sensor keys, matching the exact reference implementation already shipped on beta (commit `7dc95f7`).
- `discover_optional_sensors` now accepts `entity_registry` and matches Solcast via `_map_registry_entities` (already used for other platforms); the old `entity_id` substring branch is removed.
- `backend/api.py`'s discovery endpoint now passes the already-fetched `registry` through.
- `core/bess/debug_data_exporter.py`'s debug-bundle filters now include `solcast_solar`/`solcast`, so a future locale-detection bug report is actually diagnosable from the debug log.
- Updated `docs/SOFTWARE_DESIGN.md` (stale description of the old substring mechanism) and 5 mock-HA scenario fixtures that previously relied on the removed substring fallback.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (0 errors, 0 warnings)
- [x] Unit tests: registry-based Solcast matching with a localized (non-English) `entity_id`, and confirmation that states-only substring matching no longer detects Solcast without a registry entry
- [x] Backend wiring test: `discover_optional_sensors` receives the registry
- [x] Local e2e verification via `docker-compose.ci.yml` (podman): hit the real `POST /api/setup/discover` endpoint against the `ci-wizard-full` mock-HA scenario — confirmed Solcast sensors resolve correctly, then patched the registry to use Dutch entity_ids (`sensor.zonnepaneel_voorspelling_vandaag`) with the same `unique_id` and confirmed detection still works (the exact case the old substring match couldn't handle), then confirmed removing the registry entries makes detection correctly absent (no silent fallback)

Closes #218