### PR TITLE
fix: allow issue triage bot to run for non-collaborator reporters

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -47,6 +47,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
+          # Anyone can open an issue, so triage must run for non-collaborators
+          # too — otherwise external bug reports never get asked for a debug
+          # log. Safe here: Haiku, classify/label/comment only, no code access.
+          allowed_non_write_users: "*"
           # Haiku is plenty for classify+label; saves ~3x vs Sonnet.
           claude_args: "--max-turns 12 --permission-mode bypassPermissions --model claude-haiku-4-5"
           prompt: |


### PR DESCRIPTION
## Summary
- Add `allowed_non_write_users: "*"` to the `claude-code-action` step in `issue-triage.yml`
- The action gates on the triggering actor having write access to the repo; external issue reporters (e.g. #252, filed by a non-collaborator) got silently skipped instead of triaged
- Stage 1 only classifies, labels, and comments with Haiku — no source access, no code changes — so it's safe to run for anyone who can open an issue

## Test plan
- [ ] Merge and verify a test issue from a non-collaborator account gets triaged (labeled + asked for debug log if missing)
- [ ] Confirm existing behavior for collaborator-filed issues is unchanged

Fixes the gap found while investigating why #252 never got triaged automatically.