### PR TITLE
release: v10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to BESS Battery Manager will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [10.0.1] - 2026-08-02
 
 ### Fixed
 

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "10.0.0"
+version: "10.0.1"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false


### PR DESCRIPTION
## [10.0.1] - 2026-08-02

### Fixed
- `HuaweiController.sync_soc_limits` now reads before writing SOC limits, instead of writing unconditionally on every sync. (#427)
- A failed startup timezone fetch now surfaces on the runtime-failures banner instead of silently falling back to `Europe/Stockholm`. (#440)
- The Runtime Errors panel no longer shows a blank "Error:" line; it now shows the real message and occurrence count. (#60)
- "Report a Problem" → "File GitHub Issue" no longer gets silently dropped by popup blockers. (#60)
- **Default InfluxDB bucket pointed at a nonexistent database, and InfluxDB errors hid their real cause** — Corrected the default bucket name and included the response body in all error messages. (#434)

Version-bump-only patch release, no unreleased content beyond the above.