### PR TITLE
fix: split Solis signed grid-power sensor into import/export (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Growatt VPP-mode IDLE periods no longer drain the battery for house self-consumption overnight — IDLE now holds the battery via `battery_first` instead of falling back to native self-use. ([#466](https://github.com/johanzander/bess-manager/issues/466))
 - Huawei LUNA2000 installs now auto-discover lifetime solar/battery energy sensors, fixing a false "SYSTEM DEGRADED" health check and zero-valued savings graphs. ([#471](https://github.com/johanzander/bess-manager/issues/471))
 - **Local E2E verification for Growatt VPP scenarios now completes a full schedule build** instead of failing partway through. ([#469](https://github.com/johanzander/bess-manager/issues/469))
+- Solis installs now auto-configure grid export power, derived from the same signed sensor as import power. Previously export power was always unconfigured. ([#475](https://github.com/johanzander/bess-manager/issues/475))
 ### Fixed
 
 - The consumption forecast now refreshes intraday like solar already does, instead of caching stale data until the 23:55 job. ([#395](https://github.com/johanzander/bess-manager/issues/395))

--- a/backend/api.py
+++ b/backend/api.py
@@ -350,6 +350,7 @@ async def patch_settings(updates: dict):
         # unconditionally rather than only on a "sensors" key match.
         bess_controller.refresh_active_sensors()
         bess_controller.refresh_service_domain()
+        bess_controller.refresh_grid_power_polarity()
         _refresh_health(bess_controller)
         return await get_settings()
 
@@ -3659,6 +3660,7 @@ async def setup_complete(payload: APISetupCompletePayload):
         # which per-platform sensor sub-dict is active.
         bess_controller.refresh_active_sensors()
         bess_controller.refresh_service_domain()
+        bess_controller.refresh_grid_power_polarity()
         if payload.growattDeviceId:
             bess_controller.ha_controller.growatt_device_id = payload.growattDeviceId
         if payload.huaweiDeviceId:

--- a/backend/app.py
+++ b/backend/app.py
@@ -144,6 +144,7 @@ class BESSController:
             growatt_device_id,
             huawei_device_id,
             self.settings_store.get_service_domain(),
+            self.settings_store.get_grid_power_polarity(),
         )
 
         # Enable test mode from environment variable OR persisted demo_mode setting.
@@ -217,6 +218,7 @@ class BESSController:
         growatt_device_id=None,
         huawei_device_id=None,
         service_domain=None,
+        grid_power_polarity=None,
     ):
         """Initialize Home Assistant API controller based on environment.
 
@@ -225,6 +227,8 @@ class BESSController:
             growatt_device_id: Growatt device ID for TOU segment operations.
             huawei_device_id: Huawei device ID for battery operations.
             service_domain: HA integration domain for vendor service calls.
+            grid_power_polarity: Sign convention for a platform whose
+                import_power/export_power share one signed entity.
         """
         ha_token = os.getenv("HASSIO_TOKEN")
         if ha_token:
@@ -244,6 +248,7 @@ class BESSController:
             growatt_device_id=growatt_device_id,
             huawei_device_id=huawei_device_id,
             service_domain=service_domain,
+            grid_power_polarity=grid_power_polarity,
         )
 
     def _load_options(self):
@@ -299,6 +304,18 @@ class BESSController:
         the previous integration until the next restart.
         """
         self.ha_controller.service_domain = self.settings_store.get_service_domain()
+
+    def refresh_grid_power_polarity(self) -> None:
+        """Sync the live ha_controller.grid_power_polarity from persisted settings.
+
+        Like service_domain, this is a plain copy taken at init — an
+        inverter platform switch changes which sign convention (if any)
+        applies to a shared signed grid-power sensor. Call this after any
+        settings mutation that can touch the inverter section.
+        """
+        self.ha_controller.grid_power_polarity = (
+            self.settings_store.get_grid_power_polarity()
+        )
 
     def apply_discovered_config(
         self,

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -77,6 +77,7 @@ class HomeAssistantAPIController:
         growatt_device_id: str | None = None,
         huawei_device_id: str | None = None,
         service_domain: str | None = None,
+        grid_power_polarity: str | None = None,
     ):
         """Initialize the Controller with Home Assistant API access.
 
@@ -89,6 +90,10 @@ class HomeAssistantAPIController:
             service_domain: HA integration domain for vendor service calls
                 (SettingsStore.get_service_domain() — "huawei_solar",
                 "growatt_server", or a compatible integration's own domain)
+            grid_power_polarity: Sign convention for a platform whose
+                import_power/export_power share one signed entity
+                (SettingsStore.get_grid_power_polarity() — "import_positive"
+                or "" when the platform has separate entities)
 
         """
         self.base_url = ha_url
@@ -115,6 +120,10 @@ class HomeAssistantAPIController:
         # domain from the entity_id prefix; these target a device, so the
         # domain is configuration — see SettingsStore.get_service_domain.
         self.service_domain = service_domain or ""
+
+        # Sign convention for a platform whose import_power/export_power
+        # share one signed entity (see get_import_power/get_export_power).
+        self.grid_power_polarity = grid_power_polarity or ""
 
         # Runtime failure tracker (injected by BatterySystemManager)
         self.failure_tracker = None
@@ -2403,12 +2412,42 @@ class HomeAssistantAPIController:
         """Get current solar PV power production in watts."""
         return self._get_sensor_value("pv_power")
 
+    def _is_shared_signed_grid_power(self) -> bool:
+        """True when import_power/export_power resolve to one signed entity.
+
+        Some platforms (Solis) expose grid power as a single signed sensor
+        instead of separate import/export entities. get_import_power/
+        get_export_power detect this case and split the one raw reading by
+        sign instead of reading the entity twice unmodified.
+        """
+        import_entity = self.sensors.get("import_power")
+        export_entity = self.sensors.get("export_power")
+        return bool(
+            self.grid_power_polarity
+            and import_entity
+            and import_entity == export_entity
+        )
+
     def get_import_power(self):
         """Get current grid import power in watts."""
+        if self._is_shared_signed_grid_power():
+            raw = self._get_sensor_value("import_power")
+            if raw is None:
+                return None
+            if self.grid_power_polarity == "import_positive":
+                return max(0.0, raw)
+            return max(0.0, -raw)  # export_positive
         return self._get_sensor_value("import_power")
 
     def get_export_power(self):
         """Get current grid export power in watts."""
+        if self._is_shared_signed_grid_power():
+            raw = self._get_sensor_value("import_power")
+            if raw is None:
+                return None
+            if self.grid_power_polarity == "import_positive":
+                return max(0.0, -raw)
+            return max(0.0, raw)  # export_positive
         return self._get_sensor_value("export_power")
 
     def get_local_load_power(self):
@@ -3550,6 +3589,12 @@ class HomeAssistantAPIController:
                     if k not in solis_sensors
                 }
             )
+            # Solis has no separate export_power entity — grid_power_net is
+            # a single signed sensor (see SOLIS_SUFFIX_MAP comment). Point
+            # export_power at the same entity so HAApiController's signed
+            # split (grid_power_polarity) can derive both readings from it.
+            if "import_power" in solis_sensors and "export_power" not in solis_sensors:
+                solis_sensors["export_power"] = solis_sensors["import_power"]
             # Monitoring sensors are always mapped, but only auto-select
             # solis_modbus as the detected platform when the Grid TOU v2
             # marker is present — without it, schedule writes fail on every

--- a/core/bess/settings_store.py
+++ b/core/bess/settings_store.py
@@ -106,6 +106,18 @@ PLATFORM_SERVICE_DOMAIN = {
     "huawei_solar_luna2000": "huawei_solar",
 }
 
+# Sign convention for platforms exposing grid power as a single signed sensor
+# instead of separate import/export entities. Unlike PLATFORM_SERVICE_DOMAIN,
+# this is a fixed hardware/integration fact, not something an install can
+# override. "" (the default for any platform not listed) means the platform
+# has no signed-shared-sensor split to perform — every other consumer reads
+# import_power/export_power independently as always.
+#
+# "import_positive": positive raw value = importing from grid, negative = exporting.
+PLATFORM_GRID_POWER_POLARITY = {
+    "solis_modbus": "import_positive",  # Grid Power Net register 33263/33264
+}
+
 
 class SettingsStore:
     """Read/write /data/bess_settings.json with atomic writes.
@@ -204,6 +216,16 @@ class SettingsStore:
         if override:
             return override
         return PLATFORM_SERVICE_DOMAIN.get(inverter.get("platform", ""), "")
+
+    def get_grid_power_polarity(self) -> str:
+        """Return the sign convention for this platform's grid power sensor.
+
+        "" for platforms with separate import/export entities (no split
+        needed) and for an unconfigured install. Not user-overridable —
+        see PLATFORM_GRID_POWER_POLARITY.
+        """
+        inverter = self.data.get("inverter", {})
+        return PLATFORM_GRID_POWER_POLARITY.get(inverter.get("platform", ""), "")
 
     def get_active_sensors(self) -> dict:
         """Return a flat sensor dict merging the active platform's sensors with shared sensors.

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -273,6 +273,68 @@ class TestSensorReading:
         assert c.get_discharge_inhibit_active() is False
 
 
+# ── Signed grid power split (issue #475) ──────────────────────────────────────
+#
+# Platforms like Solis expose grid power as a single signed sensor rather than
+# separate import/export entities. When import_power and export_power are
+# both configured to the same entity_id and grid_power_polarity is set, the
+# single raw reading must be split by sign into the two internal keys instead
+# of being returned unmodified from two independent reads.
+
+
+@pytest.fixture
+def signed_grid_ctrl():
+    """Controller with import_power and export_power sharing one signed entity."""
+    c = HomeAssistantAPIController(
+        ha_url="http://ha.local:8123",
+        token="test-token",
+        sensor_config={
+            "import_power": "sensor.solis_grid_power_net",
+            "export_power": "sensor.solis_grid_power_net",
+        },
+        grid_power_polarity="import_positive",
+    )
+    c.max_attempts = 1
+    c.retry_base_delay = 0
+    return c
+
+
+class TestSignedGridPowerSplit:
+    def test_positive_raw_is_import_only(self, signed_grid_ctrl):
+        signed_grid_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "1500"})
+        )
+        assert signed_grid_ctrl.get_import_power() == 1500.0
+        assert signed_grid_ctrl.get_export_power() == 0.0
+
+    def test_negative_raw_is_export_only(self, signed_grid_ctrl):
+        signed_grid_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "-1500"})
+        )
+        assert signed_grid_ctrl.get_import_power() == 0.0
+        assert signed_grid_ctrl.get_export_power() == 1500.0
+
+    def test_unavailable_raw_returns_none(self, signed_grid_ctrl):
+        signed_grid_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "unavailable"})
+        )
+        assert signed_grid_ctrl.get_import_power() is None
+        assert signed_grid_ctrl.get_export_power() is None
+
+    def test_separate_entities_unaffected_by_polarity(self, ctrl):
+        """A platform with two distinct entities must read them independently,
+        even if grid_power_polarity somehow ended up set (defense against a
+        future platform reusing the field incorrectly)."""
+        ctrl.sensors["import_power"] = "sensor.import"
+        ctrl.sensors["export_power"] = "sensor.export"
+        ctrl.grid_power_polarity = "import_positive"
+        ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "42"})
+        )
+        assert ctrl.get_import_power() == 42.0
+        assert ctrl.get_export_power() == 42.0
+
+
 # ── set_* / grid_charge ─────────────────────────────────────────────────────
 
 

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -1266,6 +1266,9 @@ class TestDiscoverSensorsFromRegistry:
         )
         assert solis["import_power"] == "sensor.solis_grid_power_net"
         assert solis["pv_power"] == "sensor.solis_pv_power_1"
+        # Single signed sensor backs both keys (issue #475) — HAApiController
+        # splits it by sign at read time via grid_power_polarity.
+        assert solis["export_power"] == "sensor.solis_grid_power_net"
 
         # Dict-embedded monitoring sensors matched via the Solis-scoped
         # substring matcher (verified integration bug, see

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -464,8 +464,12 @@ uses. TOU period times (`time.py`) and per-slot enable switches
   sensor is added.
 - `import_power` and `export_power` both resolve to the single signed "Grid
   Power Net" sensor (Solis exposes no separate import/export power
-  entities); `export_power` is left unconfigured by auto-discovery since one
-  suffix-map entry can only resolve to one BESS sensor key.
+  entities). `HomeAssistantAPIController.grid_power_polarity`
+  (`"import_positive"` for `solis_modbus`, set via
+  `SettingsStore.get_grid_power_polarity()`) splits the one raw reading by
+  sign at read time: positive → `import_power`, negative → `export_power`.
+  Not user-configurable — it's a fixed property of the platform, not
+  install-specific.
 
 ### Huawei LUNA2000 (Local) — `huawei_solar_luna2000`
 
@@ -716,7 +720,7 @@ GEN4 above (`limit_grid_export` / `grid_export_limit`, registers 122/123) —
 | `battery_soc` | sensor | dict-embedded: `'unique': 'solis_modbus_inverter_battery_soc'` | Current battery level |
 | `battery_charge_power` | sensor | `solis_modbus_inverter_battery_charge_power` (derived, clean) | Charge power (W) |
 | `battery_discharge_power` | sensor | `solis_modbus_inverter_battery_discharge_power` (derived, clean) | Discharge power (W) |
-| `import_power` / `export_power` | sensor | `solis_modbus_inverter_grid_power_net` (derived, clean, signed) | Net grid power (W); only `import_power` is auto-mapped |
+| `import_power` / `export_power` | sensor | `solis_modbus_inverter_grid_power_net` (derived, clean, signed) | Net grid power (W); both keys map to this entity, split by sign at read time (`grid_power_polarity`) |
 | `pv_power` | sensor | `solis_modbus_inverter_dc_power_1` (derived, clean) | PV string 1 power (W) — see known gaps above |
 | `local_load_power` | sensor | dict-embedded: `'unique': 'solis_modbus_inverter_household_load_power'` | Home consumption (W) |
 

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -422,6 +422,10 @@ This is what lets an integration that exposes the same services under its own do
 
 `SolaxModbusGrowattController` subclasses `GrowattMinController` — the scheduling algorithm (9 TOU slots, differential updates, corruption recovery) is identical. Only the hardware I/O differs: `growatt_server` uses a single service call per slot, while `solax_modbus` uses 4 entity writes (`select.select_option`) plus a button press per slot.
 
+#### Signed grid power sensors
+
+A platform-fixed sibling of the service-domain pattern above: some platforms (Solis) expose grid power as one signed sensor instead of separate import/export entities. `SettingsStore.get_grid_power_polarity()` resolves `PLATFORM_GRID_POWER_POLARITY` (`"import_positive"` for `solis_modbus`, `""` elsewhere) — not user-overridable, since polarity is a hardware fact, not configuration. Held on `HomeAssistantAPIController.grid_power_polarity`; `get_import_power()`/`get_export_power()` split the single reading by sign whenever both keys resolve to the same entity_id.
+
 ### Platform Capabilities
 
 Different inverter platforms support different hardware features. The class hierarchy handles **behavioral** differences (TOU scheduling vs. period lists vs. VPP commands — genuinely different algorithms). Capabilities handle the narrower question: what does code *outside* the controller need to know about the platform?


### PR DESCRIPTION
## Summary
- Solis hybrid inverters expose grid power as a single signed sensor (`grid_power_net`) instead of separate import/export entities. Auto-discovery only ever mapped it to `import_power`; `export_power` was silently left unconfigured on every Solis install.
- Adds `HomeAssistantAPIController.grid_power_polarity`, resolved once via `SettingsStore.get_grid_power_polarity()` / `PLATFORM_GRID_POWER_POLARITY` — mirrors the `service_domain` pattern from #412 exactly (platform-fixed, not user-overridable). `get_import_power()`/`get_export_power()` now split one raw reading by sign whenever both keys resolve to the same entity_id.
- Solis discovery now maps `export_power` to the same entity as `import_power`, so both auto-populate.

## Root cause
`_map_registry_entities` is a strict 1-suffix→1-bess_key function; nothing in `HAApiController` could derive two internal sensor values from one signed physical entity. Found while investigating #438 (Huawei EMMA monitoring entities) — same underlying gap on a different platform; this PR fixes it on Solis first since the mechanism is now needed by both.

## Scope assessment
Structural, not a workaround: implements a real semantic (one signed source, two logical readings) the schema couldn't express before, following the same shape and owners (`HAApiController` + `SettingsStore` + `app.py` wiring) as the `service_domain` precedent. No flag/fallback routing around an unrelated problem.

## Test plan
- [x] `./scripts/quality-check.sh` equivalent (fast suite) — 1518 passed, 15 skipped
- [x] Slow suite — 391 passed, 3 skipped
- [x] New `TestSignedGridPowerSplit` in `test_ha_api_controller.py` (positive/negative/unavailable raw, plus a guard that unrelated platforms are unaffected) — confirmed RED (TypeError, missing constructor param) before the fix, GREEN after
- [x] `test_solis_modbus_only` extended to assert `export_power` now maps to the same entity as `import_power`
- [x] Local verification against a live mock-HA instance over real HTTP (not mocked `requests.Session`): drove `sensor.solis_grid_power_net` to -1500 → observed `export_power=1500.0`, `import_power=0.0`; drove it to 1500 → observed `import_power=1500.0`, `export_power=0.0`

Closes #475