### PR TITLE
fix: align Battery SOC graph colors with Energy Flow graph

### DIFF
--- a/frontend/src/components/BatteryLevelChart.tsx
+++ b/frontend/src/components/BatteryLevelChart.tsx
@@ -34,8 +34,8 @@ export const BatteryLevelChart: React.FC<BatteryLevelChartProps> = ({ hourlyData
     soc: '#16a34a',
     solarCharging: '#fbbf24',
     gridCharging: '#3b82f6',
-    homeDischarging: '#f87171',
-    gridDischarging: '#dc2626'
+    homeDischarging: '#dc2626',
+    gridDischarging: '#1d4ed8'
   };
 
   // Extract values from FormattedValue objects or fallback to raw numbers


### PR DESCRIPTION
## Summary
- The "Battery SOC and Energy Flow" chart used light red for `Battery → Home` and dark red for `Battery → Grid`, inconsistent with the "Energy Flow" chart's yellow/red/blue = solar/home/grid convention.
- Swapped so grid-related flow (`Battery → Grid`) is now blue and home-related flow (`Battery → Home`) is now dark red, matching the top chart.

## Test plan
- [ ] Visually confirm the Battery SOC chart legend/tooltip/areas show blue for Battery → Grid and red for Battery → Home
- [ ] Confirm Energy Flow chart colors unchanged