### PR TITLE
docs: use regular merge instead of squash for beta release PRs

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -38,12 +38,14 @@
      --base main --head beta-release-tmp \
      --title "release: v<version>" --body "<changelog>"
    ```
+
+   **If `beta/main`'s history still contains an old squash-merged release (from before step 12 switched to a regular merge), the Commits tab on this PR will show ~100 unrelated-looking commits spanning weeks — that's expected, not a sign something went wrong.** A squashed release commit has no ancestry to `origin/main`'s individual commits, so a branch cut fresh from `origin/main` (step 3) sees all of that history as "not yet in `beta/main`," even though most of it already shipped to beta users in substance. Once every release in the chain has used a regular merge (step 12), this stops happening — `beta/main` stays a true descendant of `origin/main` and each release's diff shrinks to the real delta. To review what's actually new regardless, use the **Files Changed** diff (`gh pr diff <pr-number> --stat`), not the Commits tab.
 11. **Monitor CI** on the PR. Check with:
    ```
    gh pr checks <pr-number> --repo johanzander/bess-manager-beta --watch
    ```
    **If any check fails**: read the failure logs with `gh run view <run-id> --repo johanzander/bess-manager-beta --log-failed`, fix the issue locally, commit, push, and re-check. Do NOT proceed to merge until all required checks pass. Also run `npx tsc --noEmit` locally before pushing — the CI type-check catches errors that `npm run build` misses.
-12. **Merge PR**: `gh pr merge <pr-number> --repo johanzander/bess-manager-beta --squash`
+12. **Merge PR with a regular merge commit, not squash**: `gh pr merge <pr-number> --repo johanzander/bess-manager-beta --merge`. Squashing discards `beta/main`'s ancestry to `origin/main`'s real commit history, so every future release branch (cut fresh from `origin/main`, step 3) sees `beta/main`'s file content as unrelated blobs instead of an older snapshot of the same lineage — producing spurious merge conflicts in step 5 on any file that changed in between, even when one side is simply stale. A regular merge keeps `beta/main` a true descendant of `origin/main`, so subsequent releases get a clean 3-way merge with only the two structurally-expected conflicts.
 13. **Tag and push tag**:
     ```
     git fetch beta main


### PR DESCRIPTION
## Summary
- Step 12 of the release skill squash-merged beta release PRs, which discarded `beta/main`'s ancestry to `origin/main`'s commit history.
- This caused spurious merge conflicts in step 5 of subsequent releases (git couldn't tell that beta/main's file content was just a stale snapshot of the same lineage, not unrelated content) — hit 4 unexpected conflicts during the v9.9.0b26 release for exactly this reason.
- It also produced the ~100-commit noise on every release PR's Commits tab, since `beta/main` never actually gained any of `origin/main`'s individual commits.
- Switched step 12 to a regular merge (`gh pr merge --merge`) so `beta/main` stays a true descendant of `origin/main` going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)