### PR TITLE
docs: update terminal-value docs for the flat-export-tariff cap skip

### DIFF
--- a/core/bess/simulation/verification.py
+++ b/core/bess/simulation/verification.py
@@ -96,10 +96,11 @@ def realized_under_solar_error(
     answer to "is the schedule robust to solar forecast error?".
 
     Both figures are credited for usable energy left in the battery at horizon end
-    (mirroring BatterySystemManager._calculate_terminal_value's capped
-    median-buy-price valuation), otherwise a run that legitimately stores more
-    bonus solar than the forecast run — real value carried past the horizon,
-    not waste — looks like a loss purely from the horizon cutoff.
+    (mirroring BatterySystemManager._calculate_terminal_value's median-buy-price
+    valuation, capped unless the export tariff is fixed — see #359), otherwise a
+    run that legitimately stores more bonus solar than the forecast run — real
+    value carried past the horizon, not waste — looks like a loss purely from the
+    horizon cutoff.
     """
     buy_based = max(
         0.0,

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -69,7 +69,7 @@ where `buy_prices`/`sell_prices` are already truncated to whatever the
 current horizon is, capped at `max(sell_prices) * efficiency_discharge -
 cycle_cost` — an **arbitrage-consistency cap** that prevents the estimate
 from exceeding what could actually be realized by selling right now at the
-best available price (`core/bess/battery_system_manager.py:1840-1908`,
+best available price (`core/bess/battery_system_manager.py:1841-1921`,
 `_calculate_terminal_value`; see issues #126/#244/#246/#345). This is the
 mechanism to check first for "why didn't the battery discharge everything
 right before midnight" or "why does it hold charge near the end of the
@@ -78,6 +78,15 @@ so this remains the first thing to check even after tomorrow's prices have
 arrived (until #345, it was incorrectly zeroed in that case; see the #345/
 #126 threads for the "tonight's export moves a day later" symptom this was
 suspected of, and ultimately ruled out for a specific bundle).
+
+The cap is skipped entirely on a fixed/flat export tariff (`max(sell_prices)
+== min(sell_prices)`, e.g. UK Octopus Outgoing Fixed) — there, every period
+shares the same sell price, so `max(sell_prices)` is not a real future
+opportunity being forgone, and applying the cap anyway forces terminal value
+below the round-trip breakeven for any buy price, making it arithmetically
+impossible to store surplus solar for post-horizon use (issue #359). On any
+market with genuine price variation (Nordic, Belpex, UK variable-export),
+this carve-out is inert and the cap applies exactly as described above.
 
 **Self-throttling near self-consumption (issue #240)**: In `_compute_reward`,
 a discharge whose overshoot above `home_consumption` is


### PR DESCRIPTION
## Summary
- Follow-up to #360 (code review found these while reviewing that PR)
- `docs/agents/bess-knowledge.md` still described the terminal-value cap as unconditional; adds the flat-export-tariff skip condition from #359 and fixes the stale line citation for `_calculate_terminal_value` (shifted from 1840-1908 to 1841-1921 after #360's docstring addition)
- `core/bess/simulation/verification.py`'s docstring for `realized_under_solar_error` said the mirrored valuation is "capped" unconditionally, which is no longer accurate now that the cap is skipped on fixed tariffs

## Test plan
- [x] `black --check` / `ruff check` clean on both changed files
- Docs/comment-only change, no logic touched