### PR TITLE
fix: currency-aware default for battery cycle cost

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -2933,12 +2933,20 @@ async def run_setup_discovery():
         detected_currency = integrations.get("currency")
         detected_vat = integrations.get("vat_multiplier")
         if detected_currency or detected_vat is not None:
+            from core.bess.settings import CYCLE_COST_BY_CURRENCY
+
             home = bess_controller.settings_store.get_section("home")
             elec = bess_controller.settings_store.get_section("electricity_price")
+            battery = bess_controller.settings_store.get_section("battery")
             changed = False
+            battery_changed = False
             if detected_currency and home.get("currency") != detected_currency:
                 home["currency"] = detected_currency
                 changed = True
+                cycle_cost = CYCLE_COST_BY_CURRENCY.get(detected_currency)
+                if cycle_cost is not None:
+                    battery["cycle_cost_per_kwh"] = cycle_cost
+                    battery_changed = True
             if detected_vat is not None and elec.get("vat_multiplier") != detected_vat:
                 elec["vat_multiplier"] = detected_vat
                 changed = True
@@ -2956,13 +2964,16 @@ async def run_setup_discovery():
                 if ep.get("provider") != "octopus":
                     ep["provider"] = "octopus"
                     bess_controller.settings_store.save_section("energy_provider", ep)
+            if battery_changed:
+                bess_controller.settings_store.save_section("battery", battery)
             if changed:
                 bess_controller.settings_store.save_section("home", home)
                 bess_controller.settings_store.save_section("electricity_price", elec)
                 logger.info(
-                    "Persisted locale defaults: currency=%s, vat=%s",
+                    "Persisted locale defaults: currency=%s, vat=%s, cycle_cost=%s",
                     detected_currency,
                     detected_vat,
+                    battery.get("cycle_cost_per_kwh") if battery_changed else None,
                 )
 
         sensors: dict[str, str] = {}

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -74,6 +74,15 @@ SAFETY_MARGIN_FACTOR = 1.0  # Safety margin for power calculations (100%)
 # Currency defaults
 DEFAULT_CURRENCY = "SEK"  # Default currency for price display (override in config.yaml)
 
+# BATTERY_CHARGE_CYCLE_COST is denominated in SEK. It approximates battery
+# wear cost per kWh cycled, so it must be re-based per currency rather than
+# reused as-is for non-Swedish installs.
+CYCLE_COST_BY_CURRENCY: dict[str, float] = {
+    "SEK": BATTERY_CHARGE_CYCLE_COST,
+    "EUR": 0.035,
+    "GBP": 0.031,
+}
+
 
 @dataclass
 class PriceSettings:

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -19,6 +19,14 @@ import type { DiscoveryResult, InverterForm } from '../components/settings/Senso
 
 const STEPS = ['Scan', 'Review Sensors', 'Electricity Pricing', 'Battery', 'Home', 'Control Mode', 'Done'];
 
+// Battery cycle cost approximates wear cost per kWh cycled, so the SEK
+// default (0.40) is wrong for other currencies. Mirrors
+// core.bess.settings.CYCLE_COST_BY_CURRENCY.
+const CYCLE_COST_BY_CURRENCY: Record<string, number> = { SEK: 0.40, EUR: 0.035, GBP: 0.031 };
+// Placeholder values (bootstrap SEK default, initial form default) treated as
+// "not yet user-configured" so a detected currency can safely replace them.
+const UNSET_CYCLE_COST_DEFAULTS = new Set([0.40, 0.50]);
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -130,6 +138,14 @@ const SetupWizardPage: React.FC = () => {
         ...(d.octopusEntities?.exportTomorrow ? { octopusExportTomorrowEntity: d.octopusEntities.exportTomorrow } : {}),
         ...(d.entsoeEntity ? { entsoeEntity: d.entsoeEntity } : {}),
       }));
+      if (d.currency && CYCLE_COST_BY_CURRENCY[d.currency] !== undefined) {
+        const cycleCost = CYCLE_COST_BY_CURRENCY[d.currency];
+        setBatteryForm(f => (
+          UNSET_CYCLE_COST_DEFAULTS.has(f.cycleCostPerKwh)
+            ? { ...f, cycleCostPerKwh: cycleCost }
+            : f
+        ));
+      }
       // Auto-select the first detected platform; user can switch if multiple
       const detected = d.detectedInverterPlatforms ?? [];
       const detectedPlatform = detected[0] ?? null;


### PR DESCRIPTION
## Summary
- `BATTERY_CHARGE_CYCLE_COST` (0.40) is denominated in SEK, but non-Swedish installs inherited it as-is since it's hidden under advanced settings and rarely changed by users.
- Added `CYCLE_COST_BY_CURRENCY` (SEK 0.40, EUR 0.035, GBP 0.031) in `core/bess/settings.py`.
- Extended the existing setup-discovery locale-defaults block in `backend/api.py` (the one that already fixes `currency`/`vat_multiplier`/Octopus cost fields, #113) to also persist a currency-correct `cycle_cost_per_kwh`.
- Mirrored the same mapping in the setup wizard (`SetupWizardPage.tsx`) so the Battery step shows the right value immediately, without clobbering an already-customized value.

This only affects setup discovery (new/re-run wizard flows) — no migration of already-saved settings.

## Test plan
- [x] `.venv/bin/pytest -m "not slow"` — 1001 passed
- [x] `.venv/bin/pytest backend/tests/test_setup_api.py` — 56 passed
- [x] `npx tsc --noEmit` — clean
- [x] `black --check` / `ruff check` — clean
- [x] `eslint` on changed file — clean