### PR TITLE
fix: correct default InfluxDB bucket and surface InfluxDB error bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - A failed startup timezone fetch now surfaces on the runtime-failures banner instead of silently falling back to `Europe/Stockholm`. ([#440](https://github.com/johanzander/bess-manager/issues/440))
+- **Default InfluxDB bucket pointed at a nonexistent database, and InfluxDB errors hid their real cause** — Corrected the default bucket name and included the response body in all error messages. ([#434](https://github.com/johanzander/bess-manager/pull/434))
 
 ## [10.0.0] - 2026-07-30
 

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -22,7 +22,7 @@ auth_api: true
 options:
   influxdb:
     url: "http://homeassistant.local:8086/api/v2/query"
-    bucket: "home_assistant/autogen"
+    bucket: "homeassistant/autogen"
     username: "your_db_username_here"
     password: "your_db_password_here"
 schema:

--- a/core/bess/influxdb_helper.py
+++ b/core/bess/influxdb_helper.py
@@ -132,9 +132,18 @@ def test_influxdb_connection() -> dict:
                 403: "Flux query language is not enabled in your InfluxDB configuration",
                 404: "InfluxDB API endpoint not found — check the URL",
             }
+            # Include the InfluxDB response body: for unmapped statuses (e.g.
+            # HTTP 500 "failed to initialize execute state: no database", which
+            # is what a wrong bucket/database produces) the body is the only
+            # thing that names the real cause.
+            body = response.text.strip()
             message = status_messages.get(
                 response.status_code,
-                f"InfluxDB returned HTTP {response.status_code}",
+                (
+                    f"InfluxDB returned HTTP {response.status_code}: {body}"
+                    if body
+                    else f"InfluxDB returned HTTP {response.status_code}"
+                ),
             )
             return {
                 "status": "error",
@@ -251,10 +260,22 @@ def get_sensor_data(sensors_list, start_time=None, stop_time=None) -> dict:
             return {"status": "error", "message": "No data found"}
 
         if response.status_code != 200:
-            _LOGGER.error("Error from InfluxDB: %s", response.status_code)
+            # The response body carries the real reason (e.g. a wrong
+            # bucket/database yields HTTP 500 "failed to initialize execute
+            # state: no database"); logging only the status code hid it.
+            body = response.text.strip()
+            _LOGGER.error(
+                "Error from InfluxDB: %s%s",
+                response.status_code,
+                f" — {body}" if body else "",
+            )
             return {
                 "status": "error",
-                "message": f"InfluxDB error: {response.status_code}",
+                "message": (
+                    f"InfluxDB error: {response.status_code}: {body}"
+                    if body
+                    else f"InfluxDB error: {response.status_code}"
+                ),
             }
 
         sensor_readings = parse_influxdb_response(response.text)
@@ -462,10 +483,22 @@ def get_sensor_data_batch(sensors_list, target_date) -> dict:
             return {"status": "error", "message": "No data found"}
 
         if response.status_code != 200:
-            _LOGGER.error("Error from InfluxDB: %s", response.status_code)
+            # The response body carries the real reason (e.g. a wrong
+            # bucket/database yields HTTP 500 "failed to initialize execute
+            # state: no database"); logging only the status code hid it.
+            body = response.text.strip()
+            _LOGGER.error(
+                "Error from InfluxDB: %s%s",
+                response.status_code,
+                f" — {body}" if body else "",
+            )
             return {
                 "status": "error",
-                "message": f"InfluxDB error: {response.status_code}",
+                "message": (
+                    f"InfluxDB error: {response.status_code}: {body}"
+                    if body
+                    else f"InfluxDB error: {response.status_code}"
+                ),
             }
 
         # Log first few lines of response for debugging
@@ -783,10 +816,22 @@ def get_power_sensor_data_batch(power_sensors: list[str], target_date) -> dict:
             return {"status": "error", "message": "No data found"}
 
         if response.status_code != 200:
-            _LOGGER.error("Error from InfluxDB: %s", response.status_code)
+            # The response body carries the real reason (e.g. a wrong
+            # bucket/database yields HTTP 500 "failed to initialize execute
+            # state: no database"); logging only the status code hid it.
+            body = response.text.strip()
+            _LOGGER.error(
+                "Error from InfluxDB: %s%s",
+                response.status_code,
+                f" — {body}" if body else "",
+            )
             return {
                 "status": "error",
-                "message": f"InfluxDB error: {response.status_code}",
+                "message": (
+                    f"InfluxDB error: {response.status_code}: {body}"
+                    if body
+                    else f"InfluxDB error: {response.status_code}"
+                ),
             }
 
         period_data = _parse_power_batch_response(response.text, target_date, local_tz)

--- a/core/bess/tests/unit/test_influxdb_helper.py
+++ b/core/bess/tests/unit/test_influxdb_helper.py
@@ -7,7 +7,10 @@ failing) a real HTTP connection for every user who never configured InfluxDB.
 """
 
 from datetime import date
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
 
 from core.bess import influxdb_helper
 
@@ -17,6 +20,26 @@ PLACEHOLDER_CONFIG = {
     "username": "your_db_username_here",
     "password": "your_db_password_here",
 }
+
+VALID_CONFIG = {
+    "url": "http://homeassistant.local:8086/api/v2/query",
+    "bucket": "homeassistant/autogen",
+    "username": "real_user",
+    "password": "real_password",
+}
+
+# The exact body InfluxDB 1.x returns (HTTP 500) when the bucket names a
+# database that does not exist -- e.g. the erroneous "home_assistant/autogen"
+# (underscore) instead of "homeassistant/autogen". This is the real failure
+# a user hit whose only symptom was a bare "InfluxDB error: 500".
+NO_DATABASE_BODY = "error failed to initialize execute state: no database"
+
+
+def _mock_response(status_code: int, text: str) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
 
 
 class TestGetSensorDataBatchSkipsUnconfigured:
@@ -65,3 +88,89 @@ class TestIsInfluxdbConfiguredRequiresBucket:
         }
         with patch.object(influxdb_helper, "get_influxdb_config", return_value=config):
             assert influxdb_helper.is_influxdb_configured() is False
+
+
+class TestErrorBodyIsSurfaced:
+    """When InfluxDB returns a non-200, the actual response body carries the
+    real reason (e.g. 'no database' for a wrong bucket). Surfacing only the
+    status code ('InfluxDB error: 500') hid that reason and turned a
+    one-line misconfiguration into an opaque failure. Every error path must
+    include the body."""
+
+    def test_connection_test_includes_body_for_unmapped_status(self):
+        with (
+            patch.object(
+                influxdb_helper, "get_influxdb_config", return_value=VALID_CONFIG
+            ),
+            patch.object(
+                influxdb_helper.requests,
+                "post",
+                return_value=_mock_response(500, NO_DATABASE_BODY),
+            ),
+        ):
+            result = influxdb_helper.test_influxdb_connection()
+
+        assert result["status"] == "error"
+        assert (
+            "no database" in result["message"]
+        ), f"Expected the InfluxDB body to be surfaced, got: {result['message']!r}"
+
+    def test_batch_fetch_includes_body_on_error(self):
+        with (
+            patch.object(influxdb_helper, "is_influxdb_configured", return_value=True),
+            patch.object(
+                influxdb_helper, "get_influxdb_config", return_value=VALID_CONFIG
+            ),
+            patch.object(
+                influxdb_helper.requests,
+                "post",
+                return_value=_mock_response(500, NO_DATABASE_BODY),
+            ),
+        ):
+            result = influxdb_helper.get_sensor_data_batch(
+                ["battery_soc"], date(2026, 7, 30)
+            )
+
+        assert result["status"] == "error"
+        assert (
+            "no database" in result["message"]
+        ), f"Expected the InfluxDB body to be surfaced, got: {result['message']!r}"
+
+    def test_power_batch_fetch_includes_body_on_error(self):
+        with (
+            patch.object(influxdb_helper, "is_influxdb_configured", return_value=True),
+            patch.object(
+                influxdb_helper, "get_influxdb_config", return_value=VALID_CONFIG
+            ),
+            patch.object(
+                influxdb_helper.requests,
+                "post",
+                return_value=_mock_response(500, NO_DATABASE_BODY),
+            ),
+        ):
+            result = influxdb_helper.get_power_sensor_data_batch(
+                ["solar_power"], date(2026, 7, 30)
+            )
+
+        assert result["status"] == "error"
+        assert (
+            "no database" in result["message"]
+        ), f"Expected the InfluxDB body to be surfaced, got: {result['message']!r}"
+
+
+class TestShippedConfigDefaultBucket:
+    """The shipped add-on default bucket must be a valid InfluxDB 1.x DBRP
+    for a stock Home Assistant install. The database is 'homeassistant'
+    (no underscore); the earlier default 'home_assistant/autogen' pointed at
+    a non-existent database and made every data fetch fail with HTTP 500."""
+
+    def test_config_yaml_default_bucket_matches_stock_ha_database(self):
+        config_path = (
+            Path(__file__).resolve().parents[4] / "bess_manager" / "config.yaml"
+        )
+        config = yaml.safe_load(config_path.read_text())
+        bucket = config["options"]["influxdb"]["bucket"]
+        assert bucket == "homeassistant/autogen", (
+            f"Shipped default bucket must target the stock HA database "
+            f"'homeassistant' (no underscore), got {bucket!r}"
+        )


### PR DESCRIPTION
## Summary

Two independent, pre-existing bugs that compound each other: a wrong default
InfluxDB bucket makes every data fetch fail with an opaque `HTTP 500`, and the
error handling then hides the one message that would explain it.

### 1. Default InfluxDB bucket targets a non-existent database

The shipped `bess_manager/config.yaml` default bucket is
`home_assistant/autogen` (with an underscore), but a stock Home Assistant
InfluxDB database is named `homeassistant` (no underscore). InfluxDB 1.x
returns **HTTP 500** — `failed to initialize execute state: no database` — for a
bucket whose database doesn't exist, so every periodic data fetch fails for
anyone who takes the default. `DOCS.md` already documents the correct value
(`homeassistant/autogen`); only the config default disagreed.

### 2. Every InfluxDB error path discards the response body

`test_influxdb_connection` (the Health screen's "Data Retrieval" check) and the
three `get_*` fetchers in `influxdb_helper.py` logged and returned only the
numeric status code, throwing away `response.text` — the field that names the
actual cause. The only visible symptom of bug 1 was a bare `InfluxDB error:
500`, with no path to the reason.

## Root cause — reproduced against a live InfluxDB 1.8.10

```
bucket=homeassistant/autogen   -> HTTP 200
bucket=home_assistant/autogen  -> HTTP 500  | error failed to initialize execute state: no database
```

After the fix, the same wrong-bucket config surfaces the real reason in the
Health check instead of a bare 500:

```
WRONG bucket (home_assistant/autogen):
  {'status': 'error', 'message': 'InfluxDB returned HTTP 500: error\nfailed to initialize execute state: no database'}
CORRECT bucket (homeassistant/autogen):
  {'status': 'ok', 'message': 'InfluxDB connection successful'}
```

## Changes

- `bess_manager/config.yaml` — default bucket `home_assistant/autogen` →
  `homeassistant/autogen` (matches `DOCS.md` and a stock HA install).
- `core/bess/influxdb_helper.py` — all four error paths
  (`test_influxdb_connection` + the three `get_*` fetchers) now include
  `response.text` in both the log line and the returned `message`.
- `core/bess/tests/unit/test_influxdb_helper.py` — 4 new tests:
  error-body surfacing on all three fetch paths, plus a guard that the shipped
  config default bucket targets the stock HA database.

## Testing

- New tests written RED (failed against unpatched code) → GREEN after the fix.
- Full fast suite green: `1190 passed, 14 skipped`. `ruff` clean.
- End-to-end verified against a live InfluxDB 1.8.10 (output above).

Both bugs are pre-existing on `main` and independent of any other work.
