### PR TITLE
fix: dedupe redundant grid_charge/discharge_rate writes on Growatt cloud

### DIFF
--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -109,6 +109,18 @@ class InverterController(ABC):
     # full-power discharge instead of gently covering a dip (#324).
     discharge_rate_is_load_following: ClassVar[bool] = True
 
+    # Whether the default _write_period_to_hardware() should skip re-sending
+    # a register (grid_charge/discharge_rate) that already matches the last
+    # value it successfully wrote (#402: unguarded resends from the 15-min
+    # period tick, its own retry, and the discharge-inhibit path could each
+    # independently re-trigger the same Growatt cloud API write, which was
+    # implicated in rate-limit write failures there). True by default for
+    # the base register-write path. SolaxModbusGrowattController's TOU mode
+    # overrides this to False -- it deliberately writes unconditionally
+    # pending a real-hardware test of the #166 gate revert, and must not be
+    # silently re-gated by this unrelated change.
+    dedupe_register_writes: ClassVar[bool] = True
+
     def discharge_resolution_kw(self, max_discharge_power_kw: float) -> float:
         """Smallest controllable discharge increment this platform can
         execute, in kW. Default: Growatt's integer-percent-of-max grid (1%
@@ -139,6 +151,13 @@ class InverterController(ABC):
         self.strategic_intents: list[str] = []
         self.tou_intervals: list[dict] = []
         self.corruption_detected: bool = False
+
+        # Last register values successfully written by _write_period_to_hardware,
+        # so repeat calls with an unchanged value skip the hardware write instead
+        # of re-sending it (grid_charge/discharge_rate #402). None means unknown
+        # (always write). Left unset on a failed write so the next call retries.
+        self._last_written_grid_charge: bool | None = None
+        self._last_written_discharge_rate: int | None = None
 
     # ── Period utility ────────────────────────────────────────────────────────
 
@@ -826,19 +845,29 @@ class InverterController(ABC):
         """
         errors = []
 
-        try:
-            controller.set_grid_charge(grid_charge)
-        except Exception as e:
-            logger.error("FAILED: set_grid_charge(%s): %s", grid_charge, e)
-            errors.append(str(e))
+        if (
+            not self.dedupe_register_writes
+            or grid_charge != self._last_written_grid_charge
+        ):
+            try:
+                controller.set_grid_charge(grid_charge)
+                self._last_written_grid_charge = grid_charge
+            except Exception as e:
+                logger.error("FAILED: set_grid_charge(%s): %s", grid_charge, e)
+                errors.append(str(e))
 
-        try:
-            controller.set_discharging_power_rate(discharge_rate)
-        except Exception as e:
-            logger.error(
-                "FAILED: set_discharging_power_rate(%s): %s", discharge_rate, e
-            )
-            errors.append(str(e))
+        if (
+            not self.dedupe_register_writes
+            or discharge_rate != self._last_written_discharge_rate
+        ):
+            try:
+                controller.set_discharging_power_rate(discharge_rate)
+                self._last_written_discharge_rate = discharge_rate
+            except Exception as e:
+                logger.error(
+                    "FAILED: set_discharging_power_rate(%s): %s", discharge_rate, e
+                )
+                errors.append(str(e))
 
         if errors:
             return False, "; ".join(errors)

--- a/core/bess/solax_modbus_growatt_controller.py
+++ b/core/bess/solax_modbus_growatt_controller.py
@@ -43,6 +43,7 @@ SolaX's autorepeat duration.
 
 import logging
 import time
+from typing import ClassVar
 
 from . import time_utils
 from .dp_schedule import DPSchedule
@@ -68,6 +69,14 @@ class SolaxModbusGrowattController(GrowattMinController):
     hardware, with ``write_to_hardware`` doing only the one-time VPP
     enable sequence.
     """
+
+    # TOU mode's per-period write goes through the inherited base
+    # _write_period_to_hardware() (#166 comment above _apply_period_tou):
+    # writes unconditionally rather than gating on the last-written value,
+    # since the #166 gate-removal is itself an active real-hardware test on
+    # GEN4. Do not let GrowattMinController's dedupe_register_writes (#402,
+    # cloud-only) silently re-gate this.
+    dedupe_register_writes: ClassVar[bool] = False
 
     def __init__(
         self, battery_settings: BatterySettings, control_mode: str = "tou"

--- a/core/bess/tests/unit/test_controller_coverage.py
+++ b/core/bess/tests/unit/test_controller_coverage.py
@@ -442,6 +442,61 @@ class TestApplyPeriod:
         assert success is False
         assert "fail" in error
 
+    def test_repeat_call_with_unchanged_values_skips_writes(
+        self, min_ctrl, mock_controller
+    ):
+        """#402: GrowattMinController (cloud) must not re-send a register
+        that already matches the last value it successfully wrote -- the
+        15-min period tick, its retry, and the discharge-inhibit path each
+        independently call apply_period() and previously always re-issued
+        both hardware writes even when nothing had changed."""
+        min_ctrl.apply_period(mock_controller, grid_charge=True, discharge_rate=50)
+        min_ctrl.apply_period(mock_controller, grid_charge=True, discharge_rate=50)
+
+        assert mock_controller.calls["grid_charge"] == [True]
+        assert mock_controller.calls["discharge_rate"] == [50]
+
+    def test_changed_value_is_still_written(self, min_ctrl, mock_controller):
+        min_ctrl.apply_period(mock_controller, grid_charge=True, discharge_rate=50)
+        min_ctrl.apply_period(mock_controller, grid_charge=False, discharge_rate=75)
+
+        assert mock_controller.calls["grid_charge"] == [True, False]
+        assert mock_controller.calls["discharge_rate"] == [50, 75]
+
+    def test_failed_write_is_retried_next_call(self, min_ctrl, mock_controller):
+        mock_controller.set_grid_charge = lambda _: (_ for _ in ()).throw(
+            RuntimeError("fail")
+        )
+        min_ctrl.apply_period(mock_controller, grid_charge=True, discharge_rate=50)
+
+        mock_controller.set_grid_charge = lambda enable: mock_controller.calls[
+            "grid_charge"
+        ].append(enable)
+        min_ctrl.apply_period(mock_controller, grid_charge=True, discharge_rate=50)
+
+        assert mock_controller.calls["grid_charge"] == [True]
+
+
+class TestSolaxModbusGrowattTouWritesUnconditionally:
+    """#402: unlike GrowattMinController (cloud), the solax_modbus TOU path
+    must keep writing every period regardless of whether the value changed
+    -- it deliberately writes unconditionally pending a real-hardware test
+    of the #166 gate revert, and must not be silently re-gated."""
+
+    def test_repeat_call_with_unchanged_values_still_writes(self, mock_controller):
+        ctrl = SolaxModbusGrowattController(
+            battery_settings=BatterySettings(), control_mode="tou"
+        )
+        ctrl._write_period_to_hardware(
+            mock_controller, grid_charge=True, discharge_rate=50
+        )
+        ctrl._write_period_to_hardware(
+            mock_controller, grid_charge=True, discharge_rate=50
+        )
+
+        assert mock_controller.calls["grid_charge"] == [True, True]
+        assert mock_controller.calls["discharge_rate"] == [50, 50]
+
 
 class TestComputeRatesForPeriod:
     def test_grid_charging_intent(self, min_ctrl):


### PR DESCRIPTION
## Summary

`InverterController._write_period_to_hardware()` (the Growatt cloud/`GrowattMinController` path) re-sent `grid_charge` and `discharge_rate` to Home Assistant unconditionally on every call. Three independent triggers — the 15-min period tick, its own 3/8-min retry, and the every-minute discharge-inhibit poll — could each re-fire this, causing repeated `Set switch ac_charge to 0` writes even when nothing had changed. This is a plausible contributor to the `GrowattV1ApiError` write failures seen in HA logs.

## Fix

- Added a last-written-value cache (`_last_written_grid_charge`, `_last_written_discharge_rate`) to `InverterController`, gated by a new `dedupe_register_writes` class flag (default `True`). A value is only re-sent when it actually differs from the last one successfully written. A failed write leaves the cache unset so the next call still retries.
- **Scoped to the Growatt cloud platform only.** `SolaxModbusGrowattController` (local Modbus GEN4, TOU mode) inherits the same base method but was deliberately changed to write unconditionally as part of an active real-hardware test (`#166` revert) — it explicitly overrides `dedupe_register_writes = False` so this fix doesn't silently re-gate that experiment.

## Test plan

- [x] `pytest -m "not slow"` — 1363 passed, 15 skipped
- [x] `black --check` / `ruff check` — clean
- [x] New regression tests in `test_controller_coverage.py`:
  - unchanged values skip both writes (Growatt cloud)
  - changed values still write
  - a failed write is retried on the next call
  - Modbus TOU path (`SolaxModbusGrowattController`) still writes unconditionally, confirming it wasn't silently re-gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)