### PR TITLE
chore: allow git merge --ff-only without a permission prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,8 @@
       "Bash(podman machine stop)",
       "Bash(podman-compose *)",
       "Bash(git commit *)",
-      "Bash(git push *)"
+      "Bash(git push *)",
+      "Bash(git merge --ff-only *)"
     ],
     "deny": [
       "Bash(podman machine rm *)",


### PR DESCRIPTION
## Summary
- Adds \`Bash(git merge --ff-only *)\` to the project allowlist. This form can't create a merge commit or lose work — it fails outright unless already a fast-forward — so it doesn't need the same confirmation as plain \`git merge\` (which stays in \`ask\`)
- Came up mid-session doing a routine \`git merge --ff-only origin/main\` as part of the beta release skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)