### PR TITLE
fix: eliminate stale ha_controller.sensors cache after platform/settings changes

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -149,21 +149,6 @@ def _refresh_health(bess_controller) -> None:
         logger.warning("Could not refresh health state after settings update: %s", exc)
 
 
-def _refresh_active_sensors(bess_controller) -> None:
-    """Sync the live ha_controller.sensors map from persisted settings.
-
-    ha_controller.sensors is a plain dict copy, not a live view of the
-    settings store — it only reflects the sensor map that was active when it
-    was last assigned. Any settings mutation that can change which sensors
-    are active (a direct "sensors" edit, or an inverter/growatt platform
-    switch, which selects a different per-platform sensor sub-dict) must call
-    this afterward, unconditionally, or the copy goes stale until the next
-    "sensors"-specific PATCH or a process restart.
-    """
-    active = bess_controller.settings_store.get_active_sensors()
-    bess_controller.ha_controller.sensors = {k: v for k, v in active.items() if v}
-
-
 # ---------------------------------------------------------------------------
 # Unified settings endpoints
 # ---------------------------------------------------------------------------
@@ -346,7 +331,7 @@ async def patch_settings(updates: dict):
         # Any of the sections above (sensors directly, or growatt/inverter via
         # a platform switch) can change which sensors are active — refresh
         # unconditionally rather than only on a "sensors" key match.
-        _refresh_active_sensors(bess_controller)
+        bess_controller.refresh_active_sensors()
         _refresh_health(bess_controller)
         return await get_settings()
 
@@ -3139,7 +3124,7 @@ async def get_setup_status():
     """
     from app import bess_controller
 
-    sensors = bess_controller.ha_controller.sensors
+    sensors = bess_controller.settings_store.get_active_sensors()
     total = len(sensors)
     configured = sum(1 for v in sensors.values() if v)
     system_configured = bess_controller.system.is_configured
@@ -3547,7 +3532,7 @@ async def setup_complete(payload: APISetupCompletePayload):
         # without requiring a restart. Unconditional, not gated on
         # payload.sensors: an inverter platform switch above also changes
         # which per-platform sensor sub-dict is active.
-        _refresh_active_sensors(bess_controller)
+        bess_controller.refresh_active_sensors()
         if payload.growattDeviceId:
             bess_controller.ha_controller.growatt_device_id = payload.growattDeviceId
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -149,6 +149,21 @@ def _refresh_health(bess_controller) -> None:
         logger.warning("Could not refresh health state after settings update: %s", exc)
 
 
+def _refresh_active_sensors(bess_controller) -> None:
+    """Sync the live ha_controller.sensors map from persisted settings.
+
+    ha_controller.sensors is a plain dict copy, not a live view of the
+    settings store — it only reflects the sensor map that was active when it
+    was last assigned. Any settings mutation that can change which sensors
+    are active (a direct "sensors" edit, or an inverter/growatt platform
+    switch, which selects a different per-platform sensor sub-dict) must call
+    this afterward, unconditionally, or the copy goes stale until the next
+    "sensors"-specific PATCH or a process restart.
+    """
+    active = bess_controller.settings_store.get_active_sensors()
+    bess_controller.ha_controller.sensors = {k: v for k, v in active.items() if v}
+
+
 # ---------------------------------------------------------------------------
 # Unified settings endpoints
 # ---------------------------------------------------------------------------
@@ -324,17 +339,14 @@ async def patch_settings(updates: dict):
                 if control_mode and platform == "solax_modbus_growatt_min":
                     bess_controller.system.switch_control_mode(control_mode)
 
-            elif store_key == "sensors":
-                # Update live ha_controller.sensors from the merged flat view
-                active = bess_controller.settings_store.get_active_sensors()
-                bess_controller.ha_controller.sensors = {
-                    k: v for k, v in active.items() if v
-                }
-
             elif store_key == "demo_mode":
                 enabled = section.get("enabled", False)
                 bess_controller.system.set_demo_mode(enabled)
 
+        # Any of the sections above (sensors directly, or growatt/inverter via
+        # a platform switch) can change which sensors are active — refresh
+        # unconditionally rather than only on a "sensors" key match.
+        _refresh_active_sensors(bess_controller)
         _refresh_health(bess_controller)
         return await get_settings()
 
@@ -3532,13 +3544,10 @@ async def setup_complete(payload: APISetupCompletePayload):
                 bess_controller.system.switch_control_mode(payload.inverterControlMode)
 
         # Apply settings to live system so BESS starts immediately
-        # without requiring a restart.
-        if payload.sensors:
-            # Update live ha_controller.sensors from the merged flat view
-            active = bess_controller.settings_store.get_active_sensors()
-            bess_controller.ha_controller.sensors = {
-                k: v for k, v in active.items() if v
-            }
+        # without requiring a restart. Unconditional, not gated on
+        # payload.sensors: an inverter platform switch above also changes
+        # which per-platform sensor sub-dict is active.
+        _refresh_active_sensors(bess_controller)
         if payload.growattDeviceId:
             bess_controller.ha_controller.growatt_device_id = payload.growattDeviceId
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -250,6 +250,21 @@ class BESSController:
 
         return options
 
+    def refresh_active_sensors(self) -> None:
+        """Sync the live ha_controller.sensors map from persisted settings.
+
+        ha_controller.sensors is a plain dict copy, not a live view of the
+        settings store — it only reflects the sensor map that was active when
+        it was last assigned. Any settings mutation that can change which
+        sensors are active (a direct sensor edit, or an inverter/growatt
+        platform switch, which selects a different per-platform sensor
+        sub-dict) must call this afterward, or the copy goes stale until the
+        next call or a process restart. This is the single place that
+        performs the sync — call sites should not reimplement it.
+        """
+        active = self.settings_store.get_active_sensors()
+        self.ha_controller.sensors = {k: v for k, v in active.items() if v}
+
     def apply_discovered_config(
         self,
         sensor_map: dict,
@@ -273,7 +288,7 @@ class BESSController:
         )
 
         # Apply to running controller so BESS starts using new sensors immediately
-        self.ha_controller.sensors.update({k: v for k, v in sensor_map.items() if v})
+        self.refresh_active_sensors()
         if growatt_device_id:
             self.ha_controller.growatt_device_id = growatt_device_id
         if nordpool_area:

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -106,9 +106,14 @@ def mock_controller():
         result.update(sensors.get(platform, {}))
         return result
 
+    def _refresh_active_sensors() -> None:
+        active = _get_active_sensors()
+        ctrl.ha_controller.sensors = {k: v for k, v in active.items() if v}
+
     ctrl.settings_store.get_section.side_effect = _get_section
     ctrl.settings_store.save_section.side_effect = _save_section
     ctrl.settings_store.get_active_sensors.side_effect = _get_active_sensors
+    ctrl.refresh_active_sensors.side_effect = _refresh_active_sensors
 
     ctrl.ha_controller.sensors = {}
 

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -99,9 +99,14 @@ def complete_controller():
         result.update(sensors.get(platform, {}))
         return result
 
+    def _refresh_active_sensors() -> None:
+        active = _get_active_sensors()
+        ctrl.ha_controller.sensors = {k: v for k, v in active.items() if v}
+
     ctrl.settings_store.get_section.side_effect = _get_section
     ctrl.settings_store.save_all.side_effect = _save_all
     ctrl.settings_store.get_active_sensors.side_effect = _get_active_sensors
+    ctrl.refresh_active_sensors.side_effect = _refresh_active_sensors
 
     sys.modules["app"].bess_controller = ctrl
     return ctrl
@@ -155,7 +160,10 @@ class TestGetSetupStatus:
     """GET /api/setup/status."""
 
     def test_wizard_needed_when_no_sensors(self, mock_controller):
-        mock_controller.ha_controller.sensors = {"battery_soc": "", "solar_power": ""}
+        mock_controller.settings_store.get_active_sensors.return_value = {
+            "battery_soc": "",
+            "solar_power": "",
+        }
         resp = _client.get("/api/setup/status")
         assert resp.status_code == 200
         body = resp.json()
@@ -163,7 +171,7 @@ class TestGetSetupStatus:
         assert body["configuredSensors"] == 0
 
     def test_wizard_not_needed_when_sensors_configured(self, mock_controller):
-        mock_controller.ha_controller.sensors = {
+        mock_controller.settings_store.get_active_sensors.return_value = {
             "battery_soc": "sensor.growatt_battery_soc",
             "solar_power": "sensor.growatt_solar_power",
         }
@@ -175,7 +183,7 @@ class TestGetSetupStatus:
         assert body["totalSensors"] == 2
 
     def test_partially_configured_still_needs_wizard(self, mock_controller):
-        mock_controller.ha_controller.sensors = {
+        mock_controller.settings_store.get_active_sensors.return_value = {
             "battery_soc": "sensor.growatt_battery_soc",
             "solar_power": "",
             "import_power": "",

--- a/backend/tests/test_setup_wizard_scenarios.py
+++ b/backend/tests/test_setup_wizard_scenarios.py
@@ -105,9 +105,14 @@ class TestWizardComplete:
                 result.update(platform_sensors)
             return result
 
+        def _refresh_active_sensors() -> None:
+            active = _get_active_sensors()
+            ctrl.ha_controller.sensors = {k: v for k, v in active.items() if v}
+
         ctrl.settings_store.get_section.side_effect = _get_section
         ctrl.settings_store.save_all.side_effect = _save_all
         ctrl.settings_store.get_active_sensors.side_effect = _get_active_sensors
+        ctrl.refresh_active_sensors.side_effect = _refresh_active_sensors
         sys.modules["app"].bess_controller = ctrl
 
         # POST the wizard payload


### PR DESCRIPTION
## Summary

Follow-up to the architecture question raised in #331's review: `ha_controller.sensors` is a plain dict copy, not a live view of the settings store, and was only refreshed by three independent, ad hoc call sites — two of them gated on the PATCH request happening to touch a `"sensors"` key specifically.

- `PATCH /api/settings` only refreshed the live sensor map when `store_key == "sensors"` matched — so switching the inverter/growatt platform (which selects a different per-platform sensor sub-dict via `switch_inverter_platform()`) left the map stale until a coincidental sensors-PATCH or a process restart. This isn't just a debug-export concern: live sensor reads (TOU segments, VPP registers, `discharge_inhibit`, `local_load_power`) all resolve through this same map.
- `POST /api/setup/complete` had the identical bug, gated on `payload.sensors`.
- `apply_discovered_config` (`backend/app.py`) had a *third*, independently-written sync using `.update()` merge semantics instead of full reassignment.

## Changes

- Added `BESSController.refresh_active_sensors()` (`backend/app.py`) as the single implementation of "sync `ha_controller.sensors` from `settings_store.get_active_sensors()`".
- `patch_settings` and `setup_complete` now call it unconditionally after any settings mutation, instead of duplicating the sync logic behind a conditional.
- `apply_discovered_config` now calls the same method instead of its own `.update()`-based variant.
- `GET /api/setup/status` now reads `settings_store.get_active_sensors()` directly instead of the cached `ha_controller.sensors` copy, removing a fourth place whose correctness depended on the cache being fresh by convention.
- Updated test fixtures in `test_settings_api.py`, `test_setup_api.py`, `test_setup_wizard_scenarios.py` to wire `refresh_active_sensors`/`get_active_sensors` side effects consistently.

## Test plan

- [x] `black`/`ruff` — clean
- [x] `pytest -m "not slow"` — 1187 passed, 14 skipped

## Follow-up

This still leaves `ha_controller.sensors` as a cache that must be refreshed by every mutation site, rather than eliminating the cache entirely. That requires moving `SettingsStore` out of `backend/` into `core/bess/` (it has no backend-specific dependencies) so the controller can hold a live reference and `.sensors` can become a computed property — tracked as a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)