### PR TITLE
fix: swap SOC and grid-charging colors in battery chart

### DIFF
--- a/frontend/src/components/BatteryLevelChart.tsx
+++ b/frontend/src/components/BatteryLevelChart.tsx
@@ -31,9 +31,9 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
     background: isDarkMode ? '#1f2937' : '#ffffff',
     tooltip: isDarkMode ? '#374151' : '#ffffff',
     tooltipBorder: isDarkMode ? '#4b5563' : '#d1d5db',
-    soc: '#3b82f6',
+    soc: '#16a34a',
     solarCharging: '#fbbf24',
-    gridCharging: '#16a34a',
+    gridCharging: '#3b82f6',
     homeDischarging: '#f87171',
     gridDischarging: '#dc2626'
   };


### PR DESCRIPTION
## Summary
- SOC line/legend is now green (`#16a34a`) instead of blue
- Grid→Battery charging is now blue (`#3b82f6`) instead of green
- Follow-up to #370 (`BatteryLevelChart.tsx`)

## Test plan
- [ ] Visually confirm in the dashboard chart that SOC renders green and Grid→Battery renders blue, in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)