### PR TITLE
fix: derive Savings export badge from backend intent, fix debug bundle Time column

### DIFF
--- a/core/bess/debug_report_formatter.py
+++ b/core/bess/debug_report_formatter.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 
 from .debug_data_exporter import DebugDataExport
+from .time_utils import format_period
 
 logger = logging.getLogger(__name__)
 
@@ -399,7 +400,8 @@ Findings (top) and System Logs (bottom).*
         for p in export.historical_periods:
             if p is None:
                 continue
-            ts = str(p.get("timestamp", ""))[:16]
+            period = p.get("period", "")
+            time_str = format_period(period) if isinstance(period, int) else ""
             src = p.get("data_source", "")[:6]
             dec = p.get("decision", {})
             intent = dec.get("strategic_intent", "")[:16]
@@ -412,7 +414,7 @@ Findings (top) and System Logs (bottom).*
             econ = p.get("economic", {})
             savings = econ.get("hourly_savings", 0)
             rows.append(
-                f"| {p.get('period', ''):>3} | {ts[11:16]:5} | {src:<6} |"
+                f"| {period:>3} | {time_str:5} | {src:<6} |"
                 f" {intent:<16} | {observed:<16} |"
                 f" {soe_s:>4.1f}→{soe_e:<4.1f} | {solar:>5.2f} | {imp:>6.2f} | {savings:>7.4f} |"
             )
@@ -505,10 +507,10 @@ Findings (top) and System Logs (bottom).*
             econ = p.get("economic", {})
             buy = econ.get("buy_price", 0)
             savings = econ.get("hourly_savings", 0)
-            ts = str(p.get("timestamp", ""))
-            time_str = ts[11:16] if len(ts) >= 16 else ""
+            period = p.get("period", "")
+            time_str = format_period(period) if isinstance(period, int) else ""
             rows.append(
-                f"| {p.get('period', ''):>3} | {time_str:5} |"
+                f"| {period:>3} | {time_str:5} |"
                 f" {intent:<16} | {observed:<16} |"
                 f" {batt_act:>+7.3f} | {soe_s:>4.1f}→{soe_e:<4.1f} |"
                 f" {buy:>8.4f} | {savings:>7.4f} |"

--- a/core/bess/tests/unit/test_debug_report_formatter.py
+++ b/core/bess/tests/unit/test_debug_report_formatter.py
@@ -1,0 +1,102 @@
+"""Tests for debug_report_formatter markdown table rendering."""
+
+from core.bess.debug_data_exporter import DebugDataExport
+from core.bess.debug_report_formatter import DebugReportFormatter
+
+
+def _minimal_export(**overrides) -> DebugDataExport:
+    defaults = {
+        "export_timestamp": "2026-07-07T21:45:00+02:00",
+        "timezone": "Europe/Stockholm",
+        "bess_version": "9.9.0b9",
+        "python_version": "3.12.0",
+        "system_uptime_hours": 1.0,
+        "health_check_results": {},
+        "battery_settings": {},
+        "price_settings": {},
+        "price_data": {},
+        "home_settings": {},
+        "energy_provider_config": {},
+        "addon_options": {},
+        "entity_snapshot": {},
+        "historical_periods": [],
+        "historical_summary": {"total_periods": 0, "periods_with_data": 0},
+        "inverter_tou_segments": [],
+        "schedules": [],
+        "schedules_summary": {"total_schedules": 0},
+        "snapshots": [],
+        "snapshots_summary": {"total_snapshots": 0},
+        "todays_log_content": "",
+        "log_file_info": {},
+        "compact": True,
+    }
+    defaults.update(overrides)
+    return DebugDataExport(**defaults)
+
+
+class TestHistoricalDataTimeColumn:
+    """The Time column must reflect the period's own start time, not the
+    raw collection timestamp (which is stamped at the *end* of the period)."""
+
+    def test_time_column_uses_period_start_not_collection_timestamp(self):
+        # Period 86 covers 21:30-21:45; data for it is collected/stamped at
+        # 21:45 (the start of period 87). The raw timestamp would mislabel
+        # this row as "21:45", which is actually period 87's start time.
+        period = {
+            "period": 86,
+            "timestamp": "2026-07-07T21:45:00+02:00",
+            "data_source": "actual",
+            "decision": {"strategic_intent": "BATTERY_EXPORT", "observed_intent": None},
+            "energy": {
+                "battery_soe_start": 8.1,
+                "battery_soe_end": 7.3,
+                "solar_production": 0.0,
+                "grid_imported": 0.0,
+            },
+            "economic": {"hourly_savings": 0.0},
+        }
+        export = _minimal_export(
+            historical_periods=[period],
+            historical_summary={"total_periods": 1, "periods_with_data": 1},
+        )
+
+        report = DebugReportFormatter()._format_historical_data(export)
+
+        assert "|  86 | 21:30 |" in report
+        assert "|  86 | 21:45 |" not in report
+
+
+class TestPeriodDecisionsTimeColumn:
+    """Same period-start convention applies to the schedules 'Period
+    Decisions' table."""
+
+    def test_time_column_uses_period_start_not_collection_timestamp(self):
+        period = {
+            "period": 86,
+            "timestamp": "2026-07-07T21:45:00+02:00",
+            "decision": {"strategic_intent": "BATTERY_EXPORT", "observed_intent": None},
+            "energy": {"battery_soe_start": 8.1, "battery_soe_end": 7.3},
+            "economic": {"buy_price": 1.0, "hourly_savings": 0.0},
+        }
+        export = _minimal_export(
+            schedules=[
+                {
+                    "optimization_period": 86,
+                    "optimization_result": {
+                        "economic_summary": {},
+                        "input_data": {},
+                        "period_data": [period],
+                    },
+                }
+            ],
+            schedules_summary={
+                "total_schedules": 1,
+                "first_optimization": "N/A",
+                "last_optimization": "N/A",
+            },
+        )
+
+        report = DebugReportFormatter()._format_schedules(export)
+
+        assert "|  86 | 21:30 |" in report
+        assert "|  86 | 21:45 |" not in report

--- a/frontend/src/components/BatteryModeTimeline.tsx
+++ b/frontend/src/components/BatteryModeTimeline.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { HourlyData } from '../types';
 import { DataResolution } from '../hooks/useUserPreferences';
+import { getIntent, StrategicIntent } from '../utils/intent';
 
 // Must match the YAxis width and ComposedChart margin used in EnergyFlowChart and BatteryLevelChart
 // so the timeline bar aligns horizontally with the chart plot areas.
@@ -8,8 +9,6 @@ import { DataResolution } from '../hooks/useUserPreferences';
 // Both charts: margin.right=5 + YAxis.width=60 → plot ends at W-65px
 const CHART_LEFT_OFFSET = 65;
 const CHART_RIGHT_OFFSET = 65;
-
-type StrategicIntent = 'GRID_CHARGING' | 'SOLAR_STORAGE' | 'LOAD_SUPPORT' | 'BATTERY_EXPORT' | 'SOLAR_EXPORT' | 'IDLE';
 
 const INTENT_CONFIG: Record<StrategicIntent, { label: string; color: string; darkColor: string }> = {
   GRID_CHARGING: { label: 'Charging from Grid', color: '#a855f7', darkColor: '#a855f7' },
@@ -46,8 +45,7 @@ function buildSegments(
 
   for (let i = 0; i < hourlyData.length; i++) {
     const h = hourlyData[i];
-    const rawIntent = (h.dataSource === 'actual' && h.observedIntent) ? h.observedIntent : h.strategicIntent;
-    const intent = (rawIntent as StrategicIntent) || 'IDLE';
+    const intent = getIntent(h);
     const startHour = resolution === 'quarter-hourly' ? i * 0.25 : i;
     const endHour = startHour + step;
 
@@ -61,7 +59,7 @@ function buildSegments(
 
   if (tomorrowData && tomorrowData.length > 0) {
     for (let i = 0; i < tomorrowData.length; i++) {
-      const intent = (tomorrowData[i].strategicIntent as StrategicIntent) || 'IDLE';
+      const intent = getIntent(tomorrowData[i]);
       const startHour = 24 + (resolution === 'quarter-hourly' ? i * 0.25 : i);
       const endHour = startHour + step;
 

--- a/frontend/src/components/SavingsOverview.tsx
+++ b/frontend/src/components/SavingsOverview.tsx
@@ -52,6 +52,13 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
     return '???';
   };
 
+  // For actual periods, observedIntent reflects what really happened (derived
+  // from sensor flows); strategicIntent can default to "IDLE" when no DP plan
+  // covered the period. Same precedence as BatteryModeTimeline.tsx.
+  const isBatteryExport = (hour: any) => {
+    const intent = (hour.dataSource === 'actual' && hour.observedIntent) ? hour.observedIntent : hour.strategicIntent;
+    return intent === 'BATTERY_EXPORT';
+  };
 
   if (loading) {
     return (
@@ -336,7 +343,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                           {hour.batteryToHome?.display}
                         </span>
                       )}
-                      {(hour.batteryToGrid?.value ?? 0) > 0.05 && (
+                      {isBatteryExport(hour) && (
                         <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                           <Zap className="h-2.5 w-2.5" />
                           {hour.batteryToGrid?.display}
@@ -345,7 +352,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                     </div>
                   </div>
                 </td>
-                
+
                 <td className="px-3 py-2 whitespace-nowrap text-sm text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 text-center">
                   <div className="font-medium">{getFormattedText(hour.batterySocEnd)}</div>
                   <div className="text-xs text-gray-500 dark:text-gray-400">
@@ -395,7 +402,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                           {hour.solarToGrid?.display}
                         </span>
                       )}
-                      {(hour.batteryToGrid?.value ?? 0) > 0.05 && (
+                      {isBatteryExport(hour) && (
                         <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                           <Battery className="h-2.5 w-2.5" />
                           {hour.batteryToGrid?.display}
@@ -735,7 +742,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                                   {hour.batteryToHome?.display}
                                 </span>
                               )}
-                              {(hour.batteryToGrid?.value ?? 0) > 0.05 && (
+                              {isBatteryExport(hour) && (
                                 <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                                   <Zap className="h-2.5 w-2.5" />
                                   {hour.batteryToGrid?.display}
@@ -794,7 +801,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                                   {hour.solarToGrid?.display}
                                 </span>
                               )}
-                              {(hour.batteryToGrid?.value ?? 0) > 0.05 && (
+                              {isBatteryExport(hour) && (
                                 <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                                   <Battery className="h-2.5 w-2.5" />
                                   {hour.batteryToGrid?.display}

--- a/frontend/src/components/SavingsOverview.tsx
+++ b/frontend/src/components/SavingsOverview.tsx
@@ -5,6 +5,7 @@ import FormattedValueComponent from './FormattedValue';
 import { useDashboardData } from '../hooks/useDashboardData';
 import { DataResolution } from '../hooks/useUserPreferences';
 import { periodToTimeString, periodToEndTime } from '../utils/timeUtils';
+import { getIntent } from '../utils/intent';
 
 interface SavingsOverviewProps {
   resolution: DataResolution;
@@ -50,14 +51,6 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
     }
     // No fallback - if unit is missing, it indicates a backend configuration issue
     return '???';
-  };
-
-  // For actual periods, observedIntent reflects what really happened (derived
-  // from sensor flows); strategicIntent can default to "IDLE" when no DP plan
-  // covered the period. Same precedence as BatteryModeTimeline.tsx.
-  const isBatteryExport = (hour: any) => {
-    const intent = (hour.dataSource === 'actual' && hour.observedIntent) ? hour.observedIntent : hour.strategicIntent;
-    return intent === 'BATTERY_EXPORT';
   };
 
   if (loading) {
@@ -343,7 +336,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                           {hour.batteryToHome?.display}
                         </span>
                       )}
-                      {isBatteryExport(hour) && (
+                      {getIntent(hour) === 'BATTERY_EXPORT' && (
                         <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                           <Zap className="h-2.5 w-2.5" />
                           {hour.batteryToGrid?.display}
@@ -402,7 +395,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                           {hour.solarToGrid?.display}
                         </span>
                       )}
-                      {isBatteryExport(hour) && (
+                      {getIntent(hour) === 'BATTERY_EXPORT' && (
                         <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                           <Battery className="h-2.5 w-2.5" />
                           {hour.batteryToGrid?.display}
@@ -742,7 +735,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                                   {hour.batteryToHome?.display}
                                 </span>
                               )}
-                              {isBatteryExport(hour) && (
+                              {getIntent(hour) === 'BATTERY_EXPORT' && (
                                 <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                                   <Zap className="h-2.5 w-2.5" />
                                   {hour.batteryToGrid?.display}
@@ -801,7 +794,7 @@ export const SavingsOverview: React.FC<SavingsOverviewProps> = ({ resolution }) 
                                   {hour.solarToGrid?.display}
                                 </span>
                               )}
-                              {isBatteryExport(hour) && (
+                              {getIntent(hour) === 'BATTERY_EXPORT' && (
                                 <span className="text-xs font-medium bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 px-1 py-0 rounded flex items-center gap-0.5">
                                   <Battery className="h-2.5 w-2.5" />
                                   {hour.batteryToGrid?.display}

--- a/frontend/src/components/SystemStatusCard.tsx
+++ b/frontend/src/components/SystemStatusCard.tsx
@@ -3,6 +3,7 @@ import api from '../lib/api';
 import { useDashboardData } from '../hooks/useDashboardData';
 import { FormattedValue } from '../types';
 import { DashboardResponse } from '../api/scheduleApi';
+import { getIntent } from '../utils/intent';
 import { 
   DollarSign, 
   Battery, 
@@ -241,7 +242,7 @@ const SystemStatusCard: React.FC<SystemStatusCardProps> = ({ className = "", sys
       SOLAR_EXPORT: 'Solar Exporting',
       IDLE: 'Standby',
     };
-    const rawIntent = currentHourData.strategicIntent?.toUpperCase().replace(/ /g, '_') ?? 'IDLE';
+    const rawIntent = getIntent(currentHourData).toUpperCase().replace(/ /g, '_');
     const strategicIntent = intentDisplayNames[rawIntent] ?? rawIntent;
 
     return {

--- a/frontend/src/components/__tests__/SavingsOverview.test.tsx
+++ b/frontend/src/components/__tests__/SavingsOverview.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SavingsOverview } from '../SavingsOverview'
+
+const fv = (value: number, display: string, unit = 'kWh') => ({
+  value,
+  display,
+  unit,
+  text: `${display} ${unit}`,
+})
+
+const baseHour = {
+  period: 86,
+  dataSource: 'actual',
+  batteryCharged: fv(0, '0.00'),
+  batteryDischarged: fv(0.84, '0.84'),
+  batterySocEnd: fv(50, '50'),
+  batterySoeEnd: fv(7.3, '7.3'),
+  gridImported: fv(0, '0.00'),
+  gridExported: fv(0.04, '0.04'),
+  gridToHome: fv(0, '0.00'),
+  gridToBattery: fv(0, '0.00'),
+  solarToBattery: fv(0, '0.00'),
+  solarToGrid: fv(0, '0.00'),
+  batteryToHome: fv(0.8, '0.80'),
+  // Below the frontend's old 0.05 kWh display threshold, but above the
+  // backend's 0.01 kWh BATTERY_EXPORT classification threshold — this is
+  // the exact mismatch reported in issue #247. Uses a display value distinct
+  // from every other field in this fixture so the assertion can't pass by
+  // matching an unrelated cell.
+  batteryToGrid: fv(0.0403, '0.04-export-badge'),
+  strategicIntent: 'BATTERY_EXPORT',
+  buyPrice: fv(1, '1.00', 'SEK'),
+  homeConsumption: fv(1, '1.00'),
+  hourlyCost: fv(0, '0.00', 'SEK'),
+  hourlySavings: fv(0, '0.00', 'SEK'),
+}
+
+let mockHour: Record<string, unknown> = baseHour
+
+vi.mock('../../hooks/useDashboardData', () => ({
+  useDashboardData: () => ({
+    data: {
+      currentPeriod: 86,
+      hourlyData: [mockHour],
+      summary: {},
+      tomorrowData: null,
+    },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+describe('SavingsOverview grid-export badge', () => {
+  it('shows the battery-to-grid badge when the backend classified the period as BATTERY_EXPORT, even below the old 0.05 kWh display threshold', () => {
+    mockHour = baseHour
+    render(<SavingsOverview resolution="quarter-hourly" />)
+
+    // The badge renders the batteryToGrid display value only when the
+    // period is recognized as an export period. It should appear (Battery
+    // column and Grid Export column) even though 0.0403 < the old 0.05 kWh
+    // frontend threshold.
+    expect(screen.getAllByText('0.04-export-badge').length).toBeGreaterThan(0)
+  })
+
+  it('prefers observedIntent over strategicIntent for actual periods, matching BatteryModeTimeline', () => {
+    // strategicIntent defaults to IDLE when no DP plan covered this period
+    // (see battery_system_manager.py's `planned_intent or "IDLE"`), but the
+    // period actually exported to the grid — observedIntent reflects the
+    // real sensor-derived outcome and must win for actual data.
+    mockHour = {
+      ...baseHour,
+      strategicIntent: 'IDLE',
+      observedIntent: 'BATTERY_EXPORT',
+    }
+    render(<SavingsOverview resolution="quarter-hourly" />)
+
+    expect(screen.getAllByText('0.04-export-badge').length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/utils/__tests__/intent.test.ts
+++ b/frontend/src/utils/__tests__/intent.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { getIntent } from '../intent'
+
+describe('getIntent', () => {
+  it('prefers observedIntent over strategicIntent for actual periods', () => {
+    // strategicIntent defaults to IDLE on the backend when no DP plan covered
+    // the period, even though the period really did something (observedIntent
+    // reflects the real sensor-derived outcome). See battery_system_manager.py's
+    // `planned_intent or "IDLE"`.
+    expect(
+      getIntent({ dataSource: 'actual', strategicIntent: 'IDLE', observedIntent: 'BATTERY_EXPORT' })
+    ).toBe('BATTERY_EXPORT')
+  })
+
+  it('falls back to strategicIntent for actual periods with no observedIntent', () => {
+    expect(
+      getIntent({ dataSource: 'actual', strategicIntent: 'LOAD_SUPPORT', observedIntent: undefined })
+    ).toBe('LOAD_SUPPORT')
+  })
+
+  it('ignores observedIntent for predicted periods', () => {
+    // Predicted/future periods shouldn't have observedIntent, but even if
+    // present it must not override the plan for a period that hasn't happened.
+    expect(
+      getIntent({ dataSource: 'predicted', strategicIntent: 'SOLAR_STORAGE', observedIntent: 'BATTERY_EXPORT' })
+    ).toBe('SOLAR_STORAGE')
+  })
+
+  it('defaults to IDLE when no intent is present', () => {
+    expect(getIntent({})).toBe('IDLE')
+  })
+})

--- a/frontend/src/utils/intent.ts
+++ b/frontend/src/utils/intent.ts
@@ -1,0 +1,29 @@
+// Single source of truth for reading a period's battery strategic intent.
+// The backend computes both fields (core/bess/decision_intelligence.py):
+// strategicIntent is the DP-planned intent (defaults to "IDLE" when no plan
+// covered the period), observedIntent is derived from real sensor flows and
+// is only set for actual/historical periods. Every UI surface that displays
+// or reasons about "what did the battery do this period" must resolve the
+// two the same way, or displays can disagree about the same period.
+
+export type StrategicIntent =
+  | 'GRID_CHARGING'
+  | 'SOLAR_STORAGE'
+  | 'LOAD_SUPPORT'
+  | 'BATTERY_EXPORT'
+  | 'SOLAR_EXPORT'
+  | 'IDLE';
+
+export interface IntentSource {
+  dataSource?: string;
+  strategicIntent?: string;
+  observedIntent?: string;
+}
+
+export function getIntent(hour: IntentSource): StrategicIntent {
+  const raw =
+    hour.dataSource === 'actual' && hour.observedIntent
+      ? hour.observedIntent
+      : hour.strategicIntent;
+  return (raw as StrategicIntent) || 'IDLE';
+}


### PR DESCRIPTION
## Summary
- Extracted a single shared `getIntent()` helper (`frontend/src/utils/intent.ts`) that resolves a period's real battery intent (preferring `observedIntent` over `strategicIntent` for actual periods), and replaced all three independent copies of this logic across the frontend: `SavingsOverview.tsx`'s new export-badge check, `BatteryModeTimeline.tsx`'s inline precedence logic, and `SystemStatusCard.tsx`'s intent read.
- Debug bundle's "Historical Sensor Data" and "Period Decisions" tables now label their Time column using the period's own start time instead of the raw collection timestamp.

## Root cause
From the bot's Stage 2 analysis on #247:
> The backend correctly discharged with a tiny grid-export slice... The backend's strategic-intent classifier uses a 0.01 kWh noise floor... The Savings page, however, only renders a grid-export flow badge when the same `batteryToGrid` value exceeds 0.05 kWh — 5x less sensitive... Both views are individually "correct" against their own threshold — they just disagree because the thresholds don't match.
>
> [Proposed fix] have the frontend derive "is this an export period" from the backend's already-computed strategic intent rather than re-deriving it from a second, independently-tuned numeric threshold.

The first commit on this branch fixed only the reported component (`SavingsOverview.tsx`), adding a local `isBatteryExport()` helper. That missed that `BatteryModeTimeline.tsx` already had the identical duplicated precedence logic (`observedIntent` for actual periods, else `strategicIntent`), and that `SystemStatusCard.tsx` read intent a third way with no `observedIntent` handling at all — the same class of drift that caused #247. The second commit generalizes this into one shared helper used everywhere.

`InverterStatusDashboard.tsx`'s `strategicIntent` merge (line ~470) is a different concern — it combines two separate API responses (schedule vs dashboard data), not actual-vs-observed precedence within one hour object — so it's left as-is.

Separately, the bot noted the debug bundle's own "Historical Sensor Data" table labels its Time column with the raw collection timestamp rather than `format_period()`'s period-start convention used elsewhere in the codebase, which caused a mis-read during the bot's own investigation.

## Fix
- `frontend/src/utils/intent.ts` (new): `getIntent(hour)` + exported `StrategicIntent` type, single source of truth for intent resolution.
- `frontend/src/components/SavingsOverview.tsx`: 4 duplicated threshold/intent checks now call `getIntent(hour) === 'BATTERY_EXPORT'`.
- `frontend/src/components/BatteryModeTimeline.tsx`: inline precedence logic replaced with `getIntent()`; local `StrategicIntent` type now imported from the shared module.
- `frontend/src/components/SystemStatusCard.tsx`: intent read now goes through `getIntent()` too (no behavior change today — the current/live period never has `observedIntent` set — but it's now consistent and correct if that ever changes).
- `core/bess/debug_report_formatter.py`: `_format_historical_data` and `_format_schedules` now derive the Time column via `format_period(period)` instead of slicing the raw stored `timestamp`.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (fast suite: 1034 passed; frontend: 49/49, TS/ESLint clean)
- [x] `.venv/bin/pytest -m slow` passes (357 passed)
- [x] `/code-review` run on the first commit; 1 CONFIRMED finding (badge logic ignored `observedIntent` for actual periods) — fixed and re-verified with a new regression test, then generalized further per user feedback
- [x] Downloaded the real debug bundle attached to #247, extracted its actual `historical_periods` JSON, and ran the real (fixed) `DebugReportFormatter` against it directly: period 86 (21:30–21:45) now renders `Time = 21:30` instead of the bundle's original incorrect `21:45` — confirms the exact reported mis-read is fixed against real production data.
- [x] New tests: `frontend/src/utils/__tests__/intent.test.ts` (shared helper precedence rules), `frontend/src/components/__tests__/SavingsOverview.test.tsx`, `core/bess/tests/unit/test_debug_report_formatter.py`

Closes #247