### PR TITLE
fix: keep Savings chart bars visible in Safari at any window width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Huawei TOU writes no longer fail on installs with no working-mode select (e.g. behind an EMMA energy manager); the health check reports this explicitly. ([#412](https://github.com/johanzander/bess-manager/pull/412))
 - Editing the Huawei battery Device ID in Settings now saves to the inverter section and applies without a restart, instead of being written to the Growatt section.
+- The Savings chart's bars could flicker invisible in Safari, especially with many thin bars (e.g. quarter-hourly resolution) — Safari fails to reliably anti-alias sub-pixel-width SVG shapes. Bars now use a fixed minimum width so they stay visible regardless of window size.
 ### Fixed
 
 - The consumption forecast now refreshes intraday like solar already does, instead of caching stale data until the 23:55 job. ([#395](https://github.com/johanzander/bess-manager/issues/395))

--- a/frontend/src/components/SavingsAggregateView.tsx
+++ b/frontend/src/components/SavingsAggregateView.tsx
@@ -386,6 +386,7 @@ export const SavingsAggregateView: React.FC<SavingsAggregateViewProps> = ({ peri
                   fill={colors.text}
                   fillOpacity={0.35}
                   isAnimationActive={false}
+                  barSize={4}
                   radius={[4, 4, 0, 0]}
                 />
                 <Bar
@@ -394,6 +395,7 @@ export const SavingsAggregateView: React.FC<SavingsAggregateViewProps> = ({ peri
                   fill={colors.cost}
                   fillOpacity={0.8}
                   isAnimationActive={false}
+                  barSize={4}
                   radius={[4, 4, 0, 0]}
                 />
                 <Bar
@@ -402,6 +404,7 @@ export const SavingsAggregateView: React.FC<SavingsAggregateViewProps> = ({ peri
                   fill={colors.savings}
                   fillOpacity={0.8}
                   isAnimationActive={false}
+                  barSize={4}
                   radius={[4, 4, 0, 0]}
                 />
               </BarChart>


### PR DESCRIPTION
## Summary
- The "Hours in Today" Savings chart's bars could render at near-zero visibility in Safari, flickering in and out as the window was resized. Chrome was unaffected.
- Root cause: Safari doesn't reliably anti-alias very thin (sub-~2px) SVG shapes. Recharts auto-computes each bar's width from the container size divided by the number of categories (up to 96 for quarter-hourly resolution) and series (3), which at normal window widths puts bars right in that danger zone.
- Fix: give each `<Bar>` a fixed `barSize={4}` so bar width no longer shrinks below Safari's rendering floor, regardless of window size.

## Test plan
- [x] `npx vitest run src/components/__tests__/SavingsAggregateView.test.tsx` — 26/26 passing
- [x] `./scripts/quality-check.sh` — 0 errors
- [x] Manually confirmed in Safari (regular + private window) that bars render solidly at all window widths after the fix; Chrome unaffected