### PR TITLE
fix: energy-flow split invents flows from cross-sensor noise

### DIFF
--- a/core/bess/models.py
+++ b/core/bess/models.py
@@ -119,14 +119,22 @@ class EnergyData:
         grid_to_battery = min(
             max(0, self.battery_charged - solar_to_battery), self.grid_imported
         )
-        # Grid to home is the remainder of actual imports
-        grid_to_home = self.grid_imported - grid_to_battery
+        # Grid to home is capped by what home still needs after solar+battery.
+        # Any leftover grid_imported beyond that is cross-sensor noise between
+        # independent lifetime counters (see validate_energy_balance's
+        # tolerance) - it must not be invented as a flow to an entity that
+        # consumed nothing.
+        grid_to_home = min(
+            remaining_consumption, max(0, self.grid_imported - grid_to_battery)
+        )
 
-        # Step 4: Export flow reconciliation (ensure exports match measured total)
-        calculated_export = solar_to_grid + battery_to_grid
-        if self.grid_exported != calculated_export:
-            # Adjust battery_to_grid to match actual grid export total
-            battery_to_grid = self.grid_exported - solar_to_grid
+        # Step 4: Export flow reconciliation, capped by what the battery
+        # actually discharged - never invented to force-match grid_exported,
+        # for the same cross-sensor-noise reason as grid_to_home above.
+        battery_to_grid = min(
+            max(0, self.grid_exported - solar_to_grid),
+            self.battery_discharged - battery_to_home,
+        )
 
         # Assign calculated flows
         self.solar_to_home = solar_to_home

--- a/core/bess/tests/unit/test_data_models.py
+++ b/core/bess/tests/unit/test_data_models.py
@@ -133,6 +133,32 @@ class TestEnergyData:
         assert is_valid, f"Energy balance should be valid: {message}"
         assert "Energy balance OK" in message
 
+    def test_detailed_flows_never_exceed_aggregate_totals(self):
+        """Cross-sensor noise must not be misattributed to a real-looking flow.
+
+        Reproduces a real bundle period where independent lifetime-counter
+        sensors disagreed by ~0.1 kWh (within validate_energy_balance's 0.2 kWh
+        tolerance). home_consumption and battery_discharged both derive to
+        exactly 0, but grid_imported/grid_exported are nonzero. The detailed
+        flow split must not invent grid_to_home or battery_to_grid flows for
+        entities that consumed/discharged nothing.
+        """
+        energy = EnergyData(
+            solar_production=0.3999999999996362,
+            home_consumption=0.0,
+            grid_imported=0.3000000000001819,
+            grid_exported=0.3999999999996362,
+            battery_charged=0.4000000000005457,
+            battery_discharged=0.0,
+            battery_soe_start=2.0,
+            battery_soe_end=2.2,
+        )
+
+        # No home consumption -> no flow can be attributed to home.
+        assert energy.grid_to_home == 0.0
+        # No battery discharge -> no flow can be attributed to battery export.
+        assert energy.battery_to_grid == 0.0
+
     def test_energy_balance_validation_with_tolerance(self):
         """Test energy balance validation respects tolerance."""
         energy = EnergyData(


### PR DESCRIPTION
## Summary
- `EnergyData._calculate_detailed_flows()` reconciled `grid_to_home` and `battery_to_grid` directly against the measured `grid_imported`/`grid_exported` totals, without capping them by `home_consumption`/`battery_discharged`.
- When independent lifetime-counter sensors disagree by a small amount (normal noise, tolerated by `validate_energy_balance()` up to 0.2 kWh), that noise got misattributed as a real flow to an entity that consumed/discharged nothing — e.g. a period with `home_consumption == 0` showing a nonzero `grid_to_home`.
- Found while building a debug-bundle visualization for issue #328's discussion: period 26 (2026-07-17 06:30) showed `grid_to_home: 0.30` with `home_consumption: 0`, and `battery_to_grid: 0.40` with `battery_discharged: 0.0`.
- Fix caps both flows by their governing aggregate; any leftover import/export beyond that is left unattributed (honest shortfall) rather than invented.

## Test plan
- [x] New regression test `test_detailed_flows_never_exceed_aggregate_totals` reproduces the exact period-26 sensor values and confirms it fails before the fix (RED) and passes after (GREEN)
- [x] Full existing `TestEnergyData` suite passes unchanged (19/19)
- [x] Full fast suite passes (`pytest -m "not slow"`, 1200 passed)
- [x] `black` + `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)