### PR TITLE
docs: clarify consumption-forecast outlier filtering, add worktree-first rule

### DIFF
--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -286,8 +286,14 @@ is always caused by a specific, identifiable change.
 The optimizer needs a consumption forecast.  Four strategies exist:
 
 - **ha_statistics** (recommended): Builds a 96-period time-of-day profile
-  from the past 7 days of HA Recorder data.  Uses trimmed mean to filter
-  out spikes like EV charging.  Higher during evening peaks, lower overnight.
+  from the past 7 days of HA Recorder data, bucketed by hour-of-day.  For
+  each hour it drops only the single highest (and lowest, if ≥5 samples)
+  of the 7 daily values before averaging.  This discounts a one-off
+  irregular spike (e.g. an unusual EV charging session on one day) but
+  does **not** strip out a regular/nightly EV charging habit — if most of
+  the 7 samples for an hour are elevated together, the average stays high
+  and the forecast correctly bakes that load in.  Higher during evening
+  peaks, lower overnight.
 - **influxdb_7d_avg**: Same concept but queries InfluxDB instead of HA.
 - **sensor**: Reads a 48-hour rolling average sensor.  Produces a flat
   prediction (same value all day).

--- a/docs/agents/rules.md
+++ b/docs/agents/rules.md
@@ -3,6 +3,26 @@
 These rules apply to every agent working on this codebase.
 They are non-negotiable and override any other instruction.
 
+## Working Location
+
+- **Never edit, create, or delete a file while checked out on `main`** (or any
+  shared long-lived branch) — not even a one-line doc fix or a typo
+  correction made mid-discussion. Before the *first* edit in a session,
+  create or enter a worktree (`EnterWorktree`) or a feature branch.
+- This applies unconditionally — it is not scoped to `implement-issue`,
+  `feature-lifecycle`, or any other skill/workflow stage. A plain
+  conversation ("can you fix this doc line") is not an exemption.
+- If you notice partway through a session that you're on `main` with
+  uncommitted edits: stop, move the changes into a worktree (stash the
+  specific file, enter/create a worktree, apply the stash there — don't
+  touch unrelated pre-existing changes on `main`), and continue there.
+- **`EnterWorktree` switches the shell's cwd, not file-tool paths.**
+  `Read`/`Edit`/`Write` take the literal absolute path given — after
+  entering a worktree, every such path must start with the worktree root
+  (`.claude/worktrees/<name>/...`), never the original repo root. Verify
+  this on the first file operation after switching, not just once at
+  session start.
+
 ## Environment
 
 - Each worktree has its own `.venv` — never use bare `pytest`, `black`, `ruff`, or global/absolute Python paths


### PR DESCRIPTION
## Summary
- `bess-knowledge.md`: spell out exactly how the `ha_statistics` consumption-forecast strategy filters outliers (drop highest, and lowest if ≥5 samples, per hour-bucket) and clarify it preserves regular/nightly load patterns rather than only discounting one-off spikes.
- `rules.md`: add a "Working Location" section codifying that agents must never edit/create/delete files while checked out on `main` (or any shared branch), even for a one-line fix, and that `EnterWorktree` only moves the shell's cwd, not file-tool paths.

Both changes were sitting uncommitted in a stale worktree from a prior session; recovered and cleanly rebased onto current `main`.

## Test plan
- [x] Docs-only change, no code affected