### PR TITLE
fix: skip influxdb_7d_avg comparison entry when InfluxDB unconfigured

### DIFF
--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1050,6 +1050,8 @@ class BatterySystemManager:
                     quarterly = self.home_settings.default_hourly / 4.0
                     forecast = [quarterly] * 96
                 elif name == "influxdb_7d_avg":
+                    if not is_influxdb_configured():
+                        raise ValueError("InfluxDB not configured")
                     forecast = self._get_influxdb_7d_avg_forecast()
                 elif name == "ha_statistics":
                     forecast = self._get_ha_statistics_forecast()


### PR DESCRIPTION
## Summary
- `get_consumption_forecast_comparison()` always attempted the `influxdb_7d_avg` forecast even when InfluxDB isn't configured, generating 7 `WARNING`-level log lines per call (one per historical day queried) — noisy in mock runs and on any production system that hasn't set up InfluxDB.
- Guard the branch with the existing `is_influxdb_configured()` check (same pattern already used elsewhere in this file), so it's marked unavailable immediately instead of attempting and failing 7 queries.

## Test plan
- [x] `.venv/bin/pytest -m "not slow"` — 1199 passed, 14 skipped
- [x] `./scripts/quality-check.sh` — 0 errors, 4 pre-existing unrelated warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)