### PR TITLE
fix: unshadow live-mounted backend in docker-compose.ci.yml

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,6 @@
 # CI-friendly docker-compose for E2E tests.
-# No volume mounts, no live reload — builds everything into the image.
+# Bind-mounts live source over the built image so edits are picked up on
+# container restart without a rebuild.
 #
 # Usage:
 #   SCENARIO=ci-normal-day docker compose -f docker-compose.ci.yml up -d
@@ -26,6 +27,13 @@ services:
       - ./frontend/dist:/app/frontend:ro
       - ${BESS_OPTIONS:-./e2e/ci-options.json}:/data/options.json:ro
       - ${BESS_SETTINGS:-./e2e/ci-bess-settings.json}:/data/bess_settings.json
+    # Dockerfile.dev's WORKDIR is /app, which the image also uses as the
+    # build-time COPY destination for backend/*.py — without this override,
+    # sys.path[0] resolves to that stale baked copy instead of the live
+    # bind-mounted /app/backend, so backend-root edits (app.py, api.py, ...)
+    # would silently not take effect on restart. Matches docker-compose.yml's
+    # dev setup, which cds into /app/backend before invoking uvicorn.
+    working_dir: /app/backend
     command: ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
     depends_on:
       mock-ha:


### PR DESCRIPTION
## Summary
- `docker-compose.ci.yml`'s `bess` service now sets `working_dir: /app/backend`
- Reworded the header comment, which claimed "no volume mounts, no live reload" while the file directly below it defines several

## Root cause
`backend/Dockerfile.dev` sets `WORKDIR /app` and also uses `/app` as the `COPY backend/ /app/` destination at build time. `docker-compose.ci.yml` then bind-mounts the same source at `/app/backend` (live) alongside the stale baked copy at `/app/*.py`. Because uvicorn runs from `WORKDIR /app`, Python puts cwd (`/app`) at `sys.path[0]` — ahead of the `PYTHONPATH=/app/backend:/app` entries — so `import app`/`api`/`api_conversion` resolve to the stale build-time copy, not the live-mounted one. A restart after editing any backend-root file silently keeps running old code.

`docker-compose.yml` (the regular dev compose) already works around this by running `sh -c "cd /app/backend && python3 watch.py"` before invoking uvicorn — this PR applies the same fix to the CI compose file via the `working_dir` directive instead.

## Fix
Added `working_dir: /app/backend` to the `bess` service so `sys.path[0]` resolves to the live bind mount ahead of the baked copy. Also fixed the file's own header comment, which was already wrong before this change (claims no volume mounts exist, contradicted by the `volumes:` block a few lines below).

## Test plan
- [x] `./scripts/quality-check.sh` passes locally
- [x] Brought up `docker-compose.ci.yml` locally with podman (`podman-compose`), confirmed via `podman exec` that `cwd=/app/backend` and `import api` resolves to `/app/backend/api.py`
- [x] Reproduced the original bug: temporarily removed `working_dir`, recreated the container (no rebuild), confirmed cwd reverts to `/app` and a live-edited marker log line does NOT appear after restart (0 occurrences)
- [x] Confirmed the fix: restored `working_dir`, recreated, same live-edited marker now appears in logs on restart without a rebuild (2/2 requests logged it)

Closes #226