### PR TITLE
fix: cap DP terminal-value estimate at best in-horizon export price (replaces #245)

### DIFF
--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1702,19 +1702,33 @@ class BatterySystemManager:
         return optimization_period, optimization_data
 
     def _calculate_terminal_value(
-        self, buy_prices: list[float], optimization_period: int
+        self,
+        buy_prices: list[float],
+        sell_prices: list[float],
+        optimization_period: int,
     ) -> float:
         """Calculate terminal value per kWh for the DP optimization.
 
         When the horizon already extends past today (i.e. tomorrow's prices are
         included), return 0.0 since the DP has explicit future data. Otherwise,
-        estimate value from the median buy price adjusted for efficiency
-        and cycle cost.
+        estimate value from the median buy price adjusted for efficiency and
+        cycle cost ("avoid tomorrow's purchase"), capped at the best achievable
+        in-horizon export value ("arbitrage-consistency cap").
 
-        Using the median avoids inflating the terminal value with peak prices.
+        The cap is required because cycle cost is only ever charged on
+        charging, never on discharge (see `_compute_reward`): an uncapped
+        buy-median terminal value can exceed the best real, known export price
+        already visible inside today's horizon, which makes the DP hold charge
+        to chase a fictitious future bonus instead of exporting now (#126,
+        #244). The cap is self-calibrating from data the DP already has, so it
+        collapses on wide-spread contracts (e.g. Belgian ENTSO-e/Belpex)
+        without needing a market-specific threshold, and stays inert on
+        ordinary/Nordic-shaped markets where the best in-horizon peak is
+        already above the buy-median estimate (#246, supersedes #245).
 
         Args:
             buy_prices: Full buy price array (from optimization_period onwards)
+            sell_prices: Full sell price array (from optimization_period onwards)
             optimization_period: Current optimization starting period
 
         Returns:
@@ -1738,16 +1752,27 @@ class BatterySystemManager:
             return 0.0
 
         median_price = statistics.median(buy_prices)
-        terminal_value = (
+        max_sell_price = max(sell_prices)
+        buy_based = max(
+            0.0,
             median_price * self.battery_settings.efficiency_discharge
-            - self.battery_settings.cycle_cost_per_kwh
+            - self.battery_settings.cycle_cost_per_kwh,
         )
-        terminal_value = max(0.0, terminal_value)
+        sell_cap = max(
+            0.0,
+            max_sell_price * self.battery_settings.efficiency_discharge
+            - self.battery_settings.cycle_cost_per_kwh,
+        )
+        terminal_value = min(buy_based, sell_cap)
 
         logger.info(
-            "Terminal value: %.3f/kWh (median_price=%.3f, efficiency=%.2f, cycle_cost=%.3f)",
+            "Terminal value: %.3f/kWh (buy_based=%.3f, sell_cap=%.3f, "
+            "median_buy=%.3f, max_sell=%.3f, efficiency=%.2f, cycle_cost=%.3f)",
             terminal_value,
+            buy_based,
+            sell_cap,
             median_price,
+            max_sell_price,
             self.battery_settings.efficiency_discharge,
             self.battery_settings.cycle_cost_per_kwh,
         )
@@ -1869,7 +1894,7 @@ class BatterySystemManager:
 
             # Calculate terminal value for end-of-horizon energy valuation
             terminal_value = self._calculate_terminal_value(
-                buy_prices, optimization_period
+                buy_prices, sell_prices, optimization_period
             )
 
             # Get temperature-based charge power limits if derating is enabled.

--- a/core/bess/simulation/verification.py
+++ b/core/bess/simulation/verification.py
@@ -96,16 +96,21 @@ def realized_under_solar_error(
     answer to "is the schedule robust to solar forecast error?".
 
     Both figures are credited for usable energy left in the battery at horizon end
-    (mirroring BatterySystemManager._calculate_terminal_value's median-buy-price
-    valuation), otherwise a run that legitimately stores more bonus solar than the
-    forecast run — real value carried past the horizon, not waste — looks like a
-    loss purely from the horizon cutoff.
+    (mirroring BatterySystemManager._calculate_terminal_value's capped
+    median-buy-price valuation), otherwise a run that legitimately stores more
+    bonus solar than the forecast run — real value carried past the horizon,
+    not waste — looks like a loss purely from the horizon cutoff.
     """
-    terminal_value_per_kwh = max(
+    buy_based = max(
         0.0,
         statistics.median(buy_price) * settings.efficiency_discharge
         - settings.cycle_cost_per_kwh,
     )
+    sell_cap = max(
+        0.0,
+        max(sell_price) * settings.efficiency_discharge - settings.cycle_cost_per_kwh,
+    )
+    terminal_value_per_kwh = min(buy_based, sell_cap)
     result = optimize_battery_schedule(
         buy_price=buy_price,
         sell_price=sell_price,

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -290,7 +290,7 @@ class TestCalculateTerminalValue:
 
         # 192 buy prices remaining but only ~96 today periods remaining from period 0
         terminal_value = system._calculate_terminal_value(
-            buy_prices=[1.0] * 192, optimization_period=0
+            buy_prices=[1.0] * 192, sell_prices=[0.8] * 192, optimization_period=0
         )
 
         assert terminal_value == 0.0
@@ -300,12 +300,13 @@ class TestCalculateTerminalValue:
         source = MockSource([1.0] * 96)
         system = _make_system(source)
 
-        # Only 50 remaining prices (clearly today-only)
+        # Only 50 remaining prices (clearly today-only), sell prices high enough
+        # that the arbitrage cap doesn't bind.
         terminal_value = system._calculate_terminal_value(
-            buy_prices=[1.0] * 50, optimization_period=46
+            buy_prices=[1.0] * 50, sell_prices=[1.0] * 50, optimization_period=46
         )
 
-        # Should be avg_buy * efficiency_discharge - cycle_cost > 0
+        # Should be median_buy * efficiency_discharge - cycle_cost > 0
         assert terminal_value > 0.0
 
     def test_floored_at_zero(self):
@@ -316,10 +317,52 @@ class TestCalculateTerminalValue:
         system.battery_settings.cycle_cost_per_kwh = 5.0
 
         terminal_value = system._calculate_terminal_value(
-            buy_prices=[0.01] * 10, optimization_period=86
+            buy_prices=[0.01] * 10, sell_prices=[0.01] * 10, optimization_period=86
         )
 
         assert terminal_value == 0.0
+
+    def test_capped_by_sell_price_on_wide_spread(self):
+        """Belgian-shaped case (#126/#244): wide buy/sell spread must cap the
+        buy-median terminal value at the best achievable in-horizon export,
+        so the DP doesn't hold charge to chase a fictitious bonus."""
+        source = MockSource([0.3] * 96)
+        system = _make_system(source)
+        system.battery_settings.cycle_cost_per_kwh = 0.05
+
+        buy_prices = [0.21, 0.24, 0.30, 0.35, 0.38]  # median = 0.30
+        sell_prices = [0.10, 0.12, 0.13, 0.15, 0.16]  # max = 0.16
+
+        terminal_value = system._calculate_terminal_value(
+            buy_prices=buy_prices, sell_prices=sell_prices, optimization_period=91
+        )
+
+        eff = system.battery_settings.efficiency_discharge
+        buy_based = 0.30 * eff - 0.05
+        sell_cap = 0.16 * eff - 0.05
+        assert sell_cap < buy_based, "test fixture must exercise the binding cap"
+        assert terminal_value == pytest.approx(sell_cap)
+
+    def test_uses_buy_based_when_cap_does_not_bind(self):
+        """Ordinary/Nordic-shaped case: a narrow evening peak sits well above
+        the buy-median estimate, so the cap must not bind and today's
+        reserve-holding behavior is preserved (the gap #245 left untested)."""
+        source = MockSource([0.6] * 96)
+        system = _make_system(source)
+        system.battery_settings.cycle_cost_per_kwh = 0.05
+
+        buy_prices = [0.6, 0.6, 0.6, 1.4, 1.4]  # median = 0.6
+        sell_prices = [p * 0.85 for p in buy_prices]  # max = 1.19
+
+        terminal_value = system._calculate_terminal_value(
+            buy_prices=buy_prices, sell_prices=sell_prices, optimization_period=91
+        )
+
+        eff = system.battery_settings.efficiency_discharge
+        buy_based = 0.6 * eff - 0.05
+        sell_cap = max(sell_prices) * eff - 0.05
+        assert buy_based < sell_cap, "test fixture must exercise the non-binding cap"
+        assert terminal_value == pytest.approx(buy_based)
 
 
 class TestPrepareNextDayTimestamps:

--- a/core/bess/tests/unit/test_terminal_value.py
+++ b/core/bess/tests/unit/test_terminal_value.py
@@ -1,5 +1,7 @@
 """Tests for terminal value parameter in DP optimization."""
 
+import statistics
+
 import pytest
 
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
@@ -113,6 +115,155 @@ class TestTerminalValueHoldsEnergy:
         assert discharge_with_tv <= discharge_no_tv, (
             f"Terminal value should reduce low-price discharge: "
             f"without={discharge_no_tv:.2f}, with={discharge_with_tv:.2f}"
+        )
+
+
+class TestTerminalValueCapRegression:
+    """Scenario-level regression tests for the arbitrage-consistency cap (#246).
+
+    Both scenarios apply the same terminal-value formula the production code
+    uses in `BatterySystemManager._calculate_terminal_value`:
+    ``min(buy-median-based, sell-max-based)``. Reusing real numbers from
+    #126/#244 (Belgian) and the ordinary/Nordic-shaped counter-scenario
+    bess-analyst used to reject #245's straight sell-swap fix.
+    """
+
+    def test_belgian_shaped_market_exports_at_evening_peak(self):
+        """Wide buy/sell spread: an uncapped buy-median terminal value exceeds
+        the real evening export price and makes the DP hold charge instead of
+        exporting (#126/#244's actual bug). The cap must collapse the
+        terminal value below that real peak so the DP exports."""
+        settings = BatterySettings(
+            total_capacity=15.0,
+            min_soc=10,
+            max_soc=100,
+            max_charge_power_kw=5.0,
+            max_discharge_power_kw=5.0,
+            cycle_cost_per_kwh=0.04,
+        )
+
+        # Mirrors #244's evidence: horizon=38 (14:30 to midnight), buy prices
+        # ~0.21-0.38 (median ~0.30), real achievable export peak ~0.13-0.16
+        # around 20:00-22:00, otherwise low sell prices.
+        buy = [0.21] * 10 + [0.30] * 18 + [0.38] * 10
+        sell = [0.10] * 22 + [0.16] * 8 + [0.12] * 8
+        consumption = [0.3] * 38
+        solar = [0.0] * 38
+
+        buy_based = max(
+            0.0,
+            statistics.median(buy) * settings.efficiency_discharge
+            - settings.cycle_cost_per_kwh,
+        )
+        sell_cap = max(
+            0.0,
+            max(sell) * settings.efficiency_discharge - settings.cycle_cost_per_kwh,
+        )
+        assert sell_cap < buy_based, "scenario must exercise the binding cap"
+        capped_terminal_value = min(buy_based, sell_cap)
+
+        result_uncapped = optimize_battery_schedule(
+            buy_price=buy,
+            sell_price=sell,
+            home_consumption=consumption,
+            battery_settings=settings,
+            solar_production=solar,
+            initial_soe=14.0,
+            terminal_value_per_kwh=buy_based,  # old, buggy (#244) behavior
+        )
+        result_capped = optimize_battery_schedule(
+            buy_price=buy,
+            sell_price=sell,
+            home_consumption=consumption,
+            battery_settings=settings,
+            solar_production=solar,
+            initial_soe=14.0,
+            terminal_value_per_kwh=capped_terminal_value,  # fixed (#246) behavior
+        )
+
+        peak_price = max(sell)
+        peak_period_indices = {i for i, p in enumerate(sell) if p == peak_price}
+
+        def total_export(result):
+            return sum(
+                abs(pd.decision.battery_action)
+                for i, pd in enumerate(result.period_data)
+                if i in peak_period_indices
+                and pd.decision.battery_action is not None
+                and pd.decision.battery_action < -consumption[i]
+            )
+
+        export_uncapped = total_export(result_uncapped)
+        export_capped = total_export(result_capped)
+
+        assert export_uncapped == pytest.approx(0.0, abs=1e-6), (
+            "sanity check: uncapped buy-median value should reproduce the "
+            "reported bug (holds through the peak instead of exporting)"
+        )
+        assert export_capped > 0.0, (
+            "capped terminal value should let the DP export during the real "
+            "evening peak instead of holding for a fictitious bonus"
+        )
+
+    def test_nordic_shaped_market_retains_reserve(self):
+        """Ordinary/Nordic-shaped market with a genuine narrow evening peak:
+        the best in-horizon sell price is already above the buy-median
+        estimate, so the cap must not bind and the battery should still
+        retain a substantial reserve at horizon end (the exact regression
+        #245's straight sell-swap fix introduced, left untested there)."""
+        settings = BatterySettings(
+            total_capacity=15.0,
+            min_soc=10,
+            max_soc=100,
+            max_charge_power_kw=5.0,
+            max_discharge_power_kw=5.0,
+            cycle_cost_per_kwh=0.04,
+        )
+
+        # 0.6 baseline, narrow 1-hour peak at 1.4, sell = 0.85x buy throughout.
+        # No home consumption: isolates the pure hold-vs-export arbitrage
+        # decision the terminal value governs, since discharging to serve
+        # real consumption is rational whenever its value beats the buy
+        # price regardless of terminal value, which would confound the
+        # reserve check below.
+        buy = [0.6] * 30 + [1.4] * 4 + [0.6] * 6
+        sell = [round(p * 0.85, 4) for p in buy]
+        consumption = [0.0] * 40
+        solar = [0.0] * 40
+
+        buy_based = max(
+            0.0,
+            statistics.median(buy) * settings.efficiency_discharge
+            - settings.cycle_cost_per_kwh,
+        )
+        sell_cap = max(
+            0.0,
+            max(sell) * settings.efficiency_discharge - settings.cycle_cost_per_kwh,
+        )
+        assert buy_based < sell_cap, "scenario must exercise the non-binding cap"
+        capped_terminal_value = min(buy_based, sell_cap)
+        assert capped_terminal_value == pytest.approx(buy_based), (
+            "cap should not alter the terminal value on an ordinary/Nordic-"
+            "shaped market"
+        )
+
+        result = optimize_battery_schedule(
+            buy_price=buy,
+            sell_price=sell,
+            home_consumption=consumption,
+            battery_settings=settings,
+            solar_production=solar,
+            initial_soe=14.9,
+            terminal_value_per_kwh=capped_terminal_value,
+        )
+
+        final_soe = result.period_data[-1].energy.battery_soe_end
+        usable_capacity = settings.total_capacity - settings.min_soe_kwh
+        final_reserve_fraction = (final_soe - settings.min_soe_kwh) / usable_capacity
+
+        assert final_reserve_fraction > 0.5, (
+            f"DP should retain a substantial reserve at horizon end on an "
+            f"ordinary market, got {final_reserve_fraction:.1%} of usable capacity"
         )
 
 


### PR DESCRIPTION
## Summary
- `_calculate_terminal_value()` priced leftover battery charge at horizon end using only the median buy price, which can exceed the real achievable evening export price on wide buy/sell-spread contracts (Belgian ENTSO-e/Belpex), causing the DP to hold charge through the evening peak instead of exporting (#126, #244).
- Adds an arbitrage-consistency cap: `terminal_value = min(buy_based, sell_cap)`, where `sell_cap` is derived from the best sell price already visible in the DP's own horizon. Self-calibrating — no market-specific threshold.
- Same fix applied to the duplicated estimator in `core/bess/simulation/verification.py` (`realized_under_solar_error`).

## Root cause
> A terminal value estimating "worth of a kWh surviving past the horizon boundary" is only valid if it never exceeds the best certain payoff already visible and actionable inside today's own horizon. If it does, the DP forgoes a known-good, in-horizon outcome (e.g. exporting at a real evening peak price) in favor of a fictitious future one.

A prior attempt (#245) swapped buy price for sell price outright. bess-analyst review found this structurally biased *below* ordinary in-horizon export value for roughly half of any normal day (cycle cost is only ever charged on charging, never discharge), over-draining Nordic-shaped markets — the exact regression this PR's `test_nordic_shaped_market_retains_reserve` test now covers.

## Fix
- `core/bess/battery_system_manager.py`: `_calculate_terminal_value` now takes `sell_prices` and caps `buy_based` at `sell_cap = max(0, max(sell_prices)*efficiency_discharge - cycle_cost)`.
- `core/bess/simulation/verification.py`: identical cap applied to `realized_under_solar_error`'s terminal-value estimate.
- Tests: extended `TestCalculateTerminalValue` (binding-cap and non-binding-cap unit cases with hand-computed numbers), new `TestTerminalValueCapRegression` in `test_terminal_value.py` (Belgian-shaped scenario proving the DP now exports at the real evening peak; Nordic-shaped scenario proving reserve is still retained when the cap doesn't bind).

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (fast suite, Black, Ruff)
- [x] Full fast suite (`pytest -m "not slow"`): 1018 passed
- [x] Full slow suite (`pytest -m slow`): 336 passed, including `test_extended_horizon.py`, `test_terminal_value.py`, `test_plan_faithfulness.py`
- [x] `/code-review` (medium effort, 8 finder angles + verify pass): 2 confirmed cleanup findings (hardcoded test index violating rules.md's "no algorithm-specific boundaries" rule; redundant `max()` recomputation) — both fixed, re-verified green
- [x] Replayed #126/#244's actual reported debug bundle (`bess-debug-2026-07-07-143926.md`, Frank Leysen's real Belpex prices/config/battery state) through the real backend via `mock-run.sh`. Confirmed in logs: `Terminal value: 0.103/kWh (buy_based=0.257, sell_cap=0.103, median_buy=0.313, max_sell=0.150, ...)` — the cap binds exactly as expected on this real data. The resulting schedule shows the battery actively discharging (`LOAD_SUPPORT`, -0.9 kWh/period) through the real 0.15 EUR/kWh evening peak (periods 84-92) instead of sitting `IDLE` through it, which is the exact symptom reported in #126/#244.

Supersedes #245 (closed). Root issue: #244.

Closes #246