### PR TITLE
fix: persist HistoricalDataStore to disk via DailyViewStore

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -564,8 +564,9 @@ def _aggregate_quarterly_to_hourly(
 async def get_dashboard_available_dates():
     """List ISO dates that have dashboard data available (for date-picker greying).
 
-    Today is always included even though it isn't persisted to the
-    DailyViewStore until day rollover.
+    Today is always included even though it is deliberately excluded from
+    DailyViewStore.list_available_dates() by design — today's view is
+    persisted continuously, but only past days are listed as history.
     """
     from app import bess_controller
 

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1633,6 +1633,8 @@ class BatterySystemManager:
         else:
             logger.info("Historical store: no periods stored yet")
 
+        self._persist_today_view()
+
     def _get_planned_intent_for_period(self, period: int) -> str | None:
         """Get the DP-planned strategic intent for a period.
 
@@ -3090,6 +3092,20 @@ class BatterySystemManager:
 
         # Build daily view with current period
         return self.daily_view_builder.build_daily_view(current_period)
+
+    def _persist_today_view(self) -> None:
+        """Best-effort snapshot of today's merged view to disk.
+
+        Write-through cache for HistoricalDataStore: called on every tick
+        that may have recorded new actuals, so a mid-day restart can seed
+        from disk instead of relying solely on InfluxDB backfill. No-op
+        until the first schedule of the day exists (build_daily_view raises
+        ValueError otherwise) — this mirrors the is_first_run skip that used
+        to gate the old 23:55-only save call.
+        """
+        if self.schedule_store.get_latest_schedule() is None:
+            return
+        self.daily_view_store.save_day(self.get_current_daily_view())
 
     def adjust_charging_power(self) -> None:
         """Adjust charging power based on house consumption.

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -1462,17 +1462,10 @@ class BatterySystemManager:
                 logger.warning(f"Failed to get initial SOC: {e}")
 
         if prepare_next_day:
-            logger.info(
-                "Preparing for next day - saving daily view and refreshing predictions"
-            )
-            if is_first_run:
-                # No schedule has ever been created yet (fresh start/restart), so
-                # there is no completed day's view to persist.
-                logger.info(
-                    "Skipping daily view save: no schedule exists yet for today"
-                )
-            else:
-                self.daily_view_store.save_day(self.get_current_daily_view())
+            # Today's file is already current — _persist_today_view() (called
+            # from _update_energy_data on every tick, including this one) has
+            # been keeping it up to date all day. Nothing to save here.
+            logger.info("Preparing for next day - refreshing predictions")
             self.prediction_snapshot_store.clear()
             self._fetch_predictions()
 

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -838,6 +838,36 @@ class BatterySystemManager:
         logger.info("Historical seed loaded: %d periods from '%s'", loaded, seed_file)
         return loaded > 0
 
+    def _load_today_from_disk(self, current_period: int) -> None:
+        """Seed historical_store from today's persisted DailyView, if any.
+
+        Only periods marked data_source == "actual" are trusted as real
+        recovered data. Periods the file marked "predicted" or "missing"
+        (e.g. a period a scheduler tick never got around to recording, see
+        issue #403) are deliberately left unseeded so the InfluxDB backfill
+        that runs after this can still attempt them.
+        """
+        view = self.daily_view_store.load_day(time_utils.today())
+        if view is None:
+            return
+
+        seeded = 0
+        for period_data in view.periods:
+            if period_data.data_source != "actual":
+                continue
+            if not 0 <= period_data.period < current_period:
+                continue
+            try:
+                self.historical_store.record_period(period_data.period, period_data)
+                seeded += 1
+            except ValueError as e:
+                logger.warning(
+                    "Could not seed period %d from disk: %s", period_data.period, e
+                )
+
+        if seeded:
+            logger.info("Seeded %d period(s) from today's persisted file", seeded)
+
     def _fetch_and_initialize_historical_data(self, status_callback=None) -> None:
         """Fetch and initialize historical data using quarterly resolution."""
         try:
@@ -851,6 +881,9 @@ class BatterySystemManager:
             if current_period > 0 and self._load_historical_seed(current_period):
                 self.sensor_collector.warm_readings_cache()
                 return
+
+            if current_period > 0:
+                self._load_today_from_disk(current_period)
 
             if not is_influxdb_configured():
                 logger.info(
@@ -875,6 +908,8 @@ class BatterySystemManager:
                         status_callback(
                             f"Fetching historical data ({hour}/{total_hours}h)..."
                         )
+                    if self.historical_store.get_period(period) is not None:
+                        continue
                     try:
                         # Collect cumulative sensor readings at period boundary (calculate deltas for energy flows)
                         period_energy_data = self.sensor_collector.collect_energy_data(

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -3130,10 +3130,22 @@ class BatterySystemManager:
         until the first schedule of the day exists (build_daily_view raises
         ValueError otherwise) — this mirrors the is_first_run skip that used
         to gate the old 23:55-only save call.
+
+        Never lets a disk-related failure propagate: this is called from
+        _update_energy_data on every tick, and an uncaught exception here
+        would abort that tick's optimization and hardware write.
         """
+        # Skip during BESS_HISTORICAL_SEED_FILE replay (see _load_historical_seed):
+        # persisting replayed fixture data to /data/daily_views would corrupt
+        # real disk state for a test/E2E run.
+        if os.environ.get("BESS_HISTORICAL_SEED_FILE", ""):
+            return
         if self.schedule_store.get_latest_schedule() is None:
             return
-        self.daily_view_store.save_day(self.get_current_daily_view())
+        try:
+            self.daily_view_store.save_day(self.get_current_daily_view())
+        except Exception as e:
+            logger.warning("Failed to persist today's view: %s", e)
 
     def adjust_charging_power(self) -> None:
         """Adjust charging power based on house consumption.

--- a/core/bess/daily_view_store.py
+++ b/core/bess/daily_view_store.py
@@ -16,6 +16,7 @@ from dataclasses import asdict
 from datetime import date
 from pathlib import Path
 
+from . import time_utils
 from .daily_view_builder import DailyView
 from .prediction_snapshot import _daily_view_from_dict
 
@@ -29,6 +30,9 @@ class DailyViewStore:
 
     def __init__(self, persist_dir: Path = PERSIST_DIR):
         self._persist_dir = persist_dir
+
+    def _is_today(self, path: Path) -> bool:
+        return path.stem == time_utils.today().isoformat()
 
     def save_day(self, view: DailyView) -> None:
         """Persist the given day's full view, overwriting any existing file for that date."""
@@ -58,24 +62,31 @@ class DailyViewStore:
             return None
 
     def list_available_dates(self) -> list[str]:
-        """Return ISO dates that have a saved snapshot, sorted ascending."""
+        """Return ISO dates that have a saved snapshot, sorted ascending.
+
+        Excludes today — today's file is a live write-through cache, not a
+        completed day's history entry.
+        """
         if not self._persist_dir.exists():
             return []
-        return sorted(p.stem for p in self._persist_dir.glob("*.json"))
+        return sorted(
+            p.stem for p in self._persist_dir.glob("*.json") if not self._is_today(p)
+        )
 
     def get_disk_usage(self) -> dict:
-        """Return {"day_count": int, "total_bytes": int} for the saved snapshots."""
+        """Return {"day_count": int, "total_bytes": int} for saved snapshots, excluding today."""
         if not self._persist_dir.exists():
             return {"day_count": 0, "total_bytes": 0}
-        files = list(self._persist_dir.glob("*.json"))
+        files = [f for f in self._persist_dir.glob("*.json") if not self._is_today(f)]
         return {
             "day_count": len(files),
             "total_bytes": sum(f.stat().st_size for f in files),
         }
 
     def clear_all(self) -> None:
-        """Delete every saved snapshot."""
+        """Delete every saved snapshot except today's."""
         if not self._persist_dir.exists():
             return
         for f in self._persist_dir.glob("*.json"):
-            f.unlink()
+            if not self._is_today(f):
+                f.unlink()

--- a/core/bess/savings_aggregator.py
+++ b/core/bess/savings_aggregator.py
@@ -150,9 +150,10 @@ def build_buckets(
     `load_day(day: date) -> DailyView | None` (duck-typed to DailyViewStore).
 
     `today_view`, if given, is used only for `period="day"` and only for the
-    bucket whose single date equals `today` and has no persisted snapshot yet
-    (i.e. today, before the 23:55 rollover writes it to the store). It never
-    overrides a persisted snapshot.
+    bucket whose single date equals `today` and has no persisted snapshot
+    (i.e. today, which is deliberately excluded from the store's listing by
+    design — see DailyViewStore.list_available_dates()). It never overrides
+    a persisted snapshot.
     """
     if period not in VALID_PERIODS:
         raise ValueError(f"Unknown period type: {period!r}")

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -274,8 +274,6 @@ class TestHandleSpecialCases:
         today's real sensor data early and produced false "missing hours"
         and a broken chart (issue #380 follow-up)."""
         with (
-            patch.object(system, "get_current_daily_view"),
-            patch.object(system.daily_view_store, "save_day"),
             patch.object(system, "_fetch_predictions"),
             patch.object(system.historical_store, "clear") as mock_clear,
         ):
@@ -287,53 +285,16 @@ class TestHandleSpecialCases:
     def test_prepare_next_day_clears_stores_and_refetches(self, system):
         system._consumption_predictions = [1.0] * 96
         system._solar_predictions = [0.0] * 96
-        with (
-            patch.object(system, "get_current_daily_view"),
-            patch.object(system.daily_view_store, "save_day"),
-            patch.object(system, "_fetch_predictions") as mock_fetch,
-        ):
+        with patch.object(system, "_fetch_predictions") as mock_fetch:
             system._handle_special_cases(
                 period=0, prepare_next_day=True, is_first_run=False
             )
             mock_fetch.assert_called_once()
 
-    def test_prepare_next_day_saves_daily_view_before_clearing(self, system, tmp_path):
-        from datetime import date as date_cls
-        from unittest.mock import patch
-
-        from core.bess.daily_view_builder import DailyView
-        from core.bess.daily_view_store import DailyViewStore
-
-        # Use a temp persist dir instead of the production default (/data/daily_views),
-        # which isn't writable in local/sandboxed test environments.
-        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
-
-        fake_view = DailyView(
-            date=date_cls(2026, 7, 9),
-            periods=[],
-            total_savings=1.5,
-            actual_count=0,
-            predicted_count=0,
-        )
-
-        with patch.object(system, "get_current_daily_view", return_value=fake_view):
-            with patch.object(system, "_fetch_predictions"):
-                system._handle_special_cases(
-                    period=0, prepare_next_day=True, is_first_run=False
-                )
-
-        saved = system.daily_view_store.load_day(date_cls(2026, 7, 9))
-        assert saved is not None
-        assert saved.total_savings == 1.5
-
-    def test_prepare_next_day_skips_save_on_first_run(self, system, tmp_path):
-        """No schedule has ever been created yet, so there is nothing to save.
-
-        This reproduces the CI failure in PR #260: build_daily_view() raises
-        ValueError("No optimization schedule available") when schedule_store
-        is empty, which previously aborted update_battery_schedule entirely
-        on the very first call of a fresh run.
-        """
+    def test_prepare_next_day_does_not_save_daily_view_itself(self, system, tmp_path):
+        """Saving today's file is now _persist_today_view()'s job (called every
+        tick from _update_energy_data), not _handle_special_cases's. Regression
+        guard against reintroducing a second, now-redundant write path."""
         from core.bess.daily_view_store import DailyViewStore
 
         system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
@@ -344,7 +305,7 @@ class TestHandleSpecialCases:
             patch.object(system, "_fetch_predictions"),
         ):
             system._handle_special_cases(
-                period=0, prepare_next_day=True, is_first_run=True
+                period=95, prepare_next_day=True, is_first_run=False
             )
 
         mock_get_view.assert_not_called()

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -346,6 +346,15 @@ class TestPersistTodayView:
         assert saved.total_savings == 4.0
 
 
+class TestUpdateEnergyDataCallsPersist:
+    def test_update_energy_data_calls_persist_today_view(self, system):
+        with patch.object(system, "_persist_today_view") as mock_persist:
+            system._update_energy_data(
+                period=1, is_first_run=True, prepare_next_day=False
+            )
+        mock_persist.assert_called_once()
+
+
 class TestRuntimeFailureTracking:
     def test_no_failures_initially(self, system):
         assert system.get_runtime_failures() == []
@@ -947,8 +956,10 @@ class TestLoadTodayFromDisk:
 
 class TestBackfillSkipsDiskSeededPeriods:
     def test_infludb_backfill_does_not_recollect_seeded_period(self, system, tmp_path):
+        from datetime import date as date_cls
         from datetime import datetime
 
+        from core.bess.daily_view_builder import DailyView
         from core.bess.daily_view_store import DailyViewStore
         from core.bess.models import DecisionData, EnergyData, PeriodData
 
@@ -969,7 +980,18 @@ class TestBackfillSkipsDiskSeededPeriods:
             data_source="actual",
             decision=DecisionData(),
         )
-        system.historical_store.record_period(0, seeded_period)
+        # Pre-seed disk with today's view (rather than calling
+        # historical_store.record_period directly) so this test also proves
+        # _load_today_from_disk (invoked by _fetch_and_initialize_historical_data
+        # below) is what performs the seeding.
+        view = DailyView(
+            date=date_cls(2026, 7, 27),
+            periods=[seeded_period],
+            total_savings=0.0,
+            actual_count=1,
+            predicted_count=0,
+        )
+        system.daily_view_store.save_day(view)
 
         with (
             patch(

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -351,6 +351,39 @@ class TestHandleSpecialCases:
         mock_save.assert_not_called()
 
 
+class TestPersistTodayView:
+    def test_no_op_when_no_schedule_exists_yet(self, system):
+        with patch.object(system, "get_current_daily_view") as mock_get_view:
+            system._persist_today_view()
+        mock_get_view.assert_not_called()
+
+    def test_saves_current_view_when_schedule_exists(self, system, tmp_path):
+        from core.bess.daily_view_builder import DailyView
+        from core.bess.daily_view_store import DailyViewStore
+        from datetime import date as date_cls
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+        fake_view = DailyView(
+            date=date_cls(2026, 7, 27),
+            periods=[],
+            total_savings=4.0,
+            actual_count=0,
+            predicted_count=0,
+        )
+
+        with (
+            patch.object(
+                system.schedule_store, "get_latest_schedule", return_value=MagicMock()
+            ),
+            patch.object(system, "get_current_daily_view", return_value=fake_view),
+        ):
+            system._persist_today_view()
+
+        saved = system.daily_view_store.load_day(date_cls(2026, 7, 27))
+        assert saved is not None
+        assert saved.total_savings == 4.0
+
+
 class TestRuntimeFailureTracking:
     def test_no_failures_initially(self, system):
         assert system.get_runtime_failures() == []

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -358,9 +358,10 @@ class TestPersistTodayView:
         mock_get_view.assert_not_called()
 
     def test_saves_current_view_when_schedule_exists(self, system, tmp_path):
+        from datetime import date as date_cls
+
         from core.bess.daily_view_builder import DailyView
         from core.bess.daily_view_store import DailyViewStore
-        from datetime import date as date_cls
 
         system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
         fake_view = DailyView(
@@ -921,3 +922,114 @@ class TestNotApplyBranchRefreshesCurrentSchedule:
 
         assert system._inverter_controller.current_schedule is second_schedule
         assert system._inverter_controller.current_schedule.actions == [5.0, 6.0]
+
+
+class TestLoadTodayFromDisk:
+    def test_seeds_only_actual_periods_within_range(self, system, tmp_path):
+        from datetime import date as date_cls
+        from datetime import datetime
+
+        from core.bess.daily_view_builder import DailyView
+        from core.bess.daily_view_store import DailyViewStore
+        from core.bess.models import DecisionData, EnergyData, PeriodData
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+
+        def _period(index, data_source):
+            return PeriodData(
+                period=index,
+                energy=EnergyData(
+                    solar_production=0.0,
+                    home_consumption=0.5,
+                    battery_charged=0.0,
+                    battery_discharged=0.0,
+                    grid_imported=0.5,
+                    grid_exported=0.0,
+                    battery_soe_start=10.0,
+                    battery_soe_end=10.0,
+                ),
+                timestamp=datetime(2026, 7, 27, index // 4, (index % 4) * 15),
+                data_source=data_source,
+                decision=DecisionData(),
+            )
+
+        view = DailyView(
+            date=date_cls(2026, 7, 27),
+            periods=[
+                _period(0, "actual"),
+                _period(1, "actual"),
+                _period(2, "missing"),
+                _period(3, "actual"),  # out of range: current_period will be 2
+            ],
+            total_savings=0.0,
+            actual_count=2,
+            predicted_count=0,
+        )
+        system.daily_view_store.save_day(view)
+
+        system._load_today_from_disk(current_period=2)
+
+        assert system.historical_store.get_period(0) is not None
+        assert system.historical_store.get_period(1) is not None
+        assert (
+            system.historical_store.get_period(2) is None
+        )  # was "missing", not seeded
+        assert system.historical_store.get_period(3) is None  # out of range, not seeded
+
+    def test_no_op_when_no_file_saved(self, system, tmp_path):
+        from core.bess.daily_view_store import DailyViewStore
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+        system._load_today_from_disk(current_period=4)
+        assert system.historical_store.get_stored_count() == 0
+
+
+class TestBackfillSkipsDiskSeededPeriods:
+    def test_infludb_backfill_does_not_recollect_seeded_period(self, system, tmp_path):
+        from datetime import datetime
+
+        from core.bess.daily_view_store import DailyViewStore
+        from core.bess.models import DecisionData, EnergyData, PeriodData
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+        seeded_period = PeriodData(
+            period=0,
+            energy=EnergyData(
+                solar_production=0.0,
+                home_consumption=0.5,
+                battery_charged=0.0,
+                battery_discharged=0.0,
+                grid_imported=0.5,
+                grid_exported=0.0,
+                battery_soe_start=10.0,
+                battery_soe_end=10.0,
+            ),
+            timestamp=datetime(2026, 7, 27, 0, 0),
+            data_source="actual",
+            decision=DecisionData(),
+        )
+        system.historical_store.record_period(0, seeded_period)
+
+        with (
+            patch(
+                "core.bess.battery_system_manager.is_influxdb_configured",
+                return_value=True,
+            ),
+            patch.object(
+                system.sensor_collector, "collect_energy_data"
+            ) as mock_collect,
+            patch.object(
+                system.price_manager,
+                "get_available_prices",
+                return_value=([1.0] * 96, [0.5] * 96),
+            ),
+            patch("core.bess.battery_system_manager.time_utils.now") as mock_now,
+        ):
+            mock_now.return_value = datetime(2026, 7, 27, 0, 30)
+            system._fetch_and_initialize_historical_data()
+
+        # Period 0 was already seeded (from disk, in this test's setup) —
+        # the backfill loop must not re-collect it.
+        collected_periods = [call.args[0] for call in mock_collect.call_args_list]
+        assert 0 not in collected_periods
+        assert 1 in collected_periods

--- a/core/bess/tests/unit/test_daily_view_store.py
+++ b/core/bess/tests/unit/test_daily_view_store.py
@@ -152,3 +152,40 @@ class TestDiskUsageAndClear:
 
         assert store.list_available_dates() == []
         assert store.get_disk_usage() == {"day_count": 0, "total_bytes": 0}
+
+
+class TestTodayExcludedFromHistoryWideOperations:
+    def test_list_available_dates_excludes_today(self, tmp_path, monkeypatch):
+        from core.bess import time_utils
+
+        monkeypatch.setattr(time_utils, "today", lambda: date(2026, 7, 27))
+        store = DailyViewStore(persist_dir=tmp_path)
+        store.save_day(_make_view(date(2026, 7, 26)))
+        store.save_day(_make_view(date(2026, 7, 27)))
+
+        assert store.list_available_dates() == ["2026-07-26"]
+
+    def test_disk_usage_excludes_today(self, tmp_path, monkeypatch):
+        from core.bess import time_utils
+
+        monkeypatch.setattr(time_utils, "today", lambda: date(2026, 7, 27))
+        store = DailyViewStore(persist_dir=tmp_path)
+        store.save_day(_make_view(date(2026, 7, 26)))
+        store.save_day(_make_view(date(2026, 7, 27)))
+
+        usage = store.get_disk_usage()
+
+        assert usage["day_count"] == 1
+
+    def test_clear_all_leaves_todays_file_in_place(self, tmp_path, monkeypatch):
+        from core.bess import time_utils
+
+        monkeypatch.setattr(time_utils, "today", lambda: date(2026, 7, 27))
+        store = DailyViewStore(persist_dir=tmp_path)
+        store.save_day(_make_view(date(2026, 7, 26)))
+        store.save_day(_make_view(date(2026, 7, 27)))
+
+        store.clear_all()
+
+        assert store.load_day(date(2026, 7, 26)) is None
+        assert store.load_day(date(2026, 7, 27)) is not None

--- a/core/bess/tests/unit/test_energy_data_collection_resilience.py
+++ b/core/bess/tests/unit/test_energy_data_collection_resilience.py
@@ -23,6 +23,8 @@ def _make_bsm():
     bsm._price_manager = MagicMock()
     bsm.battery_settings = MagicMock(cycle_cost_per_kwh=0.5)
     bsm._log_energy_balance = MagicMock()
+    bsm.schedule_store = MagicMock()
+    bsm.schedule_store.get_latest_schedule.return_value = None
     return bsm
 
 

--- a/docs/superpowers/plans/2026-07-27-historical-data-store-persistence.md
+++ b/docs/superpowers/plans/2026-07-27-historical-data-store-persistence.md
@@ -1,0 +1,606 @@
+# HistoricalDataStore Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make today's `HistoricalDataStore` actuals survive a mid-day process restart by folding it into `DailyViewStore`'s existing per-day file, instead of it being purely in-memory.
+
+**Architecture:** `HistoricalDataStore` becomes a write-through cache: `BatterySystemManager` persists the merged `DailyView` (via the existing `DailyViewBuilder`/`DailyViewStore`) on every tick that records new actuals, and on startup seeds `HistoricalDataStore` from today's file before falling back to InfluxDB for anything still missing. "Clear Savings History" is changed to leave today's file alone.
+
+**Tech Stack:** Python (backend), pytest, existing `DailyViewStore`/`DailyViewBuilder`/`ScheduleStore` classes — no new dependencies.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-27-historical-data-store-persistence-design.md` — every task below implements a specific section of it.
+- Scope is `HistoricalDataStore` only. Do not touch `PredictionSnapshotStore` or `ScheduleStore`'s persistence formats.
+- Disk writes must never raise out of the calling code path — mirror `DailyViewStore.save_day()`'s existing best-effort `OSError` handling; do not add new exception types.
+- Run `.venv/bin/pytest -m "not slow"` after every task; it must stay green before moving to the next task.
+
+---
+
+### Task 1: Exclude today's file from `DailyViewStore`'s history-wide operations
+
+**Files:**
+- Modify: `core/bess/daily_view_store.py`
+- Test: `core/bess/tests/unit/test_daily_view_store.py`
+
+**Interfaces:**
+- Consumes: `core.bess.time_utils.today() -> date` (existing).
+- Produces: `DailyViewStore.list_available_dates()`, `DailyViewStore.get_disk_usage()`, `DailyViewStore.clear_all()` — same signatures as today, but all three now skip `{today}.json`. No change to `save_day()`/`load_day()` signatures (today's file must still be writable/readable by those).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `core/bess/tests/unit/test_daily_view_store.py`:
+
+```python
+class TestTodayExcludedFromHistoryWideOperations:
+    def test_list_available_dates_excludes_today(self, tmp_path, monkeypatch):
+        from core.bess import time_utils
+
+        monkeypatch.setattr(time_utils, "today", lambda: date(2026, 7, 27))
+        store = DailyViewStore(persist_dir=tmp_path)
+        store.save_day(_make_view(date(2026, 7, 26)))
+        store.save_day(_make_view(date(2026, 7, 27)))
+
+        assert store.list_available_dates() == ["2026-07-26"]
+
+    def test_disk_usage_excludes_today(self, tmp_path, monkeypatch):
+        from core.bess import time_utils
+
+        monkeypatch.setattr(time_utils, "today", lambda: date(2026, 7, 27))
+        store = DailyViewStore(persist_dir=tmp_path)
+        store.save_day(_make_view(date(2026, 7, 26)))
+        store.save_day(_make_view(date(2026, 7, 27)))
+
+        usage = store.get_disk_usage()
+
+        assert usage["day_count"] == 1
+
+    def test_clear_all_leaves_todays_file_in_place(self, tmp_path, monkeypatch):
+        from core.bess import time_utils
+
+        monkeypatch.setattr(time_utils, "today", lambda: date(2026, 7, 27))
+        store = DailyViewStore(persist_dir=tmp_path)
+        store.save_day(_make_view(date(2026, 7, 26)))
+        store.save_day(_make_view(date(2026, 7, 27)))
+
+        store.clear_all()
+
+        assert store.load_day(date(2026, 7, 26)) is None
+        assert store.load_day(date(2026, 7, 27)) is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_daily_view_store.py -v`
+Expected: the three new tests FAIL (today's file is currently included/deleted like any other).
+
+- [ ] **Step 3: Implement the exclusion**
+
+In `core/bess/daily_view_store.py`, add the import and a private helper, then use it in the three methods:
+
+```python
+from . import time_utils
+```
+
+```python
+    def _is_today(self, path: Path) -> bool:
+        return path.stem == time_utils.today().isoformat()
+
+    def list_available_dates(self) -> list[str]:
+        """Return ISO dates that have a saved snapshot, sorted ascending.
+
+        Excludes today — today's file is a live write-through cache, not a
+        completed day's history entry.
+        """
+        if not self._persist_dir.exists():
+            return []
+        return sorted(
+            p.stem for p in self._persist_dir.glob("*.json") if not self._is_today(p)
+        )
+
+    def get_disk_usage(self) -> dict:
+        """Return {"day_count": int, "total_bytes": int} for saved snapshots, excluding today."""
+        if not self._persist_dir.exists():
+            return {"day_count": 0, "total_bytes": 0}
+        files = [f for f in self._persist_dir.glob("*.json") if not self._is_today(f)]
+        return {
+            "day_count": len(files),
+            "total_bytes": sum(f.stat().st_size for f in files),
+        }
+
+    def clear_all(self) -> None:
+        """Delete every saved snapshot except today's."""
+        if not self._persist_dir.exists():
+            return
+        for f in self._persist_dir.glob("*.json"):
+            if not self._is_today(f):
+                f.unlink()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_daily_view_store.py -v`
+Expected: all tests PASS, including the pre-existing ones (`test_clear_all_removes_every_saved_day` etc. use dates that aren't "today" in real time, so they're unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/bess/daily_view_store.py core/bess/tests/unit/test_daily_view_store.py
+git commit -m "feat: exclude today's file from DailyViewStore history-wide operations"
+```
+
+---
+
+### Task 2: Write-through persistence from `BatterySystemManager`
+
+**Files:**
+- Modify: `core/bess/battery_system_manager.py`
+- Test: `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py`
+
+**Interfaces:**
+- Consumes: `self.schedule_store.get_latest_schedule() -> StoredSchedule | None` (existing), `self.get_current_daily_view() -> DailyView` (existing, line ~3065), `self.daily_view_store.save_day(view: DailyView) -> None` (existing).
+- Produces: `BatterySystemManager._persist_today_view() -> None` — new private method. No schedule exists yet → no-op (silent). Schedule exists → best-effort `save_day()` call (`save_day` itself never raises).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py`, near `TestHandleSpecialCases`:
+
+```python
+class TestPersistTodayView:
+    def test_no_op_when_no_schedule_exists_yet(self, system):
+        with patch.object(system, "get_current_daily_view") as mock_get_view:
+            system._persist_today_view()
+        mock_get_view.assert_not_called()
+
+    def test_saves_current_view_when_schedule_exists(self, system, tmp_path):
+        from core.bess.daily_view_builder import DailyView
+        from core.bess.daily_view_store import DailyViewStore
+        from datetime import date as date_cls
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+        fake_view = DailyView(
+            date=date_cls(2026, 7, 27),
+            periods=[],
+            total_savings=4.0,
+            actual_count=0,
+            predicted_count=0,
+        )
+
+        with (
+            patch.object(
+                system.schedule_store, "get_latest_schedule", return_value=MagicMock()
+            ),
+            patch.object(system, "get_current_daily_view", return_value=fake_view),
+        ):
+            system._persist_today_view()
+
+        saved = system.daily_view_store.load_day(date_cls(2026, 7, 27))
+        assert saved is not None
+        assert saved.total_savings == 4.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_bsm_settings_and_lifecycle.py::TestPersistTodayView -v`
+Expected: FAIL with `AttributeError: 'BatterySystemManager' object has no attribute '_persist_today_view'`
+
+- [ ] **Step 3: Implement `_persist_today_view()` and wire it into `_update_energy_data`**
+
+In `core/bess/battery_system_manager.py`, add a new method directly after `get_current_daily_view` (which ends at line 3092):
+
+```python
+    def _persist_today_view(self) -> None:
+        """Best-effort snapshot of today's merged view to disk.
+
+        Write-through cache for HistoricalDataStore: called on every tick
+        that may have recorded new actuals, so a mid-day restart can seed
+        from disk instead of relying solely on InfluxDB backfill. No-op
+        until the first schedule of the day exists (build_daily_view raises
+        ValueError otherwise) — this mirrors the is_first_run skip that used
+        to gate the old 23:55-only save call.
+        """
+        if self.schedule_store.get_latest_schedule() is None:
+            return
+        self.daily_view_store.save_day(self.get_current_daily_view())
+```
+
+Then in `_update_energy_data`, call it unconditionally at the end of the method — replace the closing lines (currently ending at line 1634, `logger.info("Historical store: no periods stored yet")`) so the method ends with:
+
+```python
+        else:
+            logger.info("Historical store: no periods stored yet")
+
+        self._persist_today_view()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_bsm_settings_and_lifecycle.py -v`
+Expected: all PASS, including the new `TestPersistTodayView` tests and every pre-existing test in the file (none of them assert `_update_energy_data` doesn't call anything extra at the end).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/bess/battery_system_manager.py core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+git commit -m "feat: persist today's DailyView to disk on every actuals-collecting tick"
+```
+
+---
+
+### Task 3: Startup recovery — seed from today's file before InfluxDB
+
+**Files:**
+- Modify: `core/bess/battery_system_manager.py`
+- Test: `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py` (or a new focused test module if that file is getting unwieldy — check its line count first; if it's already large, create `core/bess/tests/unit/test_bsm_historical_recovery.py` instead, following the same `system` fixture pattern)
+
+**Interfaces:**
+- Consumes: `self.daily_view_store.load_day(day: date) -> DailyView | None` (existing), `self.historical_store.record_period(period_index: int, period_data: PeriodData) -> None` (existing, raises `ValueError` out of range), `self.historical_store.get_period(period_index: int) -> PeriodData | None` (existing).
+- Produces: `BatterySystemManager._load_today_from_disk(current_period: int) -> None` — new private method, called from `_fetch_and_initialize_historical_data`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py`:
+
+```python
+class TestLoadTodayFromDisk:
+    def test_seeds_only_actual_periods_within_range(self, system, tmp_path):
+        from core.bess.daily_view_builder import DailyView
+        from core.bess.daily_view_store import DailyViewStore
+        from core.bess.models import DecisionData, EnergyData, PeriodData
+        from datetime import date as date_cls, datetime
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+
+        def _period(index, data_source):
+            return PeriodData(
+                period=index,
+                energy=EnergyData(
+                    solar_production=0.0,
+                    home_consumption=0.5,
+                    battery_charged=0.0,
+                    battery_discharged=0.0,
+                    grid_imported=0.5,
+                    grid_exported=0.0,
+                    battery_soe_start=10.0,
+                    battery_soe_end=10.0,
+                ),
+                timestamp=datetime(2026, 7, 27, index // 4, (index % 4) * 15),
+                data_source=data_source,
+                decision=DecisionData(),
+            )
+
+        view = DailyView(
+            date=date_cls(2026, 7, 27),
+            periods=[
+                _period(0, "actual"),
+                _period(1, "actual"),
+                _period(2, "missing"),
+                _period(3, "actual"),  # out of range: current_period will be 2
+            ],
+            total_savings=0.0,
+            actual_count=2,
+            predicted_count=0,
+        )
+        system.daily_view_store.save_day(view)
+
+        system._load_today_from_disk(current_period=2)
+
+        assert system.historical_store.get_period(0) is not None
+        assert system.historical_store.get_period(1) is not None
+        assert system.historical_store.get_period(2) is None  # was "missing", not seeded
+        assert system.historical_store.get_period(3) is None  # out of range, not seeded
+
+    def test_no_op_when_no_file_saved(self, system, tmp_path):
+        from core.bess.daily_view_store import DailyViewStore
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+        system._load_today_from_disk(current_period=4)
+        assert system.historical_store.get_stored_count() == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_bsm_settings_and_lifecycle.py::TestLoadTodayFromDisk -v`
+Expected: FAIL with `AttributeError: 'BatterySystemManager' object has no attribute '_load_today_from_disk'`
+
+- [ ] **Step 3: Implement `_load_today_from_disk` and wire it into `_fetch_and_initialize_historical_data`**
+
+In `core/bess/battery_system_manager.py`, add a new method right before `_fetch_and_initialize_historical_data` (currently starting at line 841):
+
+```python
+    def _load_today_from_disk(self, current_period: int) -> None:
+        """Seed historical_store from today's persisted DailyView, if any.
+
+        Only periods marked data_source == "actual" are trusted as real
+        recovered data. Periods the file marked "predicted" or "missing"
+        (e.g. a period a scheduler tick never got around to recording, see
+        issue #403) are deliberately left unseeded so the InfluxDB backfill
+        that runs after this can still attempt them.
+        """
+        view = self.daily_view_store.load_day(time_utils.today())
+        if view is None:
+            return
+
+        seeded = 0
+        for period_data in view.periods:
+            if period_data.data_source != "actual":
+                continue
+            if not 0 <= period_data.period < current_period:
+                continue
+            try:
+                self.historical_store.record_period(
+                    period_data.period, period_data
+                )
+                seeded += 1
+            except ValueError as e:
+                logger.warning(
+                    "Could not seed period %d from disk: %s", period_data.period, e
+                )
+
+        if seeded:
+            logger.info("Seeded %d period(s) from today's persisted file", seeded)
+```
+
+Then modify `_fetch_and_initialize_historical_data` (existing method, current lines 841-963) in two places:
+
+1. Call the new method right after the seed-file check, before the InfluxDB-configured check:
+
+```python
+            if current_period > 0 and self._load_historical_seed(current_period):
+                self.sensor_collector.warm_readings_cache()
+                return
+
+            if current_period > 0:
+                self._load_today_from_disk(current_period)
+
+            if not is_influxdb_configured():
+```
+
+2. Skip already-seeded periods inside the existing backfill loop — insert this right after the `status_callback` block and before the `try:` that calls `collect_energy_data`:
+
+```python
+                for period in range(0, current_period):
+                    # Report progress at each hour boundary (every 4th period)
+                    if status_callback and period % 4 == 0:
+                        hour = period // 4
+                        total_hours = current_period // 4
+                        status_callback(
+                            f"Fetching historical data ({hour}/{total_hours}h)..."
+                        )
+                    if self.historical_store.get_period(period) is not None:
+                        continue
+                    try:
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_bsm_settings_and_lifecycle.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Add a test proving InfluxDB backfill skips already-seeded periods**
+
+Add to `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py`:
+
+```python
+class TestBackfillSkipsDiskSeededPeriods:
+    def test_infludb_backfill_does_not_recollect_seeded_period(self, system, tmp_path):
+        from core.bess.daily_view_store import DailyViewStore
+        from core.bess.models import DecisionData, EnergyData, PeriodData
+        from datetime import datetime
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+        seeded_period = PeriodData(
+            period=0,
+            energy=EnergyData(
+                solar_production=0.0,
+                home_consumption=0.5,
+                battery_charged=0.0,
+                battery_discharged=0.0,
+                grid_imported=0.5,
+                grid_exported=0.0,
+                battery_soe_start=10.0,
+                battery_soe_end=10.0,
+            ),
+            timestamp=datetime(2026, 7, 27, 0, 0),
+            data_source="actual",
+            decision=DecisionData(),
+        )
+        system.historical_store.record_period(0, seeded_period)
+
+        with (
+            patch(
+                "core.bess.battery_system_manager.is_influxdb_configured",
+                return_value=True,
+            ),
+            patch.object(
+                system.sensor_collector, "collect_energy_data"
+            ) as mock_collect,
+            patch.object(
+                system.price_manager,
+                "get_available_prices",
+                return_value=([1.0] * 96, [0.5] * 96),
+            ),
+            patch("core.bess.battery_system_manager.time_utils.now") as mock_now,
+        ):
+            mock_now.return_value = datetime(2026, 7, 27, 0, 30)
+            system._fetch_and_initialize_historical_data()
+
+        # Period 0 was already seeded (from disk, in this test's setup) —
+        # the backfill loop must not re-collect it.
+        collected_periods = [call.args[0] for call in mock_collect.call_args_list]
+        assert 0 not in collected_periods
+        assert 1 in collected_periods
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_bsm_settings_and_lifecycle.py::TestBackfillSkipsDiskSeededPeriods -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/bess/battery_system_manager.py core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+git commit -m "feat: seed HistoricalDataStore from today's persisted file before InfluxDB backfill"
+```
+
+---
+
+### Task 4: Remove the now-redundant 23:55 save call
+
+**Files:**
+- Modify: `core/bess/battery_system_manager.py:1403-1442` (`_handle_special_cases`)
+- Test: `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py:248-351` (`TestHandleSpecialCases`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `_handle_special_cases`'s `prepare_next_day` branch no longer calls `get_current_daily_view()`/`daily_view_store.save_day()` — that's now handled every tick by `_persist_today_view()` from Task 2, including the 23:55 tick itself (since `_update_energy_data` runs on every `update_battery_schedule()` call regardless of `prepare_next_day`).
+
+- [ ] **Step 1: Update `_handle_special_cases`**
+
+Replace the `prepare_next_day` branch (current lines 1429-1442):
+
+```python
+        if prepare_next_day:
+            logger.info(
+                "Preparing for next day - saving daily view and refreshing predictions"
+            )
+            if is_first_run:
+                # No schedule has ever been created yet (fresh start/restart), so
+                # there is no completed day's view to persist.
+                logger.info(
+                    "Skipping daily view save: no schedule exists yet for today"
+                )
+            else:
+                self.daily_view_store.save_day(self.get_current_daily_view())
+            self.prediction_snapshot_store.clear()
+            self._fetch_predictions()
+```
+
+with:
+
+```python
+        if prepare_next_day:
+            # Today's file is already current — _persist_today_view() (called
+            # from _update_energy_data on every tick, including this one) has
+            # been keeping it up to date all day. Nothing to save here.
+            logger.info("Preparing for next day - refreshing predictions")
+            self.prediction_snapshot_store.clear()
+            self._fetch_predictions()
+```
+
+- [ ] **Step 2: Update the tests that asserted the old save behavior**
+
+In `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py`, replace
+`test_prepare_next_day_saves_daily_view_before_clearing` and
+`test_prepare_next_day_skips_save_on_first_run` (their premise — that
+`_handle_special_cases` itself saves — no longer holds; that behavior is
+now covered by Task 2's `TestPersistTodayView`) with a single test proving
+`_handle_special_cases` does *not* touch `daily_view_store` at all:
+
+```python
+    def test_prepare_next_day_does_not_save_daily_view_itself(self, system, tmp_path):
+        """Saving today's file is now _persist_today_view()'s job (called every
+        tick from _update_energy_data), not _handle_special_cases's. Regression
+        guard against reintroducing a second, now-redundant write path."""
+        from core.bess.daily_view_store import DailyViewStore
+
+        system.daily_view_store = DailyViewStore(persist_dir=tmp_path)
+
+        with (
+            patch.object(system, "get_current_daily_view") as mock_get_view,
+            patch.object(system.daily_view_store, "save_day") as mock_save,
+            patch.object(system, "_fetch_predictions"),
+        ):
+            system._handle_special_cases(
+                period=95, prepare_next_day=True, is_first_run=False
+            )
+
+        mock_get_view.assert_not_called()
+        mock_save.assert_not_called()
+```
+
+Also simplify `test_prepare_next_day_does_not_clear_historical_store` and
+`test_prepare_next_day_clears_stores_and_refetches` by removing their now-
+unnecessary `patch.object(system, "get_current_daily_view")` and
+`patch.object(system.daily_view_store, "save_day")` context managers —
+`_handle_special_cases` no longer calls either, so patching them adds
+nothing:
+
+```python
+    def test_prepare_next_day_does_not_clear_historical_store(self, system):
+        """prepare_next_day fires at 23:55, 5 minutes before midnight, while
+        today's dashboard still needs today's actuals. Clearing here wiped
+        today's real sensor data early and produced false "missing hours"
+        and a broken chart (issue #380 follow-up)."""
+        with (
+            patch.object(system, "_fetch_predictions"),
+            patch.object(system.historical_store, "clear") as mock_clear,
+        ):
+            system._handle_special_cases(
+                period=95, prepare_next_day=True, is_first_run=False
+            )
+            mock_clear.assert_not_called()
+
+    def test_prepare_next_day_clears_stores_and_refetches(self, system):
+        system._consumption_predictions = [1.0] * 96
+        system._solar_predictions = [0.0] * 96
+        with patch.object(system, "_fetch_predictions") as mock_fetch:
+            system._handle_special_cases(
+                period=0, prepare_next_day=True, is_first_run=False
+            )
+            mock_fetch.assert_called_once()
+```
+
+- [ ] **Step 3: Run the full test file**
+
+Run: `.venv/bin/pytest core/bess/tests/unit/test_bsm_settings_and_lifecycle.py -v`
+Expected: all PASS. `TestHandleSpecialCases` should now have no reference
+to `daily_view_store`/`get_current_daily_view` except in the new
+`test_prepare_next_day_does_not_save_daily_view_itself` regression guard.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/bess/battery_system_manager.py core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+git commit -m "refactor: remove redundant 23:55 daily-view save now that persistence is incremental"
+```
+
+---
+
+### Task 5: Full test suite and quality gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the fast suite**
+
+Run: `.venv/bin/pytest -m "not slow"`
+Expected: all PASS.
+
+- [ ] **Step 2: Run the full quality gate**
+
+Run: `./scripts/quality-check.sh`
+Expected: black/ruff/mypy/tests all PASS. Fix any formatting/lint issues it surfaces and re-run.
+
+- [ ] **Step 3: Run the slow suite**
+
+Run: `.venv/bin/pytest -m slow`
+Expected: all PASS (this suite includes algorithm/integration tests that exercise `update_battery_schedule` end-to-end and could be sensitive to `_persist_today_view()` being called on every tick).
+
+- [ ] **Step 4: Commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix: address quality-check.sh findings"
+```
+
+(Skip this commit if step 2/3 found nothing to fix.)
+
+---
+
+## Explicitly out of scope (per spec)
+
+- `_load_historical_seed` (the `BESS_HISTORICAL_SEED_FILE` test/E2E-replay path) does **not** call `_persist_today_view()` or get touched by this plan — it's a fixture-injection mechanism for mock-HA scenarios, not real production data collection, and persisting replayed fixtures to `/data/daily_views` would conflate the two.
+- No UI or endpoint for clearing today's in-progress data.
+- No changes to `PredictionSnapshotStore` or `ScheduleStore`.
+- No fix for issue #403 itself (the scheduler misfire) — this plan only makes its symptom recoverable via the InfluxDB-fills-remaining-gaps step in Task 3.

--- a/docs/superpowers/specs/2026-07-27-historical-data-store-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-27-historical-data-store-persistence-design.md
@@ -1,0 +1,181 @@
+# Persistent `HistoricalDataStore`
+
+## Problem
+
+`HistoricalDataStore` (`core/bess/historical_data_store.py`) holds today's
+real sensor/economic actuals — the data the "Incomplete Historical Data"
+dashboard banner and the savings numbers are built from — entirely in a
+`dict[int, PeriodData]` in memory. It is the only one of the project's four
+"today" stores with zero disk persistence:
+
+| Store | Persists? | Where |
+|---|---|---|
+| `HistoricalDataStore` | ❌ in-memory only | — |
+| `PredictionSnapshotStore` | ✅ | `/data/bess_prediction_snapshots.json` |
+| `ScheduleStore` (strategic intents) | ✅ | `/config/bess_strategic_intents.json` |
+| `DailyViewStore` | ✅ (forever, until user clears) | `/data/daily_views/{date}.json`, one file/day |
+
+Any process restart during the day — a crash, an add-on auto-update, a
+manual restart — wipes everything `HistoricalDataStore` has collected so
+far. Recovery depends entirely on `_fetch_and_initialize_historical_data`
+re-querying InfluxDB at the next startup, and that only covers periods that
+had already fully elapsed *before that particular process started*.
+
+Two real production incidents on 2026-07-27 (beta b25) demonstrated the
+gap:
+
+1. The add-on auto-updated (b24→b25) at 00:26:58, restarting the container
+   mid-period. InfluxDB backfill on restart correctly recovered the one
+   already-elapsed period — but this depends on InfluxDB being configured,
+   and is a slow, indirect round-trip for data the process had itself
+   already collected minutes earlier.
+2. Separately (tracked as #403), the quarterly schedule-update job's tight
+   `misfire_grace_time=30` let a scheduler tick get silently coalesced away
+   while the previous tick was still busy retrying a slow hardware write —
+   permanently dropping a whole 15-minute period's actuals, with no
+   recovery path at all (InfluxDB backfill only covers periods elapsed
+   *before* the current process's startup, not gaps that open up mid-day).
+
+This design fixes the first class of loss directly (a file to restart
+from) and, as a side effect, also closes gaps like #403 (see "Startup
+recovery" below) without needing that fix to land first.
+
+**Scope**: this design covers `HistoricalDataStore` only.
+`PredictionSnapshotStore` and `ScheduleStore` already persist (just via
+different bespoke formats/paths) and are not being touched here — their
+inconsistency is real but isn't causing data loss today. The direction
+chosen below is explicitly the one that leads toward eventually folding all
+"today" stores into one, but that consolidation is future work, not part of
+this change.
+
+## Design
+
+### Architecture
+
+`HistoricalDataStore` stops being the source of truth and becomes a
+**write-through in-memory cache** in front of `DailyViewStore`'s existing
+per-day file (`/data/daily_views/{date}.json`), rather than gaining its own
+separate persistence file. `DailyViewStore` already exists, is already
+keyed one-file-per-calendar-day, and its `DailyView` schema already
+supports a mix of `data_source == "actual"` / `"predicted"` / `"missing"`
+per period — exactly what an in-progress "today" needs, and exactly what
+gets written for a completed day already (via `prepare_next_day` at
+23:55). Reusing it avoids introducing a fifth on-disk format.
+
+- **Write path**: every `HistoricalDataStore.record_period()` call (≈ once
+  per 15-minute tick, plus each period written during InfluxDB backfill)
+  additionally calls `DailyViewBuilder.get_current_daily_view()` — the same
+  function `prepare_next_day` already calls once at 23:55 — and passes the
+  result to `DailyViewStore.save_day()`. No new merge logic: this reuses
+  the existing actual+predicted merge that already runs once a day, just
+  starting from period 0 and running on every tick instead of only at
+  23:55.
+- **Read path (intraday)**: unchanged. `DailyViewBuilder` continues to read
+  live from the in-memory `HistoricalDataStore` for "today" — nothing
+  needs to read the file back during normal operation.
+- **Read path (startup)**: new — see "Startup recovery" below.
+- **Midnight rollover**: because the file is date-keyed, no explicit
+  "close out today's file" step is needed — once the date rolls over, all
+  new writes target a new filename, and yesterday's file is already
+  complete from its last tick before midnight. This makes the existing
+  23:55 `prepare_next_day` → `daily_view_store.save_day()` call redundant;
+  **this design removes that call** rather than leaving two write paths to
+  the same file.
+
+### Startup recovery
+
+Replaces `_fetch_and_initialize_historical_data`'s current "InfluxDB or
+nothing" logic with a layered recovery:
+
+1. On `start()`, before anything else, try
+   `daily_view_store.load_day(today)`.
+2. If a file exists: seed `HistoricalDataStore`'s in-memory dict from every
+   period in it with `data_source == "actual"`. Periods marked
+   `"predicted"` or `"missing"` in the file are not seeded — they're not
+   real actuals.
+3. Run the existing InfluxDB backfill loop
+   (`is_influxdb_configured()` check, `for period in range(0,
+   current_period)`) as today, but skip any period step 2 already
+   populated from the file. Periods the file marked `"missing"` (e.g. a
+   past #403-style dropped tick) or `"predicted"` are attempted via
+   InfluxDB exactly like any other unrecovered period — the file is not
+   treated as a final answer for those.
+4. If no file exists at all (first-ever run, or an unreadable/corrupt
+   file — `DailyViewStore.load_day()` already catches
+   `json.JSONDecodeError`/`OSError`/`KeyError`/`ValueError`, logs a
+   warning, and returns `None`), behavior is exactly what it is today:
+   InfluxDB backfill only, or skipped entirely if InfluxDB isn't
+   configured.
+
+Neither source (file or InfluxDB) is trusted exclusively; each fills in
+whatever the other doesn't have.
+
+### Clearing semantics
+
+"Clear Savings History" (`DELETE /api/savings/history` →
+`DailyViewStore.clear_all()`) must **not** touch today's file:
+
+- `clear_all()` gets a date-exclusion: skip `{today}.json` when deleting.
+- `list_available_dates()` and `get_disk_usage()` (used for the "N days
+  recorded (size)" text in Settings) also exclude today's file, so the
+  displayed count/size continues to mean "completed days," matching
+  current behavior.
+- No new UI or endpoint for clearing today's in-progress data — out of
+  scope. Today's file is naturally superseded at midnight rollover as
+  described above.
+
+### Error handling
+
+Mirrors `DailyViewStore.save_day()`'s existing pattern — disk writes are
+best-effort, never fatal:
+
+- Write failure (`OSError`, disk full, permissions): log a warning,
+  continue operating from the in-memory cache, retry naturally on the next
+  tick's write. Never raises out of `record_period()`.
+- Read failure at startup: already handled by `DailyViewStore.load_day()`
+  today; startup recovery falls through to "no file" behavior (step 4
+  above).
+- No new exception types.
+
+### Testing
+
+- **Unit** (`core/bess/tests/unit/`): extend
+  `test_historical_data_store.py` to cover the write-through behavior —
+  `record_period()` triggers a `DailyViewStore.save_day()` call with the
+  merged view; a write failure logs but does not raise.
+- **Startup recovery**: new tests for the three paths — file-only,
+  file+InfluxDB-fills-gaps (a file with some `"missing"`/`"predicted"`
+  periods, asserting InfluxDB is queried only for those), and no-file
+  (today's existing InfluxDB-only behavior, unchanged).
+- **Clear History**: test that `{today}.json` survives `clear_all()` /
+  `DELETE /api/savings/history`, and that disk-usage/day-count figures
+  exclude it.
+- **Removed 23:55 save**: update `test_bsm_settings_and_lifecycle.py`
+  (already covers the `prepare_next_day` clear-timing fix, #396) to
+  reflect that `prepare_next_day` no longer calls
+  `daily_view_store.save_day()` itself, and instead assert the day's file
+  is already correct at that point because of incremental writes.
+- No new integration/E2E coverage planned — this is a backend persistence
+  change with no UI surface beyond the existing Settings "days recorded"
+  count already covered above.
+
+## Out of scope
+
+- Consolidating `PredictionSnapshotStore` and `ScheduleStore` into the same
+  file/format. Explicitly deferred; this design is one step toward that
+  end state, not the full migration.
+- A UI/endpoint for clearing only today's in-progress data.
+- Fixing #403 (silently-skipped scheduler tick) directly — this design
+  incidentally recovers from its symptom via InfluxDB backfill (step 3
+  above) but does not address its root cause.
+
+## Related
+
+- #403 — quarterly schedule-update tick can be silently skipped, dropping
+  a period's actuals with no recovery path (this design's startup recovery
+  covers the resulting gap when InfluxDB is configured, but does not fix
+  the underlying scheduler issue).
+- #396 — `historical_store.clear()` timing fix (23:55 → true midnight).
+  Unrelated failure mode (premature clearing vs. mid-day data loss on
+  restart) but touches the same clear/save lifecycle code
+  (`_handle_special_cases`).


### PR DESCRIPTION
## Summary
- `HistoricalDataStore` (today's live sensor/economic actuals) was the only one of four "today" stores with zero disk persistence — a mid-day restart (crash, add-on auto-update) wiped everything collected so far, recoverable only via an InfluxDB backfill limited to periods that had already elapsed before that process started.
- Folds it into the existing `DailyViewStore` as a write-through cache: every tick that collects new actuals also persists the merged `DailyView` to `/data/daily_views/{date}.json`; startup seeds `historical_store` from today's file first, then runs the existing InfluxDB backfill only for whatever's still missing (closing gaps from any cause, including issue #403).
- "Clear Savings History" now excludes today's file (it's a live cache, not completed history); the now-redundant explicit 23:55 `prepare_next_day` save was removed since incremental writes supersede it.
- Includes an exception-safety fix (`_persist_today_view()` is now genuinely best-effort per its docstring/spec) and a guard so `BESS_HISTORICAL_SEED_FILE` E2E replay mode never persists fixture data.
- Design spec and implementation plan are included under `docs/superpowers/`.

## Test plan
- [x] `.venv/bin/pytest -m "not slow"` — 1372 passed
- [x] `./scripts/quality-check.sh` — 0 errors
- [x] `.venv/bin/pytest -m slow` — all green
- [x] Mutation-verified: the two new integration call sites are proven load-bearing (deleting either fails a specific new test)
- [x] Full 5-task implementation plan executed with per-task review + a final whole-branch review, all findings resolved

Related: #403 (silently-skipped scheduler tick — this PR makes its data-loss symptom recoverable but doesn't fix the scheduler root cause, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)