### PR TITLE
fix: allow gh issue/pr commands so bot workflows don't get silently denied

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,15 @@
       "Bash(podman-compose *)",
       "Bash(git commit *)",
       "Bash(git push *)",
-      "Bash(git merge --ff-only *)"
+      "Bash(git merge --ff-only *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue edit *)",
+      "Bash(gh issue comment *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr review *)",
+      "Bash(gh pr create *)"
     ],
     "deny": [
       "Bash(podman machine rm *)",


### PR DESCRIPTION
## Summary
- Every issue-triage.yml run since 2026-07-11 has reported `success` but applied zero labels/comments (`permission_denials_count` went from 0 to 2-3 that day, with no repo-side change to explain it).
- Traced to `anthropics/claude-code-action@v1` (floating tag) picking up a Claude Code CLI bump from 2.1.206 to 2.1.207 in that window — `--permission-mode bypassPermissions` appears to no longer force-allow Bash commands (like `gh`) that aren't already on the project's explicit allow list.
- Adds the `gh issue`/`gh pr` subcommands actually used across the bot pipeline (triage/analyze/fix/review) to `.claude/settings.json`'s allow list, so those bots don't depend on bypass-mode behavior at all.

## Test plan
- [ ] Merge, then re-run triage on issue #304 (`gh workflow run issue-triage.yml -f issue_number=304`) and confirm labels + comment actually land this time