### PR TITLE
docs: fetch origin/main before cutting a worktree branch in implement-issue

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -98,7 +98,12 @@ implementation on a wrong diagnosis *or* a wrong placement.
 
 ### 4. Worktree + branch
 
-Invoke `superpowers:using-git-worktrees`.
+`git fetch origin main` first — `using-git-worktrees`' git fallback branches
+from the current local `HEAD`, not `origin/main`, so a stale local checkout
+silently cuts the branch behind main (missed release cuts, changelog
+rewrites, other merged fixes), surfacing later as an avoidable merge
+conflict. Then invoke `superpowers:using-git-worktrees`, basing the new
+branch on `origin/main`.
 
 ### 5. TDD implementation
 


### PR DESCRIPTION
## Summary
- `implement-issue` Step 4 now runs `git fetch origin main` before invoking `using-git-worktrees`, and bases the new branch on `origin/main` explicitly.

## Why
`using-git-worktrees`' git fallback (`git worktree add "$path" -b "$BRANCH_NAME"`) branches from whatever the local checkout's current `HEAD` is — not `origin/main`. Root-caused via PR #443: its branch was cut from a local `HEAD` 3 commits behind `origin/main`, missing the `v10.0.0` release cut and its `CHANGELOG.md` rewrite, which surfaced later as an avoidable merge conflict when the PR was pushed.

## Test plan
- [x] N/A — docs-only change to a skill file, no code path affected.