### PR TITLE
docs(release skill): note fresh worktrees need their own .venv

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -24,6 +24,7 @@
 
    Any *other* file conflicting is not expected and needs real investigation (usually: `origin/main` moved between when this branch's base was chosen and now, surfacing content `beta/main` hasn't seen — resolve by taking the newer, `origin/main`-based side, since that's always the more current code). Commit the resolution as `git commit -m "merge: reconcile beta/main history for v<beta-version> release"`.
 6. **Run tests locally** — ALL of these must pass before proceeding:
+   - **If this branch/worktree has no `.venv` yet** (e.g. it was cut fresh via `git worktree add ... origin/main`, per the Worktree Conventions in `CLAUDE.md`), create one before running anything: check `.python-version` for the pinned interpreter (use `pyenv exec` if the system `python3` is older — mismatched versions surface as unrelated-looking `TypeError`s on `X | None` syntax deep in imports, not as a version error), then `python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt -r backend/requirements.txt`. `.venv` is gitignored, so it never comes along with the worktree/branch even though other worktrees in the repo each have their own.
    - `pytest -m "not slow"` (includes scenario discovery regression tests)
    - `pytest core/bess/tests/unit/test_scenario_discovery.py -v` (show individual scenario results)
    - `npx vitest run` (frontend tests)


### PR DESCRIPTION
## Summary
- Hit an unrelated-looking `TypeError` deep in imports while running the release skill's local test suite in a fresh worktree cut from `origin/main` — root cause was a missing `.venv` (gitignored, never carried into a new worktree) plus a stale system Python.
- Documents the fix inline in the beta release skill's test step: check `.python-version`, use `pyenv exec` if needed, create `.venv`, install `requirements-dev.txt` + `backend/requirements.txt`.

## Test plan
- [x] Docs-only change, no code affected