### PR TITLE
fix: pin week-bucket tests to an explicit date instead of implicit today

### DIFF
--- a/backend/tests/test_savings_aggregate_api.py
+++ b/backend/tests/test_savings_aggregate_api.py
@@ -73,7 +73,7 @@ class TestSavingsAggregate:
             _seeded_store(tmp_path)
         )
 
-        resp = _client.get("/api/savings/aggregate?period=week&count=1")
+        resp = _client.get("/api/savings/aggregate?period=week&count=1&date=2026-07-08")
 
         assert resp.status_code == 200
         body = resp.json()
@@ -123,7 +123,7 @@ class TestSavingsAggregate:
             _seeded_store(tmp_path)
         )
 
-        resp = _client.get("/api/savings/aggregate?period=week&count=1")
+        resp = _client.get("/api/savings/aggregate?period=week&count=1&date=2026-07-08")
 
         assert resp.status_code == 200
         bucket = resp.json()["buckets"][0]
@@ -134,7 +134,7 @@ class TestSavingsAggregate:
             _seeded_store(tmp_path)
         )
 
-        resp = _client.get("/api/savings/aggregate?period=week&count=1")
+        resp = _client.get("/api/savings/aggregate?period=week&count=1&date=2026-07-08")
 
         assert resp.status_code == 200
         bucket = resp.json()["buckets"][0]
@@ -269,7 +269,7 @@ class TestSolarBatterySavingsSplit:
             self._store_with_solar_and_battery(tmp_path)
         )
 
-        resp = _client.get("/api/savings/aggregate?period=week&count=1")
+        resp = _client.get("/api/savings/aggregate?period=week&count=1&date=2026-07-08")
 
         assert resp.status_code == 200
         bucket = resp.json()["buckets"][0]


### PR DESCRIPTION
## Summary
- `test_savings_aggregate_api.py`'s 4 week-bucket tests queried `/api/savings/aggregate?period=week&count=1` without the endpoint's optional `date=` anchor, relying on `date.today()` landing in the same ISO week as the fixture date (`2026-07-08`).
- That broke deterministically once "today" rolled into a new week (discovered while running the fast suite locally ahead of a beta release, on 2026-07-13, a Monday).
- Anchored all 4 to `date=2026-07-08` so they no longer depend on wall-clock date.

## Test plan
- [x] `pytest backend/tests/test_savings_aggregate_api.py -m "not slow"` — 16 passed
- [x] `pytest -m "not slow"` (full fast suite) — 1106 passed, 13 skipped
- [x] `black --check` / `ruff check` clean