### PR TITLE
docs: stop CHANGELOG entries from self-reinforcing into multi-paragraph essays

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -209,8 +209,12 @@ not satisfied by re-stating that `quality-check.sh` passed.
 
 Add a `CHANGELOG.md` entry under `## [Unreleased]` (create that heading at
 the top if it's not already there), in the matching `### Added` / `### Changed`
-/ `### Fixed` subsection, following the existing entries' style (bold summary
-line, link to the issue/PR). This is a normal part of the PR, not a release
+/ `### Fixed` subsection — one line, per `docs/agents/workflow.md`'s CHANGELOG
+Format (bold lead-in, issue/PR link, ~25-word cap; no root cause or
+file/function names — that's the PR description's job, not the changelog's).
+Match existing entries' *format* only, never their *length* — several past
+entries are multi-sentence root-cause essays; do not use those as a length
+precedent. This is a normal part of the PR, not a release
 step — per `docs/superpowers/specs/2026-07-09-release-workflow-design.md`,
 `Unreleased` entries accumulate as each PR merges; the release skill only
 ever renames or copies that section, it never authors it. Skipping this here

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -119,10 +119,22 @@ build checklist.
 
 ### Fixed
 
-- Short description.
+- Short description. ([#123](https://github.com/johanzander/bess-manager/issues/123))
 ```
 
-One line per change. No implementation details. Match existing style.
+**One line per change, hard limit ~25 words after the bold lead-in. No root
+cause, no file/function names, no "confirmed via debug bundle" narrative —
+that belongs in the PR description, not the changelog.** Bad (an actual past
+entry, do not reproduce this): *"Terminal-value arbitrage cap used an
+already-committed near-term sell price, causing large spurious swings...
+`_calculate_terminal_value`'s arbitrage-consistency cap (`sell_cap =
+max(sell_prices) * efficiency_discharge - cycle_cost`) used `max()` over the
+*entire* remaining horizon..."* (150+ words). Good: *"Fixed a terminal-value
+bug that caused spurious swings in tomorrow's export plan."*
+
+Match existing entries' **format** (bold lead, trailing issue/PR link) —
+never their **length**. Many existing entries are far too long; that history
+is not the style to match.
 
 ## Labels
 


### PR DESCRIPTION
## Summary
- `docs/agents/workflow.md`'s CHANGELOG Format section said "one line... match existing style" in the same breath, contradicting itself since existing entries are multi-sentence root-cause essays. Now states explicitly: match the entries' *format* (bold lead-in + issue/PR link), never their *length*, with a real oversized entry shown as the anti-pattern and a ~25-word cap.
- `implement-issue`'s Step 9 had the same gap (told authors to match existing style, no length constraint at all) — updated to point at the same rule.

## Why
Root-caused while fixing #443: every new PR's changelog entry got written by matching the previous entry's style, and since that style had drifted into full root-cause narratives, every new entry reinforced and extended the drift rather than correcting it.

## Test plan
- [x] N/A — docs-only change to guidance files, no code path affected.