### PR TITLE
fix: derive release image repo from github.repository, not hardcoded prod name

### DIFF
--- a/.github/workflows/release-addon.yml
+++ b/.github/workflows/release-addon.yml
@@ -61,8 +61,11 @@ jobs:
             BUILD_VERSION=${{ steps.version.outputs.version }}
             BUILD_DATE=${{ github.event.release.published_at }}
             BUILD_REF=${{ github.sha }}
+          # Image repo derived from the current GitHub repo so each repo pushes to
+          # its own GHCR packages: prod → bess-manager-{arch}, beta → bess-manager-beta-{arch}.
+          # (config.yaml image: must match per repo.)
           tags: |
-            ${{ env.REGISTRY }}/johanzander/bess-manager-${{ matrix.arch }}:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/johanzander/bess-manager-${{ matrix.arch }}:latest
+            ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.arch }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.arch }}:latest
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}


### PR DESCRIPTION
The v9.9.0b10 beta release build just failed with `denied: permission_denied: write_package` trying to push to `ghcr.io/johanzander/bess-manager-amd64` (the **stable** package) from the **beta** repo. Root cause: this templating fix already existed on beta (commit a36c9cd, part of the old ad hoc sync process) but was missed when reconciling beta-only commits into main during the release-workflow migration (#253 ported the ci.yml carry-forward step but not this file). Restores it on main permanently so it flows to beta via the normal sync, instead of being a recurring beta-only patch.