### PR TITLE
fix: unify Battery/Home settings startup/PATCH paths, drop *_STORE_TO_API registries (#219)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -8,6 +8,9 @@ import threading
 from datetime import datetime, timedelta
 
 from api_conversion import (
+    _BATTERY_DATACLASS_FIELDS as _BATTERY_MODEL_ATTRS,
+)
+from api_conversion import (
     convert_keys_to_camel_case,
     convert_keys_to_snake_case,
 )
@@ -29,7 +32,6 @@ from settings_store import VALID_PLATFORMS
 
 from core.bess import time_utils
 from core.bess.health_check import run_system_health_checks
-from core.bess.settings import BatterySettings as _BatterySettings
 from core.bess.time_utils import get_period_count
 
 router = APIRouter()
@@ -158,13 +160,13 @@ _SECTION_MAP: dict[str, str] = {
     "demoMode": "demo_mode",
 }
 
-# Derived from the BatterySettings dataclass — fields with init=True are the
-# writable attributes; init=False fields (min_soe_kwh, max_soe_kwh,
-# reserved_capacity) are computed and must not be sent to update_settings().
-# temperature_derating is a nested dict handled separately below.
-_BATTERY_MODEL_ATTRS: frozenset[str] = frozenset(
-    f.name for f in dataclasses.fields(_BatterySettings) if f.init
-)
+# _BATTERY_MODEL_ATTRS (imported above as _BATTERY_DATACLASS_FIELDS) is derived
+# from the BatterySettings dataclass — fields with init=True are the writable
+# attributes; init=False fields (min_soe_kwh, max_soe_kwh, reserved_capacity)
+# are computed and must not be sent to update_settings(). temperature_derating
+# is a nested dict handled separately below. Defined once in api_conversion.py
+# so build_system_settings() (startup) and this PATCH handler filter on the
+# exact same set — see TestBatteryModelAttrsConsistency.
 
 
 @router.get("/api/settings")
@@ -3204,28 +3206,32 @@ async def setup_complete(payload: APISetupCompletePayload):
 
         live_updates: dict = {}
         if "battery" in sections:
+            # BatterySettings.update() takes snake_case (store field names)
+            # directly — no camelCase translation (issue #219).
             live_updates["battery"] = _nn(
                 {
-                    "totalCapacity": payload.totalCapacity,
-                    "minSoc": payload.minSoc,
-                    "maxSoc": payload.maxSoc,
-                    "maxChargePowerKw": payload.maxChargeDischargePower,
-                    "maxDischargePowerKw": payload.maxChargeDischargePower,
-                    "cycleCostPerKwh": payload.cycleCost,
-                    "minActionProfitThreshold": payload.minActionProfitThreshold,
+                    "total_capacity": payload.totalCapacity,
+                    "min_soc": payload.minSoc,
+                    "max_soc": payload.maxSoc,
+                    "max_charge_power_kw": payload.maxChargeDischargePower,
+                    "max_discharge_power_kw": payload.maxChargeDischargePower,
+                    "cycle_cost_per_kwh": payload.cycleCost,
+                    "min_action_profit_threshold": payload.minActionProfitThreshold,
                 }
             )
         if "home" in sections:
+            # HomeSettings.update() takes snake_case (store field names)
+            # directly — no camelCase translation (issue #219).
             live_updates["home"] = _nn(
                 {
-                    "defaultHourly": payload.consumption,
+                    "default_hourly": payload.consumption,
                     "currency": payload.currency,
-                    "consumptionStrategy": payload.consumptionStrategy,
-                    "maxFuseCurrent": payload.maxFuseCurrent,
+                    "consumption_strategy": payload.consumptionStrategy,
+                    "max_fuse_current": payload.maxFuseCurrent,
                     "voltage": payload.voltage,
-                    "safetyMargin": payload.safetyMarginFactor,
-                    "phaseCount": payload.phaseCount,
-                    "powerMonitoringEnabled": payload.powerMonitoringEnabled,
+                    "safety_margin": payload.safetyMarginFactor,
+                    "phase_count": payload.phaseCount,
+                    "power_monitoring_enabled": payload.powerMonitoringEnabled,
                 }
             )
         if "electricity_price" in sections:

--- a/backend/api_conversion.py
+++ b/backend/api_conversion.py
@@ -1,46 +1,74 @@
 """Unified API conversion system - simple snake_case to camelCase conversion.
 
-Also defines the canonical store→API field name mappings for each settings
-section.  These dicts are the single source of truth for:
-  - which fields are required at startup (_apply_settings in app.py)
-  - how store snake_case names map to the camelCase names used by update_settings()
+Also defines the canonical settings field requirements for each section.
+These are the single source of truth for which fields are required at
+startup (_apply_settings in app.py).  Battery and Home settings reach BSM
+in snake_case unchanged — BatterySettings.update()/HomeSettings.update()
+(core/bess/settings.py) do not translate camelCase, so startup and PATCH
+both pass the same store field names straight through (issue #219, mirrors
+the Price fix in #197/#216). Price still uses the older camelCase
+translation dict (PRICE_STORE_TO_API) pending #216.
 
-Both the startup path (app.py) and tests import from here so the mapping
-can never drift between validation and usage.
+Both the startup path (app.py) and tests import from here so the
+requirements can never drift between validation and usage.
 """
 
 import re
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, fields, is_dataclass
 from typing import Any
 
+from core.bess.settings import BatterySettings, HomeSettings
+
 # ---------------------------------------------------------------------------
-# Canonical settings field mappings  (store snake_case → update_settings camelCase)
+# Canonical settings field requirements
 # ---------------------------------------------------------------------------
 
 # Fields required at startup by build_system_settings().  Adding a key here
 # makes it required in the bootstrap defaults and in contract tests.
 # Note: charging_power_rate, efficiency_charge, efficiency_discharge are also
-# in the store but have defaults and are not required at startup.
-BATTERY_STORE_TO_API: dict[str, str] = {
-    "total_capacity": "totalCapacity",
-    "min_soc": "minSoc",
-    "max_soc": "maxSoc",
-    "cycle_cost_per_kwh": "cycleCostPerKwh",
-    "max_charge_power_kw": "maxChargePowerKw",
-    "max_discharge_power_kw": "maxDischargePowerKw",
-    "min_action_profit_threshold": "minActionProfitThreshold",
-}
+# in the store but have defaults and are not required at startup — they still
+# flow through via _BATTERY_DATACLASS_FIELDS below.
+BATTERY_REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {
+        "total_capacity",
+        "min_soc",
+        "max_soc",
+        "cycle_cost_per_kwh",
+        "max_charge_power_kw",
+        "max_discharge_power_kw",
+        "min_action_profit_threshold",
+    }
+)
 
-HOME_STORE_TO_API: dict[str, str] = {
-    "default_hourly": "defaultHourly",
-    "currency": "currency",
-    "max_fuse_current": "maxFuseCurrent",
-    "voltage": "voltage",
-    "safety_margin": "safetyMargin",
-    "phase_count": "phaseCount",
-    "consumption_strategy": "consumptionStrategy",
-    "power_monitoring_enabled": "powerMonitoringEnabled",
-}
+# All BatterySettings/HomeSettings init-time attributes — used to filter the
+# battery/home store sections before passthrough. Needed because a store
+# section can carry non-dataclass keys that would raise AttributeError if
+# passed to update() directly: battery has temperature_derating (a nested
+# dict), and home can carry a stale pre-migration key (e.g. 'consumption')
+# if it and its renamed successor ('default_hourly') ever coexisted in a
+# persisted store (see settings_store.py's rename-if-absent migration guard).
+# api.py imports _BATTERY_DATACLASS_FIELDS directly (aliased as
+# _BATTERY_MODEL_ATTRS) so the PATCH path and startup path filter on the
+# exact same set — see TestBatteryModelAttrsConsistency.
+_BATTERY_DATACLASS_FIELDS: frozenset[str] = frozenset(
+    f.name for f in fields(BatterySettings) if f.init
+)
+_HOME_DATACLASS_FIELDS: frozenset[str] = frozenset(
+    f.name for f in fields(HomeSettings) if f.init
+)
+
+HOME_REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {
+        "default_hourly",
+        "currency",
+        "max_fuse_current",
+        "voltage",
+        "safety_margin",
+        "phase_count",
+        "consumption_strategy",
+        "power_monitoring_enabled",
+    }
+)
 
 PRICE_STORE_TO_API: dict[str, str] = {
     "area": "area",
@@ -73,8 +101,9 @@ def build_system_settings(options: dict) -> dict:
                  ``home`` sections using store snake_case field names.
 
     Returns:
-        Dict with ``battery``, ``home``, and ``price`` sections in camelCase,
-        ready to pass to ``system.update_settings()``.
+        Dict with ``battery``, ``home``, and ``price`` sections ready to pass
+        to ``system.update_settings()``. Battery and Home are snake_case
+        (unchanged); Price is still translated to camelCase pending #216.
 
     Raises:
         ValueError: If a required section or field is missing.
@@ -88,7 +117,7 @@ def build_system_settings(options: dict) -> dict:
     electricity_price_config = options["electricity_price"]
     home_config = options["home"]
 
-    for key in BATTERY_STORE_TO_API:
+    for key in BATTERY_REQUIRED_FIELDS:
         if key not in battery_config:
             raise ValueError(f"Required battery setting '{key}' is missing from config")
     for key in PRICE_STORE_TO_API:
@@ -96,18 +125,18 @@ def build_system_settings(options: dict) -> dict:
             raise ValueError(
                 f"Required electricity_price setting '{key}' is missing from config"
             )
-    for key in HOME_STORE_TO_API:
+    for key in HOME_REQUIRED_FIELDS:
         if key not in home_config:
             raise ValueError(f"Required home setting '{key}' is missing from config")
 
     return {
+        # Filtered to known BatterySettings/HomeSettings attributes — excludes
+        # non-dataclass or stale keys sharing the same store section (see
+        # _BATTERY_DATACLASS_FIELDS/_HOME_DATACLASS_FIELDS comment above).
         "battery": {
-            camel: battery_config[snake]
-            for snake, camel in BATTERY_STORE_TO_API.items()
+            k: v for k, v in battery_config.items() if k in _BATTERY_DATACLASS_FIELDS
         },
-        "home": {
-            camel: home_config[snake] for snake, camel in HOME_STORE_TO_API.items()
-        },
+        "home": {k: v for k, v in home_config.items() if k in _HOME_DATACLASS_FIELDS},
         "price": {
             camel: electricity_price_config[snake]
             for snake, camel in PRICE_STORE_TO_API.items()

--- a/backend/tests/test_settings_contracts.py
+++ b/backend/tests/test_settings_contracts.py
@@ -14,12 +14,16 @@ caught:
 
 How to use when adding or renaming a settings field
 -----------------------------------------------------
-  1. Update the relevant mapping in ``api_conversion.py``
-     (BATTERY_STORE_TO_API / HOME_STORE_TO_API / PRICE_STORE_TO_API).
+  1. Battery/Home: update ``BATTERY_REQUIRED_FIELDS`` / ``HOME_REQUIRED_FIELDS``
+     in ``api_conversion.py``. Price: update ``PRICE_STORE_TO_API`` (still a
+     camelCase translation dict pending #216).
   2. Update ``_bootstrap_defaults`` in ``settings_store.py`` so it writes
      the new key name.
   3. If the BatterySettings dataclass changed, ``_BATTERY_MODEL_ATTRS`` in
      ``api.py`` updates automatically — the test here will verify that.
+     Same for BatterySettings/HomeSettings via ``BATTERY_REQUIRED_FIELDS`` /
+     ``HOME_REQUIRED_FIELDS`` (TestBatteryRequiredFieldsConsistency /
+     TestHomeRequiredFieldsConsistency below).
   4. Run this file.  All tests should pass before committing.
 """
 
@@ -30,8 +34,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import settings_store as _sm
 from api_conversion import (
-    BATTERY_STORE_TO_API,
-    HOME_STORE_TO_API,
+    BATTERY_REQUIRED_FIELDS,
+    HOME_REQUIRED_FIELDS,
     PRICE_STORE_TO_API,
 )
 from settings_store import SettingsStore
@@ -60,6 +64,11 @@ def _valid_options() -> dict:
             "max_charge_power_kw": 15.0,
             "max_discharge_power_kw": 15.0,
             "min_action_profit_threshold": 0.0,
+            # Present in every real store (added by migration) but not
+            # required at startup — see BATTERY_REQUIRED_FIELDS.
+            "charging_power_rate": 40,
+            "efficiency_charge": 0.97,
+            "efficiency_discharge": 0.95,
         },
         "home": {
             "default_hourly": 3.5,
@@ -95,7 +104,7 @@ class TestBootstrapFieldConsistency:
     def test_battery_keys(self, tmp_path, monkeypatch):
         store = _fresh_store(tmp_path, monkeypatch)
         battery = store.data["battery"]
-        for key in BATTERY_STORE_TO_API:
+        for key in BATTERY_REQUIRED_FIELDS:
             assert key in battery, (
                 f"Bootstrap defaults missing required battery key '{key}'. "
                 f"Add it to _bootstrap_defaults() in settings_store.py."
@@ -104,7 +113,7 @@ class TestBootstrapFieldConsistency:
     def test_home_keys(self, tmp_path, monkeypatch):
         store = _fresh_store(tmp_path, monkeypatch)
         home = store.data["home"]
-        for key in HOME_STORE_TO_API:
+        for key in HOME_REQUIRED_FIELDS:
             assert key in home, (
                 f"Bootstrap defaults missing required home key '{key}'. "
                 f"Add it to _bootstrap_defaults() in settings_store.py."
@@ -163,23 +172,65 @@ class TestBootstrapFieldConsistency:
 class TestApplySettings:
     """build_system_settings must reject stale field names and produce correct output."""
 
-    def test_valid_options_produce_camelcase_battery(self):
+    def test_valid_options_produce_battery_unchanged_snake_case(self):
+        """Battery settings reach BSM in snake_case unchanged — no camelCase
+        translation, matching the Price fix in #216 (issue #219)."""
         from api_conversion import build_system_settings
 
         result = build_system_settings(_valid_options())
-        assert result["battery"]["totalCapacity"] == 30.0
-        assert result["battery"]["maxChargePowerKw"] == 15.0
-        assert result["battery"]["maxDischargePowerKw"] == 15.0
-        assert result["battery"]["cycleCostPerKwh"] == 0.5
-        assert result["battery"]["minActionProfitThreshold"] == 0.0
+        assert result["battery"]["total_capacity"] == 30.0
+        assert result["battery"]["max_charge_power_kw"] == 15.0
+        assert result["battery"]["max_discharge_power_kw"] == 15.0
+        assert result["battery"]["cycle_cost_per_kwh"] == 0.5
+        assert result["battery"]["min_action_profit_threshold"] == 0.0
+        assert "totalCapacity" not in result["battery"]
 
-    def test_valid_options_produce_camelcase_home(self):
+    def test_valid_options_battery_passes_through_optional_fields(self):
+        """charging_power_rate/efficiency_charge/efficiency_discharge are in
+        every real store (added by migration) but aren't startup-required —
+        they must still flow through to BSM instead of being silently
+        dropped, matching what the PATCH path already applies."""
         from api_conversion import build_system_settings
 
         result = build_system_settings(_valid_options())
-        assert result["home"]["defaultHourly"] == 3.5
-        assert result["home"]["safetyMargin"] == 1.0
+        assert result["battery"]["charging_power_rate"] == 40
+        assert result["battery"]["efficiency_charge"] == 0.97
+        assert result["battery"]["efficiency_discharge"] == 0.95
+
+    def test_valid_options_battery_excludes_non_dataclass_keys(self):
+        """temperature_derating lives in the same store section as battery
+        settings but is not a BatterySettings attribute — it must be
+        filtered out, or BatterySettings.update() raises AttributeError at
+        startup for any user who has ever enabled it via PATCH."""
+        from api_conversion import build_system_settings
+
+        options = _valid_options()
+        options["battery"]["temperature_derating"] = {"enabled": True}
+        result = build_system_settings(options)
+        assert "temperature_derating" not in result["battery"]
+
+    def test_valid_options_produce_home_unchanged_snake_case(self):
+        """Home settings reach BSM in snake_case unchanged — no camelCase
+        translation, matching the Price fix in #216 (issue #219)."""
+        from api_conversion import build_system_settings
+
+        result = build_system_settings(_valid_options())
+        assert result["home"]["default_hourly"] == 3.5
+        assert result["home"]["safety_margin"] == 1.0
         assert result["home"]["currency"] == "SEK"
+        assert "defaultHourly" not in result["home"]
+
+    def test_valid_options_home_excludes_non_dataclass_keys(self):
+        """A stray key in the home store section (e.g. a stale pre-migration
+        field left behind if both the old and new key ever coexist — see
+        settings_store.py's rename-if-absent migration guards) must not
+        reach HomeSettings.update(), or startup raises AttributeError."""
+        from api_conversion import build_system_settings
+
+        options = _valid_options()
+        options["home"]["consumption"] = 3.5  # stale pre-migration key
+        result = build_system_settings(options)
+        assert "consumption" not in result["home"]
 
     def test_valid_options_produce_camelcase_price(self):
         from api_conversion import build_system_settings
@@ -257,6 +308,138 @@ class TestBatteryModelAttrsConsistency:
             f"Extra in api.py:     {_BATTERY_MODEL_ATTRS - expected}\n"
             f"Missing from api.py: {expected - _BATTERY_MODEL_ATTRS}"
         )
+
+
+# ---------------------------------------------------------------------------
+# 3b. api_conversion.BATTERY_REQUIRED_FIELDS / HOME_REQUIRED_FIELDS must
+# match the store-backed fields of BatterySettings / HomeSettings.
+#
+# charging_power_rate, efficiency_charge, efficiency_discharge (Battery) and
+# min_valid (Home) are excluded: they have dataclass defaults and are not
+# required at startup (see api_conversion.py comment). If this fails after
+# adding a field, add it to the relevant *_REQUIRED_FIELDS set (store-backed)
+# or to the exclusion set below (has-a-default / internal-only).
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryRequiredFieldsConsistency:
+    def test_required_fields_match_store_backed_dataclass_fields(self):
+        from core.bess.settings import BatterySettings
+
+        has_default = {
+            "charging_power_rate",
+            "efficiency_charge",
+            "efficiency_discharge",
+        }
+        expected = frozenset(
+            f.name
+            for f in dataclasses.fields(BatterySettings)
+            if f.init and f.name not in has_default
+        )
+        assert BATTERY_REQUIRED_FIELDS == expected, (
+            f"BATTERY_REQUIRED_FIELDS in api_conversion.py doesn't match BatterySettings.\n"
+            f"Extra:   {BATTERY_REQUIRED_FIELDS - expected}\n"
+            f"Missing: {expected - BATTERY_REQUIRED_FIELDS}"
+        )
+
+
+class TestHomeRequiredFieldsConsistency:
+    def test_required_fields_match_store_backed_dataclass_fields(self):
+        from core.bess.settings import HomeSettings
+
+        internal_only = {"min_valid"}
+        expected = frozenset(
+            f.name
+            for f in dataclasses.fields(HomeSettings)
+            if f.init and f.name not in internal_only
+        )
+        assert HOME_REQUIRED_FIELDS == expected, (
+            f"HOME_REQUIRED_FIELDS in api_conversion.py doesn't match HomeSettings.\n"
+            f"Extra:   {HOME_REQUIRED_FIELDS - expected}\n"
+            f"Missing: {expected - HOME_REQUIRED_FIELDS}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3c. Startup and PATCH paths must reach BSM identically for Battery/Home
+# (issue #219, mirrors #197's TestPriceSettingsRoundTrip).
+#
+# Startup goes through build_system_settings(); PATCH /api/settings passes
+# the raw store dict straight to update_settings() (battery is filtered by
+# _BATTERY_MODEL_ATTRS first; home is passed through unfiltered). Both must
+# land on the same values on a real BatterySystemManager.
+# ---------------------------------------------------------------------------
+
+
+def _bsm():
+    from core.bess.battery_system_manager import BatterySystemManager
+    from core.bess.ha_api_controller import HomeAssistantAPIController
+    from core.bess.price_manager import MockSource
+
+    return BatterySystemManager(
+        controller=MagicMock(spec=HomeAssistantAPIController),
+        price_source=MockSource([1.0] * 96),
+    )
+
+
+class TestBatterySettingsRoundTrip:
+    def test_startup_and_patch_paths_produce_identical_bsm_state(
+        self, tmp_path, monkeypatch
+    ):
+        from api_conversion import build_system_settings
+
+        store = _fresh_store(tmp_path, monkeypatch)
+        battery = dict(store.data["battery"])
+        battery["cycle_cost_per_kwh"] = 0.6
+        battery["min_action_profit_threshold"] = 1.5
+        store.data["battery"] = battery
+
+        options = {
+            "battery": store.data["battery"],
+            "home": store.data["home"],
+            "electricity_price": store.data["electricity_price"],
+        }
+
+        startup_system = _bsm()
+        startup_system.update_settings(build_system_settings(options))
+
+        # PATCH /api/settings filters by _BATTERY_MODEL_ATTRS (api.py) before
+        # calling update_settings — replicate that filtering here.
+        from api import _BATTERY_MODEL_ATTRS  # type: ignore[import]
+
+        patch_system = _bsm()
+        in_mem = {k: v for k, v in battery.items() if k in _BATTERY_MODEL_ATTRS}
+        patch_system.update_settings({"battery": in_mem})
+
+        assert startup_system.battery_settings == patch_system.battery_settings
+
+
+class TestHomeSettingsRoundTrip:
+    def test_startup_and_patch_paths_produce_identical_bsm_state(
+        self, tmp_path, monkeypatch
+    ):
+        from api_conversion import build_system_settings
+
+        store = _fresh_store(tmp_path, monkeypatch)
+        home = dict(store.data["home"])
+        home["default_hourly"] = 5.2
+        home["phase_count"] = 1
+        store.data["home"] = home
+
+        options = {
+            "battery": store.data["battery"],
+            "home": store.data["home"],
+            "electricity_price": store.data["electricity_price"],
+        }
+
+        startup_system = _bsm()
+        startup_system.update_settings(build_system_settings(options))
+
+        # PATCH /api/settings passes the raw store dict directly (api.py).
+        patch_system = _bsm()
+        patch_system.update_settings({"home": store.data["home"]})
+
+        assert startup_system.home_settings == patch_system.home_settings
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -531,21 +531,23 @@ class TestSetupComplete:
     # -- Live system updates --
 
     def test_live_battery_update_sent(self, complete_controller):
+        """Battery is sent snake_case, matching Price's #216 fix (issue #219)."""
         _client.post("/api/setup/complete", json=_full_wizard_payload())
         calls = complete_controller.system.update_settings.call_args_list
         battery_calls = [c for c in calls if "battery" in c[0][0]]
         assert len(battery_calls) >= 1
         sent = battery_calls[0][0][0]["battery"]
-        assert sent["totalCapacity"] == 30.0
-        assert sent["maxChargePowerKw"] == 15.0
+        assert sent["total_capacity"] == 30.0
+        assert sent["max_charge_power_kw"] == 15.0
 
     def test_live_home_update_sent(self, complete_controller):
+        """Home is sent snake_case, matching Price's #216 fix (issue #219)."""
         _client.post("/api/setup/complete", json=_full_wizard_payload())
         calls = complete_controller.system.update_settings.call_args_list
         home_calls = [c for c in calls if "home" in c[0][0]]
         assert len(home_calls) >= 1
         sent = home_calls[0][0][0]["home"]
-        assert sent["defaultHourly"] == 3.5
+        assert sent["default_hourly"] == 3.5
         assert sent["currency"] == "SEK"
 
     def test_live_price_update_sent(self, complete_controller):

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -15,7 +15,7 @@ For production configuration, all user-facing values must be properly configured
 """
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Any
 
 
@@ -139,15 +139,18 @@ class BatterySettings:
         self.reserved_capacity = self.min_soe_kwh
 
     def update(self, **kwargs: Any) -> None:
-        """Update settings from dict."""
+        """Update settings from a snake_case dict — the store's native format.
+
+        Unlike the old camelCase-translating contract, both the startup and
+        PATCH paths pass snake_case store field names directly. CamelCase
+        API payloads are converted to snake_case in the API layer before
+        reaching here (issue #219, mirrors PriceSettings' #197 fix).
+        """
+        valid_fields = {f.name for f in fields(self)}
         for key, value in kwargs.items():
-            # Convert camelCase to snake_case for compatibility with API layer
-            snake_key = _camel_to_snake(key)
-            if not hasattr(self, snake_key):
-                raise AttributeError(
-                    f"BatterySettings has no attribute '{snake_key}' (from key '{key}')"
-                )
-            setattr(self, snake_key, value)
+            if key not in valid_fields:
+                raise AttributeError(f"BatterySettings has no attribute '{key}'")
+            setattr(self, key, value)
 
         self.__post_init__()
 
@@ -194,15 +197,18 @@ class HomeSettings:
         ), f"phase_count must be 1 or 3, got {self.phase_count}"
 
     def update(self, **kwargs: Any) -> None:
-        """Update settings from dict."""
+        """Update settings from a snake_case dict — the store's native format.
+
+        Unlike the old camelCase-translating contract, both the startup and
+        PATCH paths pass snake_case store field names directly. CamelCase
+        API payloads are converted to snake_case in the API layer before
+        reaching here (issue #219, mirrors PriceSettings' #197 fix).
+        """
+        valid_fields = {f.name for f in fields(self)}
         for key, value in kwargs.items():
-            # Convert camelCase to snake_case for compatibility with API layer
-            snake_key = _camel_to_snake(key)
-            if not hasattr(self, snake_key):
-                raise AttributeError(
-                    f"HomeSettings has no attribute '{snake_key}' (from key '{key}')"
-                )
-            setattr(self, snake_key, value)
+            if key not in valid_fields:
+                raise AttributeError(f"HomeSettings has no attribute '{key}'")
+            setattr(self, key, value)
         self.__post_init__()
 
     def from_ha_config(self, config: dict) -> "HomeSettings":

--- a/core/bess/tests/unit/test_settings.py
+++ b/core/bess/tests/unit/test_settings.py
@@ -123,38 +123,37 @@ def test_battery_settings_action_threshold():
     assert settings.min_action_profit_threshold == 2.0
 
 
-def test_battery_settings_camelcase_update():
-    """Test that update method handles camelCase keys from API layer."""
+def test_battery_settings_camelcase_no_longer_accepted():
+    """BatterySettings.update() no longer translates camelCase — snake_case
+    is the canonical, single format for both the startup and PATCH paths
+    (issue #219, mirrors #197's PriceSettings fix). CamelCase translation
+    for API payloads belongs in the API layer, not here."""
     settings = BatterySettings()
 
-    # Update with camelCase keys (as sent from frontend/API)
-    settings.update(
-        totalCapacity=25.0,
-        maxChargePowerKw=8.0,
-        cycleCostPerKwh=0.55,
-        minActionProfitThreshold=1.2,
-    )
-
-    # Verify that values were correctly mapped to snake_case attributes
-    assert settings.total_capacity == 25.0
-    assert settings.max_charge_power_kw == 8.0
-    assert settings.cycle_cost_per_kwh == 0.55
-    assert settings.min_action_profit_threshold == 1.2
-
-    # Verify computed fields are updated
-    assert settings.reserved_capacity == 2.5  # 10% of 25
+    with pytest.raises(AttributeError):
+        settings.update(totalCapacity=25.0)
 
 
 def test_battery_settings_invalid_key_raises_error():
     """Test that update method raises AttributeError for invalid keys."""
     settings = BatterySettings()
 
-    # Attempt to update with an invalid key should raise AttributeError
     with pytest.raises(AttributeError) as exc_info:
-        settings.update(invalidKey=123)
+        settings.update(invalid_key=123)
 
     assert "BatterySettings has no attribute 'invalid_key'" in str(exc_info.value)
-    assert "from key 'invalidKey'" in str(exc_info.value)
+
+
+def test_battery_settings_update_rejects_method_names():
+    """update() validates against dataclass fields, not hasattr() — a key
+    matching a method/property name (e.g. 'update' itself) must raise, not
+    silently overwrite the method via setattr."""
+    settings = BatterySettings()
+
+    with pytest.raises(AttributeError):
+        settings.update(update=123)
+
+    assert callable(settings.update)
 
 
 def test_battery_settings_independent_charge_discharge_power():
@@ -162,13 +161,13 @@ def test_battery_settings_independent_charge_discharge_power():
     settings = BatterySettings()
 
     # Test both orderings - should give same result regardless of key order
-    settings.update(maxChargePowerKw=10.0, maxDischargePowerKw=8.0)
+    settings.update(max_charge_power_kw=10.0, max_discharge_power_kw=8.0)
     assert settings.max_charge_power_kw == 10.0
     assert settings.max_discharge_power_kw == 8.0
 
     # Test reverse order - should NOT have dict ordering bugs
     settings2 = BatterySettings()
-    settings2.update(maxDischargePowerKw=8.0, maxChargePowerKw=10.0)
+    settings2.update(max_discharge_power_kw=8.0, max_charge_power_kw=10.0)
     assert settings2.max_charge_power_kw == 10.0
     assert settings2.max_discharge_power_kw == 8.0
 
@@ -292,11 +291,11 @@ def test_home_settings_phase_count_invalid():
 
 
 def test_home_settings_update_phase_count():
-    """Test update() with phaseCount (camelCase conversion)."""
+    """Test update() with phase_count (snake_case, the store's native format)."""
     settings = HomeSettings()
     assert settings.phase_count == 3
 
-    settings.update(phaseCount=1)
+    settings.update(phase_count=1)
     assert settings.phase_count == 1
 
 
@@ -305,7 +304,29 @@ def test_home_settings_update_phase_count_invalid():
     settings = HomeSettings()
 
     with pytest.raises(AssertionError, match="phase_count must be 1 or 3"):
-        settings.update(phaseCount=2)
+        settings.update(phase_count=2)
+
+
+def test_home_settings_camelcase_no_longer_accepted():
+    """HomeSettings.update() no longer translates camelCase — snake_case
+    is the canonical, single format for both the startup and PATCH paths
+    (issue #219, mirrors #197's PriceSettings fix)."""
+    settings = HomeSettings()
+
+    with pytest.raises(AttributeError):
+        settings.update(phaseCount=1)
+
+
+def test_home_settings_update_rejects_method_names():
+    """update() validates against dataclass fields, not hasattr() — a key
+    matching a method/property name (e.g. 'update' itself) must raise, not
+    silently overwrite the method via setattr."""
+    settings = HomeSettings()
+
+    with pytest.raises(AttributeError):
+        settings.update(update=123)
+
+    assert callable(settings.update)
 
 
 def test_home_settings_from_ha_config_phase_count():


### PR DESCRIPTION
## Summary
- `BatterySettings.update()`/`HomeSettings.update()` (`core/bess/settings.py`) no longer translate camelCase — snake_case (the settings store's native format) is now the single canonical shape for both the startup path and the PATCH `/api/settings` path, mirroring the identical fix already applied to Price settings in #197/#216.
- `BATTERY_STORE_TO_API`/`HOME_STORE_TO_API` (hand-maintained `dict[str,str]` translation registries in `backend/api_conversion.py`) are replaced with `BATTERY_REQUIRED_FIELDS`/`HOME_REQUIRED_FIELDS` (presence-validation-only `frozenset[str]`), each kept in sync with their dataclass by new structural tests.
- `backend/api.py`'s `setup_complete()` live-apply path for battery/home now builds snake_case keys directly (the one remaining camelCase producer, same as the Price fix).

## Root cause
The startup path filtered store fields through hand-maintained `BATTERY_STORE_TO_API`/`HOME_STORE_TO_API` translation dicts before calling `update_settings()`. The PATCH handler already bypassed them and passed the raw snake_case store dict directly — working only because `_camel_to_snake()` was a no-op on already-snake_case keys. A field present in the store but missing from the registry (e.g. `charging_power_rate`, `efficiency_charge`, `efficiency_discharge`) was silently dropped at startup while continuing to work via PATCH — the same bug class fixed for Price in #197/#216 (itself traced back to #126's `spot_multiplier` revert-on-restart bug). Filed as #219, a follow-up to #197 since that issue's scope was Price-only.

## Fix
- `core/bess/settings.py`: `BatterySettings.update()`/`HomeSettings.update()` drop the `_camel_to_snake()` call — kwargs must already be snake_case. Also replaced `hasattr()`-based key validation with an explicit dataclass-field membership check (`hasattr` also matches method names, e.g. `update(update=123)` would have silently clobbered the `update` method itself).
- `backend/api_conversion.py`: `BATTERY_STORE_TO_API`/`HOME_STORE_TO_API` → `BATTERY_REQUIRED_FIELDS`/`HOME_REQUIRED_FIELDS`; `build_system_settings()` filters the battery/home sections to each dataclass's known fields instead of translating keys (excludes non-dataclass keys sharing the same store section, e.g. battery's `temperature_derating`, or a stray pre-migration key in home).
- `backend/api.py`: `setup_complete`'s battery/home live-update dicts now use snake_case keys; also deduplicated `_BATTERY_MODEL_ATTRS` to import the one definition from `api_conversion.py` instead of recomputing an identical `dataclasses.fields()` derivation in two files.
- Tests: updated existing contract/unit tests for the new snake_case-only contract; added `TestBatteryRequiredFieldsConsistency`, `TestHomeRequiredFieldsConsistency`, `TestBatterySettingsRoundTrip`, `TestHomeSettingsRoundTrip`, and regression coverage for the non-dataclass-key filtering and the `hasattr`→field-check fix.

## Review findings fixed
A medium-effort `/code-review` pass (8 independent finder angles) surfaced and verified three issues before this was considered done:
1. **Home passthrough was unfiltered** — `build_system_settings()` filtered battery to known dataclass fields but passed home through completely unchanged; a stray key surviving a partial migration (e.g. both `consumption` and `default_hourly` coexisting) would crash the whole app at startup. Fixed with a `_HOME_DATACLASS_FIELDS` filter matching battery's.
2. **`_BATTERY_DATACLASS_FIELDS` duplicated `api.py`'s pre-existing `_BATTERY_MODEL_ATTRS`** — identical `dataclasses.fields()` derivation computed independently in two files with no test asserting they matched. `api.py` now imports the one definition.
3. **`hasattr()` used for key validation** — violates the repo's explicit "never use hasattr" rule and has a latent footgun (matches method names). Replaced with an explicit field-membership check.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (0 errors, 0 warnings — Python + frontend)
- [x] Full fast suite: `976 passed, 12 skipped`
- [x] Local runtime verification (podman, real containers built from this branch's code against `docker-compose.ci.yml`'s mock-HA + e2e fixtures, not mocked):
  - Startup applies the e2e fixture's battery/home settings correctly.
  - `PATCH /api/settings` for battery and home → `200`, persisted and echoed correctly.
  - **Container restart** → PATCHed values survive.
  - `charging_power_rate`/`efficiency_charge`/`efficiency_discharge` (previously silently dropped at startup) now correctly reach the in-memory `BatterySettings`.
  - Injected a stray pre-migration key (`consumption` coexisting with `default_hourly`) into the persisted store → app boots cleanly with the fix; confirmed via direct call that the same input **would** raise `AttributeError` → `SystemConfigurationError` → `RuntimeError` (whole-app-boot crash) without the `_HOME_DATACLASS_FIELDS` filter.

Closes #219