### PR TITLE
fix: remove unverified load_first EMS discharge=0 write gate (SolaxModbus)

### DIFF
--- a/core/bess/solax_modbus_growatt_controller.py
+++ b/core/bess/solax_modbus_growatt_controller.py
@@ -150,16 +150,18 @@ class SolaxModbusGrowattController(GrowattMinController):
                     logger.error("FAILED: set TOU segment mode to %s: %s", mode, e)
                     errors.append(str(e))
 
-        # load_first uses inverter-native discharge control; touching the EMS
-        # discharge rate register with 0 disables discharge entirely. But
-        # LOAD_SUPPORT also maps to load_first and can carry a real non-zero
-        # rate (#200) — only withhold the write when there's nothing to write.
-        if mode != "load_first" or discharge_rate != 0:
-            success, error_msg = self._write_period_to_hardware(
-                controller, grid_charge, discharge_rate
-            )
-            if not success:
-                errors.append(error_msg)
+        # #166 added a gate here to skip writing discharge_rate=0 in load_first
+        # mode, on the theory that it disables the inverter's native self-use
+        # discharge. That theory was never confirmed against real hardware and
+        # left SOLAR_STORAGE/IDLE with a stale discharge_rate register (#issue
+        # reported by Doodlehusse on #200 follow-up). This beta build removes
+        # the gate to test on real GEN4 hardware — writes unconditionally, same
+        # as GrowattMinController's cloud path.
+        success, error_msg = self._write_period_to_hardware(
+            controller, grid_charge, discharge_rate
+        )
+        if not success:
+            errors.append(error_msg)
 
         if errors:
             return False, "; ".join(errors)

--- a/core/bess/tests/integration/test_cross_platform.py
+++ b/core/bess/tests/integration/test_cross_platform.py
@@ -159,9 +159,10 @@ class TestCrossPlatformHardwareWrites:
             assert len(mock_controller.calls["vpp_disabled"]) == 1
             assert len(mock_controller.calls["vpp_calls"]) == 0
         elif _is_solax_modbus(platform_system):
-            # IDLE → load_first; inverter-native control, EMS registers not written
-            assert mock_controller.calls["grid_charge"] == []
-            assert mock_controller.calls["discharge_rate"] == []
+            # IDLE → load_first; EMS registers now written unconditionally
+            # (experimental, see #166/#261)
+            assert mock_controller.calls["grid_charge"][-1] is False
+            assert mock_controller.calls["discharge_rate"][-1] == 0
         else:
             # IDLE: grid_charge=False and discharge_rate=0
             assert mock_controller.calls["grid_charge"][-1] is False
@@ -179,8 +180,9 @@ class TestCrossPlatformHardwareWrites:
         elif _is_solax(platform_system):
             assert len(mock_controller.calls["vpp_disabled"]) == 1
         elif _is_solax_modbus(platform_system):
-            # SOLAR_STORAGE → load_first; inverter-native control, EMS register not written
-            assert mock_controller.calls["grid_charge"] == []
+            # SOLAR_STORAGE → load_first; EMS registers now written
+            # unconditionally (experimental, see #166/#261)
+            assert mock_controller.calls["grid_charge"][-1] is False
         else:
             assert mock_controller.calls["grid_charge"][-1] is False
 

--- a/core/bess/tests/unit/test_solax_modbus_growatt_single_segment.py
+++ b/core/bess/tests/unit/test_solax_modbus_growatt_single_segment.py
@@ -205,11 +205,15 @@ class TestApplyPeriod:
         assert mock_ha.calls["grid_charge"][-1] is True
         assert len(mock_ha.calls["discharge_rate"]) == 1
 
-    def test_load_first_skips_ems_discharge_write(self, controller, mock_ha):
-        """EMS discharge rate must not be written in load_first mode.
+    def test_load_first_writes_zero_ems_discharge_rate(self, controller, mock_ha):
+        """EMS discharge rate=0 must be written in load_first mode (experimental).
 
-        Writing discharge_rate=0 to the EMS register disables inverter discharge,
-        defeating Load First's inverter-native discharge control.
+        #166 previously gated this write out, on the unconfirmed theory that
+        writing discharge_rate=0 to the EMS register disables the inverter's
+        native self-use discharge. That gate left SOLAR_STORAGE/IDLE with a
+        stale discharge_rate register (reported against #200 by Doodlehusse).
+        This beta build removes the gate to test on real GEN4 hardware — it
+        now writes unconditionally, same as GrowattMinController's cloud path.
         """
         intents = hourly_to_quarterly({0: "IDLE"})
         schedule = make_schedule(intents)
@@ -218,8 +222,7 @@ class TestApplyPeriod:
 
         self._apply_at_period(controller, mock_ha, 0, "IDLE")
 
-        assert len(mock_ha.calls["discharge_rate"]) == 0
-        assert len(mock_ha.calls["grid_charge"]) == 0
+        assert mock_ha.calls["discharge_rate"] == [0]
 
     def test_load_first_writes_nonzero_load_support_discharge_rate(
         self, controller, mock_ha
@@ -227,9 +230,8 @@ class TestApplyPeriod:
         """LOAD_SUPPORT's real discharge rate must reach the inverter.
 
         Regression test for #200: LOAD_SUPPORT maps to load_first, same as
-        IDLE, but unlike IDLE it can compute a non-zero discharge rate. The
-        load_first gate must only withhold zero-rate writes (see
-        test_load_first_skips_ems_discharge_write above), not this one.
+        IDLE, and both now write discharge_rate unconditionally (see
+        test_load_first_writes_zero_ems_discharge_rate above).
         """
         from datetime import datetime
 


### PR DESCRIPTION
## Summary
- `apply_period()` on the Solax Modbus / local-Modbus Growatt controller (`core/bess/solax_modbus_growatt_controller.py`) no longer withholds the EMS discharge-rate write when `mode == "load_first"` and `discharge_rate == 0`
- Writes unconditionally now, matching `GrowattMinController`'s cloud path
- Regression test updated to assert `discharge_rate=0` is written in `load_first` mode instead of asserting it's skipped

## Background
#166 added a gate to skip writing `discharge_rate=0` to the EMS register in `load_first` mode, on the theory that writing 0 disables the inverter's native self-use discharge entirely. That theory was **never confirmed against real hardware** — #166 was self-filed by automation during code analysis, not from an observed hardware symptom or debug log.

The gate's side effect: `SOLAR_STORAGE` and `IDLE` (which both resolve to `discharge_rate=0` under `load_first`) never write to the register, leaving whatever value the last active period wrote (stale). Doodlehusse reported this on the #200 follow-up (chat, not a filed issue yet) — he has a Growatt MID 15KTL3-XH on `solax_modbus` and confirmed discharge % correctly zeroes with Growatt-native cloud, but stays stale with `solax_modbus` in `solar_storage`/`idle`.

## Purpose of this PR
This is an **experimental hardware-verification build**, not a confirmed fix. It removes the #166 gate so Doodlehusse can test on his real GEN4 hardware whether writing `discharge_rate=0` during `load_first` actually disables self-use discharge (the original #166 concern) or not. Depending on his result:
- If self-use discharge is **not** affected: this becomes the real fix.
- If self-use discharge **is** disabled: this PR should be closed/reverted and we look at alternatives (e.g. writing a non-zero "uncapped" value instead of 0).

No CHANGELOG entry yet — pending hardware confirmation.

## Test plan
- [x] `./scripts/quality-check.sh` Python checks pass (Black, Ruff, 1038 tests, 0 errors)
- [ ] Real-hardware verification by Doodlehusse (Growatt MID 15KTL3-XH via solax_modbus) — pending