### PR TITLE
chore: use union merge for CHANGELOG.md to auto-resolve additive conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` marking `CHANGELOG.md` with `merge=union`, so Git auto-includes both sides' added lines on merge instead of emitting conflict markers.

## Why
Independent feature branches worked from `main` in parallel routinely collide when merging/rebasing, because every PR appends bullets to the same `## [Unreleased]` section. These are almost always pure additive collisions (two different bullets, same location) — union merge resolves them automatically without losing either side's entry.

## Test plan
- [x] N/A — config-only change, no code path affected.