### PR TITLE
feat: port multiplicative spot-price adjustment (spot_multiplier) to main

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -659,6 +659,12 @@ Additionally, `device_sn` is extracted, returned in the API response as `deviceS
 - Refactor all API endpoints to use dataclass-based serialization (with robust mapping for all field variants) for consistent, type-safe, and future-proof API responses. Ensure all details and fields are preserved as in the original dict-based implementation.
 - Check if all sensors in config.yaml are actually needed and used (lifetime e.g.)
 
+**From #221 (spot_multiplier/export_spot_multiplier) code review — deferred cleanup, not bugs**:
+
+- `backend/api.py`'s `_pricing_defaults_for_discovery()` duplicates the provider-priority chain (`octopus > entsoe > nordpool_official > nordpool_hacs`, gated on `not nordpool_found`) already computed independently in `frontend/src/pages/SetupWizardPage.tsx`'s `autoProvider` logic. The two can drift out of sync if the priority order changes in only one place. Consider deriving both from a single shared source (e.g. have the backend return the resolved provider and have the frontend just consume it, instead of recomputing it).
+- `backend/api_conversion.py`'s `PRICE_STORE_TO_API` (startup/read path) and `backend/api.py`'s `_PRICE_MAP` in `setup_complete()` (wizard-write path) are two independently-maintained camelCase↔snake_case tables for the same `PriceSettings` fields. The new `TestPriceModelAttrsConsistency` contract test (added in #221) only guards `PRICE_STORE_TO_API` — `_PRICE_MAP` can still silently drift for a future field with no test to catch it. Consider consolidating to one table, or extending the contract test to also cover `_PRICE_MAP`.
+- `backend/settings_store.py`'s `_migrate_schema()` electricity_price migration block hardcodes `spot_multiplier`/`export_spot_multiplier`/`use_actual_price` by name instead of iterating `PRICE_STORE_TO_API` + `PriceSettings` defaults generically. Every future `PriceSettings` field will need a new hand-written migration block, and it's easy to forget (silent `ValueError` in `build_system_settings()` at startup for existing users' configs). Consider making the migration generic against `PRICE_STORE_TO_API`.
+
 **TOU Segment Matching is Fragile**:
 The current TOU comparison uses exact matching on start_time, end_time, batt_mode. If a segment shifts by 15 minutes (e.g., 00:00-00:59 → 00:15-01:14), it's seen as completely different, resulting in 2 hardware writes (disable old + add new) instead of 1 update. Consider:
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -2863,6 +2863,39 @@ async def get_setup_status():
     )
 
 
+_PROVIDER_PRICING_DEFAULTS: dict[str, dict] = {
+    "nordpool_official": {
+        "spotMultiplier": 1.0,
+        "exportSpotMultiplier": 1.0,
+    },
+    "nordpool_hacs": {
+        "spotMultiplier": 1.0,
+        "exportSpotMultiplier": 1.0,
+    },
+    "entsoe": {
+        "spotMultiplier": 1.0175,
+        "exportSpotMultiplier": 1.018,
+    },
+    "octopus": {
+        "spotMultiplier": 1.0,
+        "exportSpotMultiplier": 1.0,
+    },
+}
+
+
+def _pricing_defaults_for_discovery(integrations: dict) -> dict:
+    """Return suggested spot-multiplier defaults matching the auto-detected provider."""
+    if integrations.get("octopus_found") and not integrations.get("nordpool_found"):
+        return _PROVIDER_PRICING_DEFAULTS["octopus"]
+    if integrations.get("entsoe_found") and not integrations.get("nordpool_found"):
+        return _PROVIDER_PRICING_DEFAULTS["entsoe"]
+    if integrations.get("nordpool_config_entry_id"):
+        return _PROVIDER_PRICING_DEFAULTS["nordpool_official"]
+    if integrations.get("nordpool_custom_area"):
+        return _PROVIDER_PRICING_DEFAULTS["nordpool_hacs"]
+    return _PROVIDER_PRICING_DEFAULTS["nordpool_official"]
+
+
 @router.post("/api/setup/discover")
 async def run_setup_discovery():
     """Run auto-discovery of inverter and pricing integrations.
@@ -3029,6 +3062,9 @@ async def run_setup_discovery():
         # Attach sensor dicts without key conversion
         result["sensors"] = sensors
         result["platformSensors"] = platform_sensors
+        # Suggested spot-multiplier defaults for the auto-detected provider —
+        # already camelCase, attach after conversion to avoid double-conversion.
+        result["pricingDefaults"] = _pricing_defaults_for_discovery(integrations)
         # Attach Octopus entities for pricing form auto-fill
         if octopus_entities:
             result["octopusEntities"] = octopus_entities
@@ -3123,6 +3159,8 @@ async def setup_complete(payload: APISetupCompletePayload):
             "vatMultiplier": "vat_multiplier",
             "additionalCosts": "additional_costs",
             "taxReduction": "tax_reduction",
+            "spotMultiplier": "spot_multiplier",
+            "exportSpotMultiplier": "export_spot_multiplier",
         }
         area = payload.area or payload.nordpoolArea
         if any(getattr(payload, f) is not None for f in _PRICE_MAP) or area:
@@ -3245,6 +3283,8 @@ async def setup_complete(payload: APISetupCompletePayload):
                     "vat_multiplier": payload.vatMultiplier,
                     "additional_costs": payload.additionalCosts,
                     "tax_reduction": payload.taxReduction,
+                    "spot_multiplier": payload.spotMultiplier,
+                    "export_spot_multiplier": payload.exportSpotMultiplier,
                 }
             )
         if live_updates:

--- a/backend/api_conversion.py
+++ b/backend/api_conversion.py
@@ -82,9 +82,21 @@ HOME_REQUIRED_FIELDS: frozenset[str] = frozenset(
 # (core/bess/settings.py) does not translate camelCase, so startup and PATCH
 # both pass the same store field names straight through. This set only
 # validates presence at startup; kept in sync with the PriceSettings
-# dataclass by TestPriceModelAttrsConsistency (issue #197).
+# dataclass by TestPriceModelAttrsConsistency (issue #197). spot_multiplier/
+# export_spot_multiplier are wizard-configurable and store-backed like the
+# other required fields (issue #221); use_actual_price is excluded — it is
+# an internal-only field, never read from the store or written by the
+# wizard, matching min_profit's exclusion.
 PRICE_REQUIRED_FIELDS: frozenset[str] = frozenset(
-    {"area", "markup_rate", "vat_multiplier", "additional_costs", "tax_reduction"}
+    {
+        "area",
+        "markup_rate",
+        "vat_multiplier",
+        "additional_costs",
+        "tax_reduction",
+        "spot_multiplier",
+        "export_spot_multiplier",
+    }
 )
 
 # Legacy inverter_type values ("MIN"/"SPH") → canonical inverter.platform.

--- a/backend/api_dataclasses.py
+++ b/backend/api_dataclasses.py
@@ -993,6 +993,8 @@ class APISetupCompletePayload(BaseModel):
     vatMultiplier: float | None = None
     additionalCosts: float | None = None
     taxReduction: float | None = None
+    spotMultiplier: float | None = None
+    exportSpotMultiplier: float | None = None
     # Energy provider
     provider: str | None = None
     # Nordpool HACS entity (required when provider == "nordpool_hacs")

--- a/backend/settings_store.py
+++ b/backend/settings_store.py
@@ -360,12 +360,15 @@ class SettingsStore:
             BATTERY_STORAGE_SIZE_KWH,
             DEFAULT_AREA,
             DEFAULT_CURRENCY,
+            EXPORT_SPOT_MULTIPLIER,
             HOME_HOURLY_CONSUMPTION_KWH,
             HOUSE_MAX_FUSE_CURRENT_A,
             HOUSE_VOLTAGE_V,
             MARKUP_RATE,
             SAFETY_MARGIN_FACTOR,
+            SPOT_MULTIPLIER,
             TAX_REDUCTION,
+            USE_ACTUAL_PRICE,
             VAT_MULTIPLIER,
         )
 
@@ -395,6 +398,9 @@ class SettingsStore:
                 "additional_costs": ADDITIONAL_COSTS,
                 "tax_reduction": TAX_REDUCTION,
                 "area": DEFAULT_AREA,
+                "spot_multiplier": SPOT_MULTIPLIER,
+                "export_spot_multiplier": EXPORT_SPOT_MULTIPLIER,
+                "use_actual_price": USE_ACTUAL_PRICE,
             },
             "energy_provider": {
                 "provider": "nordpool_official",
@@ -430,6 +436,9 @@ class SettingsStore:
             BATTERY_EFFICIENCY_CHARGE,
             BATTERY_EFFICIENCY_DISCHARGE,
             BATTERY_MIN_ACTION_PROFIT_THRESHOLD,
+            EXPORT_SPOT_MULTIPLIER,
+            SPOT_MULTIPLIER,
+            USE_ACTUAL_PRICE,
         )
 
         changed = False
@@ -497,6 +506,29 @@ class SettingsStore:
 
             if changed:
                 self.data["home"] = home
+
+        # --- electricity_price: spot_multiplier / export_spot_multiplier / use_actual_price ---
+        # Added after these fields were introduced on PriceSettings; without a
+        # default, build_system_settings() would raise ValueError at startup
+        # for any config written before this migration existed.
+        price = self.data.get("electricity_price")
+        if isinstance(price, dict):
+            for key, default in (
+                ("spot_multiplier", SPOT_MULTIPLIER),
+                ("export_spot_multiplier", EXPORT_SPOT_MULTIPLIER),
+                ("use_actual_price", USE_ACTUAL_PRICE),
+            ):
+                if key not in price:
+                    price[key] = default
+                    logger.info(
+                        "Schema migration: added electricity_price.%s = %s",
+                        key,
+                        default,
+                    )
+                    changed = True
+
+            if changed:
+                self.data["electricity_price"] = price
 
         ep = self.data.get("energy_provider")
         if isinstance(ep, dict):

--- a/backend/tests/test_settings_contracts.py
+++ b/backend/tests/test_settings_contracts.py
@@ -97,6 +97,9 @@ def _valid_options() -> dict:
             "vat_multiplier": 1.25,
             "additional_costs": 0.77,
             "tax_reduction": 0.2,
+            "spot_multiplier": 1.0175,
+            "export_spot_multiplier": 1.018,
+            "use_actual_price": False,
         },
     }
 

--- a/backend/tests/test_settings_store.py
+++ b/backend/tests/test_settings_store.py
@@ -494,6 +494,43 @@ class TestSchemaMigration:
                 field in battery
             ), f"Expected default for '{field}' to be added by migration"
 
+    def test_electricity_price_missing_multiplier_fields_get_defaults(
+        self, tmp_path, monkeypatch
+    ):
+        """Configs written before spot_multiplier existed must get safe defaults.
+
+        Without this, build_system_settings() raises ValueError at startup
+        for any pre-existing config (PRICE_STORE_TO_API requires the key).
+        """
+        store = self._store_with_data(
+            tmp_path,
+            monkeypatch,
+            {"electricity_price": {"area": "SE4", "markup_rate": 0.08}},
+        )
+        price = store.get_section("electricity_price")
+        assert price["spot_multiplier"] == 1.0
+        assert price["export_spot_multiplier"] == 1.0
+        assert price["use_actual_price"] is False
+
+    def test_electricity_price_existing_multiplier_fields_preserved(
+        self, tmp_path, monkeypatch
+    ):
+        """Migration must not clobber a user's already-configured multiplier."""
+        store = self._store_with_data(
+            tmp_path,
+            monkeypatch,
+            {
+                "electricity_price": {
+                    "area": "EUR",
+                    "spot_multiplier": 1.0175,
+                    "export_spot_multiplier": 1.018,
+                }
+            },
+        )
+        price = store.get_section("electricity_price")
+        assert price["spot_multiplier"] == 1.0175
+        assert price["export_spot_multiplier"] == 1.018
+
     def test_migration_persists_to_disk(self, tmp_path, monkeypatch):
         """Migrated field names must be written back to disk immediately."""
         path = _settings_path(tmp_path)

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -404,6 +404,20 @@ class TestSetupComplete:
         assert elec["additional_costs"] == 0.77
         assert elec["tax_reduction"] == 0.20
 
+    def test_spot_multiplier_fields_persisted(self, complete_controller):
+        """spotMultiplier/exportSpotMultiplier must reach electricity_price, not be dropped."""
+        payload = _full_wizard_payload(
+            provider="entsoe",
+            spotMultiplier=1.0175,
+            exportSpotMultiplier=1.018,
+        )
+        resp = _client.post("/api/setup/complete", json=payload)
+        assert resp.status_code == 200
+        call_args = complete_controller.settings_store.save_all.call_args[0][0]
+        elec = call_args["electricity_price"]
+        assert elec["spot_multiplier"] == 1.0175
+        assert elec["export_spot_multiplier"] == 1.018
+
     def test_price_fields_saved_without_markup_or_vat(self, complete_controller):
         """additionalCosts/taxReduction must be persisted even without markupRate/vatMultiplier."""
         payload = {"additionalCosts": 0.99, "taxReduction": 0.25}
@@ -558,6 +572,23 @@ class TestSetupComplete:
         assert len(price_calls) >= 1
         sent = price_calls[0][0][0]["price"]
         assert sent["vat_multiplier"] == 1.25
+
+    def test_live_spot_multiplier_update_sent(self, complete_controller):
+        """spotMultiplier/exportSpotMultiplier must reach the live system update,
+        not just the persisted store — otherwise the optimizer keeps using the
+        default 1.0 until the addon restarts."""
+        payload = _full_wizard_payload(
+            provider="entsoe",
+            spotMultiplier=1.0175,
+            exportSpotMultiplier=1.018,
+        )
+        _client.post("/api/setup/complete", json=payload)
+        calls = complete_controller.system.update_settings.call_args_list
+        price_calls = [c for c in calls if "price" in c[0][0]]
+        assert len(price_calls) >= 1
+        sent = price_calls[0][0][0]["price"]
+        assert sent["spot_multiplier"] == 1.0175
+        assert sent["export_spot_multiplier"] == 1.018
 
     def test_live_energy_provider_update_sent(self, complete_controller):
         _client.post("/api/setup/complete", json=_full_wizard_payload())
@@ -865,6 +896,81 @@ class TestDiscoverLocaleDefaults:
         ctrl.ha_controller.discover_optional_sensors.assert_called_once_with(
             [], registry
         )
+
+
+class TestDiscoverPricingDefaults:
+    """POST /api/setup/discover must suggest provider-aware pricing defaults.
+
+    Without this, the setup wizard has no way to pre-fill spotMultiplier for
+    an auto-detected ENTSO-e provider — the user would have to know the
+    Luminus-style 1.0175 factor and enter it manually.
+    """
+
+    def _run_discover(self, ctrl, integrations):
+        ha = ctrl.ha_controller
+        ha.discover_integrations.return_value = (integrations, [])
+        ha.fetch_entity_registry.return_value = []
+        ha.discover_sensors_from_registry.return_value = ({}, None)
+        ha.discover_current_sensors.return_value = {}
+        ha.discover_optional_sensors.return_value = {}
+        ha.discover_octopus_entities.return_value = {}
+        ha.ENTITY_SUFFIX_MAP = {}
+        ha.SOLAX_GROWATT_MIN_SUFFIX_MAP = {}
+        ha.SOLAX_GROWATT_SPH_SUFFIX_MAP = {}
+        ha.SOLAX_NATIVE_SUFFIX_MAP = {}
+        sys.modules["app"].bess_controller = ctrl
+        return _client.post("/api/setup/discover")
+
+    def _integrations(self, **overrides) -> dict:
+        base = {
+            "growatt_found": False,
+            "device_sn": None,
+            "growatt_device_id": None,
+            "solax_found": False,
+            "nordpool_found": False,
+            "nordpool_area": None,
+            "nordpool_custom_area": None,
+            "nordpool_custom_entity": None,
+            "nordpool_config_entry_id": None,
+            "octopus_found": False,
+            "entsoe_found": False,
+            "detected_inverter_platforms": [],
+            "detected_phase_count": None,
+            "currency": None,
+            "vat_multiplier": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_entsoe_only_suggests_spot_multiplier_defaults(self):
+        store = deepcopy(_PRE_EXISTING_STORE)
+        ctrl = _make_discover_controller(store)
+        integrations = self._integrations(entsoe_found=True)
+        resp = self._run_discover(ctrl, integrations)
+        assert resp.status_code == 200
+        defaults = resp.json()["pricingDefaults"]
+        assert defaults["spotMultiplier"] == 1.0175
+        assert defaults["exportSpotMultiplier"] == 1.018
+
+    def test_octopus_only_suggests_no_adjustment(self):
+        store = deepcopy(_PRE_EXISTING_STORE)
+        ctrl = _make_discover_controller(store)
+        integrations = self._integrations(octopus_found=True)
+        resp = self._run_discover(ctrl, integrations)
+        assert resp.status_code == 200
+        defaults = resp.json()["pricingDefaults"]
+        assert defaults["spotMultiplier"] == 1.0
+        assert defaults["exportSpotMultiplier"] == 1.0
+
+    def test_nordpool_official_suggests_no_adjustment(self):
+        store = deepcopy(_PRE_EXISTING_STORE)
+        ctrl = _make_discover_controller(store)
+        integrations = self._integrations(nordpool_config_entry_id="entry-123")
+        resp = self._run_discover(ctrl, integrations)
+        assert resp.status_code == 200
+        defaults = resp.json()["pricingDefaults"]
+        assert defaults["spotMultiplier"] == 1.0
+        assert defaults["exportSpotMultiplier"] == 1.0
 
 
 # ===========================================================================

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -156,6 +156,8 @@ class BatterySystemManager:
             additional_costs=self.price_settings.additional_costs,
             tax_reduction=self.price_settings.tax_reduction,
             area=self.price_settings.area,
+            spot_multiplier=self.price_settings.spot_multiplier,
+            export_spot_multiplier=self.price_settings.export_spot_multiplier,
         )
 
         # Initialize monitors (created in start() if controller available)
@@ -2905,6 +2907,12 @@ class BatterySystemManager:
                 )
                 self._price_manager.tax_reduction = self.price_settings.tax_reduction
                 self._price_manager.area = self.price_settings.area
+                self._price_manager.spot_multiplier = (
+                    self.price_settings.spot_multiplier
+                )
+                self._price_manager.export_spot_multiplier = (
+                    self.price_settings.export_spot_multiplier
+                )
                 self._price_manager.clear_cache()
 
             if "energy_provider" in settings:

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -389,6 +389,8 @@ class PriceManager:
         additional_costs: float,
         tax_reduction: float,
         area: str,
+        spot_multiplier: float = 1.0,
+        export_spot_multiplier: float = 1.0,
     ) -> None:
         """Initialize the price manager.
 
@@ -399,6 +401,8 @@ class PriceManager:
             additional_costs: Additional fixed costs added to buy prices
             tax_reduction: Tax reduction applied to sell prices
             area: Price area code (e.g. "SE4", "NO1", "DK1")
+            spot_multiplier: Multiplicative factor on spot buy price (1.0 = no adjustment)
+            export_spot_multiplier: Multiplicative factor on spot sell price
         """
         self.price_source = price_source
         self.markup_rate = markup_rate
@@ -406,6 +410,8 @@ class PriceManager:
         self.additional_costs = additional_costs
         self.tax_reduction = tax_reduction
         self.area = area
+        self.spot_multiplier = spot_multiplier
+        self.export_spot_multiplier = export_spot_multiplier
         self._logger = logging.getLogger(__name__)
 
         # Cache for today's prices
@@ -436,7 +442,9 @@ class PriceManager:
         Returns:
             Calculated retail price
         """
-        result = (base_price + self.markup_rate) * self.vat_multiplier
+        result = (
+            base_price * self.spot_multiplier + self.markup_rate
+        ) * self.vat_multiplier
         return result + self.additional_costs
 
     def _calculate_sell_price(self, base_price: float) -> float:
@@ -448,7 +456,7 @@ class PriceManager:
         Returns:
             Calculated sell-back price
         """
-        return base_price + self.tax_reduction
+        return base_price * self.export_spot_multiplier + self.tax_reduction
 
     def get_price_data(self, target_date: date | None = None) -> list:
         """Get formatted price data for the specified date.

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -27,6 +27,8 @@ ADDITIONAL_COSTS = (
 TAX_REDUCTION = (
     0.1988  # export compensation (Nätnytta) per kWh, e.g. E.ON: 0.1988 SEK/kWh
 )
+SPOT_MULTIPLIER = 1.0  # multiplicative factor on spot (1.0 = no adjustment)
+EXPORT_SPOT_MULTIPLIER = 1.0  # multiplicative factor on spot for sell price
 MIN_PROFIT = 0.2  # Minimum profit per kWh to consider a charge/discharge cycle
 USE_ACTUAL_PRICE = False  # Use raw Nordpool spot prices or include markup, VAT, etc.
 
@@ -82,6 +84,8 @@ class PriceSettings:
     vat_multiplier: float = VAT_MULTIPLIER
     additional_costs: float = ADDITIONAL_COSTS
     tax_reduction: float = TAX_REDUCTION
+    spot_multiplier: float = SPOT_MULTIPLIER
+    export_spot_multiplier: float = EXPORT_SPOT_MULTIPLIER
     min_profit: float = MIN_PROFIT
     use_actual_price: bool = USE_ACTUAL_PRICE
 

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -57,6 +57,20 @@ class TestUpdateSettings:
             system.update_settings({"price": {"vat_multiplier": 1.25}})
             mock_clear.assert_called_once()
 
+    def test_spot_multiplier_synced_to_price_manager(self, system):
+        system.update_settings(
+            {
+                "price": {
+                    "spot_multiplier": 1.0175,
+                    "export_spot_multiplier": 1.018,
+                }
+            }
+        )
+        assert system.price_settings.spot_multiplier == 1.0175
+        assert system.price_settings.export_spot_multiplier == 1.018
+        assert system._price_manager.spot_multiplier == 1.0175
+        assert system._price_manager.export_spot_multiplier == 1.018
+
     def test_invalid_settings_raises_system_configuration_error(self, system):
         with pytest.raises(SystemConfigurationError):
             system.update_settings({"battery": {"capacity": "not_a_number"}})

--- a/core/bess/tests/unit/test_price_manager.py
+++ b/core/bess/tests/unit/test_price_manager.py
@@ -36,6 +36,43 @@ def test_direct_price_initialization():
     assert pm.get_sell_prices() == pm.sell_prices
 
 
+def test_spot_multiplier_applied_to_buy_price():
+    """Multiplicative spot adjustment must apply before markup/VAT (Luminus-style contracts)."""
+    mock_source = MockSource([1.0])
+    pm = PriceManager(
+        price_source=mock_source,
+        markup_rate=0.198,
+        vat_multiplier=1.06,
+        additional_costs=0.0,
+        tax_reduction=-0.012685,
+        area="EUR",
+        spot_multiplier=1.0175,
+        export_spot_multiplier=1.018,
+    )
+
+    expected_buy_price = (1.0 * 1.0175 + 0.198) * 1.06
+    assert pm.buy_prices[0] == expected_buy_price
+
+    expected_sell_price = 1.0 * 1.018 + (-0.012685)
+    assert pm.sell_prices[0] == expected_sell_price
+
+
+def test_spot_multiplier_defaults_to_no_adjustment():
+    """Omitting spot_multiplier/export_spot_multiplier must reproduce the additive-only formula."""
+    mock_source = MockSource([1.0])
+    pm = PriceManager(
+        price_source=mock_source,
+        markup_rate=0.1,
+        vat_multiplier=1.25,
+        additional_costs=0.5,
+        tax_reduction=0.2,
+        area="SE4",
+    )
+
+    assert pm.buy_prices[0] == (1.0 + 0.1) * 1.25 + 0.5
+    assert pm.sell_prices[0] == 1.0 + 0.2
+
+
 def test_controller_price_fetching():
     """Test price fetching from controller."""
     mock_controller = MagicMock()

--- a/frontend/src/components/settings/PricingFormSection.tsx
+++ b/frontend/src/components/settings/PricingFormSection.tsx
@@ -16,6 +16,8 @@ export interface PricingForm {
   vatMultiplier: number;
   additionalCosts: number;
   taxReduction: number;
+  spotMultiplier: number;
+  exportSpotMultiplier: number;
 }
 
 interface Props {
@@ -25,13 +27,16 @@ interface Props {
 
 export function PricingFormSection({ form, onChange }: Props) {
   const isOctopus = form.provider === 'octopus';
+  const isEntsoe = form.provider === 'entsoe';
   const currency = isOctopus ? 'GBP' : form.currency;
 
+  const sm = form.spotMultiplier ?? 1.0;
+  const esm = form.exportSpotMultiplier ?? 1.0;
   const previewSpot = 1.0;
   const previewBuy = Number(
-    ((previewSpot + form.markupRate) * form.vatMultiplier + form.additionalCosts).toFixed(4),
+    ((previewSpot * sm + form.markupRate) * form.vatMultiplier + form.additionalCosts).toFixed(4),
   );
-  const previewSell = Number((previewSpot + form.taxReduction).toFixed(4));
+  const previewSell = Number((previewSpot * esm + form.taxReduction).toFixed(4));
 
   return (
     <div className="space-y-3">
@@ -105,11 +110,16 @@ export function PricingFormSection({ form, onChange }: Props) {
         title="Price Calculation"
         description={isOctopus
           ? 'Octopus prices are already final (VAT-inclusive, GBP/kWh). Only tax reduction applies.'
-          : 'Calculate your actual electricity costs from spot prices, fees and taxes.'}
+          : isEntsoe
+            ? 'Calculate your actual electricity costs from ENTSO-e/Belpex spot prices. Supports both additive markup and multiplicative spot adjustments.'
+            : 'Calculate your actual electricity costs from spot prices, fees and taxes.'}
       >
         {!isOctopus && (
           <>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {isEntsoe && numField('Import Spot Multiplier', form.spotMultiplier,
+                v => onChange({ ...form, spotMultiplier: v }),
+                { unit: 'factor (1.0 = no adjustment)', min: 0.5, max: 2.0, step: 0.0001 })}
               {numField('Markup Rate', form.markupRate,
                 v => onChange({ ...form, markupRate: v }),
                 { unit: `${currency}/kWh (ex-VAT)`, min: 0, step: 0.001 })}
@@ -119,25 +129,46 @@ export function PricingFormSection({ form, onChange }: Props) {
               {numField('Additional Costs', form.additionalCosts,
                 v => onChange({ ...form, additionalCosts: v }),
                 { unit: `${currency}/kWh`, min: 0, step: 0.001 })}
+              {isEntsoe && numField('Export Spot Multiplier', form.exportSpotMultiplier,
+                v => onChange({ ...form, exportSpotMultiplier: v }),
+                { unit: 'factor (1.0 = no adjustment)', min: 0.5, max: 2.0, step: 0.0001 })}
               {numField('Export Compensation', form.taxReduction,
                 v => onChange({ ...form, taxReduction: v }),
                 { unit: `${currency}/kWh`, min: 0, step: 0.001 })}
             </div>
-            <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/40 px-4 py-3 space-y-3 text-xs text-gray-600 dark:text-gray-400">
-              <div className="space-y-2">
-                <div><span className="font-medium text-blue-900 dark:text-blue-200">Markup Rate:</span> Energy provider margin fee. E.g. Tibber 0.08 (8 öre/kWh), Ellevio ~0.15. Applied before VAT.</div>
-                <div><span className="font-medium text-blue-900 dark:text-blue-200">VAT Multiplier:</span> VAT factor. 1.25 = 25% (Sweden/Norway), 1.20 = 20% (UK/EU).</div>
-                <div><span className="font-medium text-blue-900 dark:text-blue-200">Additional Costs:</span> Grid transfer fee + energy tax (sum ex-VAT, then VAT applied). E.g. E.ON: (0.2584 + 0.3600) × 1.25 = 0.773 SEK/kWh.</div>
-                <div><span className="font-medium text-blue-900 dark:text-blue-200">Export Compensation:</span> Per-kWh payment from grid operator (Nätnytta) when selling surplus electricity. Check your energy bill under "Producent/Självfaktura". E.g. E.ON: 0.1988 (19.88 öre/kWh).</div>
+            {isEntsoe ? (
+              <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/40 px-4 py-3 space-y-3 text-xs text-gray-600 dark:text-gray-400">
+                <div className="space-y-2">
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Import Spot Multiplier:</span> Contract-specific factor applied to raw spot price. E.g. Luminus Dynamic: 1.0175.</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Markup Rate:</span> Fixed costs before VAT: supplier margin, excise duty, grid fees, etc.</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">VAT Multiplier:</span> VAT factor on import. 1.06 = 6% (Belgium), 1.21 = 21% (Netherlands).</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Additional Costs:</span> Post-VAT fixed costs. Set to 0 if all costs are already included above.</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Export Spot Multiplier:</span> Contract-specific factor on spot for export/injection. E.g. Luminus: 1.018.</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Export Compensation:</span> Fixed per-kWh payment or deduction for exported energy. Use negative values for deductions.</div>
+                </div>
+                <div className="space-y-2 pt-2 border-t border-blue-200 dark:border-blue-700">
+                  <p className="font-medium text-blue-900 dark:text-blue-200">How the raw spot price is converted:</p>
+                  <p className="pl-2 border-l-2 border-blue-300 dark:border-blue-600"><strong>Buy price:</strong> (spot × import multiplier + markup) × VAT + additional costs</p>
+                  <p className="pl-2 border-l-2 border-blue-300 dark:border-blue-600"><strong>Sell price:</strong> spot × export multiplier + export compensation</p>
+                </div>
               </div>
+            ) : (
+              <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/40 px-4 py-3 space-y-3 text-xs text-gray-600 dark:text-gray-400">
+                <div className="space-y-2">
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Markup Rate:</span> Energy provider margin fee. E.g. Tibber 0.08 (8 öre/kWh), Ellevio ~0.15. Applied before VAT.</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">VAT Multiplier:</span> VAT factor. 1.25 = 25% (Sweden/Norway), 1.20 = 20% (UK/EU).</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Additional Costs:</span> Grid transfer fee + energy tax (sum ex-VAT, then VAT applied). E.g. E.ON: (0.2584 + 0.3600) × 1.25 = 0.773 SEK/kWh.</div>
+                  <div><span className="font-medium text-blue-900 dark:text-blue-200">Export Compensation:</span> Per-kWh payment from grid operator (Nätnytta) when selling surplus electricity. Check your energy bill under "Producent/Självfaktura". E.g. E.ON: 0.1988 (19.88 öre/kWh).</div>
+                </div>
 
-              <div className="space-y-2 pt-2 border-t border-blue-200 dark:border-blue-700">
-                <p className="font-medium text-blue-900 dark:text-blue-200">How the raw spot price is converted:</p>
-                <p className="pl-2 border-l-2 border-blue-300 dark:border-blue-600"><strong>Buy price:</strong> (raw spot + markup) × VAT multiplier + grid fees</p>
-                <p className="pl-2 border-l-2 border-blue-300 dark:border-blue-600"><strong>Sell price:</strong> raw spot + export compensation</p>
-                <p className="text-gray-500 dark:text-gray-500 italic">Note: Markup is added before VAT (ex-VAT), while grid fees already include VAT.</p>
+                <div className="space-y-2 pt-2 border-t border-blue-200 dark:border-blue-700">
+                  <p className="font-medium text-blue-900 dark:text-blue-200">How the raw spot price is converted:</p>
+                  <p className="pl-2 border-l-2 border-blue-300 dark:border-blue-600"><strong>Buy price:</strong> (raw spot + markup) × VAT multiplier + grid fees</p>
+                  <p className="pl-2 border-l-2 border-blue-300 dark:border-blue-600"><strong>Sell price:</strong> raw spot + export compensation</p>
+                  <p className="text-gray-500 dark:text-gray-500 italic">Note: Markup is added before VAT (ex-VAT), while grid fees already include VAT.</p>
+                </div>
               </div>
-            </div>
+            )}
             <div className="rounded-lg bg-gray-50 dark:bg-gray-700/50 px-4 py-3 text-sm space-y-1.5">
               <p className="text-xs text-gray-500 dark:text-gray-400">
                 Preview at spot = 1.00

--- a/frontend/src/components/settings/SensorConfigSection.tsx
+++ b/frontend/src/components/settings/SensorConfigSection.tsx
@@ -46,6 +46,7 @@ export interface DiscoveryResult {
   detectedPhaseCount: number | null;
   currency: string | null;
   vatMultiplier: number | null;
+  pricingDefaults?: Record<string, number>;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -53,7 +53,7 @@ const EMPTY_PRICING: PricingForm = {
   octopusExportTodayEntity: '', octopusExportTomorrowEntity: '',
   entsoeEntity: '',
   area: '', markupRate: 0, vatMultiplier: 1.25, additionalCosts: 0,
-  taxReduction: 0,
+  taxReduction: 0, spotMultiplier: 1.0, exportSpotMultiplier: 1.0,
 };
 const EMPTY_INVERTER: InverterForm = { inverterPlatform: 'growatt_server_min', deviceId: '' };
 
@@ -200,6 +200,8 @@ const SettingsPage: React.FC = () => {
         vatMultiplier: elec_s.vatMultiplier ?? 1.25,
         additionalCosts: elec_s.additionalCosts ?? 0,
         taxReduction: elec_s.taxReduction ?? 0,
+        spotMultiplier: elec_s.spotMultiplier ?? 1.0,
+        exportSpotMultiplier: elec_s.exportSpotMultiplier ?? 1.0,
       };
       setPricingForm(p);
       savedPricing.current = JSON.stringify(p);
@@ -402,6 +404,8 @@ const SettingsPage: React.FC = () => {
           vatMultiplier: pricingForm.vatMultiplier,
           additionalCosts: pricingForm.additionalCosts,
           taxReduction: pricingForm.taxReduction,
+          spotMultiplier: pricingForm.spotMultiplier,
+          exportSpotMultiplier: pricingForm.exportSpotMultiplier,
           useActualPrice: false,
         },
         energyProvider: {

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -77,6 +77,8 @@ const SetupWizardPage: React.FC = () => {
     vatMultiplier: 1.25,
     additionalCosts: 0.77,
     taxReduction: 0.2,
+    spotMultiplier: 1.0,
+    exportSpotMultiplier: 1.0,
   });
 
   const handleScan = useCallback(async () => {
@@ -110,6 +112,12 @@ const SetupWizardPage: React.FC = () => {
       const autoArea = hasOfficialNordpool ? d.nordpoolArea : d.nordpoolCustomArea;
       setPricingForm(f => ({
         ...f,
+        // Only seed spot-multiplier defaults when the provider is newly
+        // auto-detected (changing) — never on a re-scan of an already
+        // configured provider, or this would clobber a saved custom
+        // contract-specific value (e.g. a real Luminus vs. non-Luminus
+        // ENTSO-e multiplier) every time the wizard mounts or rescans.
+        ...(autoProvider && autoProvider !== f.provider ? (d.pricingDefaults ?? {}) : {}),
         ...(autoProvider ? { provider: autoProvider } : {}),
         ...(d.currency ? { currency: d.currency } : {}),
         ...(autoArea ? { area: autoArea } : {}),
@@ -230,6 +238,8 @@ const SetupWizardPage: React.FC = () => {
         vatMultiplier:         elec.vatMultiplier                   ?? f.vatMultiplier,
         additionalCosts:       elec.additionalCosts                 ?? f.additionalCosts,
         taxReduction:          elec.taxReduction                    ?? f.taxReduction,
+        spotMultiplier:        elec.spotMultiplier                  ?? f.spotMultiplier,
+        exportSpotMultiplier:  elec.exportSpotMultiplier            ?? f.exportSpotMultiplier,
         // Restore saved config entry IDs so manual entries survive a wizard re-run
         nordpoolConfigEntryId: ep.nordpoolOfficial?.configEntryId ?? f.nordpoolConfigEntryId,
         nordpoolEntity:        ep.nordpoolHacs?.entity           ?? f.nordpoolEntity,
@@ -296,6 +306,8 @@ const SetupWizardPage: React.FC = () => {
         vatMultiplier: pricingForm.vatMultiplier,
         additionalCosts: pricingForm.additionalCosts,
         taxReduction: pricingForm.taxReduction,
+        spotMultiplier: pricingForm.spotMultiplier,
+        exportSpotMultiplier: pricingForm.exportSpotMultiplier,
         // Nordpool HACS entity
         nordpoolEntity: pricingForm.nordpoolEntity || undefined,
         // Octopus Energy entity IDs


### PR DESCRIPTION
## Summary
- Ports beta's multiplicative spot-price adjustment (`spot_multiplier`/`export_spot_multiplier`) to `main`, needed for contracts that scale the raw spot price instead of adding a fixed markup (e.g. Belgian Luminus Dynamic: `spot * 1.0175 + fees`).
- Adds `PriceSettings.spot_multiplier`/`export_spot_multiplier`, wires them through `PriceManager`'s buy/sell formulas, `BatterySystemManager`, the setup wizard (provider-aware defaults + persistence), and the Settings page.
- Also wires `use_actual_price` into the same startup/migration path — it had the identical "silently reverts to default on restart" gap and was touched by the same code, so it was folded in rather than left half-fixed.

## Root cause
From the issue: "main's `entsoe` provider (#208) only supports the additive markup model as Nordpool (`(spot + markup) * VAT + fees`). Beta built out `spot_multiplier` / `export_spot_multiplier` fields to support contracts that scale the raw spot price instead... Without this, Luminus-style contract users get systematically wrong prices." Beta commit `994bc74` (parent of `v9.10.0b1`) was the reference diff. PR #223 (closing #218) split items 1+2 (the `spot_multiplier` port and the setup wizard's `_PRICE_MAP` allow-list gap) out to this issue, since neither existed on `main` yet.

## Fix
- `core/bess/settings.py`, `core/bess/price_manager.py`, `core/bess/battery_system_manager.py`: new fields, multiplicative buy/sell formula, wiring.
- `backend/api_dataclasses.py`, `backend/api_conversion.py` (`PRICE_STORE_TO_API`), `backend/api.py` (`_PRICE_MAP`, `_PROVIDER_PRICING_DEFAULTS`/`_pricing_defaults_for_discovery`): full read/write plumbing so the wizard, PATCH, and startup paths all agree.
- `backend/settings_store.py`: bootstrap defaults + a migration block so existing installs get the new fields backfilled instead of crashing at startup (`build_system_settings()` now requires them, since `PRICE_STORE_TO_API` grew).
- `backend/tests/test_settings_contracts.py`: new `TestPriceModelAttrsConsistency` contract test so a future `PriceSettings` field can't silently be forgotten in `PRICE_STORE_TO_API` again.
- Frontend: `PricingFormSection.tsx` (provider-aware ENTSO-e fields + help text), `SetupWizardPage.tsx`, `SettingsPage.tsx`, `SensorConfigSection.tsx`.

**Two bugs found and fixed during code review before this PR opened** (not present in the final diff):
- `setup_complete()`'s live-update path omitted the two new fields, so a wizard-configured multiplier only took effect after an addon restart.
- Two spots (`PricingFormSection`'s provider-switch handler, `SetupWizardPage`'s scan-on-mount) unconditionally overwrote a user's already-saved custom multiplier with a generic default.

Three lower-severity cleanup items (duplicate provider-priority logic between backend/frontend, a dual camelCase↔snake_case translation-table structure, a hardcoded migration block that could be generic) were logged to `TODO.md` rather than fixed here, to keep this PR scoped to the feature.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (993 backend + 23 frontend tests, 0 errors, 0 warnings)
- [x] Local e2e verification via `docker-compose.ci.yml` (podman) against the real `ci-wizard-entsoe` mock-HA scenario:
  - `POST /api/setup/discover` returns real `pricingDefaults: {spotMultiplier: 1.0175, exportSpotMultiplier: 1.018}` for a detected ENTSO-e integration
  - Startup migration backfills `spot_multiplier`/`export_spot_multiplier`/`use_actual_price` into a pre-existing settings fixture that predates this feature (no startup crash)
  - `POST /api/setup/complete` with a real spot multiplier persists to `/api/settings` **and** fires the live update (confirmed via logs) — this is the exact live-update bug found and fixed above
  - `PATCH /api/settings` with `spotMultiplier: 0.0` round-trips correctly (falsy-zero probe, no silent coercion)

Closes #221