### PR TITLE
docs: fix stale DP-algorithm claims and document undocumented mechanisms

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -123,6 +123,20 @@ step — per `docs/superpowers/specs/2026-07-09-release-workflow-design.md`,
 ever renames or copies that section, it never authors it. Skipping this here
 means the release skill has to backfill it later from a colder context.
 
+**Documentation check (mandatory, not optional):** if the fix changed a
+mechanism, formula, threshold, or code path that `docs/agents/bess-knowledge.md`
+or `docs/SOFTWARE_DESIGN.md` describes, update the affected section in this
+same PR. These two files are read as ground truth by the AI chat, the
+GitHub analysis agent, and future implementers — a removed/changed mechanism
+left undocumented silently rots into a wrong answer later (found in practice:
+a "Bellman-optimality guardrail removal" refactor left both docs describing a
+profit-threshold gate and a reward floor that no longer existed, and a FIFO
+cost-basis claim that was never true). Concretely: grep both files for any
+function/field/formula your diff touches before opening the PR, not after.
+If neither file mentions anything your change touches, say so explicitly in
+the PR description rather than silently skipping — a reviewer shouldn't have
+to guess whether it was checked.
+
 Commit per `docs/agents/workflow.md` format (subject + blank line + body
 explaining WHY). Open a draft PR against `main` via
 `superpowers:finishing-a-development-branch` (Option 2: push + PR), body:
@@ -204,6 +218,7 @@ flow above, which stops at draft-PR-open per the Step 10 constraints.
 | "the plan doc is useful context, keep it in the PR" | Once code and tests exist, the plan only drifts — it's not the source of truth. Delete it before Step 9; keep the spec if one exists. |
 | "the user is in a hurry, just open the PR" | Time pressure from the user is not permission to skip Step 8 — it's the reason to say so explicitly and give a real ETA instead. |
 | "I'll just watch the background agent run" | Defeats the point — the whole reason it's backgrounded is so the session isn't held open through the slow suite. Let the notification bring you back. |
+| "the fix is small, docs don't need touching" | Small fixes are exactly what silently invalidates a one-line doc claim (a removed threshold, a renamed formula). Grep the two design docs before opening the PR, every time. |
 
 ## Red Flags — Stop and Go Back
 
@@ -216,6 +231,8 @@ flow above, which stops at draft-PR-open per the Step 10 constraints.
   comment already exists.
 - About to run the slow suite inline in the main session instead of
   dispatching the Step 6 background agent.
+- About to open the PR without checking whether the fix invalidates a claim
+  in `docs/agents/bess-knowledge.md` or `docs/SOFTWARE_DESIGN.md`.
 
 ## Quick Reference
 

--- a/TODO.md
+++ b/TODO.md
@@ -567,6 +567,23 @@ This eliminates the `required_methods` parameter entirely and makes the policy s
 
 ---
 
+### Remove dead `min_action_profit_threshold` config
+
+**Impact**: Low | **Effort**: Low | **Dependencies**: `settings.py`, `settings_store.py`
+
+**Description**: `min_action_profit_threshold` was the configurable gate for the DP's old profit-threshold/all-IDLE-rejection mechanism. That mechanism was removed in the "Bellman-optimality guardrail removal" refactor (commit `ee24537f`/`f57d4fed`, `docs/superpowers/specs/2026-07-06-dp-bellman-guardrail-removal-design.md`) — the current all-IDLE safety net (`core/bess/dp_battery_algorithm.py:1514-1536`) is a plain cost comparison that doesn't read this setting at all. The field is still declared in `core/bess/settings.py:127` and migrated in `backend/settings_store.py:389,480`, and likely still surfaced in the setup wizard/settings UI, but nothing consumes it anymore. Found while auditing `docs/agents/bess-knowledge.md` and `docs/SOFTWARE_DESIGN.md` for staleness (2026-07-19).
+
+**What needs to change**:
+
+- Remove `min_action_profit_threshold` from `BatterySettings` (`core/bess/settings.py`)
+- Remove it from the settings-store schema/migration (`backend/settings_store.py`)
+- Check the frontend (settings forms, setup wizard) for a corresponding field and remove it
+- Verify no other code path reads it (grep before deleting)
+
+**Files**: `core/bess/settings.py`, `backend/settings_store.py`, frontend settings components
+
+---
+
 ### Move `charging_power_rate` out of `BatterySettings`
 
 **Impact**: Low | **Effort**: Medium | **Dependencies**: `power_monitor.py`, `settings_store.py`, migration

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -80,7 +80,7 @@ def start() -> None
 2. **Backward Induction**: Starting from the last period, work backwards evaluating all feasible actions (charge/discharge/idle) at each (period, SOE) cell
 3. **Reward + Future Value**: For each action, compute the immediate reward (grid cost savings minus cycle cost) plus the optimal future value from the resulting SOE state
 4. **Policy Extraction**: Forward-simulate from the initial SOE, following the optimal action at each step to produce the final schedule
-5. **Profitability Gate**: Reject the schedule in favour of all-IDLE if total savings fall below a horizon-scaled minimum threshold
+5. **All-IDLE Safety Net**: Unconditionally compute an all-IDLE schedule and swap it in only if its cost is cheaper than the optimized schedule's — a plain O(1) comparison, not a configurable/horizon-scaled threshold. This catches numerical residual from SOE discretization; it is not an economic profitability gate. (An earlier threshold-based gate was removed in the "Bellman-optimality guardrail removal" refactor — the DP's backward induction already finds the Bellman-optimal schedule, so an extra economic veto was redundant. See `core/bess/dp_battery_algorithm.py:1514-1536`.)
 
 **Inputs**:
 
@@ -163,7 +163,7 @@ class StoredSchedule:
 **Base class** `InverterController` provides shared intent-to-control mapping, hourly settings aggregation, and the abstract schedule interface. Four subclasses implement hardware-specific logic:
 
 - **GrowattMinController** — Growatt MIN/MID/MOD (AC-coupled, cloud). Groups quarterly periods into TOU intervals (max 9 segments). Only creates segments for battery-first/grid-first; idle periods use load-first default. Writes via `growatt_server.update_time_segment` service call.
-- **GrowattSolaxModbusController** — Growatt MIN/MID/MOD (AC-coupled, local Modbus). Subclasses `GrowattMinController` — identical scheduling algorithm. Overrides only the I/O layer: writes via `select.select_option` (4 per slot) + `button.press` (1 per slot). Reads via entity state queries.
+- **SolaxModbusGrowattController** — Growatt MIN/MID/MOD (AC-coupled, local Modbus). Subclasses `GrowattMinController` — identical scheduling algorithm. Overrides only the I/O layer: writes via `select.select_option` (4 per slot) + `button.press` (1 per slot). Reads via entity state queries.
 - **GrowattSphController** — Growatt SPH (DC-coupled). Uses separate charge/discharge period lists (max 3 each) with global power and SOC settings per write call. Writes via `growatt_server.write_ac_charge_times` / `write_ac_discharge_times`.
 - **SolaxController** — SolaX (Modbus VPP). Issues per-period active-power commands instead of storing a persistent TOU schedule. Idle/solar periods disable VPP; charge/discharge periods set a watt target with autorepeat.
 
@@ -271,34 +271,33 @@ The DP algorithm uses **backward induction** to find the globally optimal batter
 
 **Actions**: Discretized charge/discharge power levels, filtered by physical constraints (available energy, remaining capacity, power limits, temperature derating).
 
-**Transition**: Each action updates SOE accounting for charging/discharging efficiency losses, and updates the cost basis of stored energy (FIFO accounting).
+**Temperature derating**: on cold days, max charge power can be capped below the configured limit via a weather-forecast-driven derating curve (`core/bess/battery_system_manager.py:1917-1966`, `_get_temperature_derated_charge_limits`). If the weather entity isn't configured, this silently returns no derating rather than failing — an installation without a weather entity behaves as if derating doesn't exist, by design, not by error.
+
+**`charging_power_rate` limitation**: this settings-page value only seeds the initial charge-power target before the first control cycle; every cycle after that, `adjust_charging_power()` (`core/bess/battery_system_manager.py:2037-2064`) derives the actual hardware rate from `INTENT_TO_CONTROL` (always 0% or 100%), never re-reading the configured percentage. Tracked as a known bug in `TODO.md`, not a documented feature.
+
+**Discharge inhibit**: an externally detected `binary_sensor` (entity ID suffix `_charging`/`_is_charging`) can force `discharge_rate` to 0 independent of the DP schedule, polled every minute (`core/bess/battery_system_manager.py:3089-3113`) and applied at schedule-write time (`core/bess/battery_system_manager.py:2578-2582`). This is the most common reason observed hardware behavior diverges from the planned schedule.
+
+**Transition**: Each action updates SOE accounting for charging/discharging efficiency losses, and updates the cost basis of stored energy. Cost basis is a **weighted average**, not FIFO — there is no queue of cost "layers". On charge: `new_cost_basis = (soe * cost_basis + new_energy_cost) / next_soe` (`core/bess/dp_battery_algorithm.py:496-498`). On discharge, `cost_basis` is left unchanged.
 
 **Objective**: Minimize net electricity cost (grid import cost minus export revenue) while accounting for battery cycle degradation costs and a terminal value for energy remaining at end of horizon.
 
 **Output**: For each period, the algorithm produces the optimal battery action, the resulting detailed energy flows (solar-to-home, grid-to-battery, etc.), economic data (costs, savings), and the strategic intent classification.
 
-**Profit threshold**: After optimization, total savings are compared against a horizon-scaled minimum threshold. If savings are too low relative to remaining day fraction, the schedule is rejected in favor of all-IDLE to prevent excessive cycling for marginal gains.
+**All-IDLE safety net**: See the "All-IDLE Safety Net" step above — this is a numerical residual check, not an economic profit threshold.
 
 ### Energy Flow Calculation
 
-The system decomposes measured energy totals into detailed flows (e.g., solar-to-home, grid-to-battery) using energy conservation constraints:
+The system decomposes measured energy totals into detailed flows (e.g., solar-to-battery, grid-to-battery) using energy conservation, but flows are **clamped to measured grid totals** (`grid_imported`/`grid_exported`) rather than derived by pure subtraction — pure subtraction can invent flows out of cross-sensor noise (fixed in PR #342). See `core/bess/models.py` (`EnergyData._calculate_detailed_flows`, ~lines 90-146) and `core/bess/energy_flow_calculator.py` (~lines 176-183) for the current formulas, e.g.:
 
 ```python
-
-# Home load priority - consume solar directly first
-
-solar_to_home = min(solar_production, home_consumption)
-
-# Remaining solar allocated to battery then grid
-
-solar_to_battery = min(remaining_solar, battery_charged)
-solar_to_grid = remaining_solar - solar_to_battery
-
-# Grid fills remaining consumption and battery charging
-
-grid_to_home = max(0, home_consumption - solar_to_home)
-grid_to_battery = max(0, battery_charged - solar_to_battery)
+solar_to_battery = max(0, solar_production - export_to_grid
+                         - self_consumption + battery_discharged)
+solar_to_battery = min(solar_to_battery, battery_charged, solar_production)
 ```
+
+Home consumption gets solar first (free), then grid; battery charges from
+solar first (free), then grid (paid) — but the split is reconciled against
+measured grid import/export, not assumed from production figures alone.
 
 ### Decision Intelligence
 
@@ -382,13 +381,13 @@ The system supports multiple inverter platforms, each with a dedicated controlle
 | Platform ID | Inverter | HA Integration | Control Method | Controller Class |
 |---|---|---|---|---|
 | `growatt_min` | Growatt MIC/MIN/MOD/MID | `growatt_server` (cloud) | TOU service calls | `GrowattMinController` |
-| `growatt_solax_modbus` | Growatt MIC/MIN/MOD/MID | `solax_modbus` (local Modbus) | TOU entity writes | `GrowattSolaxModbusController` |
+| `growatt_solax_modbus` | Growatt MIC/MIN/MOD/MID | `solax_modbus` (local Modbus) | TOU entity writes | `SolaxModbusGrowattController` |
 | `growatt_sph` | Growatt SPH | `growatt_server` (cloud) | AC charge/discharge periods | `GrowattSphController` |
 | `solax` | SolaX | `solax_modbus` (local Modbus) | VPP active-power commands | `SolaxController` |
 
 The active platform is stored in `inverter.platform`. Switching platform at runtime calls `BatterySystemManager.switch_inverter_platform()`, which destroys the current `InverterController` and creates the correct subclass. No restart is required.
 
-`GrowattSolaxModbusController` subclasses `GrowattMinController` — the scheduling algorithm (9 TOU slots, differential updates, corruption recovery) is identical. Only the hardware I/O differs: `growatt_server` uses a single service call per slot, while `solax_modbus` uses 4 entity writes (`select.select_option`) plus a button press per slot.
+`SolaxModbusGrowattController` subclasses `GrowattMinController` — the scheduling algorithm (9 TOU slots, differential updates, corruption recovery) is identical. Only the hardware I/O differs: `growatt_server` uses a single service call per slot, while `solax_modbus` uses 4 entity writes (`select.select_option`) plus a button press per slot.
 
 ### Platform Capabilities
 
@@ -608,6 +607,20 @@ The system includes comprehensive health checking:
 - **Energy Balance**: Physics validation of measured energy flows
 - **Optimization Health**: Algorithm convergence and result validation
 - **Hardware Connection**: Inverter communication and control verification
+
+**Severity model**: each component check is governed by two flags —
+`is_required` (is this component critical to the system, used to set the
+dashboard's `has_critical_errors` banner) and `required_methods` (which
+specific sensors within the component must succeed for it to be ERROR
+rather than WARNING). `determine_health_status()`
+(`core/bess/health_check.py:80-127`) combines them into three outcomes: ERROR
+only when a *required* sensor is missing/failing, WARNING when only an
+*optional* sensor fails, and SKIPPED for sensors intentionally left
+unconfigured (these don't count as a failure at all). A component with
+`is_required=False` should never surface as ERROR — if it does, check
+whether `required_methods` was mistakenly passed as "all methods" instead
+of derived from `is_required` (see `TODO.md`'s "Simplify Health Check
+Severity Model" for the known fragility here).
 
 ## API Architecture
 

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -54,20 +54,59 @@ efficiency losses and updates the **cost basis** of stored energy.
 revenue) while accounting for battery cycle degradation costs and a terminal
 value for energy remaining at end of horizon.
 
-**Cost basis tracking (FIFO)**: When the battery charges at different prices
-over time, the system tracks the cost of stored energy using FIFO (first-in,
-first-out) accounting.  When the battery discharges, the oldest (cheapest)
-energy is used first.  This determines the true profit of a discharge action.
+**Terminal value**: Only applies when the horizon does *not* already extend
+into tomorrow (i.e. tomorrow's prices aren't yet available). Without it, the
+DP has no visibility past the horizon and would have no reason not to drain
+the battery completely in the last period. Each leftover kWh at the horizon's
+end is valued at:
 
-**Profit threshold**: After optimization, the battery's own contribution
-(`solar_only_cost - battery_solar_cost` — how much better the schedule is
-than solar alone, not than a zero-solar grid-only baseline) is compared
-against a minimum threshold scaled by remaining day fraction. If that's too
-low, an all-IDLE fallback is computed as a candidate replacement — but it is
-only used if it's actually cheaper than the rejected schedule. The fallback
-still passively absorbs any solar surplus into available battery room and
-pays wear cost on it, but never discharges to recoup that cost, so it isn't
-automatically better than what it would replace.
+    terminal_value = median(buy_prices) * efficiency_discharge - cycle_cost
+
+capped at `max(sell_prices) * efficiency_discharge - cycle_cost` — an
+**arbitrage-consistency cap** that prevents the estimate from exceeding what
+could actually be realized by selling right now at the best available price
+(`core/bess/battery_system_manager.py:1840-1908`,
+`_calculate_terminal_value`; see issues #126/#244/#246). This is the
+mechanism to check first for "why didn't the battery discharge everything
+right before midnight" or "why does it hold charge near the end of the
+horizon" — once tomorrow's prices arrive and the horizon extends, this
+formula no longer applies; the real future prices take over.
+
+**Self-throttling near self-consumption (issue #240)**: In `_compute_reward`,
+a discharge whose overshoot above `home_consumption` is
+`<= BATTERY_EXPORT_THRESHOLD_KWH` (0.01 kWh,
+`core/bess/dp_battery_algorithm.py:96`) has its `grid_exported` forced to
+zero for reward purposes — the DP treats it as pure self-consumption, not an
+export sale, because load-first hardware doesn't reliably deliver a trivial
+overshoot to the grid in practice. When evaluating whether a small discharge
+was "worth" `sell_price`, check this threshold first: below it, the relevant
+alternative-value comparison is against the buy price avoided, not the sell
+price (`core/bess/dp_battery_algorithm.py:511-522`).
+
+**Cost basis tracking (weighted average)**: When the battery charges at
+different prices over time, the system tracks the cost of stored energy as a
+**weighted average**, not FIFO. On charge: `new_cost_basis = (soe *
+cost_basis + new_energy_cost) / next_soe`
+(`core/bess/dp_battery_algorithm.py:496-498`). On discharge, `cost_basis` is
+left unchanged — there is no "oldest energy first" queue or layered
+accounting anywhere in the code.
+
+**All-IDLE safety net (not a profit threshold)**: After optimization, an
+all-IDLE schedule is unconditionally computed and swapped in only if its
+`battery_solar_cost` is cheaper than the optimized schedule's
+(`core/bess/dp_battery_algorithm.py:1514-1536`). This is a plain cost
+comparison — there is **no minimum-profit threshold and no day-fraction
+scaling**. An earlier design had a threshold/guardrail here; it was removed
+in the "Bellman-optimality guardrail removal" refactor (commit
+`ee24537f`/`f57d4fed`,
+`docs/superpowers/specs/2026-07-06-dp-bellman-guardrail-removal-design.md`)
+because the DP's backward induction already finds the Bellman-optimal
+schedule, making an extra economic gate redundant. What remains is a
+numerical safety net for SOE-discretization residual, not an economic
+judgment call. The fallback still passively absorbs any solar surplus into
+available battery room and pays wear cost on it, but never discharges to
+recoup that cost, so it isn't automatically better than what it would
+replace.
 
 **Shadow price (marginal value of stored energy)**: The backward induction
 builds a value-to-go for every (period, SOE-level) state — the best achievable
@@ -110,11 +149,17 @@ which must still clear the wear cost. A 6 öre differential against a 40 öre we
 cost is a loss, not a 6 öre gain.
 
 **Reconciliation with the code:** `_compute_reward`
-(`core/bess/dp_battery_algorithm.py:361-394`) implements this as an anti-cycling
-floor — for a discharge it raises the effective floor to `sell_price` whenever solar
-will replenish the discharged capacity, so `sell × efficiency_discharge < sell ≤
-floor` blocks the trade. The function's older docstring phrasing ("value >
-cost_basis") describes that floor's implementation, not the user-facing law above.
+(`core/bess/dp_battery_algorithm.py:409-541`) no longer implements an explicit
+profitability floor. That anti-cycling floor was removed in the
+"Bellman-optimality guardrail removal" refactor (commit
+`ee24537f`/`f57d4fed`,
+`docs/superpowers/specs/2026-07-06-dp-bellman-guardrail-removal-design.md`);
+the function's current docstring states "No profitability veto: every
+physically valid discharge gets a finite reward... a separate floor on top
+of that is redundant at best." The governing economic law above still holds
+as the *outcome* of backward induction (the DP won't choose a discharge that
+isn't marginally worthwhile), but it is enforced by the value-to-go
+comparison across the whole horizon, not by a floor inside `_compute_reward`.
 
 ### Facts vs Economics — where each lives in a debug bundle
 
@@ -151,16 +196,11 @@ A battery discharges a small amount to grid in a slot where `sell = 0.46`,
 ## Strategic Intents
 
 Every 15-minute slot gets a strategic intent based on the energy flows the
-optimizer chose.  These are classified from the actual flow pattern:
-
-| Intent | Condition | What it means |
-|--------|-----------|---------------|
-| **GRID_CHARGING** | grid_to_battery >= 0.1 kWh | Buying cheap grid electricity to store in battery |
-| **SOLAR_STORAGE** | solar_to_battery > 0.1 kWh, grid_to_battery < 0.1 | Storing excess solar production for later |
-| **LOAD_SUPPORT** | battery_to_home > 0.1 kWh, battery_to_grid <= 0.1 | Using battery to power home (avoid expensive grid) |
-| **BATTERY_EXPORT** | battery_to_grid > 0.1 kWh | Selling stored battery energy to grid at high prices |
-| **SOLAR_EXPORT** | power ≈ 0, solar_to_grid > 0.01 kWh | Solar surplus exporting directly to grid, battery idle |
-| **IDLE** | No significant battery flows | No profitable action — direct solar/grid consumption |
+optimizer chose: **GRID_CHARGING**, **SOLAR_STORAGE**, **LOAD_SUPPORT**,
+**BATTERY_EXPORT**, **SOLAR_EXPORT**, **IDLE**. The exact classification
+thresholds live in `core/bess/decision_intelligence.py` — read that file
+directly rather than relying on a copy of the numbers here, since they are
+implementation detail that can change independently of this doc.
 
 **Hardware mapping**: Intents control actual inverter behavior:
 - GRID_CHARGING → battery_first mode + grid charge ON
@@ -217,6 +257,40 @@ surplus (deficit 0), so planned vs realized economics are unchanged.  The gate
 only affects *sub-15-minute* hardware behaviour.
 
 
+## Execution Layer: What Can Override the Schedule
+
+The DP schedule is not the last word — several mechanisms outside the
+optimizer can change what the hardware actually does. Check these *before*
+concluding a mechanism is "missing" from the DP when observed behavior
+doesn't match the schedule:
+
+- **Discharge inhibit sensor**: an external `binary_sensor` (auto-detected by
+  entity ID suffix `_charging`/`_is_charging`, e.g. EV charging status) can
+  force `discharge_rate` to 0 regardless of what the schedule says, checked
+  independently of the 15-min optimization cycle
+  (`core/bess/battery_system_manager.py:3089-3113`, polled every minute) and
+  applied at schedule-write time
+  (`core/bess/battery_system_manager.py:2578-2582`). If a period's
+  `Observed` behavior shows no discharge despite `Intent: BATTERY_EXPORT` or
+  `LOAD_SUPPORT`, check for an active discharge-inhibit sensor before
+  suspecting the DP or the intent-to-hardware mapping.
+- **Temperature derating**: charge power can be capped below the configured
+  max on cold days via a weather-forecast-driven derating curve
+  (`core/bess/battery_system_manager.py:1917-1966`,
+  `_get_temperature_derated_charge_limits`). If the weather entity isn't
+  configured, this **silently returns no derating** rather than failing —
+  so its absence in one installation vs. presence in another is expected,
+  not a bug.
+- **`charging_power_rate` setting is cosmetic after startup (known
+  limitation, not a documented mechanism)**: this settings-page value only
+  seeds the initial charge-power target once, before the first control
+  cycle. Every cycle after that, the actual hardware charge rate comes from
+  `INTENT_TO_CONTROL`, which only ever emits 0% or 100% — it never reads
+  this setting again (`core/bess/battery_system_manager.py:2037-2064`,
+  `adjust_charging_power`). If a user reports "changing the charge power
+  rate slider did nothing," this is why — it is a known bug, tracked in
+  `TODO.md`, not a settings-propagation issue to re-diagnose from scratch.
+
 ## Price Calculation
 
 The optimizer works with buy and sell prices derived from spot prices:
@@ -234,16 +308,21 @@ counterfactual is.
 ## Energy Flow Decomposition
 
 The system decomposes measured energy totals into detailed flows using
-energy conservation:
+energy conservation, but flows are **clamped to measured grid totals**
+(`grid_imported`/`grid_exported`) rather than derived by pure subtraction —
+pure subtraction can invent flows out of cross-sensor noise (fixed in PR
+#342). See `core/bess/models.py` (`EnergyData._calculate_detailed_flows`,
+~lines 90-146) and `core/bess/energy_flow_calculator.py` (~lines 176-183) for
+the current formulas, e.g.:
 
-    solar_to_home    = min(solar_production, home_consumption)
-    solar_to_battery = min(remaining_solar, battery_charged)
-    solar_to_grid    = remaining_solar - solar_to_battery
-    grid_to_home     = home_consumption - solar_to_home
-    grid_to_battery  = battery_charged - solar_to_battery
+    solar_to_battery = max(0, solar_production - export_to_grid
+                             - self_consumption + battery_discharged)
+    solar_to_battery = min(solar_to_battery, battery_charged, solar_production)
 
 Home consumption gets solar first (free), then grid.  Battery charges from
-solar first (free), then grid (paid).
+solar first (free), then grid (paid) — but the exact split is reconciled
+against measured grid import/export, not assumed from production figures
+alone.
 
 
 ## Prediction Snapshots and Expected Savings


### PR DESCRIPTION
## Summary
- Corrected `docs/agents/bess-knowledge.md` and `docs/SOFTWARE_DESIGN.md` claims that went stale after the Bellman-optimality guardrail-removal refactor: FIFO → weighted-average cost basis, profit-threshold gate → plain all-IDLE cost comparison, removed anti-cycling reward floor
- Removed the duplicated/drift-prone strategic-intent threshold table in favor of pointing at `decision_intelligence.py` as source of truth
- Updated stale energy-flow decomposition formulas per PR #342 (clamped to measured grid totals)
- Documented previously-undocumented mechanisms: terminal value formula + arbitrage-consistency cap, the #240 self-throttling discharge threshold, discharge-inhibit sensor override, temperature derating (and its silent no-op when unconfigured), the `charging_power_rate` cosmetic-after-startup bug, and the health-check severity model
- Added a `TODO.md` entry to remove the now-dead `min_action_profit_threshold` config
- Updated the `implement-issue` skill to require a documentation check before opening a PR, so future algorithm changes don't let these docs go stale again

## Test plan
- [x] Doc-only change, no code touched — no test suite impact
- [x] Every corrected/added claim was independently verified against current source via the `bess-analyst` agent, with file:line citations in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)