### PR TITLE
chore: sunset legacy growatt.inverter_type key and prune stale TODO items

### DIFF
--- a/.claude/skills/add-inverter-platform/SKILL.md
+++ b/.claude/skills/add-inverter-platform/SKILL.md
@@ -114,8 +114,6 @@ control path; **no silent fallbacks** (`docs/agents/rules.md`).
      `self.inverter_platform == "<platform_id>"` branch returning the new
      controller.
    - `VALID_PLATFORMS` ClassVar (line 187) — add `"<platform_id>"`.
-   - `_INVERTER_TYPE_TO_PLATFORM` (line 195) — add `"<platform_id>": "<platform_id>"`
-     plus any legacy alias.
 3. **`backend/settings_store.py`** → `VALID_PLATFORMS` — **defined twice
    (lines 35 and 58); update BOTH occurrences.** (Known wart — the tuple is
    duplicated.) Add new keys to `SHARED_SENSOR_KEYS` only if they are platform-
@@ -242,7 +240,7 @@ tester confirms (per `docs/agents/memory/` maturity conventions).
 | Model: charge/discharge period lists | `core/bess/growatt_sph_controller.py` (`GrowattSphController`) |
 | Model: local-Modbus TOU slots | `core/bess/solax_modbus_growatt_controller.py` (`SolaxModbusGrowattController`) |
 | Model: ephemeral VPP commands | `core/bess/solax_controller.py` (`SolaxController`) |
-| Controller factory + platform maps | `core/bess/battery_system_manager.py` (`_create_inverter_controller`, `VALID_PLATFORMS`, `_INVERTER_TYPE_TO_PLATFORM`, `switch_inverter_platform`) |
+| Controller factory + platform maps | `core/bess/battery_system_manager.py` (`_create_inverter_controller`, `VALID_PLATFORMS`, `switch_inverter_platform`) |
 | Settings platform list (×2) | `backend/settings_store.py` (`VALID_PLATFORMS` at L35 and L58, `SHARED_SENSOR_KEYS`) |
 | Detection + sensor suffix maps | `core/bess/ha_api_controller.py` (`*_SUFFIX_MAP`, `_*_MARKER_SUFFIX`, `_INVERTER_PLATFORMS`, `detect_inverter_integrations`) |
 | Debug export | `core/bess/debug_data_exporter.py` |

--- a/TODO.md
+++ b/TODO.md
@@ -514,21 +514,6 @@ This would make the profitability gate compare apples-to-apples with the dashboa
 
 ---
 
-### Move inverter-specific logic out of BatterySystemManager
-
-**Impact**: Low | **Effort**: Medium | **Dependencies**: `InverterController` base class
-
-**Description**: `BatterySystemManager` contains platform-specific checks like `if self.inverter_platform == "solax": return` in `adjust_charging_power()`. This logic belongs in the inverter controller layer — each controller should implement (or no-op) methods via the `InverterController` interface, so `BatterySystemManager` never branches on platform strings.
-
-**Examples**:
-
-- `adjust_charging_power()` — no-op for SolaX, active for Growatt
-- `grid_charge_enabled()` in `ha_api_controller.py` — not applicable to SolaX, logs a spurious WARNING
-
-**Files**: `core/bess/battery_system_manager.py`, `core/bess/inverter_controller.py`, `core/bess/solax_controller.py`, `core/bess/ha_api_controller.py`
-
----
-
 ### Reconsider whether the all-IDLE numerical safety net is still needed
 
 **Impact**: Low | **Effort**: Low-Medium | **Dependencies**: `dp_battery_algorithm.py`, `docs/superpowers/specs/2026-07-06-dp-bellman-guardrail-removal-design.md`
@@ -615,46 +600,6 @@ Both are called sequentially from `run_setup_discovery()` in `api.py`. They serv
 
 **Files**: `core/bess/ha_api_controller.py` (`_parse_ha_metadata`, `discover_sensors_from_registry`), `backend/api.py` (`run_setup_discovery`)
 
-### Remove device_id discovery fallbacks and dead `device_sn` code
-
-**Impact**: Low | **Effort**: Low | **Dependencies**: `ha_api_controller.py`, `api.py`, `sensorDefinitions.ts`
-
-**Description**: Device ID discovery has two strategies: config_entry match (primary, always works) and identifiers/SN match (fallback). The fallback depends on `_extract_growatt_device_sn()`, which fragily parses SOC entity IDs to extract the serial number. Real HA devices always have `config_entries` on the device object, so the fallback is unnecessary.
-
-Additionally, `device_sn` is extracted, returned in the API response as `deviceSn`, and declared in the frontend `DiscoveryResult` type — but nothing in the frontend or backend ever reads it. It's dead code end to end.
-
-**What to remove**:
-- `_extract_growatt_device_sn()` method
-- Identifiers-based device_id fallback (strategy 2 in `_parse_ha_metadata`)
-- `device_sn` from discovery result dict and API response
-- `deviceSn` from frontend `DiscoveryResult` type
-
-**Files**: `core/bess/ha_api_controller.py`, `backend/api.py`, `frontend/src/components/settings/SensorConfigSection.tsx`
-
----
-
-### Sunset the legacy `growatt.inverter_type` config key
-
-**Impact**: Low | **Effort**: Low | **Dependencies**: `settings_store.py`, `battery_system_manager.py`, `api.py`
-
-**Description**: `inverter.platform` has been the source of truth since the multi-platform work, and `_migrate_schema()` rewrites `growatt.inverter_type` → `inverter.platform` on every load. The legacy key nonetheless survives in three live code paths, each of which has to keep re-deriving what the migration already settled:
-
-- `SettingsStore._bootstrap_defaults()` still seeds `growatt: {"inverter_type": ""}` into fresh installs, so new users get a key that exists only for backwards compatibility with themselves.
-- `BatterySystemManager._resolve_initial_platform()` falls back to it at startup, via a second platform map (`_INVERTER_TYPE_TO_PLATFORM`) that duplicates `UI_TYPE_TO_PLATFORM` in `api_conversion.py`.
-- `PATCH /api/settings` accepts `growatt.inverterType` and switches the live platform from it. That path is not reachable from the current frontend, and it was the source of a real bug in #451: it switched the controller without persisting `inverter.platform`, so anything resolving from the store (the vendor service domain) kept addressing the previous platform's integration until a restart.
-
-That third case is the argument for removing it rather than maintaining it — a legacy path no UI exercises is one nothing regression-tests either, so it silently drifts out of step with whatever the current path learns to do.
-
-**What to remove**:
-- `inverter_type` from `_bootstrap_defaults()`'s `growatt` section
-- The `growatt.inverter_type` fallback in `_resolve_initial_platform()`, and `_INVERTER_TYPE_TO_PLATFORM` with it
-- The `inverterType` branch in `patch_settings`'s `growatt` handler
-- Keep `_migrate_schema()`'s rewrite — it is what makes removal safe for installs predating `inverter.platform`, and it should outlive the rest by at least one release
-
-**Files**: `core/bess/settings_store.py` (`_bootstrap_defaults`, `_migrate_schema`), `core/bess/battery_system_manager.py` (`_resolve_initial_platform`), `backend/api.py` (`patch_settings`), `core/bess/tests/unit/test_fresh_install_startup.py`, `core/bess/tests/unit/test_bsm_settings_and_lifecycle.py`
-
----
-
 ### Other Technical Debt
 
 - Refactor all API endpoints to use dataclass-based serialization (with robust mapping for all field variants) for consistent, type-safe, and future-proof API responses. Ensure all details and fields are preserved as in the original dict-based implementation.
@@ -663,7 +608,6 @@ That third case is the argument for removing it rather than maintaining it — a
 **From #221 (spot_multiplier/export_spot_multiplier) code review — deferred cleanup, not bugs**:
 
 - `backend/api.py`'s `_pricing_defaults_for_discovery()` duplicates the provider-priority chain (`octopus > entsoe > nordpool_official > nordpool_hacs`, gated on `not nordpool_found`) already computed independently in `frontend/src/pages/SetupWizardPage.tsx`'s `autoProvider` logic. The two can drift out of sync if the priority order changes in only one place. Consider deriving both from a single shared source (e.g. have the backend return the resolved provider and have the frontend just consume it, instead of recomputing it).
-- `backend/api_conversion.py`'s `PRICE_STORE_TO_API` (startup/read path) and `backend/api.py`'s `_PRICE_MAP` in `setup_complete()` (wizard-write path) are two independently-maintained camelCase↔snake_case tables for the same `PriceSettings` fields. The new `TestPriceModelAttrsConsistency` contract test (added in #221) only guards `PRICE_STORE_TO_API` — `_PRICE_MAP` can still silently drift for a future field with no test to catch it. Consider consolidating to one table, or extending the contract test to also cover `_PRICE_MAP`.
 - `backend/settings_store.py`'s `_migrate_schema()` electricity_price migration block hardcodes `spot_multiplier`/`export_spot_multiplier`/`use_actual_price` by name instead of iterating `PRICE_STORE_TO_API` + `PriceSettings` defaults generically. Every future `PriceSettings` field will need a new hand-written migration block, and it's easy to forget (silent `ValueError` in `build_system_settings()` at startup for existing users' configs). Consider making the migration generic against `PRICE_STORE_TO_API`.
 
 **TOU Segment Matching is Fragile**:
@@ -672,20 +616,11 @@ The current TOU comparison uses exact matching on start_time, end_time, batt_mod
 - Overlap-based matching: If segments overlap significantly and have same mode, treat as "same"
 - Smart merging: Detect when segments can be extended/shortened rather than replaced
 
-**Remove Hourly Aggregation Legacy**:
-With 15-min TOU resolution implemented, the hourly aggregation code is now legacy. Power rates are already set per-period in `_apply_period_settings()`. The following should be refactored or removed:
+**Remove Hourly Aggregation Legacy** (mostly done — residual only):
+The controller-side hourly aggregation is gone: `_calculate_hourly_settings_with_strategic_intents()`, `get_hourly_settings()`, `_get_hourly_intent()` and the `hourly_settings` dict no longer exist, and `adjust_charging_power()` reads `get_period_settings(current_period)` directly. What remains is display-side:
 
-- `_calculate_hourly_settings_with_strategic_intents()` - aggregates 15-min periods back to hourly
-- `get_hourly_settings()` - returns hourly settings (used by power monitor and display)
-- `_get_hourly_intent()` - majority voting for hourly intent (no longer needed for TOU)
-- `hourly_settings` dict - stores the aggregated hourly data
-
-To remove:
-
-1. Update `adjust_charging_power()` in `battery_system_manager.py` to use period-based settings
-2. Update schedule display table to show 15-min periods (or keep hourly summary for readability)
-3. Update `get_strategic_intent_summary()` to work directly with periods
-4. Remove the hourly aggregation methods listed above
+- `backend/api.py`'s `_get_hourly_settings_from_periods()` — a compatibility shim that majority-votes the 4 quarterly intents of an hour for API endpoints that still return hourly rows. Removable once the schedule display table renders 15-min periods.
+- `get_strategic_intent_summary()` (`core/bess/inverter_controller.py`) still summarises per hour rather than per period.
 
 **Re-run optimization on energy prediction method change**:
 When the user changes the consumption strategy (e.g. from `sensor` to `fixed`), the optimization should re-run immediately with the new prediction method rather than waiting for the next scheduled cycle. The prediction cache should be cleared and a fresh optimization triggered in the same request that saves the new strategy.

--- a/backend/api.py
+++ b/backend/api.py
@@ -307,29 +307,12 @@ async def patch_settings(updates: dict):
                 bess_controller.system.update_settings({"energy_provider": section})
 
             elif store_key == "growatt":
+                # Platform switching lives in the "inverter" branch below;
+                # this section only carries the Growatt cloud device_id.
                 if "device_id" in section:
                     bess_controller.ha_controller.growatt_device_id = section[
                         "device_id"
                     ]
-                # Map legacy inverter_type to platform and switch controller
-                inverter_type = section.get("inverter_type")
-                if inverter_type:
-                    platform_map = bess_controller.system._INVERTER_TYPE_TO_PLATFORM
-                    if inverter_type not in platform_map:
-                        raise HTTPException(
-                            status_code=400,
-                            detail=f"Unknown inverter_type '{inverter_type}', "
-                            f"expected one of {list(platform_map)}",
-                        )
-                    new_platform = platform_map[inverter_type]
-                    bess_controller.system.switch_inverter_platform(new_platform)
-                    # Persist it as well: the vendor service domain resolves
-                    # from inverter.platform, so switching the live controller
-                    # without writing the store leaves service calls addressing
-                    # the previous platform's integration until a restart.
-                    inv = bess_controller.settings_store.get_section("inverter")
-                    inv["platform"] = new_platform
-                    bess_controller.settings_store.save_section("inverter", inv)
 
             elif store_key == "inverter":
                 # device_id here is the Huawei battery device (the Growatt

--- a/backend/api_conversion.py
+++ b/backend/api_conversion.py
@@ -105,9 +105,6 @@ LEGACY_INVERTER_PLATFORM_MAP: dict[str, str] = {
     "SPH": "growatt_server_sph",
 }
 
-# Keep old name as alias for backward compat with PATCH /api/settings handler
-UI_TYPE_TO_PLATFORM = LEGACY_INVERTER_PLATFORM_MAP
-
 
 def build_system_settings(options: dict) -> dict:
     """Validate settings options and return the snake_case dict for update_settings().

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -344,23 +344,14 @@ class TestPatchSettingsServiceDomainValidation:
 
 
 class TestPatchSettingsLegacyInverterType:
-    """The legacy growatt.inverter_type path switches the live platform. It
-    must also persist inverter.platform, since that is what the service
-    domain resolves from — otherwise vendor calls address the old platform's
-    integration (or fail outright) until a restart runs the migration."""
+    """The legacy growatt.inverterType path was removed — platform changes go
+    through the "inverter" section only. A stray legacy key must not switch
+    the live platform behind the store's back."""
 
-    def test_platform_persisted_alongside_live_switch(self, mock_controller):
-        # The endpoint validates inverter_type against the real map; the
-        # MagicMock's __contains__ would otherwise reject everything.
-        mock_controller.system._INVERTER_TYPE_TO_PLATFORM = {
-            "MIN": "growatt_server_min",
-            "SPH": "growatt_server_sph",
-        }
-        _client.patch("/api/settings", json={"growatt": {"inverterType": "SPH"}})
-        assert (
-            mock_controller.settings_store.data["inverter"]["platform"]
-            == "growatt_server_sph"
-        )
+    def test_legacy_inverter_type_does_not_switch_platform(self, mock_controller):
+        resp = _client.patch("/api/settings", json={"growatt": {"inverterType": "SPH"}})
+        assert resp.status_code == 200
+        mock_controller.system.switch_inverter_platform.assert_not_called()
 
 
 class TestPatchSettingsCamelToSnake:

--- a/backend/tests/test_settings_store.py
+++ b/backend/tests/test_settings_store.py
@@ -100,6 +100,80 @@ class TestFirstBootMigration:
         assert store.get_section("battery")["total_capacity"] == 10.0
 
 
+class TestLegacyInverterTypeMigration:
+    """`growatt.inverter_type` -> `inverter.platform`.
+
+    This migration is the *only* remaining backward-compat path for installs
+    predating `inverter.platform`: the redundant fallback in
+    `BatterySystemManager._resolve_initial_platform()` was removed, so if this
+    rewrite ever breaks, those installs silently boot into unconfigured mode
+    with no price data. Pin it explicitly.
+    """
+
+    def _load(self, tmp_path, monkeypatch, existing: dict) -> SettingsStore:
+        path = _patch_path(tmp_path, monkeypatch)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(existing, f)
+        store = SettingsStore()
+        store.load({})
+        return store
+
+    @pytest.mark.parametrize(
+        ("legacy_type", "expected_platform"),
+        [("MIN", "growatt_server_min"), ("SPH", "growatt_server_sph")],
+    )
+    def test_legacy_type_rewritten_to_platform(
+        self, tmp_path, monkeypatch, legacy_type, expected_platform
+    ):
+        store = self._load(
+            tmp_path, monkeypatch, {"growatt": {"inverter_type": legacy_type}}
+        )
+        assert store.get_section("inverter")["platform"] == expected_platform
+
+    def test_growatt_device_id_carried_over(self, tmp_path, monkeypatch):
+        """The device_id moves with the platform — an SPH install that only
+        ever wrote growatt.device_id must not lose it."""
+        store = self._load(
+            tmp_path,
+            monkeypatch,
+            {"growatt": {"inverter_type": "SPH", "device_id": "dev-42"}},
+        )
+        assert store.get_section("inverter")["device_id"] == "dev-42"
+
+    def test_existing_platform_wins_over_legacy_type(self, tmp_path, monkeypatch):
+        """A config carrying both keys keeps inverter.platform — it is the
+        source of truth, and a stale inverter_type must not override it."""
+        store = self._load(
+            tmp_path,
+            monkeypatch,
+            {
+                "growatt": {"inverter_type": "MIN"},
+                "inverter": {"platform": "solax_modbus_native"},
+            },
+        )
+        assert store.get_section("inverter")["platform"] == "solax_modbus_native"
+
+    def test_unknown_legacy_type_leaves_platform_unset(self, tmp_path, monkeypatch):
+        """An unrecognised value must not invent a platform."""
+        store = self._load(
+            tmp_path, monkeypatch, {"growatt": {"inverter_type": "BOGUS"}}
+        )
+        assert not store.get_section("inverter").get("platform")
+
+    def test_migrated_config_resolves_to_configured_platform(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end: the migrated store feeds BatterySystemManager's startup
+        resolution, which no longer reads growatt.inverter_type itself."""
+        from core.bess.battery_system_manager import BatterySystemManager
+
+        store = self._load(tmp_path, monkeypatch, {"growatt": {"inverter_type": "SPH"}})
+        assert (
+            BatterySystemManager._resolve_initial_platform(store.data)
+            == "growatt_server_sph"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Section read / write
 # ---------------------------------------------------------------------------

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -252,41 +252,21 @@ class BatterySystemManager:
         "huawei_solar_luna2000",
     }
 
-    _INVERTER_TYPE_TO_PLATFORM: ClassVar[dict[str, str]] = {
-        "growatt_server_min": "growatt_server_min",
-        "solax_modbus_growatt_min": "solax_modbus_growatt_min",
-        "solax_modbus_growatt_sph": "solax_modbus_growatt_sph",
-        "growatt_server_sph": "growatt_server_sph",
-        "solax_modbus_native": "solax_modbus_native",
-        "solis_modbus": "solis_modbus",
-        "huawei_solar_luna2000": "huawei_solar_luna2000",
-        # Legacy values stored in growatt.inverter_type
-        "MIN": "growatt_server_min",
-        "SPH": "growatt_server_sph",
-    }
-
     @staticmethod
     def _resolve_initial_platform(options: dict) -> str | None:
         """Determine inverter platform from startup config.
 
-        Checks ``inverter.platform`` first, then falls back to the legacy
-        ``growatt.inverter_type`` key.  Returns None on a fresh install.
+        ``inverter.platform`` is the source of truth; installs predating it are
+        rewritten by ``SettingsStore._migrate_schema()`` before this runs.
+        Returns None on a fresh install.
         """
         platform = options.get("inverter", {}).get("platform")
         if not platform:
-            inverter_type = options.get("growatt", {}).get("inverter_type", "")
-            if not inverter_type:
-                logger.info(
-                    "No inverter platform configured — "
-                    "system will start in unconfigured mode"
-                )
-                return None
-            assert inverter_type in BatterySystemManager._INVERTER_TYPE_TO_PLATFORM, (
-                f"Unknown inverter_type '{inverter_type}', "
-                f"expected one of "
-                f"{list(BatterySystemManager._INVERTER_TYPE_TO_PLATFORM)}"
+            logger.info(
+                "No inverter platform configured — "
+                "system will start in unconfigured mode"
             )
-            platform = BatterySystemManager._INVERTER_TYPE_TO_PLATFORM[inverter_type]
+            return None
 
         assert platform in BatterySystemManager.VALID_PLATFORMS, (
             f"Unknown inverter platform '{platform}', "

--- a/core/bess/settings_store.py
+++ b/core/bess/settings_store.py
@@ -462,7 +462,7 @@ class SettingsStore:
                 "octopus": {},
                 "entsoe": {"entity": ""},
             },
-            "growatt": {"inverter_type": "", "device_id": ""},
+            "growatt": {"device_id": ""},
             "inverter": {
                 "platform": "",
                 "device_id": "",
@@ -628,16 +628,16 @@ class SettingsStore:
 
         growatt = self.data.get("growatt")
         if isinstance(growatt, dict):
-            from api_conversion import UI_TYPE_TO_PLATFORM
+            from api_conversion import LEGACY_INVERTER_PLATFORM_MAP
 
             old_type = growatt.get("inverter_type", "")
             inverter = dict(self.data.get("inverter", {}))
             if (
                 old_type
                 and not inverter.get("platform")
-                and old_type in UI_TYPE_TO_PLATFORM
+                and old_type in LEGACY_INVERTER_PLATFORM_MAP
             ):
-                platform = UI_TYPE_TO_PLATFORM[old_type]
+                platform = LEGACY_INVERTER_PLATFORM_MAP[old_type]
                 inverter["platform"] = platform
                 if not inverter.get("device_id") and growatt.get("device_id"):
                     inverter["device_id"] = growatt["device_id"]

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -172,27 +172,17 @@ class TestResolveInitialPlatform:
         )
         assert result == "growatt_server_sph"
 
-    def test_legacy_growatt_min(self):
-        result = BatterySystemManager._resolve_initial_platform(
-            {"growatt": {"inverter_type": "MIN"}}
-        )
-        assert result == "growatt_server_min"
-
-    def test_legacy_growatt_sph(self):
-        result = BatterySystemManager._resolve_initial_platform(
-            {"growatt": {"inverter_type": "SPH"}}
-        )
-        assert result == "growatt_server_sph"
-
     def test_fresh_install_returns_none(self):
         result = BatterySystemManager._resolve_initial_platform({})
         assert result is None
 
-    def test_unknown_legacy_type_asserts(self):
-        with pytest.raises(AssertionError):
-            BatterySystemManager._resolve_initial_platform(
-                {"growatt": {"inverter_type": "UNKNOWN"}}
-            )
+    def test_legacy_growatt_key_is_ignored(self):
+        """growatt.inverter_type is no longer read here — SettingsStore's
+        migration rewrites it to inverter.platform before startup."""
+        result = BatterySystemManager._resolve_initial_platform(
+            {"growatt": {"inverter_type": "MIN"}}
+        )
+        assert result is None
 
     def test_unknown_platform_asserts(self):
         with pytest.raises(AssertionError):

--- a/core/bess/tests/unit/test_fresh_install_startup.py
+++ b/core/bess/tests/unit/test_fresh_install_startup.py
@@ -80,11 +80,12 @@ class TestFreshInstallStartup:
         assert system.inverter_platform == "growatt_server_min"
         assert system._inverter_controller is not None
 
-    def test_legacy_inverter_type_creates_configured_system(self):
-        """Legacy growatt.inverter_type still works for existing users."""
+    def test_legacy_inverter_type_alone_stays_unconfigured(self):
+        """growatt.inverter_type is no longer a startup fallback. Existing
+        users reach a configured system because SettingsStore._migrate_schema()
+        rewrites the key to inverter.platform before this code runs."""
         system = self._make_system(addon_options={"growatt": {"inverter_type": "SPH"}})
-        assert system.is_configured
-        assert system.inverter_platform == "growatt_server_sph"
+        assert not system.is_configured
 
     # --- Transition from unconfigured to configured ---
 
@@ -100,11 +101,6 @@ class TestFreshInstallStartup:
         assert system._inverter_controller is not None
 
     # --- Invalid config still fails explicitly ---
-
-    def test_invalid_inverter_type_raises(self):
-        """A non-empty but invalid inverter_type must still raise."""
-        with pytest.raises(AssertionError, match="Unknown inverter_type"):
-            self._make_system(addon_options={"growatt": {"inverter_type": "BOGUS"}})
 
     def test_invalid_platform_raises(self):
         """A non-empty but invalid platform must still raise."""


### PR DESCRIPTION
## Summary

Technical-debt pass driven off `TODO.md`. Two code items plus an audit of the "Other Technical Debt" section.

### 1. Sunset the legacy `growatt.inverter_type` config key

`inverter.platform` has been the source of truth since the multi-platform work, and `SettingsStore._migrate_schema()` already rewrites `growatt.inverter_type` → `inverter.platform` on every load. Three live paths kept re-deriving what the migration had settled:

- `SettingsStore._bootstrap_defaults()` seeded `inverter_type: ""` into fresh installs — a key that existed only for backwards compatibility with itself.
- `BatterySystemManager._resolve_initial_platform()` fell back to it via `_INVERTER_TYPE_TO_PLATFORM`, a second platform map duplicating `api_conversion.py`'s.
- `PATCH /api/settings` switched the live platform from `growatt.inverterType`. That path is unreachable from the current frontend and was the source of the #451 bug (switched the controller without persisting `inverter.platform`, so the vendor service domain kept addressing the previous platform's integration until restart).

All three removed. **`_migrate_schema()`'s rewrite is kept** — it is what makes removal safe for installs predating `inverter.platform`, and should outlive the rest by at least one release. The `UI_TYPE_TO_PLATFORM` alias is dropped in favour of the canonical `LEGACY_INVERTER_PLATFORM_MAP`, now used only by that migration.

Legacy-path tests were rewritten as "legacy key is ignored" tests rather than deleted, so the new contract is pinned.

The `e2e/ci-*.json` fixtures keep their `inverter_type` key: all three already carry `inverter.platform`, so it is inert there and keeps representing a pre-migration install.

### 2. Move inverter-specific logic out of BatterySystemManager — already done

No code change. Both examples the TODO named are resolved: `adjust_charging_power()` gates on `InverterController.supports_charge_rate_control` rather than a platform string, and `grid_charge_enabled()` cannot fire spuriously for SolaX because `HomePowerMonitor` is only constructed when that same flag is true. The platform strings left in `BatterySystemManager` are the `_create_inverter_controller` factory and control-mode validation, both correct there. Item removed from `TODO.md`.

### 3. `TODO.md` audit

Verified each "Other Technical Debt" bullet against source. Removed as already done:

- **`device_sn` / device_id discovery fallback cleanup** — zero references remain anywhere.
- **`PRICE_STORE_TO_API` vs `_PRICE_MAP` drift** — `PRICE_STORE_TO_API` no longer exists; it was replaced by `PRICE_REQUIRED_FIELDS`, a presence-validation set rather than a second camel/snake mapping table, so the drift concern no longer applies.

Rewritten to reflect reality:

- **Remove hourly aggregation legacy** — all four named core symbols are gone and `adjust_charging_power()` is period-based. Narrowed to the display-side residual: `backend/api.py`'s `_get_hourly_settings_from_periods()` shim and `get_strategic_intent_summary()`.

Confirmed still live and left in place: the `_pricing_defaults_for_discovery`/`autoProvider` duplication, the hardcoded `spot_multiplier` migration block, TOU segment exact-matching fragility, and re-running optimization on consumption-strategy change.

## Testing

Full suite green locally: **1894 passed, 18 skipped**. `black` and `ruff check` clean.

## Notes

No CHANGELOG entry — internal refactor with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)