### PR TITLE
feat: PV export-limit curtailment on negative sell prices (#269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Optional PV export-limit curtailment on negative sell prices** — when enabled and a period is exporting at a sell price below a configurable floor, Growatt GEN2/GEN3/GEN4 hardware (via solax_modbus, with a grid CT/smart meter) now throttles PV production at the panel instead of paying to export. Off by default. ([#269](https://github.com/johanzander/bess-manager/issues/269))
+
 ### Fixed
 
 - **A silently dropped quarterly schedule-update tick permanently lost a period's actuals with no trace it ever happened** — the missed tick is now logged and surfaced as a runtime failure. ([#403](https://github.com/johanzander/bess-manager/issues/403))

--- a/backend/tests/test_settings_contracts.py
+++ b/backend/tests/test_settings_contracts.py
@@ -344,6 +344,8 @@ _BATTERY_OPTIONAL_FIELDS = frozenset(
         "efficiency_discharge",
         "inverter_max_ac_power_kw",
         "inverter_ac_power_margin",
+        "export_curtailment_enabled",
+        "export_curtailment_price_floor",
     }
 )
 # min_valid is an internal algorithm parameter, never read from the settings

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -186,6 +186,11 @@ class BatterySystemManager:
         self._desired_strategic_intent: str = ""  # alongside the rate above
         self._last_applied_discharge_rate: int = 0  # Last rate written to inverter
 
+        # Export-limit curtailment state (#269) — tracks whether the hardware
+        # is currently curtailed so release can fire even on a period whose
+        # own plan doesn't call for export (see _apply_period_schedule).
+        self._export_limit_curtailed: bool = False
+
         # Consumption forecast cache. Only used for the 'influxdb_7d_avg'
         # and 'ha_statistics' strategies, whose value is a window of full
         # calendar days ending at today's midnight and so provably can't
@@ -2156,6 +2161,18 @@ class BatterySystemManager:
                 if self._inverter_controller is not None
                 else None
             )
+            # Capability-aware, not just the raw user setting (#459 review):
+            # planning for curtailment on a platform that can't actually do
+            # it makes outcomes worse than leaving the feature off (see
+            # optimize_battery_schedule's export_curtailment_active
+            # docstring). Entity misconfiguration on a supported platform is
+            # a separate, self-correcting case surfaced by the runtime
+            # failure banner in _apply_period_schedule, not checked here.
+            export_curtailment_active = (
+                self.battery_settings.export_curtailment_enabled
+                and self._inverter_controller is not None
+                and self._inverter_controller.supports_export_limit_control
+            )
             result = optimize_battery_schedule(
                 buy_price=buy_prices,
                 sell_price=sell_prices,
@@ -2170,6 +2187,7 @@ class BatterySystemManager:
                 max_charge_power_per_period=max_charge_power_per_period,
                 discharge_resolution_kw=discharge_resolution_kw,
                 self_throttle_export_threshold_kwh=self_throttle_export_threshold_kwh,
+                export_curtailment_active=export_curtailment_active,
             )
 
             # Add timestamps to period data (algorithm is time-agnostic, operates on relative indices)
@@ -2677,15 +2695,44 @@ class BatterySystemManager:
         # charging at its rate limit while the surplus above that rate
         # exports). No-op on platforms without supports_export_limit_control
         # via InverterController.apply_export_limit's base implementation.
+        #
+        # The write is skipped only when there's genuinely nothing to assert:
+        # no export this period AND the hardware isn't currently curtailed.
+        # Any exporting period actively (re)asserts the correct state either
+        # way, and _export_limit_curtailed additionally forces a release on
+        # a later *non*-exporting period that would otherwise leave an
+        # earlier curtailment stuck on with no further write to clear it.
+        #
+        # A write failure here (e.g. an unconfigured entity) must not take
+        # down the rest of this period's hardware apply below.
         if self.battery_settings.export_curtailment_enabled:
             target_timestamp = time_utils.period_index_to_timestamp(period)
             period_data = self.schedule_store.get_period_data_at(target_timestamp)
-            if period_data is not None and period_data.energy.grid_exported > 0:
-                curtail = (
-                    period_data.economic.sell_price
+            if period_data is not None and (
+                period_data.energy.grid_exported > 0 or self._export_limit_curtailed
+            ):
+                should_curtail = (
+                    period_data.energy.grid_exported > 0
+                    and period_data.economic.sell_price
                     < self.battery_settings.export_curtailment_price_floor
                 )
-                self._inverter_controller.apply_export_limit(self.controller, curtail)
+                try:
+                    self._inverter_controller.apply_export_limit(
+                        self.controller, should_curtail
+                    )
+                    self._export_limit_curtailed = should_curtail
+                    self._runtime_failure_tracker.dismiss_by_category(
+                        "export_limit_curtailment"
+                    )
+                except Exception as e:
+                    self._runtime_failure_tracker.dismiss_by_category(
+                        "export_limit_curtailment"
+                    )
+                    self._runtime_failure_tracker.record_failure(
+                        category="export_limit_curtailment",
+                        operation=f"Period {period}: apply export-limit curtailment",
+                        error=e,
+                    )
 
         # Store the schedule's desired discharge rate before inhibit check so that
         # apply_discharge_inhibit() can restore it when the inhibit sensor clears.

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -2725,10 +2725,13 @@ class BatterySystemManager:
                         "export_limit_curtailment"
                     )
                 except Exception as e:
-                    self._runtime_failure_tracker.dismiss_by_category(
-                        "export_limit_curtailment"
-                    )
-                    self._runtime_failure_tracker.record_failure(
+                    # ha_api_controller's own retry logic already records a
+                    # failure under this same category via record_failure_once
+                    # for HTTP-level errors, so use record_failure_once here
+                    # too (rather than record_failure) to coalesce with it
+                    # instead of producing a second banner entry for one
+                    # underlying failure.
+                    self._runtime_failure_tracker.record_failure_once(
                         category="export_limit_curtailment",
                         operation=f"Period {period}: apply export-limit curtailment",
                         error=e,

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -2615,6 +2615,24 @@ class BatterySystemManager:
                         ),
                     )
 
+        # PV export-limit curtailment (issue #269): opt-in, platform-agnostic
+        # decision — curtail whenever this period is exporting at a sell
+        # price below the configured floor, regardless of strategic_intent
+        # (the reporting evidence showed the "battery full" case classifies
+        # as SOLAR_STORAGE, not SOLAR_EXPORT, since the battery is still
+        # charging at its rate limit while the surplus above that rate
+        # exports). No-op on platforms without supports_export_limit_control
+        # via InverterController.apply_export_limit's base implementation.
+        if self.battery_settings.export_curtailment_enabled:
+            target_timestamp = time_utils.period_index_to_timestamp(period)
+            period_data = self.schedule_store.get_period_data_at(target_timestamp)
+            if period_data is not None and period_data.energy.grid_exported > 0:
+                curtail = (
+                    period_data.economic.sell_price
+                    < self.battery_settings.export_curtailment_price_floor
+                )
+                self._inverter_controller.apply_export_limit(self.controller, curtail)
+
         # Store the schedule's desired discharge rate before inhibit check so that
         # apply_discharge_inhibit() can restore it when the inhibit sensor clears.
         self._desired_discharge_rate = discharge_rate

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -1434,6 +1434,7 @@ def optimize_battery_schedule(
     max_charge_power_per_period: list[float] | None = None,
     discharge_resolution_kw: float | None = None,
     self_throttle_export_threshold_kwh: float | None = None,
+    export_curtailment_active: bool = False,
 ) -> OptimizationResult:
     """
     Battery optimization that eliminates dual cost calculation by using
@@ -1455,6 +1456,17 @@ def optimize_battery_schedule(
             from temperature derating. When provided, charging actions exceeding the
             limit for each period are excluded from the optimization. Defaults to None
             (no per-period limits, uses battery_settings.max_charge_power_kw).
+        export_curtailment_active: Caller-computed, capability-aware flag for
+            whether export-limit curtailment (#269) will actually execute --
+            battery_settings.export_curtailment_enabled AND the platform
+            supports it AND the entities are configured. Deliberately NOT
+            read from battery_settings.export_curtailment_enabled directly:
+            that's just the user's opt-in preference, and planning as if
+            curtailment will happen on a platform/config that can't actually
+            do it would make outcomes worse than leaving the feature off
+            (the plan forgoes real defenses against a loss that never gets
+            neutralized). Same call-site pattern as discharge_resolution_kw
+            below. Defaults to False.
 
     Returns:
         OptimizationResult with optimal battery schedule
@@ -1505,7 +1517,7 @@ def optimize_battery_schedule(
     # BSM's execution-time curtailment trigger reads that field directly, and
     # the displayed plan should show the honest physics-only cost, not the
     # actuation override.
-    if battery_settings.export_curtailment_enabled:
+    if export_curtailment_active:
         floor = battery_settings.export_curtailment_price_floor
         reward_sell_price = [0.0 if p < floor else p for p in sell_price]
     else:
@@ -1538,6 +1550,7 @@ def optimize_battery_schedule(
     hourly_results = []
     current_soe = initial_soe
     current_cost_basis = initial_cost_basis
+    reward_objective_cost = 0.0
     soe_levels = np.arange(
         battery_settings.min_soe_kwh,
         battery_settings.max_soe_kwh + SOE_STEP_KWH,
@@ -1550,21 +1563,23 @@ def optimize_battery_schedule(
         # already-known V[t+1, :] (linearly interpolated) as the continuation
         # value -- the same reward+max(V) logic as the backward pass, applied
         # at the true state instead of one snapped to the nearest grid index.
-        action, next_soe, new_cost_basis, _ = _best_action_at_continuous_state(
-            soe=current_soe,
-            t=t,
-            V_next=V[t + 1],
-            power_levels=power_levels,
-            home_consumption=home_consumption,
-            battery_settings=battery_settings,
-            dt=dt,
-            solar_production=solar_production,
-            buy_price=buy_price,
-            sell_price=reward_sell_price,
-            cost_basis=current_cost_basis,
-            max_charge_power_per_period=max_charge_power_per_period,
-            discharge_resolution_kw=discharge_resolution_kw,
-            self_throttle_export_threshold_kwh=self_throttle_export_threshold_kwh,
+        action, next_soe, new_cost_basis, action_reward = (
+            _best_action_at_continuous_state(
+                soe=current_soe,
+                t=t,
+                V_next=V[t + 1],
+                power_levels=power_levels,
+                home_consumption=home_consumption,
+                battery_settings=battery_settings,
+                dt=dt,
+                solar_production=solar_production,
+                buy_price=buy_price,
+                sell_price=reward_sell_price,
+                cost_basis=current_cost_basis,
+                max_charge_power_per_period=max_charge_power_per_period,
+                discharge_resolution_kw=discharge_resolution_kw,
+                self_throttle_export_threshold_kwh=self_throttle_export_threshold_kwh,
+            )
         )
 
         period_data = _build_period_data(
@@ -1603,6 +1618,7 @@ def optimize_battery_schedule(
         hourly_results.append(period_data)
         current_soe = next_soe
         current_cost_basis = new_cost_basis
+        reward_objective_cost -= action_reward
 
     # Step 3: Calculate economic summary directly from PeriodData
     total_base_cost = sum(
@@ -1666,7 +1682,40 @@ def optimize_battery_schedule(
         battery_settings=battery_settings,
         dt=dt,
     )
-    if idle_schedule.economic_summary.battery_solar_cost < total_optimized_cost:
+
+    # When export_curtailment_active, the DP's action selection optimized
+    # against reward_sell_price (floored), not the real sell_price used
+    # above -- so comparing total_optimized_cost/idle_schedule at real
+    # price here would be judging the DP's plan by a different objective
+    # than the one it was asked to optimize, and could silently discard a
+    # plan the DP correctly preferred (confirmed via a randomized sweep
+    # against this optimizer, #459 review). Recompute both sides of the
+    # guardrail comparison at reward_sell_price so it's internally
+    # consistent with the actual objective; the RETURNED idle_schedule
+    # (if the guardrail fires) still reports at the real price, unchanged.
+    guardrail_optimized_cost = total_optimized_cost
+    guardrail_idle_cost = idle_schedule.economic_summary.battery_solar_cost
+    if export_curtailment_active:
+        # reward_objective_cost is accumulated directly from each period's
+        # action_reward (_best_action_at_continuous_state's own return
+        # value) -- the exact objective the DP chose actions against, not a
+        # reconstruction from reported PeriodData (which could drift from
+        # the real per-action reward, e.g. self-throttle export-credit
+        # zeroing applying to the reward calc but not to the raw
+        # grid_exported energy field).
+        guardrail_optimized_cost = reward_objective_cost
+        guardrail_idle_cost = _create_idle_schedule(
+            horizon=horizon,
+            buy_price=buy_price,
+            sell_price=reward_sell_price,
+            home_consumption=home_consumption,
+            solar_production=solar_production,
+            initial_soe=initial_soe,
+            battery_settings=battery_settings,
+            dt=dt,
+        ).economic_summary.battery_solar_cost
+
+    if guardrail_idle_cost < guardrail_optimized_cost:
         return idle_schedule
 
     return OptimizationResult(

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -1493,13 +1493,31 @@ def optimize_battery_schedule(
         f"Starting direct optimization: horizon={horizon}, initial_soe={initial_soe:.1f}, initial_cost_basis={initial_cost_basis:.3f}"
     )
 
+    # Reward-facing sell price only (#269): when export curtailment is
+    # enabled, periods priced below the curtailment floor get an effective
+    # sell price of 0.0 for the DP's own reward/action-selection calculation
+    # only -- backward induction propagates a later period's reward into
+    # every earlier period's decision via the continuation value, so leaving
+    # this unfixed would make the DP refuse a genuinely profitable earlier
+    # action just to avoid a loss that curtailment neutralizes in reality.
+    # The real sell_price list (unchanged) is still what gets reported on
+    # PeriodData.economic.sell_price below and fed to _build_period_data --
+    # BSM's execution-time curtailment trigger reads that field directly, and
+    # the displayed plan should show the honest physics-only cost, not the
+    # actuation override.
+    if battery_settings.export_curtailment_enabled:
+        floor = battery_settings.export_curtailment_price_floor
+        reward_sell_price = [0.0 if p < floor else p for p in sell_price]
+    else:
+        reward_sell_price = sell_price
+
     # Step 1: Run DP to compute the value-to-go array V. Step 2 recomputes
     # each replay action directly from V (interpolated at the true
     # continuous SoE) rather than looking up a grid-snapped policy table.
     V = _run_dynamic_programming(
         horizon=horizon,
         buy_price=buy_price,
-        sell_price=sell_price,
+        sell_price=reward_sell_price,
         home_consumption=home_consumption,
         solar_production=solar_production,
         initial_soe=initial_soe,
@@ -1542,7 +1560,7 @@ def optimize_battery_schedule(
             dt=dt,
             solar_production=solar_production,
             buy_price=buy_price,
-            sell_price=sell_price,
+            sell_price=reward_sell_price,
             cost_basis=current_cost_basis,
             max_charge_power_per_period=max_charge_power_per_period,
             discharge_resolution_kw=discharge_resolution_kw,

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -570,6 +570,11 @@ class HomeAssistantAPIController:
         "vpp_allow_ac_charging": "growatt_vpp_allow_ac_charging",
         "vpp_time": "growatt_vpp_time",
         "vpp_power": "growatt_vpp_power",
+        # Export-limit curtailment (registers 122/123, GEN2|GEN3|GEN4).
+        # See issue #269 — verified against plugin_growatt.py
+        # SELECT_TYPES/NUMBER_TYPES the same way as the VPP entries above.
+        "limit_grid_export": "growatt_export_limit_mode",
+        "grid_export_limit": "growatt_export_limit_value",
         # TOU time slots (9 slots)
         "time_1_enabled": "tou_time_1_enabled",
         "time_1_begin": "tou_time_1_begin",
@@ -650,6 +655,9 @@ class HomeAssistantAPIController:
         "vpp_allow_ac_charging": "growatt_vpp_allow_ac_charging",
         "vpp_time": "growatt_vpp_time",
         "vpp_power": "growatt_vpp_power",
+        # Export-limit curtailment (registers 122/123, GEN2|GEN3|GEN4) — #269.
+        "limit_grid_export": "growatt_export_limit_mode",
+        "grid_export_limit": "growatt_export_limit_value",
     }
 
     # SolaX native inverters via solax_modbus integration
@@ -2093,6 +2101,34 @@ class HomeAssistantAPIController:
             fallback_minutes,
             f"Growatt VPP reset fallback timer -> {fallback_minutes} min",
         )
+
+    # ── Growatt export-limit curtailment (registers 122/123) ──────────────────
+    #
+    # See issue #269 — requires a grid CT/smart meter. Curtailing writes
+    # "Meter 1" (use the CT meter to throttle PV/MPPT production) and 0%
+    # (strict zero export); releasing writes "Disabled" only — the register
+    # 123 percentage is meaningless once the meter selection is disabled, so
+    # it's left untouched (and the negative range on 123 means "allow this
+    # much import," never written here).
+
+    def set_growatt_export_limit(self, curtail: bool) -> None:
+        """Enable/disable PV export curtailment via the CT-meter export limit."""
+        mode_entity = self._get_entity_for_service("growatt_export_limit_mode")
+        option = "Meter 1" if curtail else "Disabled"
+        logger.info("Growatt export limit: mode -> %s", option)
+        self._service_call_with_retry(
+            "select",
+            "select_option",
+            operation=f"Growatt export limit mode -> {option}",
+            entity_id=mode_entity,
+            option=option,
+        )
+
+        if not curtail:
+            return
+
+        value_entity = self._get_entity_for_service("growatt_export_limit_value")
+        self._set_number_like(value_entity, 0, "Growatt export limit -> 0% (curtail)")
 
     def get_growatt_vpp_status(self) -> str | None:
         """Read the current Growatt VPP Status register state."""

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -1129,7 +1129,12 @@ class HomeAssistantAPIController:
         return self.service_domain
 
     def _service_call_with_retry(
-        self, service_domain, service_name, operation: str | None = None, **kwargs
+        self,
+        service_domain,
+        service_name,
+        operation: str | None = None,
+        category: str | None = None,
+        **kwargs,
     ):
         """Call Home Assistant service with retry logic.
 
@@ -1137,6 +1142,8 @@ class HomeAssistantAPIController:
             service_domain: Service domain (e.g., 'switch', 'number')
             service_name: Service name (e.g., 'turn_on', 'set_value')
             operation: Optional human-readable operation description for failure tracking
+            category: Optional failure-tracking category override. Defaults to a
+                domain-based heuristic when omitted.
             **kwargs: Service parameters
 
         Returns:
@@ -1199,7 +1206,8 @@ class HomeAssistantAPIController:
             "post",
             path,
             operation=operation or f"Call {service_domain}.{service_name}",
-            category=(
+            category=category
+            or (
                 "battery_control"
                 if service_domain in ["number", "input_number", "switch"]
                 else ("inverter_control" if is_vendor_domain else "other")
@@ -1372,7 +1380,9 @@ class HomeAssistantAPIController:
         """Get current battery discharging power in watts."""
         return self._get_sensor_value("battery_discharge_power")
 
-    def _set_number_like(self, entity_id: str, value, operation: str) -> None:
+    def _set_number_like(
+        self, entity_id: str, value, operation: str, category: str | None = None
+    ) -> None:
         """Write a value to a number-like entity.
 
         Supports both `number.*` (platform-native) and `input_number.*`
@@ -1384,6 +1394,7 @@ class HomeAssistantAPIController:
             domain,
             "set_value",
             operation=operation,
+            category=category,
             entity_id=entity_id,
             value=value,
         )
@@ -2180,6 +2191,7 @@ class HomeAssistantAPIController:
             "select",
             "select_option",
             operation=f"Growatt export limit mode -> {option}",
+            category="export_limit_curtailment",
             entity_id=mode_entity,
             option=option,
         )
@@ -2188,7 +2200,12 @@ class HomeAssistantAPIController:
             return
 
         value_entity = self._get_entity_for_service("growatt_export_limit_value")
-        self._set_number_like(value_entity, 0, "Growatt export limit -> 0% (curtail)")
+        self._set_number_like(
+            value_entity,
+            0,
+            "Growatt export limit -> 0% (curtail)",
+            category="export_limit_curtailment",
+        )
 
     def get_growatt_vpp_status(self) -> str | None:
         """Read the current Growatt VPP Status register state."""

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -84,6 +84,12 @@ class InverterController(ABC):
     # TOU schedule writes (SPH, SolaX native).
     supports_charge_rate_control: ClassVar[bool] = True
 
+    # Whether the platform can curtail PV export via a hardware export-limit
+    # register (issue #269), requiring a grid CT/smart meter. False by
+    # default -- most platforms' HA integrations don't expose this control
+    # at all (e.g. growatt_server exposes no export-limit service/entity).
+    supports_export_limit_control: ClassVar[bool] = False
+
     # ── SM-Period-lists scheduling model ────────────────────────────────────
     # Subclasses that build separate charge/discharge period lists (Growatt
     # SPH, Solis via solis_modbus) must override these with the strategic
@@ -545,6 +551,20 @@ class InverterController(ABC):
         return self._write_period_to_hardware(
             controller, grid_charge, discharge_rate, block_passive_charging
         )
+
+    def apply_export_limit(self, controller, curtail: bool) -> None:  # noqa: B027
+        """Enable/disable PV export curtailment for this period (issue #269).
+
+        No-op by default -- only platforms with supports_export_limit_control
+        True override this. Callers should check the capability flag before
+        relying on this doing anything; the no-op exists so BSM can call it
+        unconditionally without a per-platform branch.
+
+        Args:
+            controller: HomeAssistantAPIController instance
+            curtail: True to curtail export (write 0%/Meter mode), False to
+                release it back to normal (Disabled).
+        """
 
     def get_period_settings(self, period: int) -> dict:
         """Get control settings for a specific 15-minute period.

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -127,6 +127,10 @@ class BatterySettings:
     efficiency_discharge: float = BATTERY_EFFICIENCY_DISCHARGE
     inverter_max_ac_power_kw: float = INVERTER_MAX_AC_POWER_KW
     inverter_ac_power_margin: float = INVERTER_AC_POWER_MARGIN
+    # PV export-limit curtailment (issue #269) — opt-in, requires a grid
+    # CT/smart meter and a platform with supports_export_limit_control.
+    export_curtailment_enabled: bool = False
+    export_curtailment_price_floor: float = 0.0
     reserved_capacity: float = field(init=False)
     min_soe_kwh: float = field(init=False)
     max_soe_kwh: float = field(init=False)

--- a/core/bess/solax_modbus_growatt_controller.py
+++ b/core/bess/solax_modbus_growatt_controller.py
@@ -85,6 +85,10 @@ class SolaxModbusGrowattController(GrowattMinController):
     # cloud-only) silently re-gate this.
     dedupe_register_writes: ClassVar[bool] = False
 
+    # Export-limit registers (122/123) exist independent of control_mode —
+    # true in both TOU and VPP mode, unlike supports_charge_rate_control.
+    supports_export_limit_control: ClassVar[bool] = True
+
     def __init__(
         self, battery_settings: BatterySettings, control_mode: str = "tou"
     ) -> None:
@@ -130,6 +134,11 @@ class SolaxModbusGrowattController(GrowattMinController):
         directly, so this stays True there (base class default).
         """
         return self._is_tou_control
+
+    def apply_export_limit(self, controller, curtail: bool) -> None:
+        """Curtail/release PV export via the CT-meter export-limit registers
+        (122/123, issue #269). Independent of control_mode (tou/vpp)."""
+        controller.set_growatt_export_limit(curtail)
 
     @property
     def discharge_rate_is_load_following(self) -> bool:

--- a/core/bess/tests/conftest.py
+++ b/core/bess/tests/conftest.py
@@ -127,7 +127,9 @@ class MockHomeAssistantController(HomeAssistantAPIController):
             "growatt_vpp_status": [],
             "growatt_vpp_allow_ac_charging": [],
             "growatt_vpp_periods": [],
+            "growatt_export_limit": [],
         }
+        self._growatt_export_limit_curtailed: bool = False
         self._growatt_vpp_status_state: str = "Disabled"
         self._growatt_vpp_remote_control_state: str | None = None
 
@@ -380,6 +382,11 @@ class MockHomeAssistantController(HomeAssistantAPIController):
     def get_growatt_vpp_status(self) -> str | None:
         """Return mock Growatt VPP Status state."""
         return self._growatt_vpp_status_state
+
+    def set_growatt_export_limit(self, curtail: bool) -> None:
+        """Record Growatt export-limit curtailment write (#269)."""
+        self._growatt_export_limit_curtailed = curtail
+        self.calls["growatt_export_limit"].append(curtail)
 
     def get_growatt_vpp_remote_control(self) -> str | None:
         """Return mock Growatt VPP Remote Control state."""

--- a/core/bess/tests/unit/test_export_limit_curtailment.py
+++ b/core/bess/tests/unit/test_export_limit_curtailment.py
@@ -33,10 +33,15 @@ Two parts:
 """
 
 from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import MagicMock
 
 from core.bess import time_utils
 from core.bess.battery_system_manager import BatterySystemManager
-from core.bess.dp_battery_algorithm import optimize_battery_schedule
+from core.bess.dp_battery_algorithm import (
+    _create_idle_schedule,
+    optimize_battery_schedule,
+)
 from core.bess.models import (
     DecisionData,
     EconomicData,
@@ -172,7 +177,69 @@ class TestExportLimitCurtailment:
         assert controller.calls["growatt_export_limit"] == []
 
 
-def _curtailment_scenario(export_curtailment_enabled: bool):
+class TestExportLimitReleaseNotStuck:
+    """Regression: release must fire even when a later period's own plan
+    doesn't call for export, not just when grid_exported > 0 for that period
+    (code review on #459 -- the register was getting stuck curtailed)."""
+
+    def test_releases_on_a_later_period_with_no_planned_export(self):
+        bsm, controller = _make_bsm()
+        bsm.battery_settings.export_curtailment_enabled = True
+        bsm.battery_settings.export_curtailment_price_floor = 0.0
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.5, sell_price=-0.01)
+        bsm._apply_period_schedule(PERIOD)
+        assert controller.calls["growatt_export_limit"] == [True]
+
+        # Next period: price has recovered, but this period's own plan calls
+        # for zero export (e.g. battery has headroom) -- must still release.
+        next_period = PERIOD + 1
+        _set_intent(bsm, next_period, "SOLAR_STORAGE")
+        _store_period(bsm, next_period, grid_exported=0.0, sell_price=0.10)
+        bsm._apply_period_schedule(next_period)
+
+        assert controller.calls["growatt_export_limit"] == [True, False]
+
+    def test_stays_quiet_when_never_curtailed(self):
+        """No spurious release writes on a system that's never curtailed."""
+        bsm, controller = _make_bsm()
+        bsm.battery_settings.export_curtailment_enabled = True
+        bsm.battery_settings.export_curtailment_price_floor = 0.0
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.0, sell_price=0.10)
+
+        bsm._apply_period_schedule(PERIOD)
+
+        assert controller.calls["growatt_export_limit"] == []
+
+
+class TestExportLimitFailureIsolated:
+    """Regression: a curtailment write failure (e.g. unconfigured entity)
+    must not take down the rest of the period's hardware apply -- code
+    review on #459 found _get_entity_for_service's ValueError propagating
+    out of _apply_period_schedule uncaught, aborting apply_period() too."""
+
+    def test_curtailment_exception_does_not_block_apply_period(self):
+        bsm, controller = _make_bsm()
+        bsm.battery_settings.export_curtailment_enabled = True
+        bsm.battery_settings.export_curtailment_price_floor = 0.0
+        bsm._inverter_controller.apply_export_limit = MagicMock(
+            side_effect=ValueError("No entity ID configured for Export Limit Mode")
+        )
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.5, sell_price=-0.01)
+
+        bsm._apply_period_schedule(PERIOD)  # must not raise
+
+        assert controller.calls["discharge_rate"], (
+            "apply_period's real hardware write must still run despite the "
+            "curtailment failure"
+        )
+
+
+def _curtailment_scenario(
+    export_curtailment_active: bool, export_curtailment_enabled: bool = False
+):
     """2-period scenario isolating the DP's earlier-period reward-propagation
     bug: period 0 can preemptively discharge 1 kWh at a mild loss
     (sell_price=-0.1) to create exactly enough room for period 1's 1 kWh
@@ -181,9 +248,9 @@ def _curtailment_scenario(export_curtailment_enabled: bool):
     (not just hand-derived) against the real optimizer:
 
     - Raw sell_price fed straight into the reward (today's behavior,
-      independent of export_curtailment_enabled -- this is exactly the bug):
-      DP discharges 1 kWh at period 0 (BATTERY_EXPORT) to defend against
-      period 1's real, uncurtailed loss.
+      independent of the setting -- this is exactly the bug): DP discharges
+      1 kWh at period 0 (BATTERY_EXPORT) to defend against period 1's real,
+      uncurtailed loss.
     - sell_price[1] effectively floored to 0.0 (simulating the fix): DP holds
       (IDLE) at period 0 instead -- discharging at a loss to avoid a period-1
       cost that curtailment will neutralize anyway is no longer worth it.
@@ -191,6 +258,14 @@ def _curtailment_scenario(export_curtailment_enabled: bool):
     terminal_value_per_kwh=0.3 gives holding stored energy to the end of the
     horizon a genuine competing value (otherwise a positive-or-neutral
     discharge would trivially dominate regardless of curtailment).
+
+    export_curtailment_active is the caller-computed, capability-aware flag
+    (battery_settings.export_curtailment_enabled AND the platform actually
+    supports it AND the entities are configured) -- the DP reads only this,
+    never the raw settings field, so it can never plan as if curtailment
+    will happen on a platform/config that can't actually do it (#459 review).
+    export_curtailment_enabled is the raw user setting, passed separately
+    to prove the DP ignores it when not also reflected in the active flag.
     """
     bs = BatterySettings(
         total_capacity=2.0,
@@ -214,6 +289,7 @@ def _curtailment_scenario(export_curtailment_enabled: bool):
         initial_cost_basis=0.0,
         period_duration_hours=1.0,
         terminal_value_per_kwh=0.3,
+        export_curtailment_active=export_curtailment_active,
     )
 
 
@@ -221,17 +297,28 @@ class TestDPCurtailmentAwareReward:
     """Does the DP's own plan account for curtailment neutralizing a later
     negative-price export penalty? (#269 follow-up, folded into this PR.)"""
 
-    def test_holds_instead_of_preemptive_loss_discharge_when_enabled(self):
-        result = _curtailment_scenario(export_curtailment_enabled=True)
+    def test_holds_instead_of_preemptive_loss_discharge_when_active(self):
+        result = _curtailment_scenario(export_curtailment_active=True)
         period0 = result.period_data[0]
         assert period0.decision.strategic_intent == "IDLE"
         assert period0.energy.battery_discharged == 0.0
 
-    def test_still_defends_with_preemptive_discharge_when_disabled(self):
-        """Sanity check: curtailment disabled means the period-1 loss is
+    def test_still_defends_with_preemptive_discharge_when_inactive(self):
+        """Sanity check: curtailment inactive means the period-1 loss is
         real, so preemptively discharging at a mild loss to avoid it remains
         the correct (and unchanged) call."""
-        result = _curtailment_scenario(export_curtailment_enabled=False)
+        result = _curtailment_scenario(export_curtailment_active=False)
+        period0 = result.period_data[0]
+        assert period0.decision.strategic_intent == "BATTERY_EXPORT"
+        assert period0.energy.battery_discharged == 1.0
+
+    def test_ignores_raw_setting_when_not_reflected_in_active_flag(self):
+        """Regression (#459 review): the user setting alone must never make
+        the DP plan for curtailment on an unsupported/unconfigured platform
+        -- only the caller-computed, capability-aware active flag can."""
+        result = _curtailment_scenario(
+            export_curtailment_active=False, export_curtailment_enabled=True
+        )
         period0 = result.period_data[0]
         assert period0.decision.strategic_intent == "BATTERY_EXPORT"
         assert period0.energy.battery_discharged == 1.0
@@ -243,6 +330,93 @@ class TestDPCurtailmentAwareReward:
         must still see the real (negative) price to decide whether to
         curtail. Only the DP's internal reward/action-selection calculation
         should ever see the floored effective price."""
-        result = _curtailment_scenario(export_curtailment_enabled=True)
+        result = _curtailment_scenario(export_curtailment_active=True)
         period1 = result.period_data[1]
         assert period1.economic.sell_price == -3.0
+
+
+class TestBellmanGuardrailNotFooledByFloor:
+    """Regression (#459 review, verified by bess-analyst against the real
+    optimizer with a randomized sweep, ~1-4% of realistic volatile-price
+    scenarios): the "never worse than all-IDLE" numerical safety net
+    compares total_optimized_cost (tallied at the REAL, un-floored price)
+    against an all-IDLE schedule's REAL-price cost. But the DP's action
+    selection optimized against the FLOORED reward_sell_price when
+    export_curtailment_active -- an internally inconsistent comparison that
+    can silently discard the whole curtailment-aware plan and fall back to
+    all-IDLE, even though the DP's own (floored) objective judged its plan
+    better. The guardrail must compare both sides on the SAME objective the
+    DP actually optimized.
+
+    Minimal real repro found via a randomized sweep against the actual
+    optimizer (not hand-derived): at these exact inputs, the pre-fix
+    guardrail discards the DP's plan and returns _create_idle_schedule's
+    output verbatim (cost 3.162626315789474, identical intents) even though
+    the DP's own floored-reward search preferred an active plan."""
+
+    BUY: ClassVar[list[float]] = [0.383, 0.369, 1.762, 2.836, 1.329, 0.885]
+    SELL: ClassVar[list[float]] = [-0.889, -2.855, -1.892, -0.811, -0.521, -1.835]
+    HOME: ClassVar[list[float]] = [0.35, 0.33, 0.69, 0.43, 0.03, 1.26]
+    SOLAR: ClassVar[list[float]] = [1.11, 1.28, 0.37, 1.99, 1.72, 0.24]
+    CAP = 5.0
+    CYCLE_COST = 0.269
+    INITIAL_SOE = 1.5
+
+    def _battery_settings(self):
+        return BatterySettings(
+            total_capacity=self.CAP,
+            min_soc=0.0,
+            max_soc=100.0,
+            max_charge_power_kw=self.CAP,
+            max_discharge_power_kw=self.CAP,
+            efficiency_charge=0.95,
+            efficiency_discharge=0.95,
+            cycle_cost_per_kwh=self.CYCLE_COST,
+        )
+
+    def test_does_not_silently_fall_back_to_the_idle_schedule(self):
+        idle = _create_idle_schedule(
+            horizon=6,
+            buy_price=self.BUY,
+            sell_price=self.SELL,
+            home_consumption=self.HOME,
+            solar_production=self.SOLAR,
+            initial_soe=self.INITIAL_SOE,
+            battery_settings=self._battery_settings(),
+            dt=0.25,
+        )
+
+        result = optimize_battery_schedule(
+            buy_price=self.BUY,
+            sell_price=self.SELL,
+            home_consumption=self.HOME,
+            battery_settings=self._battery_settings(),
+            solar_production=self.SOLAR,
+            initial_soe=self.INITIAL_SOE,
+            initial_cost_basis=self.CYCLE_COST,
+            period_duration_hours=0.25,
+            export_curtailment_active=True,
+        )
+
+        assert result.economic_summary.battery_solar_cost != (
+            idle.economic_summary.battery_solar_cost
+        )
+
+    def test_matches_the_dps_own_floored_objective_choice(self):
+        """With export_curtailment_active=False on the same inputs, the
+        guardrail already compares real-price-vs-real-price correctly (no
+        floor substitution involved) -- confirm it picks a genuinely
+        different, non-idle plan there too, so this scenario is a real
+        DP-prefers-active-plan case, not just an idle-schedule quirk."""
+        result = optimize_battery_schedule(
+            buy_price=self.BUY,
+            sell_price=self.SELL,
+            home_consumption=self.HOME,
+            battery_settings=self._battery_settings(),
+            solar_production=self.SOLAR,
+            initial_soe=self.INITIAL_SOE,
+            initial_cost_basis=self.CYCLE_COST,
+            period_duration_hours=0.25,
+            export_curtailment_active=False,
+        )
+        assert any(p.energy.battery_discharged > 0 for p in result.period_data)

--- a/core/bess/tests/unit/test_export_limit_curtailment.py
+++ b/core/bess/tests/unit/test_export_limit_curtailment.py
@@ -1,0 +1,248 @@
+"""PV export-limit curtailment at negative sell price (issue #269).
+
+When solar surplus is being exported at a negative sell price and the
+battery has no better use for it (full, or the DP already chose not to
+store it), the Growatt export-limit register (122/123, via a grid CT/smart
+meter) curtails PV production at the inverter instead of paying to export.
+
+Two parts:
+
+1. Execution-time actuation (TestExportLimitCurtailment below): a per-period
+   decision in BSM's _apply_period_schedule, platform-agnostic: grid_exported
+   > 0 AND sell_price < floor. Only platforms with
+   supports_export_limit_control=True (currently SolaxModbusGrowattController)
+   actually act on it; everyone else gets a no-op via
+   InverterController.apply_export_limit's base implementation. This part
+   does not change the DP plan at all -- it fires purely on the DP's own
+   already-computed PeriodData.
+
+2. DP planning awareness (TestDPCurtailmentAwareReward below): since the DP's
+   backward induction propagates a later period's reward into every earlier
+   period's decision via the continuation value, leaving the reward function
+   unaware that curtailment will neutralize a later negative-price export
+   penalty can make the DP refuse a genuinely profitable earlier action (e.g.
+   discharging preemptively at a real, if mild, loss) purely to avoid a loss
+   that curtailment already eliminates in reality. When export_curtailment_
+   enabled is True, the DP substitutes an effective sell price of 0.0 (rather
+   than the raw negative price) into its reward calculation for periods where
+   the raw sell_price < export_curtailment_price_floor -- but ONLY inside the
+   reward/action-selection calculation, never in the reported
+   PeriodData.economic.sell_price (which stays the real market price, both
+   for accurate display and because BSM's execution-time trigger above reads
+   it directly).
+"""
+
+from types import SimpleNamespace
+
+from core.bess import time_utils
+from core.bess.battery_system_manager import BatterySystemManager
+from core.bess.dp_battery_algorithm import optimize_battery_schedule
+from core.bess.models import (
+    DecisionData,
+    EconomicData,
+    EnergyData,
+    OptimizationResult,
+    PeriodData,
+)
+from core.bess.price_manager import MockSource
+from core.bess.settings import BatterySettings
+from core.bess.solax_modbus_growatt_controller import SolaxModbusGrowattController
+from core.bess.tests.conftest import MockHomeAssistantController
+
+PERIOD = 20
+
+
+def _make_bsm() -> tuple[BatterySystemManager, MockHomeAssistantController]:
+    controller = MockHomeAssistantController()
+    bsm = BatterySystemManager(
+        controller=controller,
+        price_source=MockSource([0.2] * 96),
+        addon_options={"inverter": {"platform": "growatt_server_min"}},
+    )
+    # Replace with a platform that actually supports export-limit control —
+    # the growatt_server_min controller from addon_options resolution above
+    # does not (cloud has no export-limit service, see #269 diagnosis).
+    bsm._inverter_controller = SolaxModbusGrowattController(
+        bsm.battery_settings, control_mode="tou"
+    )
+    return bsm, controller
+
+
+def _set_intent(bsm: BatterySystemManager, period: int, intent: str) -> None:
+    intents = ["IDLE"] * 96
+    intents[period] = intent
+    bsm._inverter_controller.strategic_intents = intents
+    bsm._inverter_controller.current_schedule = SimpleNamespace(actions=[0.0] * 96)
+
+
+def _store_period(
+    bsm: BatterySystemManager,
+    period: int,
+    grid_exported: float,
+    sell_price: float,
+) -> None:
+    energy = EnergyData(
+        solar_production=grid_exported,
+        home_consumption=0.0,
+        battery_charged=0.0,
+        battery_discharged=0.0,
+        grid_imported=0.0,
+        grid_exported=grid_exported,
+        battery_soe_start=10.0,
+        battery_soe_end=10.0,
+    )
+    decision = DecisionData(strategic_intent="SOLAR_STORAGE")
+    period_data = PeriodData(
+        period=period,
+        energy=energy,
+        timestamp=time_utils.period_index_to_timestamp(period),
+        economic=EconomicData(sell_price=sell_price),
+        decision=decision,
+    )
+    result = OptimizationResult(input_data={}, period_data=[period_data])
+    bsm.schedule_store.store_schedule(result, optimization_period=period)
+
+
+class TestExportLimitCurtailment:
+    def test_curtails_when_exporting_at_negative_price(self):
+        bsm, controller = _make_bsm()
+        bsm.battery_settings.export_curtailment_enabled = True
+        bsm.battery_settings.export_curtailment_price_floor = 0.0
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.5, sell_price=-0.01)
+
+        bsm._apply_period_schedule(PERIOD)
+
+        assert controller.calls["growatt_export_limit"] == [True]
+
+    def test_releases_when_price_non_negative(self):
+        bsm, controller = _make_bsm()
+        bsm.battery_settings.export_curtailment_enabled = True
+        bsm.battery_settings.export_curtailment_price_floor = 0.0
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.5, sell_price=0.05)
+
+        bsm._apply_period_schedule(PERIOD)
+
+        assert controller.calls["growatt_export_limit"] == [False]
+
+    def test_no_curtailment_when_not_exporting(self):
+        """Negative price but nothing is being exported this period — no-op,
+        nothing to curtail (and no need to write "Disabled" every period)."""
+        bsm, controller = _make_bsm()
+        bsm.battery_settings.export_curtailment_enabled = True
+        bsm.battery_settings.export_curtailment_price_floor = 0.0
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.0, sell_price=-0.01)
+
+        bsm._apply_period_schedule(PERIOD)
+
+        assert controller.calls["growatt_export_limit"] == []
+
+    def test_disabled_by_setting_is_a_noop(self):
+        """export_curtailment_enabled=False (the default) — never writes,
+        even if exporting at a negative price. Opt-in only: requires a CT/
+        smart meter most users don't have configured."""
+        bsm, controller = _make_bsm()
+        bsm.battery_settings.export_curtailment_enabled = False
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.5, sell_price=-0.01)
+
+        bsm._apply_period_schedule(PERIOD)
+
+        assert controller.calls["growatt_export_limit"] == []
+
+    def test_platform_without_capability_is_a_noop(self):
+        """growatt_server (cloud) has no export-limit service — the base
+        InverterController.apply_export_limit no-op must not raise or write
+        anything, even with curtailment enabled and conditions met."""
+        controller = MockHomeAssistantController()
+        bsm = BatterySystemManager(
+            controller=controller,
+            price_source=MockSource([0.2] * 96),
+            addon_options={"inverter": {"platform": "growatt_server_min"}},
+        )
+        bsm.battery_settings.export_curtailment_enabled = True
+        bsm.battery_settings.export_curtailment_price_floor = 0.0
+        _set_intent(bsm, PERIOD, "SOLAR_STORAGE")
+        _store_period(bsm, PERIOD, grid_exported=0.5, sell_price=-0.01)
+
+        bsm._apply_period_schedule(PERIOD)
+
+        assert controller.calls["growatt_export_limit"] == []
+
+
+def _curtailment_scenario(export_curtailment_enabled: bool):
+    """2-period scenario isolating the DP's earlier-period reward-propagation
+    bug: period 0 can preemptively discharge 1 kWh at a mild loss
+    (sell_price=-0.1) to create exactly enough room for period 1's 1 kWh
+    solar surplus, avoiding forced export at period 1's much worse
+    sell_price=-3.0 (below the 0.0 curtailment floor). Confirmed empirically
+    (not just hand-derived) against the real optimizer:
+
+    - Raw sell_price fed straight into the reward (today's behavior,
+      independent of export_curtailment_enabled -- this is exactly the bug):
+      DP discharges 1 kWh at period 0 (BATTERY_EXPORT) to defend against
+      period 1's real, uncurtailed loss.
+    - sell_price[1] effectively floored to 0.0 (simulating the fix): DP holds
+      (IDLE) at period 0 instead -- discharging at a loss to avoid a period-1
+      cost that curtailment will neutralize anyway is no longer worth it.
+
+    terminal_value_per_kwh=0.3 gives holding stored energy to the end of the
+    horizon a genuine competing value (otherwise a positive-or-neutral
+    discharge would trivially dominate regardless of curtailment).
+    """
+    bs = BatterySettings(
+        total_capacity=2.0,
+        min_soc=0.0,
+        max_soc=100.0,
+        max_charge_power_kw=2.0,
+        max_discharge_power_kw=2.0,
+        efficiency_charge=1.0,
+        efficiency_discharge=1.0,
+        cycle_cost_per_kwh=0.0,
+    )
+    bs.export_curtailment_enabled = export_curtailment_enabled
+    bs.export_curtailment_price_floor = 0.0
+    return optimize_battery_schedule(
+        buy_price=[1.0, 1.0],
+        sell_price=[-0.1, -3.0],
+        home_consumption=[0.0, 0.0],
+        battery_settings=bs,
+        solar_production=[0.0, 1.0],
+        initial_soe=2.0,
+        initial_cost_basis=0.0,
+        period_duration_hours=1.0,
+        terminal_value_per_kwh=0.3,
+    )
+
+
+class TestDPCurtailmentAwareReward:
+    """Does the DP's own plan account for curtailment neutralizing a later
+    negative-price export penalty? (#269 follow-up, folded into this PR.)"""
+
+    def test_holds_instead_of_preemptive_loss_discharge_when_enabled(self):
+        result = _curtailment_scenario(export_curtailment_enabled=True)
+        period0 = result.period_data[0]
+        assert period0.decision.strategic_intent == "IDLE"
+        assert period0.energy.battery_discharged == 0.0
+
+    def test_still_defends_with_preemptive_discharge_when_disabled(self):
+        """Sanity check: curtailment disabled means the period-1 loss is
+        real, so preemptively discharging at a mild loss to avoid it remains
+        the correct (and unchanged) call."""
+        result = _curtailment_scenario(export_curtailment_enabled=False)
+        period0 = result.period_data[0]
+        assert period0.decision.strategic_intent == "BATTERY_EXPORT"
+        assert period0.energy.battery_discharged == 1.0
+
+    def test_reported_sell_price_stays_the_real_market_price(self):
+        """The effective-price substitution must never leak into reported
+        PeriodData -- BSM's execution-time curtailment trigger
+        (_apply_period_schedule) reads economic.sell_price directly, and it
+        must still see the real (negative) price to decide whether to
+        curtail. Only the DP's internal reward/action-selection calculation
+        should ever see the floored effective price."""
+        result = _curtailment_scenario(export_curtailment_enabled=True)
+        period1 = result.period_data[1]
+        assert period1.economic.sell_price == -3.0

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -322,6 +322,37 @@ class TestSetOperations:
             assert mock.call_args[0][:2] == ("number", "set_value")
 
 
+class TestSetGrowattExportLimit:
+    """Export-limit curtailment writes (registers 122/123, #269)."""
+
+    @pytest.fixture
+    def export_ctrl(self, ctrl):
+        ctrl.sensors["growatt_export_limit_mode"] = "select.limit_grid_export"
+        ctrl.sensors["growatt_export_limit_value"] = "number.grid_export_limit"
+        return ctrl
+
+    def test_curtail_writes_meter_1_and_zero_percent(self, export_ctrl):
+        with patch.object(export_ctrl, "_service_call_with_retry") as mock:
+            export_ctrl.set_growatt_export_limit(curtail=True)
+            calls = mock.call_args_list
+            assert ("select", "select_option") in [c[0] for c in calls]
+            assert ("number", "set_value") in [c[0] for c in calls]
+            select_call = next(c for c in calls if c[0] == ("select", "select_option"))
+            assert select_call[1]["option"] == "Meter 1"
+            number_call = next(c for c in calls if c[0] == ("number", "set_value"))
+            assert number_call[1]["value"] == 0
+
+    def test_release_writes_disabled(self, export_ctrl):
+        with patch.object(export_ctrl, "_service_call_with_retry") as mock:
+            export_ctrl.set_growatt_export_limit(curtail=False)
+            select_call = next(
+                c for c in mock.call_args_list if c[0] == ("select", "select_option")
+            )
+            assert select_call[1]["option"] == "Disabled"
+            # Release does not touch the percentage register — only the mode.
+            assert ("number", "set_value") not in [c[0] for c in mock.call_args_list]
+
+
 class TestSetTouSegmentViaEntities:
     """Regression test for #362: begin/end must use time.set_value, not
     select.select_option, when the resolved entity is HA domain `time.*`

--- a/core/bess/tests/unit/test_period_retry.py
+++ b/core/bess/tests/unit/test_period_retry.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from core.bess.battery_system_manager import BatterySystemManager
+from core.bess.settings import BatterySettings
 
 
 def _make_bsm_with_mocks():
@@ -13,6 +14,7 @@ def _make_bsm_with_mocks():
     bsm._runtime_failure_tracker = MagicMock()
     bsm._scheduler = MagicMock()
     bsm._last_applied_discharge_rate = 0
+    bsm.battery_settings = BatterySettings()
     return bsm
 
 

--- a/core/bess/tests/unit/test_platform_capabilities.py
+++ b/core/bess/tests/unit/test_platform_capabilities.py
@@ -11,7 +11,7 @@ from core.bess.inverter_controller import InverterController
 from core.bess.settings import BatterySettings
 from core.bess.solax_controller import SolaxController
 from core.bess.solax_modbus_growatt_controller import SolaxModbusGrowattController
-from core.bess.tests.conftest import MockSensorCollector
+from core.bess.tests.conftest import MockHomeAssistantController, MockSensorCollector
 
 # ── Capability declarations ──────────────────────────────────────────────────
 
@@ -60,6 +60,73 @@ class TestChargeRateControlCapability:
             control_mode="vpp",
         )
         assert controller.supports_charge_rate_control is False
+
+
+class TestExportLimitControlCapability:
+    """Verify supports_export_limit_control is declared correctly per platform (#269)."""
+
+    def test_base_class_defaults_to_false(self):
+        assert InverterController.supports_export_limit_control is False
+
+    def test_growatt_sph_cloud_does_not_support_export_limit(self):
+        # growatt_server exposes no export-limit service/entity — see #269.
+        assert GrowattSphController.supports_export_limit_control is False
+
+    def test_solax_native_does_not_support_export_limit(self):
+        assert SolaxController.supports_export_limit_control is False
+
+    def test_solax_modbus_growatt_supports_export_limit(self):
+        # Registers 122/123 exist independent of control_mode (tou vs vpp).
+        controller = SolaxModbusGrowattController(
+            BatterySettings(
+                total_capacity=50.0,
+                max_charge_power_kw=5.0,
+                max_discharge_power_kw=5.0,
+                min_soc=10.0,
+                max_soc=95.0,
+                cycle_cost_per_kwh=0.05,
+            ),
+            control_mode="tou",
+        )
+        assert controller.supports_export_limit_control is True
+
+
+class TestApplyExportLimit:
+    """Verify apply_export_limit dispatches (or no-ops) correctly (#269)."""
+
+    def test_base_class_is_a_noop(self):
+        controller = GrowattSphController(
+            BatterySettings(
+                total_capacity=50.0,
+                max_charge_power_kw=5.0,
+                max_discharge_power_kw=5.0,
+                min_soc=10.0,
+                max_soc=95.0,
+                cycle_cost_per_kwh=0.05,
+            )
+        )
+        ha = MockHomeAssistantController()
+        controller.apply_export_limit(ha, curtail=True)
+        assert ha.calls["growatt_export_limit"] == []
+
+    def test_solax_modbus_growatt_curtails(self):
+        controller = SolaxModbusGrowattController(
+            BatterySettings(
+                total_capacity=50.0,
+                max_charge_power_kw=5.0,
+                max_discharge_power_kw=5.0,
+                min_soc=10.0,
+                max_soc=95.0,
+                cycle_cost_per_kwh=0.05,
+            ),
+            control_mode="tou",
+        )
+        ha = MockHomeAssistantController()
+        controller.apply_export_limit(ha, curtail=True)
+        assert ha.calls["growatt_export_limit"] == [True]
+
+        controller.apply_export_limit(ha, curtail=False)
+        assert ha.calls["growatt_export_limit"] == [True, False]
 
 
 class TestDischargeRateLoadFollowingCapability:

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -513,6 +513,27 @@ def _solax_growatt_vpp_entities() -> list[dict]:
     ]
 
 
+def _solax_growatt_export_limit_entities() -> list[dict]:
+    """Export-limit curtailment entities (registers 122/123, issue #269).
+
+    Present on GEN2/GEN3/GEN4 Growatt hardware via solax_modbus — verified
+    against plugin_growatt.py SELECT_TYPES/NUMBER_TYPES (allowedtypes=
+    GEN2|GEN3|GEN4), same verification method as the VPP entities above.
+    """
+    return [
+        _entity(
+            "select.growatt_inverter_solax_limit_grid_export",
+            "solax_modbus",
+            "solax_limit_grid_export",
+        ),
+        _entity(
+            "number.growatt_inverter_solax_grid_export_limit",
+            "solax_modbus",
+            "solax_grid_export_limit",
+        ),
+    ]
+
+
 def _solax_growatt_gen3_registry() -> list[dict]:
     """Entity registry for a GEN3 Growatt (MIX/SPA/SPH) via solax_modbus.
 
@@ -1045,11 +1066,13 @@ class TestMapRegistryEntities:
 
         The solax_modbus integration has both:
         - sensor with unique_id suffix "solax_total_reverse_power" (export power sensor)
-        - select with unique_id suffix "solax_limit_grid_export" (export limiter config)
+        - select with unique_id suffix "solax_limit_grid_export" (export limiter config,
+          now intentionally mapped to growatt_export_limit_mode — #269)
 
         The old short suffix "grid_export" matched the select entity because
         "solax_limit_grid_export" ends with "_grid_export".  With exact
-        "solax_" prefixed suffixes, only the correct sensor should match.
+        "solax_" prefixed suffixes, only the correct sensor should match
+        export_power — the select entity should map to its own key instead.
         """
         # Place the select BEFORE the sensor to reproduce the original bug
         # (first-writer-wins with old short suffixes)
@@ -1073,10 +1096,9 @@ class TestMapRegistryEntities:
         assert result["export_power"] == (
             "sensor.growatt_inverter_solax_total_export_power"
         )
-        # The select entity must NOT appear anywhere in the result
-        assert (
+        # The select entity must map to its own key, not steal export_power
+        assert result["growatt_export_limit_mode"] == (
             "select.growatt_inverter_solax_inverter_limit_grid_export"
-            not in result.values()
         )
 
 
@@ -1363,6 +1385,41 @@ class TestDiscoverSensorsFromRegistry:
         assert (
             growatt_sph["growatt_vpp_power"]
             == "number.growatt_inverter_solax_vpp_power"
+        )
+
+    def test_solax_growatt_gen4_export_limit_entities_discovered(self):
+        """GEN4 export-limit entities are mapped alongside TOU entities (#269)."""
+        registry = (
+            _solax_growatt_tou_registry() + _solax_growatt_export_limit_entities()
+        )
+        sensors, platform = self.ctrl.discover_sensors_from_registry(registry)
+        assert platform == "solax_modbus_growatt_min"
+        growatt_min = sensors["solax_modbus_growatt_min"]
+        assert (
+            growatt_min["growatt_export_limit_mode"]
+            == "select.growatt_inverter_solax_limit_grid_export"
+        )
+        assert (
+            growatt_min["growatt_export_limit_value"]
+            == "number.growatt_inverter_solax_grid_export_limit"
+        )
+
+    def test_solax_growatt_gen3_export_limit_entities_discovered(self):
+        """GEN3 export-limit entities are mapped too — same registers, per
+        plugin_growatt.py's allowedtypes=GEN2|GEN3|GEN4."""
+        registry = (
+            _solax_growatt_gen3_registry() + _solax_growatt_export_limit_entities()
+        )
+        sensors, platform = self.ctrl.discover_sensors_from_registry(registry)
+        assert platform == "solax_modbus_growatt_sph"
+        growatt_sph = sensors["solax_modbus_growatt_sph"]
+        assert (
+            growatt_sph["growatt_export_limit_mode"]
+            == "select.growatt_inverter_solax_limit_grid_export"
+        )
+        assert (
+            growatt_sph["growatt_export_limit_value"]
+            == "number.growatt_inverter_solax_grid_export_limit"
         )
 
     def test_gen3_marker_not_detected_for_gen4(self):

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -169,6 +169,35 @@ register (`total_load` is GEN3, `home_consumption_energy` is SPF). BESS
 derives `lifetime_load_consumption` as `solar + grid_import − grid_export`.
 `total_yield` maps to `lifetime_system_production`.
 
+### Export-limit curtailment (GEN2/GEN3/GEN4) — *(optional, opt-in)*
+
+Registers 122/123 via the solax_modbus Growatt plugin — verified against
+`plugin_growatt.py` SELECT_TYPES/NUMBER_TYPES (`allowedtypes=GEN2|GEN3|GEN4`),
+so this is available on both GEN3 and GEN4 hardware, not GEN4-only. Requires
+a grid CT/smart meter; disabled (`BatterySettings.export_curtailment_enabled
+= False`) by default.
+
+When enabled and a period is exporting solar surplus at a sell price below
+`export_curtailment_price_floor`, BESS writes:
+```
+select.select_option(entity: limit_grid_export, option: "Meter 1")
+number.set_value(entity: grid_export_limit, value: 0)
+```
+This throttles PV/MPPT production at the panel via the CT meter's real-time
+export reading — genuine supply-side curtailment, not just a downstream cap
+that gets bypassed once the battery is full. Confirmed by a real user's live
+test (Meter 1 + 0% dropped measured export to 0W within seconds). Once the
+period's sell price is no longer below the floor, BESS releases the limit
+with `select.select_option(entity: limit_grid_export, option: "Disabled")`
+only — the percentage register is left untouched on release (its negative
+range means "allow this much import," never written by BESS).
+
+The decision is platform-agnostic (`grid_exported > 0 AND sell_price <
+floor`, independent of strategic intent) but the actuation itself is
+gated by the `supports_export_limit_control` capability flag — currently
+only `SolaxModbusGrowattController` implements it. `growatt_server` (cloud)
+has no equivalent HA service to hook into and stays a safe no-op.
+
 ### Growatt MIX/SPH (Local) — `growatt_solax_modbus_gen3` (GEN3)
 
 GEN3 models (MIX/SPA/SPH) connected via the solax_modbus Growatt plugin.
@@ -556,6 +585,13 @@ actively uses slot 1. A `time_N_clear` button also exists in the plugin
 | `lifetime_system_production` | `total_yield` | GEN4 register 3077 |
 | `lifetime_load_consumption` | — | **No native register.** BESS derives: solar + grid_import − grid_export |
 
+**Export-limit curtailment (GEN4, optional):**
+
+| BESS Sensor Key | Entity Type | solax_modbus Suffix | Purpose |
+|-----------------|-------------|---------------------|---------|
+| `growatt_export_limit_mode` | select | `limit_grid_export` | Meter/CT selection (Disabled/Meter 1/Meter 2/CT Clamp), register 122 |
+| `growatt_export_limit_value` | number | `grid_export_limit` | Export limit percentage, register 123 |
+
 ### Growatt MIX/SPH (Local) — GEN3 — `solax_modbus` Growatt plugin
 
 **Monitoring and EMS control (GEN3):**
@@ -586,6 +622,10 @@ actively uses slot 1. A `time_N_clear` button also exists in the plugin
 | `lifetime_export_to_grid` | `total_grid_export` | Register 1050 |
 | `lifetime_load_consumption` | `total_load` | Register 1062 |
 | `lifetime_system_production` | — | **No native register.** BESS derives from `lifetime_solar_energy` |
+
+**Export-limit curtailment (GEN3, optional):** same registers/entities as
+GEN4 above (`limit_grid_export` / `grid_export_limit`, registers 122/123) —
+`plugin_growatt.py` marks these `allowedtypes=GEN2|GEN3|GEN4`, not GEN4-only.
 
 ### SolaX — `solax_modbus` integration (native)
 

--- a/frontend/src/components/settings/BatteryFormSection.tsx
+++ b/frontend/src/components/settings/BatteryFormSection.tsx
@@ -13,6 +13,8 @@ export interface BatteryForm {
   temperatureDeratingEnabled: boolean;
   inverterMaxAcPowerKw: number;
   inverterAcPowerMargin: number;
+  exportCurtailmentEnabled: boolean;
+  exportCurtailmentPriceFloor: number;
 }
 
 interface Props {
@@ -105,6 +107,22 @@ export function BatteryFormSection({
               the midday peak. Requires per-period charge-rate control (Growatt MIN).
               The margin is a model-side haircut on the cap that compensates for hourly
               forecasts hiding short peaks; it never changes what is written to hardware.
+            </p>
+            {toggle('Curtail PV export at negative price', form.exportCurtailmentEnabled,
+              v => onChange({ ...form, exportCurtailmentEnabled: v }))}
+            {form.exportCurtailmentEnabled && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {numField('Curtailment Price Floor', form.exportCurtailmentPriceFloor,
+                  v => onChange({ ...form, exportCurtailmentPriceFloor: v }),
+                  { unit: `${currency || 'currency'}/kWh`, step: 0.01 })}
+              </div>
+            )}
+            <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+              Requires a grid CT/smart meter and hardware support (currently Growatt
+              GEN2/GEN3/GEN4 via solax_modbus only). When the sell price drops below the
+              floor and the inverter is still exporting, the export-limit register throttles
+              PV production at the panel instead of paying to export. Unsupported platforms
+              ignore this setting.
             </p>
             {toggle('Enable temperature derating', form.temperatureDeratingEnabled,
               v => onChange({ ...form, temperatureDeratingEnabled: v }))}

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -304,6 +304,13 @@ export const INTEGRATIONS: IntegrationDef[] = [
           { key: 'growatt_vpp_power', label: 'VPP Power', required: false },
         ],
       },
+      {
+        name: 'Export Limit Curtailment (optional — requires a grid CT/smart meter)',
+        sensors: [
+          { key: 'growatt_export_limit_mode', label: 'Limit Grid Export', required: false },
+          { key: 'growatt_export_limit_value', label: 'Grid Export Limit', required: false },
+        ],
+      },
     ],
   },
   {
@@ -358,6 +365,13 @@ export const INTEGRATIONS: IntegrationDef[] = [
           { key: 'growatt_vpp_allow_ac_charging', label: 'VPP Allow AC Charging', required: true },
           { key: 'growatt_vpp_time', label: 'VPP Time (Fallback Timer)', required: true },
           { key: 'growatt_vpp_power', label: 'VPP Power', required: true },
+        ],
+      },
+      {
+        name: 'Export Limit Curtailment (optional — requires a grid CT/smart meter)',
+        sensors: [
+          { key: 'growatt_export_limit_mode', label: 'Limit Grid Export', required: false },
+          { key: 'growatt_export_limit_value', label: 'Grid Export Limit', required: false },
         ],
       },
     ],

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -41,6 +41,7 @@ const EMPTY_BATTERY: BatteryForm = {
   efficiencyCharge: 97, efficiencyDischarge: 97,
   temperatureDeratingEnabled: false,
   inverterMaxAcPowerKw: 0, inverterAcPowerMargin: 0.05,
+  exportCurtailmentEnabled: false, exportCurtailmentPriceFloor: 0,
 };
 const EMPTY_HOME: HomeForm = {
   consumption: 3.5, consumptionStrategy: 'sensor',
@@ -172,6 +173,8 @@ const SettingsPage: React.FC = () => {
         temperatureDeratingEnabled: bat_s.temperatureDerating?.enabled ?? false,
         inverterMaxAcPowerKw: bat_s.inverterMaxAcPowerKw ?? 0,
         inverterAcPowerMargin: bat_s.inverterAcPowerMargin ?? 0.05,
+        exportCurtailmentEnabled: bat_s.exportCurtailmentEnabled ?? false,
+        exportCurtailmentPriceFloor: bat_s.exportCurtailmentPriceFloor ?? 0,
       };
       setBatteryForm(bat);
       savedBattery.current = JSON.stringify(bat);
@@ -451,6 +454,8 @@ const SettingsPage: React.FC = () => {
           efficiencyDischarge: batteryForm.efficiencyDischarge,
           inverterMaxAcPowerKw: batteryForm.inverterMaxAcPowerKw,
           inverterAcPowerMargin: batteryForm.inverterAcPowerMargin,
+          exportCurtailmentEnabled: batteryForm.exportCurtailmentEnabled,
+          exportCurtailmentPriceFloor: batteryForm.exportCurtailmentPriceFloor,
           temperatureDerating: {
             enabled: batteryForm.temperatureDeratingEnabled,
             weatherEntity: sensors.shared?.['weather_entity'] ?? '',

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -54,6 +54,8 @@ const SetupWizardPage: React.FC = () => {
     temperatureDeratingEnabled: false,
     inverterMaxAcPowerKw: 0,
     inverterAcPowerMargin: 0.05,
+    exportCurtailmentEnabled: false,
+    exportCurtailmentPriceFloor: 0,
   });
 
   const [inverterForm, setInverterForm] = useState<InverterForm>({

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -121,6 +121,11 @@ export interface BatterySettings {
   inverterMaxAcPowerKw: number;     // kW total AC output cap
   inverterAcPowerMargin: number; // 0-1 model-side haircut on the cap
 
+  // PV export-limit curtailment (issue #269) — opt-in, requires a grid
+  // CT/smart meter and a platform with export-limit register support.
+  exportCurtailmentEnabled: boolean;
+  exportCurtailmentPriceFloor: number; // SEK/kWh — curtail below this sell price
+
   // Consumption estimate
   estimatedConsumption: number; // kWh daily estimate
   consumptionStrategy: string;  // "sensor", "fixed", or "influxdb_7d_avg"


### PR DESCRIPTION
## Summary
- Opt-in per-period curtailment: when a period is exporting solar surplus at a sell price below a configurable floor, write the Growatt export-limit register (via the CT/smart-meter path, confirmed real-world working by a live user test on the original issue) to throttle PV production at the panel instead of paying to export.
- Platform-gated via a new `supports_export_limit_control` capability flag (default `False`) — currently only `SolaxModbusGrowattController` (GEN2/GEN3/GEN4 via solax_modbus) implements it; `growatt_server` (cloud) has no equivalent HA service to hook into, so it stays a safe no-op there.
- Also fixes a related DP planning gap found while implementing this: backward induction was propagating a later period's full uncurtailed negative-price export penalty into every earlier period's decision, which could make the DP refuse a genuinely profitable earlier action to avoid a loss curtailment actually neutralizes. The DP's reward calculation now floors the sell price to 0.0 for curtailment-eligible periods, but only internally — reported `PeriodData.economic.sell_price` always stays the real market price.

## Root cause
> `core/bess/dp_battery_algorithm.py` — `_state_transition`/`_compute_reward`: solar surplus is exported unconditionally once it exceeds available charge headroom, with no action available to avoid it, even when `sell_price < 0`. No curtailment mechanism existed anywhere in the codebase. (Original issue #269 diagnosis, re-verified against current code before implementation.)

## Fix
- `core/bess/ha_api_controller.py`: two new suffix-map entries (`limit_grid_export`, `grid_export_limit`, verified against the `wills106/homeassistant-solax-modbus` `plugin_growatt.py` source — not guessed from a reporter's entity naming) on both the GEN4 and GEN3 Growatt suffix maps; new `set_growatt_export_limit(curtail: bool)` write method.
- `core/bess/inverter_controller.py` / `solax_modbus_growatt_controller.py`: capability flag + `apply_export_limit()`, following the existing `supports_charge_rate_control` precedent.
- `core/bess/battery_system_manager.py`: platform-agnostic per-period decision in `_apply_period_schedule` — `grid_exported > 0 AND sell_price < floor`, independent of `strategic_intent` (the reporter's "battery full" evidence classified as `SOLAR_STORAGE`, not `SOLAR_EXPORT`, so gating on intent label would have missed it).
- `core/bess/dp_battery_algorithm.py`: `reward_sell_price` substitution threaded into `_run_dynamic_programming` and `_best_action_at_continuous_state` only — never into `_build_period_data`, which must keep reporting the real price (both for honest display and because the execution-time trigger above reads it directly).
- `core/bess/settings.py`: two new opt-in `BatterySettings` fields (`export_curtailment_enabled`, `export_curtailment_price_floor`), threaded through the API contract, Settings UI (new toggle + field in Battery settings, hidden from the setup wizard's advanced section same as the existing AC-power-cap fields), and `frontend/src/lib/sensorDefinitions.ts`.

## Scope assessment
Structural but fully precedented — spans discovery, a new hardware write method, a new capability flag, new per-period decision logic, new settings fields, and frontend/API surface, but every individual piece matches an existing pattern already used elsewhere in this codebase (capability flags, suffix maps, settings plumbing). No new/ambiguous ownership question. Workaround check passes: nothing added routes around an ordering/timing problem.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (fast suite: 1408 passed, 15 skipped; black/ruff clean)
- [x] `.venv/bin/pytest -m slow` passes locally (391 passed, 3 skipped) — zero regressions; confirmed the DP reward substitution is a no-op for every existing pinned scenario fixture since `export_curtailment_enabled` defaults to `False`
- [x] New tests: discovery (`test_registry_discovery.py`), write method (`test_ha_api_controller.py`), capability dispatch (`test_platform_capabilities.py`), and the core decision logic + a DP-planning-awareness scenario test (`test_export_limit_curtailment.py`, 8 tests total — the DP-awareness class calls the real `optimize_battery_schedule()` entry point against a hand-built, empirically-verified 2-period scenario, not a synthetic unit test on an inner function)
- [x] Local mock-HA replay (`docker-compose.ci.yml` + a custom scenario/settings pair): forced `_apply_period_schedule` for a negative-price exporting period through the real `HomeAssistantAPIController` against a live mock-HA server and confirmed the actual HTTP service calls in `/mock/service_log` — `select.select_option → "Meter 1"` + `number.set_value → 0` on curtailment, `select.select_option → "Disabled"` only on release. Also confirmed the Settings API GET/PATCH round-trip for both new fields against the real running server.
- [x] Independent code review (2 background passes — execution-time-only version, then re-reviewed after the DP-reward change): no CONFIRMED blocking findings

Closes #269