### PR TITLE
chore: small low-risk TODO cleanups (Nordpool warnings, dead code, TODO.md)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -535,13 +535,9 @@ This would make the profitability gate compare apples-to-apples with the dashboa
 
 ---
 
-### Savings history: untested error paths and swallowed fetch failures
+### ~~Savings history: untested error paths and swallowed fetch failures~~ ✅ Completed
 
-**Impact**: Low | **Effort**: Low | **Dependencies**: `backend/api.py`, `frontend/src/components/settings/SavingsHistorySection.tsx`
-
-**Description**: Two related test/UX gaps from the Daily Savings History feature. First, none of the three new `/api/savings/*` routes in `backend/api.py` has a test exercising its failure path — all three share an identical try/except-to-500 wrapper with no coverage proving it actually returns a 500 on an underlying error. Second, `SavingsHistorySection` fetches disk usage with a bare `.catch(() => {})`, so a failed request silently renders a plausible-but-wrong "0 days recorded" instead of an error state, unlike `SavingsAggregateView`, which has proper loading/error handling for the same kind of fetch. Neither is architecturally significant, but both are cheap to close and worth picking up together.
-
-**Files**: `backend/api.py`, `frontend/src/components/settings/SavingsHistorySection.tsx`
+**Resolution**: Both gaps are already closed in the current codebase — `backend/tests/test_savings_aggregate_api.py::TestUnderlyingErrorsReturn500` covers all three `/api/savings/*` routes returning 500 on an underlying store error, and `SavingsHistorySection.tsx` has proper `loading`/`error` state (no bare `.catch(() => {})`).
 
 ---
 
@@ -743,9 +739,7 @@ The `_get_hour_readings` (and thus the InfluxDB query) is called at startup (to 
 
 ## From #271 charge-power-rate fix code review (non-blocking, nice-to-have)
 
-**`InverterStatusDashboard.tsx`'s `batterySettings` state is now write-only**: after switching the "Charge Power Rate" tile to read `inverterStatus?.chargePowerRate` instead of `batterySettings?.chargingPowerRate`, nothing in the component reads `batterySettings` anymore — only `setBatterySettings` (from `fetchBatterySettings()`) is called. Left as-is deliberately to keep the fix minimal. Worth a follow-up to either remove the now-dead `fetchBatterySettings()` call/state or confirm another consumer still needs it.
-
-**File**: `frontend/src/components/InverterStatusDashboard.tsx`
+~~**`InverterStatusDashboard.tsx`'s `batterySettings` state is now write-only**~~ ✅ Completed — confirmed no other consumer needed it; removed the dead `fetchBatterySettings()` call, `batterySettings` state, and the now-unused `BatterySettings` interface.
 
 ---
 
@@ -753,9 +747,9 @@ The `_get_hour_readings` (and thus the InfluxDB query) is called at startup (to 
 
 **`BatteryActionsTable.tsx` TOTAL footer row shows Actual Cost as the wear-inclusive total with no "of which wear" sub-line**, while every per-period row above it now carries that breakdown. Consistent with "table content otherwise unchanged" but the totals row is the one place the per-column wear breakdown silently drops. Purely cosmetic.
 
-**`SavingsPage.test.tsx` doesn't assert DOM order** of `SavingsAggregateView` vs `DetailedSavingsAnalysis`, even though their reorder was the one functional change in that task. Cosmetic reorder, not a regression risk worth a merge block, but a `compareDocumentPosition` assertion would close the gap cheaply if this file is touched again.
+~~**`SavingsPage.test.tsx` doesn't assert DOM order** of `SavingsAggregateView` vs `DetailedSavingsAnalysis`~~ Moot — `DetailedSavingsAnalysis` has since been removed from `SavingsPage` entirely (a later refactor), so there's no DOM order left to assert.
 
-**`today_view` is built unconditionally for `period=day`** in `backend/api.py` even when today is already persisted (post-rollover) or `count>1`, cases where `build_buckets` ignores it. One wasted `daily_view_builder.build_daily_view()` call per request; negligible cost.
+~~**`today_view` is built unconditionally for `period=day`**~~ ✅ Completed — `get_savings_aggregate` now skips the `build_daily_view()` call when today's date is already persisted in `daily_view_store`.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -87,10 +87,6 @@
 
 
 
-### ~~**Improve InfluxDB health check error messages in UI**~~ ✅ Completed (v8.2.1)
-
-**Resolution**: HTTP 401/403/404 now show actionable messages; ConnectionError shows the URL that failed.
-
 ### 1. **Improve Battery SOC and Actions Component**
 
 **Impact**: Medium-High | **Effort**: High | **Dependencies**: Backend cost calculations
@@ -266,13 +262,6 @@ The discharge inhibit only blocks discharging — it does not change the TOU sch
 
 **Current State**: The inverter sometimes charges/discharges small amounts like 0.1kW. Or its a rounding error or inefficiencies losses when calculating flows. I don't think its a strategic intent, but it is interpreted as one.
 
-### ~~9. Add multi day view~~ ✅ Completed (v7.2.0-v7.3.0, PRs #21-#22)
-
-**Problem**: Today we only operate on 24h intervals.
-But at noon every day we get tomorrows schedule. We could use this information to take better economic decisions. It would mean changing a lot of places where 24h is hard coded.
-
-**Resolution**: The DP optimizer now considers up to 192 periods (2 days) when tomorrow's prices are available (PR #21). Dashboard charts (PR #22) and inverter schedule overview (PR #23) display the extended horizon. TOU deployment remains today-only due to Growatt hardware limitations.
-
 ### **Make ha_statistics consumption forecast work on all platforms**
 
 **Impact**: Medium | **Effort**: Medium | **Dependencies**: `battery_system_manager.py`, `ha_api_controller.py`
@@ -293,10 +282,6 @@ But at noon every day we get tomorrows schedule. We could use this information t
 
 **Files**: `core/bess/settings.py`, `backend/settings_store.py`, `docs/USER_GUIDE.md`
 
-### ~~**Suppress retry warnings for expected Nordpool "tomorrow not available" responses**~~ ✅ Completed
-
-**Resolution**: Added a `suppress_retry_warnings` param to `_api_request`/`_service_call_with_retry` (option 2), set by `official_nordpool_source.py` when fetching tomorrow's prices. Retry/final-failure logs downgrade to debug/info for that call instead of WARNING/ERROR.
-
 ## 🔵 **ROBUSTNESS IMPROVEMENTS** (System Observability)
 
 ### **Retry discovery on startup when HA WebSocket is not ready**
@@ -306,12 +291,6 @@ But at noon every day we get tomorrows schedule. We could use this information t
 **Description**: BESS Manager starts as an HA add-on and can launch before HA's WebSocket API is fully ready. When the initial `discover_integrations()` WS connection fails during early boot, `nordpool_config_entry_id` stays None and the system enters degraded mode with no price data — even though HA becomes ready seconds later. Observed on Niklas's system (b18, 2026-05-26): WS failed at 05:08 (4 min after boot), but by 05:45 discovery worked fine.
 
 **Fix**: Re-attempt discovery with short backoff (e.g. 5s, 10s, 20s) until `config_entry_id` is populated or a max number of retries is reached.
-
----
-
-### ~~**Complete or Remove EV Energy Meter Integration**~~ ✅ Completed (v8.0.0)
-
-**Resolution**: EV energy meter dead code removed entirely in v8.0.0 release.
 
 ---
 
@@ -535,12 +514,6 @@ This would make the profitability gate compare apples-to-apples with the dashboa
 
 ---
 
-### ~~Savings history: untested error paths and swallowed fetch failures~~ ✅ Completed
-
-**Resolution**: Both gaps are already closed in the current codebase — `backend/tests/test_savings_aggregate_api.py::TestUnderlyingErrorsReturn500` covers all three `/api/savings/*` routes returning 500 on an underlying store error, and `SavingsHistorySection.tsx` has proper `loading`/`error` state (no bare `.catch(() => {})`).
-
----
-
 ### Move inverter-specific logic out of BatterySystemManager
 
 **Impact**: Low | **Effort**: Medium | **Dependencies**: `InverterController` base class
@@ -599,10 +572,6 @@ This would make the profitability gate compare apples-to-apples with the dashboa
 **Benefits**: Type safety, extensibility for locale/timezone/precision without signature changes, future-proof for internationalization
 
 **Files**: `backend/api_dataclasses.py`, `backend/api.py`
-
-### ~~Hardcoded Fallback Values Violating CLAUDE.md~~ ✅ Completed (v8.2.1)
-
-**Resolution**: All `hasattr` guards and hardcoded fallback values removed from `api.py`. System now accesses `battery_settings`, `controller`, `price_manager`, `_schedule_manager`, and `has_critical_sensor_failures` directly. Added `_get_intent_description()` to `SphScheduleManager` to eliminate polymorphism-related `hasattr`.
 
 ### Upstream PR: growatt_server should register services per device type
 
@@ -737,19 +706,9 @@ Both are valid given each has its own matching frontend hook, but it's an incons
 
 The `_get_hour_readings` (and thus the InfluxDB query) is called at startup (to reconstruct history) and whenever a new hour is completed and needs to be recorded. It is not called every hour by a scheduler, but it is called for each hour that needs to be reconstructed or recorded.
 
-## From #271 charge-power-rate fix code review (non-blocking, nice-to-have)
-
-~~**`InverterStatusDashboard.tsx`'s `batterySettings` state is now write-only**~~ ✅ Completed — confirmed no other consumer needed it; removed the dead `fetchBatterySettings()` call, `batterySettings` state, and the now-unused `BatterySettings` interface.
-
----
-
 ## From #249 net-grid-cost-savings-redesign whole-branch review (non-blocking, low severity)
 
 **`BatteryActionsTable.tsx` TOTAL footer row shows Actual Cost as the wear-inclusive total with no "of which wear" sub-line**, while every per-period row above it now carries that breakdown. Consistent with "table content otherwise unchanged" but the totals row is the one place the per-column wear breakdown silently drops. Purely cosmetic.
-
-~~**`SavingsPage.test.tsx` doesn't assert DOM order** of `SavingsAggregateView` vs `DetailedSavingsAnalysis`~~ Moot — `DetailedSavingsAnalysis` has since been removed from `SavingsPage` entirely (a later refactor), so there's no DOM order left to assert.
-
-~~**`today_view` is built unconditionally for `period=day`**~~ ✅ Completed — `get_savings_aggregate` now skips the `build_daily_view()` call when today's date is already persisted in `daily_view_store`.
 
 ---
 
@@ -781,11 +740,7 @@ The `_get_hour_readings` (and thus the InfluxDB query) is called at startup (to 
 
 ## From #387 runtime power gap-fill code review (non-blocking)
 
-~~**`PowerSampleBuffer.consume()`'s `if values` guard is dead code**~~ ✅ Completed — the guard was removed and a comment added explaining why it's safe (`record()` always appends immediately, so no `values` list can ever be empty when `consume()` reaches it).
-
 **`sample_live_power()`'s per-getter `entity_id`/skip handling is implicit rather than defensive-by-design** (`core/bess/sensor_collector.py`) — correct today, just worth a second look if the getter-based rewrite (done in the #387 final-review fix wave) is touched again.
-
-~~**Stale line-number citation in a test docstring**~~ ✅ Completed — replaced the line-number citation with a reference to the enclosing function name (`collect_energy_data`), which won't rot as the file is edited.
 
 **`backend/app.py` constructs `BESSController()` and calls `start_in_background()` at module level**, which is what forces `backend/tests/test_scheduler_jobs.py` to patch two unrelated methods (`SettingsStore._write`, `HomeAssistantAPIController.get_ha_config`) just to import the module safely for testing.
 

--- a/TODO.md
+++ b/TODO.md
@@ -293,18 +293,9 @@ But at noon every day we get tomorrows schedule. We could use this information t
 
 **Files**: `core/bess/settings.py`, `backend/settings_store.py`, `docs/USER_GUIDE.md`
 
-### **Suppress retry warnings for expected Nordpool "tomorrow not available" responses**
+### ~~**Suppress retry warnings for expected Nordpool "tomorrow not available" responses**~~ ✅ Completed
 
-**Impact**: Low | **Effort**: Low | **Dependencies**: `official_nordpool_source.py`, `ha_api_controller.py`
-
-**Description**: The Nordpool integration returns HTTP 500 when tomorrow's prices aren't published yet (typically before ~13:00 CET). `_api_request` logs a WARNING on each retry attempt, producing misleading warnings every optimization cycle overnight (00:00–12:00). The retry eventually fails, but `get_combined_prices()` in `price_manager.py` handles this gracefully — it catches the exception and falls back to today-only prices with an INFO log. The warnings are harmless but noisy and can alarm users reading logs.
-
-**Options**:
-1. Have `official_nordpool_source.py` catch the 500 for tomorrow and raise a specific "not available yet" exception that `_api_request` doesn't retry
-2. Add a `suppress_retry_warnings=True` param to `_api_request` for expected-failure calls
-3. Accept the noise as-is (log-level only, no UI banners)
-
-**Files**: `core/bess/official_nordpool_source.py`, `core/bess/ha_api_controller.py`, `core/bess/price_manager.py`
+**Resolution**: Added a `suppress_retry_warnings` param to `_api_request`/`_service_call_with_retry` (option 2), set by `official_nordpool_source.py` when fetching tomorrow's prices. Retry/final-failure logs downgrade to debug/info for that call instead of WARNING/ERROR.
 
 ## 🔵 **ROBUSTNESS IMPROVEMENTS** (System Observability)
 
@@ -796,11 +787,11 @@ The `_get_hour_readings` (and thus the InfluxDB query) is called at startup (to 
 
 ## From #387 runtime power gap-fill code review (non-blocking)
 
-**`PowerSampleBuffer.consume()`'s `if values` guard is dead code** (`core/bess/power_sample_buffer.py`) — `record()` always appends immediately via `setdefault(...).append(watts)`, so no `values` list can ever be empty when `consume()` reaches it. Harmless but unnecessary defensiveness; inconsistent with the "no speculative fallbacks" convention.
+~~**`PowerSampleBuffer.consume()`'s `if values` guard is dead code**~~ ✅ Completed — the guard was removed and a comment added explaining why it's safe (`record()` always appends immediately, so no `values` list can ever be empty when `consume()` reaches it).
 
 **`sample_live_power()`'s per-getter `entity_id`/skip handling is implicit rather than defensive-by-design** (`core/bess/sensor_collector.py`) — correct today, just worth a second look if the getter-based rewrite (done in the #387 final-review fix wave) is touched again.
 
-**Stale line-number citation in a test docstring** (`core/bess/tests/unit/test_sensor_collector_gapfill.py:7`) — cites the InfluxDB gap-fill `if` block at a line range that has drifted by one line from its actual current location (`252-263`) after later edits in the same file. Cosmetic only.
+~~**Stale line-number citation in a test docstring**~~ ✅ Completed — replaced the line-number citation with a reference to the enclosing function name (`collect_energy_data`), which won't rot as the file is edited.
 
 **`backend/app.py` constructs `BESSController()` and calls `start_in_background()` at module level**, which is what forces `backend/tests/test_scheduler_jobs.py` to patch two unrelated methods (`SettingsStore._write`, `HomeAssistantAPIController.get_ha_config`) just to import the module safely for testing.
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -2498,7 +2498,12 @@ async def get_savings_aggregate(
         resolved_count = count or DEFAULT_COUNTS[period]
 
         today_view = None
-        if period == "day" and target_date == time_utils.today():
+        if (
+            period == "day"
+            and target_date == time_utils.today()
+            and target_date.isoformat()
+            not in bess_controller.system.daily_view_store.list_available_dates()
+        ):
             now = time_utils.now()
             current_period = now.hour * 4 + now.minute // 15
             today_view = bess_controller.system.daily_view_builder.build_daily_view(

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -1007,6 +1007,7 @@ class HomeAssistantAPIController:
         category=None,
         context: dict | None = None,
         optional: bool = False,
+        suppress_retry_warnings: bool = False,
         **kwargs,
     ):
         """Make an API request to Home Assistant with retry logic.
@@ -1019,6 +1020,10 @@ class HomeAssistantAPIController:
             context: Optional dict of contextual parameters for failure diagnostics
             optional: If True, a 404 is expected (e.g. probing a legacy/disabled
                 entity) and is logged at debug level instead of error
+            suppress_retry_warnings: If True, retry/failure logging is downgraded
+                to debug/info (e.g. Nordpool tomorrow-price calls before the
+                provider has published data — an expected daily condition, not
+                an error)
             **kwargs: Additional arguments for requests
 
         Returns:
@@ -1069,7 +1074,8 @@ class HomeAssistantAPIController:
 
                 if attempt < self.max_attempts - 1:  # Not the last attempt
                     delay = self.retry_base_delay * (2**attempt)
-                    logger.warning(
+                    log_fn = logger.debug if suppress_retry_warnings else logger.warning
+                    log_fn(
                         "API request to %s failed on attempt %d/%d: %s. Retrying in %d seconds...",
                         url,
                         attempt + 1,
@@ -1079,7 +1085,8 @@ class HomeAssistantAPIController:
                     )
                     time.sleep(delay)
                 else:  # Last attempt failed
-                    logger.error(
+                    log_fn = logger.info if suppress_retry_warnings else logger.error
+                    log_fn(
                         "API request to %s failed on final attempt %d/%d: %s",
                         path,
                         attempt + 1,
@@ -1134,6 +1141,7 @@ class HomeAssistantAPIController:
         service_name,
         operation: str | None = None,
         category: str | None = None,
+        suppress_retry_warnings: bool = False,
         **kwargs,
     ):
         """Call Home Assistant service with retry logic.
@@ -1144,6 +1152,7 @@ class HomeAssistantAPIController:
             operation: Optional human-readable operation description for failure tracking
             category: Optional failure-tracking category override. Defaults to a
                 domain-based heuristic when omitted.
+            suppress_retry_warnings: Forwarded to `_api_request` — see its docstring
             **kwargs: Service parameters
 
         Returns:
@@ -1213,6 +1222,7 @@ class HomeAssistantAPIController:
                 else ("inverter_control" if is_vendor_domain else "other")
             ),
             context=context,
+            suppress_retry_warnings=suppress_retry_warnings,
             json=json_data,
         )
 

--- a/core/bess/official_nordpool_source.py
+++ b/core/bess/official_nordpool_source.py
@@ -83,10 +83,14 @@ class OfficialNordpoolSource(PriceSource):
             if self.area:
                 service_data["areas"] = self.area
 
-            # Make service call
+            # Make service call. Tomorrow's prices are routinely unavailable
+            # before the market publishes them (~13:00 CET) — that failure is
+            # expected daily, not an error, so its retries/failure are logged
+            # quietly rather than as WARNING/ERROR.
             response = self.ha_controller._service_call_with_retry(
                 "nordpool",
                 "get_prices_for_date",
+                suppress_retry_warnings=(target_date == tomorrow_date),
                 **service_data,
                 return_response=True,
             )

--- a/core/bess/tests/unit/test_sensor_collector_gapfill.py
+++ b/core/bess/tests/unit/test_sensor_collector_gapfill.py
@@ -4,7 +4,8 @@ Cumulative HA counters (e.g. Growatt lifetime discharge energy) only tick in
 0.1 kWh steps. When a real discharge happens but is too small to register in
 a period's window, the counter delta reads exactly zero. The historical/
 backfill collection path corrects this via InfluxDB power-sensor data
-(`sensor_collector.py:251-262`). Runtime (live) collection gets its own,
+(the gap-filling block in `sensor_collector.py`'s `collect_energy_data`).
+Runtime (live) collection gets its own,
 InfluxDB-free correction via PowerSampleBuffer - see
 test_sensor_collector_runtime_gapfill.py (#387).
 """

--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -253,23 +253,6 @@ const formatBatteryMode = (mode: string): string => {
   }
 };
 
-interface BatterySettings {
-  totalCapacity: number;
-  reservedCapacity: number;
-  minSoc: number;
-  maxSoc: number;
-  minSoeKwh: number;
-  maxSoeKwh: number;
-  maxChargePowerKw: number;
-  maxDischargePowerKw: number;
-  cycleCostPerKwh: number;
-  chargingPowerRate: number;
-  dischargingPowerRate: number;
-  efficiencyCharge: number;
-  efficiencyDischarge: number;
-  estimatedConsumption: number;
-}
-
 interface DashboardData {
   hourlyData: Array<{
     period: number;
@@ -305,7 +288,6 @@ interface DashboardData {
 const InverterStatusDashboard: React.FC = () => {
   const [inverterStatus, setInverterStatus] = useState<InverterStatus | null>(null);
   const [inverterSchedule, setInverterSchedule] = useState<InverterSchedule | null>(null);
-  const [batterySettings, setBatterySettings] = useState<BatterySettings | null>(null);
   const [dashboardData, setDashboardData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -342,11 +324,6 @@ const InverterStatusDashboard: React.FC = () => {
     return response.data;
   };
 
-  const fetchBatterySettings = async (): Promise<BatterySettings> => {
-    const response = await api.get('/api/settings');
-    return response.data.battery;
-  };
-
   const fetchDashboardData = async (): Promise<DashboardData> => {
     const response = await api.get('/api/dashboard', {
       params: { resolution: 'hourly' }
@@ -364,7 +341,6 @@ const InverterStatusDashboard: React.FC = () => {
       const results = await Promise.allSettled([
         fetchInverterStatus(),
         fetchInverterSchedule(),
-        fetchBatterySettings(),
         fetchDashboardData()
       ]);
 
@@ -379,14 +355,9 @@ const InverterStatusDashboard: React.FC = () => {
         console.warn('Failed to fetch schedule:', results[1].reason);
       }
       if (results[2].status === 'fulfilled') {
-        setBatterySettings(results[2].value);
+        setDashboardData(results[2].value);
       } else {
-        console.warn('Failed to fetch battery settings:', results[2].reason);
-      }
-      if (results[3].status === 'fulfilled') {
-        setDashboardData(results[3].value);
-      } else {
-        console.warn('Failed to fetch dashboard data:', results[3].reason);
+        console.warn('Failed to fetch dashboard data:', results[2].reason);
       }
 
       setLastUpdate(new Date());


### PR DESCRIPTION
## Summary

A batch of small, low-risk items pulled from TODO.md — no hardware-detection or control-path changes.

- Suppress noisy Nordpool retry-warning/error logs for the expected daily "tomorrow's prices not published yet" 500, via a new `suppress_retry_warnings` flag on `_api_request`/`_service_call_with_retry`, set only for the tomorrow-date Nordpool call.
- Fix a stale line-number citation in `test_sensor_collector_gapfill.py`'s docstring by referencing the enclosing function name instead, so it can't drift again.
- `get_savings_aggregate` (`/api/savings/aggregate`) now skips the `build_daily_view()` call when today's date is already persisted, avoiding a wasted call `build_buckets` would ignore anyway.
- Removed dead `batterySettings` state/`fetchBatterySettings()` call from `InverterStatusDashboard.tsx` (write-only since the Charge Power Rate tile switched to `inverterStatus?.chargePowerRate` in #271) — confirmed no other consumer needs it.
- Updated TODO.md: struck 6 items as resolved, 3 of which turned out to already be fixed by prior work (savings-history 500-path tests + `SavingsHistorySection` error state, the dead `PowerSampleBuffer` guard, and the `SavingsPage` DOM-order note — moot since `DetailedSavingsAnalysis` was removed from that page entirely).

Deliberately left alone: Growatt MIN/SPH detection consolidation (real hardware-detection logic, no way to verify without real hardware) and the `immediate_value`/decision-intelligence entanglement (turned out to require a product decision on an orphaned endpoint, not a cleanup).

## Test plan

- [x] `.venv/bin/pytest backend/tests -q` — 384 passed
- [x] `.venv/bin/pytest core/bess -m "not slow" -q` — 1120 passed, 15 skipped
- [x] `.venv/bin/pytest core/bess/tests/unit -k "nordpool or ha_api_controller or api_request or service_call or gapfill" -q` — 111 passed
- [x] `black --check` / `ruff check` on touched Python files — clean
- [x] `npx vitest run` (frontend) — 19 files / 114 tests passed
- [x] `npx tsc --noEmit` / `eslint` on touched frontend files — 0 errors
- [x] `npm run build` (frontend) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)