### PR TITLE
fix: only write SOC limits to inverter when they differ from config

### DIFF
--- a/core/bess/growatt_min_controller.py
+++ b/core/bess/growatt_min_controller.py
@@ -1321,15 +1321,13 @@ class GrowattMinController(InverterController):
         return writes, disables
 
     def sync_soc_limits(self, controller) -> None:
-        """Sync SOC limits from config to inverter hardware via entity writes."""
+        """Sync SOC limits from config to inverter hardware via entity writes.
+
+        Reads current charge/discharge stop SOC from the inverter and writes
+        back only if they differ from the configured max_soc / min_soc.
+        """
         configured_min_soc = self.battery_settings.min_soc
         configured_max_soc = self.battery_settings.max_soc
-
-        controller.set_discharge_stop_soc(configured_min_soc)
-        logger.info("Set discharge_stop_soc to %d%%", configured_min_soc)
-
-        controller.set_charge_stop_soc(configured_max_soc)
-        logger.info("Set charge_stop_soc to %d%%", configured_max_soc)
 
         actual_min_soc = controller.get_discharge_stop_soc()
         actual_max_soc = controller.get_charge_stop_soc()
@@ -1343,14 +1341,24 @@ class GrowattMinController(InverterController):
                 actual_min_soc,
                 actual_max_soc,
             )
-        else:
-            logger.warning(
-                "SOC limit mismatch detected! Configured: min=%d%%, max=%d%% | Actual: min=%s%%, max=%s%%",
-                configured_min_soc,
-                configured_max_soc,
-                actual_min_soc,
-                actual_max_soc,
-            )
+            return
+
+        logger.info(
+            "SOC limit mismatch — configured: min=%d%%, max=%d%% | "
+            "actual: min=%s%%, max=%s%% — syncing",
+            configured_min_soc,
+            configured_max_soc,
+            actual_min_soc,
+            actual_max_soc,
+        )
+
+        if actual_min_soc != configured_min_soc:
+            controller.set_discharge_stop_soc(configured_min_soc)
+            logger.info("Set discharge_stop_soc to %d%%", configured_min_soc)
+
+        if actual_max_soc != configured_max_soc:
+            controller.set_charge_stop_soc(configured_max_soc)
+            logger.info("Set charge_stop_soc to %d%%", configured_max_soc)
 
     def initialize_hardware(self, controller) -> None:
         self.sync_soc_limits(controller)

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -1623,6 +1623,10 @@ class HomeAssistantAPIController:
         """Read the current SolaX power control mode."""
         return self._get_raw_state("solax_power_control_mode")
 
+    def get_solax_min_soc(self) -> float | None:
+        """Read the current battery minimum SOC from the SolaX inverter."""
+        return self._get_sensor_value("solax_battery_min_soc")
+
     # ─────────────────────────────────────────────────────────────────────────
 
     def set_test_mode(self, enabled):

--- a/core/bess/solax_controller.py
+++ b/core/bess/solax_controller.py
@@ -159,6 +159,11 @@ class SolaxController(InverterController):
         current_mode = controller.get_solax_power_control_mode()
         logger.debug("SolaX: current power control mode = %r", current_mode)
 
+        actual_min_soc = controller.get_solax_min_soc()
+        if actual_min_soc == configured_min_soc:
+            logger.info("SolaX: battery minimum SOC verified: %d%%", configured_min_soc)
+            return
+
         controller.set_solax_min_soc(configured_min_soc)
         logger.info("SolaX: battery minimum SOC set to %d%%", configured_min_soc)
 

--- a/core/bess/tests/conftest.py
+++ b/core/bess/tests/conftest.py
@@ -72,6 +72,7 @@ class MockHomeAssistantController(HomeAssistantAPIController):
             "l3_current": 12.0,
             "charge_stop_soc": 100,
             "discharge_stop_soc": 10,
+            "solax_min_soc": 10,
             "charging_power_rate": 40,
             "test_mode": False,
             "tou_settings": [],
@@ -115,6 +116,9 @@ class MockHomeAssistantController(HomeAssistantAPIController):
             # SPH
             "ac_charge_times": [],
             "ac_discharge_times": [],
+            # MIN
+            "charge_stop_soc": [],
+            "discharge_stop_soc": [],
             # SolaX
             "vpp_calls": [],
             "vpp_disabled": [],
@@ -199,10 +203,12 @@ class MockHomeAssistantController(HomeAssistantAPIController):
     def set_charge_stop_soc(self, soc):
         """Set charge stop SOC."""
         self.settings["charge_stop_soc"] = soc
+        self.calls["charge_stop_soc"].append(soc)
 
     def set_discharge_stop_soc(self, soc):
         """Set discharge stop SOC."""
         self.settings["discharge_stop_soc"] = soc
+        self.calls["discharge_stop_soc"].append(soc)
 
     def is_test_mode(self):
         """Check if test mode is enabled."""
@@ -328,7 +334,12 @@ class MockHomeAssistantController(HomeAssistantAPIController):
 
     def set_solax_min_soc(self, min_soc: int) -> None:
         """Record SolaX min SOC write."""
+        self.settings["solax_min_soc"] = min_soc
         self.calls["min_soc"].append(min_soc)
+
+    def get_solax_min_soc(self) -> int | None:
+        """Return mock SolaX min SOC."""
+        return self.settings["solax_min_soc"]
 
     def get_solax_power_control_mode(self) -> str | None:
         """Return mock power control mode."""

--- a/core/bess/tests/unit/test_controller_coverage.py
+++ b/core/bess/tests/unit/test_controller_coverage.py
@@ -215,6 +215,27 @@ class TestMinCompareSchedules:
         assert "orruption" in reason
 
 
+class TestMinSyncSocLimits:
+    def test_no_mismatch_skips_write(self, min_ctrl, mock_controller):
+        mock_controller.settings["charge_stop_soc"] = 100
+        mock_controller.settings["discharge_stop_soc"] = 10
+        min_ctrl.sync_soc_limits(mock_controller)
+        assert mock_controller.calls["charge_stop_soc"] == []
+        assert mock_controller.calls["discharge_stop_soc"] == []
+
+    def test_charge_mismatch_syncs(self, min_ctrl, mock_controller):
+        min_ctrl.battery_settings.max_soc = 90
+        min_ctrl.sync_soc_limits(mock_controller)
+        assert mock_controller.calls["charge_stop_soc"] == [90]
+        assert mock_controller.calls["discharge_stop_soc"] == []
+
+    def test_discharge_mismatch_syncs(self, min_ctrl, mock_controller):
+        min_ctrl.battery_settings.min_soc = 20
+        min_ctrl.sync_soc_limits(mock_controller)
+        assert mock_controller.calls["discharge_stop_soc"] == [20]
+        assert mock_controller.calls["charge_stop_soc"] == []
+
+
 # ── GrowattSphController ─────────────────────────────────────────────────────
 
 

--- a/core/bess/tests/unit/test_solax_controller.py
+++ b/core/bess/tests/unit/test_solax_controller.py
@@ -297,11 +297,12 @@ class TestCompareSchedules:
 
 
 class TestSyncSocLimits:
-    def test_sync_soc_limits_calls_set_solax_min_soc(
+    def test_sync_soc_limits_calls_set_solax_min_soc_on_mismatch(
         self, controller: SolaxController, battery_settings: BatterySettings
     ) -> None:
         mock_hw = MagicMock()
         mock_hw.get_solax_power_control_mode.return_value = "Self Use Mode"
+        mock_hw.get_solax_min_soc.return_value = int(battery_settings.min_soc) + 1
         controller.sync_soc_limits(mock_hw)
 
         mock_hw.set_solax_min_soc.assert_called_once_with(int(battery_settings.min_soc))
@@ -313,9 +314,20 @@ class TestSyncSocLimits:
         ctrl = SolaxController(battery_settings=battery_settings)
         mock_hw = MagicMock()
         mock_hw.get_solax_power_control_mode.return_value = "Self Use Mode"
+        mock_hw.get_solax_min_soc.return_value = 10
         ctrl.sync_soc_limits(mock_hw)
 
         mock_hw.set_solax_min_soc.assert_called_once_with(20)
+
+    def test_sync_soc_limits_skips_write_when_no_mismatch(
+        self, controller: SolaxController, battery_settings: BatterySettings
+    ) -> None:
+        mock_hw = MagicMock()
+        mock_hw.get_solax_power_control_mode.return_value = "Self Use Mode"
+        mock_hw.get_solax_min_soc.return_value = int(battery_settings.min_soc)
+        controller.sync_soc_limits(mock_hw)
+
+        mock_hw.set_solax_min_soc.assert_not_called()
 
 
 # ── check_health ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `GrowattMinController.sync_soc_limits()` and `SolaxController.sync_soc_limits()` now read the current charge/discharge stop SOC from the inverter first and only write when it differs from the configured value, instead of writing unconditionally on every startup.
- Added `HomeAssistantAPIController.get_solax_min_soc()` read accessor needed for the SolaX read-before-write check.

## Root cause
`GrowattMinController.sync_soc_limits()` (`core/bess/growatt_min_controller.py`) wrote `discharge_stop_soc` and `charge_stop_soc` to the inverter unconditionally on every `initialize_hardware()` call (i.e. every program start), then only read back afterward to log a match/mismatch message — it never checked before writing. `SolaxController.sync_soc_limits()` had the same gap despite its docstring already claiming conditional-write behavior. `GrowattSphController.sync_soc_limits()` already implemented the correct read-compare-write-only-on-mismatch pattern; this PR brings the other two controllers in line with it.

## Fix
Both `sync_soc_limits()` implementations now read the inverter's current value(s) first, compare against the configured `min_soc`/`max_soc`, and only issue a write for whichever value(s) mismatch — eliminating unnecessary flash writes on every restart.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (fast suite: 1036 passed, black/ruff clean)
- [x] `.venv/bin/pytest -m slow` passes locally (357 passed, 3 skipped, 0 failed)
- [x] New/updated unit tests cover both the "no mismatch → no write" and "mismatch → write only what changed" cases for Growatt MIN and SolaX
- [x] Verified live against the real backend + mock-HA stack (`docker-compose.ci.yml`, `ci-normal-day` scenario): startup with matching values logs `SOC limits verified: min=10%, max=100%` and issues zero `number.set_value` calls; after forcing a mismatch on `charge_stop_soc` via the mock sensor and restarting, logs `SOC limit mismatch ... — syncing` and issues exactly one `number.set_value` call for the mismatched entity only (`discharge_stop_soc`, which still matched, was not touched)

Closes #248