### PR TITLE
fix: hold battery instead of self-use draining SOC during Growatt VPP IDLE periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Huawei TOU writes no longer fail on installs with no working-mode select (e.g. behind an EMMA energy manager); the health check reports this explicitly. ([#412](https://github.com/johanzander/bess-manager/pull/412))
 - Editing the Huawei battery Device ID in Settings now saves to the inverter section and applies without a restart, instead of being written to the Growatt section.
 - The Savings chart's bars could flicker invisible in Safari, especially with many thin bars (e.g. quarter-hourly resolution) — Safari fails to reliably anti-alias sub-pixel-width SVG shapes. Bars now use a fixed minimum width so they stay visible regardless of window size.
+- Growatt VPP-mode IDLE periods no longer drain the battery for house self-consumption overnight — IDLE now holds the battery via `battery_first` instead of falling back to native self-use. ([#466](https://github.com/johanzander/bess-manager/issues/466))
 ### Fixed
 
 - The consumption forecast now refreshes intraday like solar already does, instead of caching stale data until the 23:55 job. ([#395](https://github.com/johanzander/bess-manager/issues/395))

--- a/core/bess/solax_modbus_growatt_controller.py
+++ b/core/bess/solax_modbus_growatt_controller.py
@@ -35,8 +35,16 @@ still forces a rate for it, this controller now releases VPP control instead.
   load-following self-use instead of forcing a fixed discharge rate, which
   causes unnecessary grid imports/exports whenever the schedule's load
   prediction misses)
-- SOLAR_STORAGE/IDLE (rate=0, block_passive_charging=False) -> remote_control
+- SOLAR_STORAGE (rate=0, block_passive_charging=False) -> remote_control
   disabled (load_first self-use -- battery may absorb solar surplus)
+- IDLE (rate=0) -> power=+1%, remote_control ENABLED (battery-first hold,
+  per the Growatt VPP protocol V2.01 section 3.5 -- #466: load_first
+  self-use discharges the battery to cover house load, but the DP's own
+  cost model never credits battery discharge during IDLE
+  (_idle_battery_flows in dp_battery_algorithm.py); battery-first keeps
+  self-consumption on grid/solar instead. grid_first (power<=0) does not
+  achieve this -- per #118, self-consumption is still drawn from the
+  battery in grid_first, only battery-first releases it to grid/solar)
 - SOLAR_EXPORT (rate=0, block_passive_charging=True) -> power=0,
   remote_control ENABLED (grid_first hold, per the Growatt VPP protocol
   V2.01 section 3.5 -- battery held flat, solar bypasses to grid)
@@ -231,14 +239,16 @@ class SolaxModbusGrowattController(GrowattMinController):
                 register instead. VPP mode acts on it directly (#355): it
                 has no charge_rate register, so this is its only channel for
                 distinguishing SOLAR_EXPORT (hold, block charging) from
-                SOLAR_STORAGE/IDLE (self-use, allow charging) at
-                discharge_rate=0.
+                SOLAR_STORAGE (self-use, allow charging) at discharge_rate=0.
+                IDLE is intercepted earlier via strategic_intent (#466) and
+                does not reach this flag.
             strategic_intent: The period's strategic intent string. TOU mode
                 ignores this (it derives mode from strategic_intents itself).
-                VPP mode acts on it directly (#413): grid_charge/
-                discharge_rate alone can't distinguish LOAD_SUPPORT from
-                BATTERY_EXPORT, but VPP mode must -- LOAD_SUPPORT releases
-                control instead of forcing a fixed rate.
+                VPP mode acts on it directly: distinguishes LOAD_SUPPORT
+                (#413) and IDLE (#466) from other rate=0 intents --
+                grid_charge/discharge_rate/block_passive_charging alone
+                can't tell them apart, but VPP mode must, since each needs a
+                different remote_control/power command.
 
         Returns:
             Tuple of (success, error_message). error_message is empty on success.
@@ -342,8 +352,19 @@ class SolaxModbusGrowattController(GrowattMinController):
           docs/superpowers/specs/2026-07-20-vpp-passive-charge-block-design.md.
           Not yet real-hardware-validated; ships experimental pending
           confirmation.
+        - grid_charge=False, rate=0, intent=IDLE   -> +1%, remote control
+          ENABLED (#466 -- "battery first" per the protocol's >0 branch).
+          IDLE's own DP cost model never credits battery discharge for load
+          (_idle_battery_flows), so self-consumption must come from
+          grid/solar, not the battery. grid_first (this function's block=True
+          branch) does NOT achieve that -- per #118, self-consumption is
+          still drawn from the battery under grid_first; only battery_first
+          releases it to grid/solar. Checked before the generic rate=0
+          branch below so IDLE doesn't fall into SOLAR_STORAGE's self-use
+          disable. Not yet real-hardware-validated; ships experimental
+          pending confirmation.
         - grid_charge=False, rate=0, block=False  -> 0%, remote control DISABLED
-          (load_first self-use -- SOLAR_STORAGE/IDLE, battery may absorb solar)
+          (load_first self-use -- SOLAR_STORAGE, battery may absorb solar)
         - grid_charge=False, rate>0 (otherwise, i.e. BATTERY_EXPORT)
           -> -rate% (discharge/export)
         """
@@ -352,6 +373,8 @@ class SolaxModbusGrowattController(GrowattMinController):
         if strategic_intent == "LOAD_SUPPORT":
             return 0, False
         if discharge_rate == 0:
+            if strategic_intent == "IDLE":
+                return 1, True
             return 0, block_passive_charging
         return -discharge_rate, True
 

--- a/core/bess/tests/unit/test_solax_modbus_growatt_vpp.py
+++ b/core/bess/tests/unit/test_solax_modbus_growatt_vpp.py
@@ -101,13 +101,33 @@ class TestIntentToVpp:
         assert power_pct == 100
         assert enabled is True
 
-    def test_idle_disables_remote_control(self, controller):
-        """SOLAR_STORAGE/IDLE (block_passive_charging=False) -> self-use."""
+    def test_solar_storage_disables_remote_control(self, controller):
+        """SOLAR_STORAGE (block_passive_charging=False) -> self-use, battery
+        may absorb solar surplus."""
         power_pct, enabled = controller._intent_to_vpp(
-            grid_charge=False, discharge_rate=0, block_passive_charging=False
+            grid_charge=False,
+            discharge_rate=0,
+            block_passive_charging=False,
+            strategic_intent="SOLAR_STORAGE",
         )
         assert power_pct == 0
         assert enabled is False
+
+    def test_idle_enables_battery_first_hold(self, controller):
+        """#466: IDLE must not fall back to native load_first self-use --
+        load_first discharges the battery to cover house load, but the DP's
+        own cost model (_idle_battery_flows) never credits battery discharge
+        during IDLE. remote_control=Enabled, vpp_power=+1 (battery first)
+        keeps self-consumption on grid/solar instead of draining the
+        battery, per the Growatt VPP protocol V2.01 section 3.5."""
+        power_pct, enabled = controller._intent_to_vpp(
+            grid_charge=False,
+            discharge_rate=0,
+            block_passive_charging=False,
+            strategic_intent="IDLE",
+        )
+        assert power_pct == 1
+        assert enabled is True
 
     def test_solar_export_keeps_remote_control_enabled(self, controller):
         """SOLAR_EXPORT (block_passive_charging=True) -> grid-first hold,
@@ -238,10 +258,12 @@ class TestApplyPeriodVpp:
         assert period["remote_control_enabled"] is False
         assert period["power_pct"] == 0
 
-    def test_idle_disables_remote_control_on_hardware(self, controller, mock_ha):
+    def test_idle_enables_battery_first_hold_on_hardware(self, controller, mock_ha):
+        """#466: IDLE must write remote_control=Enabled, power=+1 (battery
+        first) instead of falling back to native load_first self-use."""
         intents = hourly_to_quarterly({0: "IDLE"})
         controller.apply_intents(make_schedule(intents), current_period=0)
-        controller._last_written_vpp_remote_control = True  # force a change
+        controller._last_written_vpp_remote_control = False  # force a change
 
         _apply_at_period(
             controller,
@@ -250,10 +272,12 @@ class TestApplyPeriodVpp:
             grid_charge=False,
             discharge_rate=0,
             block_passive_charging=False,
+            strategic_intent="IDLE",
         )
 
         period = mock_ha.calls["growatt_vpp_periods"][-1]
-        assert period["remote_control_enabled"] is False
+        assert period["remote_control_enabled"] is True
+        assert period["power_pct"] == 1
 
     def test_solar_export_keeps_remote_control_enabled_on_hardware(
         self, controller, mock_ha

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -260,8 +260,10 @@ semantics" below):
 - `LOAD_SUPPORT` (any rate) → `vpp_power=0`, remote control **disabled**,
   regardless of `discharge_rate` (releases to `load_first` self-use — see
   "LOAD_SUPPORT semantics" below)
-- `SOLAR_STORAGE`/`IDLE` (rate=0, `block_passive_charging=False`) → remote
+- `SOLAR_STORAGE` (rate=0, `block_passive_charging=False`) → remote
   control disabled (`load_first`/self-use — battery may absorb solar surplus)
+- `IDLE` (rate=0) → `vpp_power=+1%`, remote control **enabled**
+  (`battery_first` hold — see "IDLE semantics" below)
 - `SOLAR_EXPORT` (rate=0, `block_passive_charging=True`) → `vpp_power=0`,
   remote control **enabled** (`grid_first` hold)
 
@@ -322,6 +324,29 @@ already-proven precedent to lean on).
 architectural gap but is **not** fixed here — no SolaX vendor protocol has
 been verified the way the Growatt spec was, so extending this fix there
 would be speculation, not a verified command. Tracked as a follow-up.
+
+**IDLE semantics (fixed — issue [#466](https://github.com/johanzander/bess-manager/issues/466)):**
+`IDLE` previously mapped to the same `remote_control=Disabled` → native
+`load_first` self-use as `SOLAR_STORAGE`. That is wrong for IDLE
+specifically: `load_first` self-use discharges the battery to cover house
+load before drawing from grid, but the DP's own cost model for IDLE periods
+(`_idle_battery_flows` in `dp_battery_algorithm.py`) never credits the
+battery discharging — it only ever models passive solar absorption
+(charging). A real overnight IDLE period therefore drained the battery for
+house load in a way the optimizer's schedule never priced for. Confirmed by
+a real-hardware report (Growatt MIN, control_mode=vpp) on issue #466.
+
+The `grid_first` hold used for `SOLAR_EXPORT` above is **not** a fix for
+this: per issue #118's real-hardware testing, `grid_first`
+(`vpp_power<=0`, remote control enabled) still draws self-consumption from
+the battery — it only stops the battery *absorbing* solar, not discharging
+for load. Only `battery_first` (`vpp_power>0`) releases self-consumption to
+grid/solar. `IDLE` now maps to `remote_control=Enabled`, `vpp_power=+1`
+(the minimal `battery_first` magnitude) instead. **Not yet
+real-hardware-validated**: ships experimental pending confirmation that this
+doesn't cause any grid-charge creep overnight (`vpp_power>0` is the same
+mechanism `GRID_CHARGING` uses at `+100%` to force-charge from grid, just at
+a 1% target).
 
 **Enable sequence** (real-hardware-tested, see issue #118 comments): write
 `vpp_status=Enabled` + `vpp_allow_ac_charging=Enabled`, wait ~1s, then write

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -233,12 +233,23 @@ implementation detail that can change independently of this doc.
 
 **Hardware mapping**: Intents control actual inverter behavior (register-
 based platforms — Growatt TOU/cloud/SPH; VPP-style platforms select
-`grid_first`/`load_first` per-period instead of via a persistent mode, see
-the SOLAR_EXPORT hardware-mapping note below):
+`grid_first`/`battery_first`/`load_first` per-period instead of via a
+persistent mode, see the SOLAR_EXPORT and IDLE hardware-mapping notes below):
 - GRID_CHARGING → battery_first mode + grid charge ON
 - LOAD_SUPPORT → load_first mode
 - BATTERY_EXPORT → grid_first mode (battery discharge to grid)
 - SOLAR_STORAGE / SOLAR_EXPORT / IDLE → load_first mode (solar serves home first)
+
+This `load_first` mapping is what register-based platforms (Growatt
+TOU/cloud/SPH) use for all three. **VPP-style platforms diverge for IDLE**
+(issue #466): `load_first` self-use discharges the battery to cover house
+load, but IDLE's own DP cost model (`_idle_battery_flows` in
+`dp_battery_algorithm.py`) never credits battery discharge — only passive
+solar absorption. VPP-mode IDLE instead maps to `remote_control=Enabled`,
+`vpp_power=+1` (`battery_first` hold), keeping self-consumption on
+grid/solar. See `docs/INVERTER_PLATFORMS.md`'s "IDLE semantics" section for
+the full mapping and why `grid_first` (the SOLAR_EXPORT pattern) doesn't
+also fix this.
 
 ### BATTERY_EXPORT vs SOLAR_EXPORT (why the split exists)
 

--- a/docs/superpowers/specs/2026-07-20-vpp-passive-charge-block-design.md
+++ b/docs/superpowers/specs/2026-07-20-vpp-passive-charge-block-design.md
@@ -102,7 +102,7 @@ either a 20-slot on-device schedule (`30411-30471`, not exposed by
 | `GRID_CHARGING` | Force charge at rate | `remote_control=Enabled`, `vpp_power=+rate%`, `allow_ac_charging=Enabled` | 30407, 30409, 30410 | Implemented, correct — `>0` → `battery first`, matches spec |
 | `LOAD_SUPPORT`/`BATTERY_EXPORT` (rate>0) | Force discharge at rate | `remote_control=Enabled`, `vpp_power=-rate%` | 30407, 30409 | Implemented, correct — `≤0` → `grid first`, matches spec |
 | `SOLAR_STORAGE` | Battery opportunistically absorbs solar surplus (no forced target) | `remote_control=Disabled` → native `load first` self-use | 30407 | Implemented, correct today (already what happens at `discharge_rate=0`) |
-| `IDLE` | No strong signal; self-use is a safe default | `remote_control=Disabled` → native `load first` | 30407 | Implemented, correct today |
+| `IDLE` | No strong signal; self-use is a safe default | `remote_control=Disabled` → native `load first` | 30407 | ~~Implemented, correct today~~ **Superseded by #466**: `load first` self-use also discharges the battery to cover house load, which IDLE's own DP cost model (`_idle_battery_flows`) never credits. Fixed to `remote_control=Enabled`, `vpp_power=+1` (`battery first`) — see #466. |
 | `SOLAR_EXPORT` | Battery held flat; solar bypasses to grid | `remote_control=Enabled`, `vpp_power=0` → documented `grid first` | 30407, 30409 | **Not implemented — this is the bug.** Currently maps to the same `remote_control=Disabled` self-use as `SOLAR_STORAGE`/`IDLE`, which is what lets solar recharge the battery in #355 |
 
 The fix for `SOLAR_EXPORT` specifically is: keep `remote_control` **enabled**


### PR DESCRIPTION
## Summary
- On Growatt inverters in VPP control mode, `IDLE` fell back to native `load_first` self-use, which discharges the battery to cover house load before drawing from grid.
- `IDLE` now maps to `remote_control=Enabled`, `vpp_power=+1` (`battery_first`, minimal magnitude), which per the Growatt VPP protocol keeps self-consumption on grid/solar instead of the battery.

## Root cause
`_intent_to_vpp()` (`core/bess/solax_modbus_growatt_controller.py`) had no IDLE-specific branch, so it fell into the generic `discharge_rate==0` path shared with `SOLAR_STORAGE`, returning `remote_control_enabled=False` → native `load_first` self-use. The DP optimizer's own cost model (`_idle_battery_flows` in `core/bess/dp_battery_algorithm.py`) hardcodes `battery_discharged=0.0` for every IDLE period — it only ever models passive solar absorption, never battery discharge for load. So a real overnight IDLE period drained the battery for house load in a way the optimizer's schedule never priced for.

`grid_first` (the pattern already shipped for `SOLAR_EXPORT` in #356) does **not** fix this either: per real-hardware testing on issue #118, `grid_first` (`vpp_power<=0`, remote enabled) still draws self-consumption from the battery — it only stops the battery *absorbing* solar, not *discharging* for load. Only `battery_first` (`vpp_power>0`) releases self-consumption to grid/solar.

## Fix
Added an IDLE-specific branch to `_intent_to_vpp()`, checked before the generic `discharge_rate==0` fallthrough (same pattern as the existing `LOAD_SUPPORT` override), returning `(power_pct=1, remote_control_enabled=True)`. `SOLAR_STORAGE` is unaffected — it still deliberately wants passive solar absorption via native self-use.

Updated docs to match: `docs/agents/bess-knowledge.md`, `docs/INVERTER_PLATFORMS.md` (new "IDLE semantics" section, following the existing SOLAR_EXPORT/LOAD_SUPPORT pattern), and `docs/superpowers/specs/2026-07-20-vpp-passive-charge-block-design.md` (superseded table row).

**Ships experimental, pending real-hardware confirmation** — same status as the SOLAR_EXPORT fix in #356. `vpp_power>0` is the same mechanism `GRID_CHARGING` uses at `+100%` to force-charge from grid, just at a 1% target; needs confirmation this doesn't cause any grid-charge creep overnight on real hardware. Not closing #466 yet for that reason — will close once confirmed.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (fast suite: 1510 passed/15 skipped; Black/Ruff clean)
- [x] `.venv/bin/pytest -m slow` passes (391 passed, 3 skipped)
- [x] Unit tests updated/added in `test_solax_modbus_growatt_vpp.py`: confirmed they fail without the fix (reverted the code change, watched both new/updated IDLE tests fail for the expected reason, then restored)
- [x] Observed the real fix working end-to-end: stood up the mock-HA + backend stack (`docker-compose.ci.yml`, `ci-growatt-vpp` scenario), exercised the real `HomeAssistantAPIController` → mock-HA write path for an IDLE period, and confirmed the actual entity states landed as `select.growatt_min_vpp_remote_control=Enabled`, `number.growatt_min_vpp_power=1` (previously would have been `Disabled`/no write). Note: this scenario has a pre-existing, unrelated bug in schedule-price-horizon computation ("list assignment index out of range") that blocks the full scheduler loop — confirmed present identically with the fix reverted, so it's not introduced by this change; worked around by exercising the controller's real HA write path directly instead of through the full scheduler.

Refs #466