### PR TITLE
feat: auto-detect Huawei power monitoring sensors (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Huawei LUNA2000 installs now auto-discover lifetime solar/battery energy sensors, fixing a false "SYSTEM DEGRADED" health check and zero-valued savings graphs. ([#471](https://github.com/johanzander/bess-manager/issues/471))
 - **Local E2E verification for Growatt VPP scenarios now completes a full schedule build** instead of failing partway through. ([#469](https://github.com/johanzander/bess-manager/issues/469))
 - Solis installs now auto-configure grid export power, derived from the same signed sensor as import power. Previously export power was always unconfigured. ([#475](https://github.com/johanzander/bess-manager/issues/475))
+- Huawei LUNA2000 installs now auto-discover all sensors (SOC, battery control, power monitoring) instead of requiring manual entity entry for every field, and gain real-time solar/grid power monitoring. ([#438](https://github.com/johanzander/bess-manager/issues/438))
 ### Fixed
 
 - The consumption forecast now refreshes intraday like solar already does, instead of caching stale data until the 23:55 job. ([#395](https://github.com/johanzander/bess-manager/issues/395))

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -847,6 +847,15 @@ class HomeAssistantAPIController:
     # (inverter), storage_total_charge/storage_total_discharge (battery),
     # grid_exported_energy/grid_accumulated_energy (separate power-meter device,
     # so these two resolve to "not configured" on meterless installs).
+    # input_power (inverter, real-time PV) and power_meter_active_power
+    # (separate power-meter device, real-time grid power) verified against
+    # the same source (issue #438). power_meter_active_power is a single
+    # signed register (positive = export, negative = import — confirmed
+    # against Huawei's official register description, not the integration
+    # source, which documents no sign convention); it maps to import_power
+    # here and discover_sensors_from_registry also points export_power at
+    # the same entity, same pattern as Solis's grid_power_net (#475) — see
+    # PLATFORM_GRID_POWER_POLARITY["huawei_solar_luna2000"] in settings_store.py.
     HUAWEI_SUFFIX_MAP: ClassVar[dict[str, str]] = {
         "storage_state_of_capacity": "battery_soc",
         "storage_charge_discharge_power": "battery_charge_power",
@@ -862,6 +871,8 @@ class HomeAssistantAPIController:
         "storage_total_discharge": "lifetime_battery_discharged",
         "grid_exported_energy": "lifetime_export_to_grid",
         "grid_accumulated_energy": "lifetime_import_from_grid",
+        "input_power": "pv_power",
+        "power_meter_active_power": "import_power",
     }
 
     def resolve_sensor_for_influxdb(self, sensor_key: str) -> str | None:
@@ -3612,6 +3623,24 @@ class HomeAssistantAPIController:
                     "inverter/firmware; monitoring sensors mapped but "
                     "solis_modbus is not auto-selected as detected_platform"
                 )
+
+        if inverter_detected.get("huawei"):
+            huawei_sensors = self._map_registry_entities(
+                entities, ["huawei_solar"], self.HUAWEI_SUFFIX_MAP
+            )
+            # power_meter_active_power is a single signed register — Huawei
+            # has no separate export_power entity (same situation as Solis's
+            # grid_power_net, #475). Point export_power at the same entity
+            # so HAApiController's signed split (grid_power_polarity) can
+            # derive both readings from it.
+            if (
+                "import_power" in huawei_sensors
+                and "export_power" not in huawei_sensors
+            ):
+                huawei_sensors["export_power"] = huawei_sensors["import_power"]
+            platform_sensors["huawei_solar_luna2000"] = huawei_sensors
+            if not detected_platform:
+                detected_platform = "huawei_solar_luna2000"
 
         return platform_sensors, detected_platform
 

--- a/core/bess/settings_store.py
+++ b/core/bess/settings_store.py
@@ -114,8 +114,10 @@ PLATFORM_SERVICE_DOMAIN = {
 # import_power/export_power independently as always.
 #
 # "import_positive": positive raw value = importing from grid, negative = exporting.
+# "export_positive": positive raw value = exporting to grid, negative = importing.
 PLATFORM_GRID_POWER_POLARITY = {
     "solis_modbus": "import_positive",  # Grid Power Net register 33263/33264
+    "huawei_solar_luna2000": "export_positive",  # power_meter_active_power (#438)
 }
 
 

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -321,6 +321,43 @@ class TestSignedGridPowerSplit:
         assert signed_grid_ctrl.get_import_power() is None
         assert signed_grid_ctrl.get_export_power() is None
 
+    def test_export_positive_polarity_splits_positive_raw_to_export(self):
+        """Huawei's power_meter_active_power (#438): positive = export."""
+        c = HomeAssistantAPIController(
+            ha_url="http://ha.local:8123",
+            token="test-token",
+            sensor_config={
+                "import_power": "sensor.huawei_power_meter_active_power",
+                "export_power": "sensor.huawei_power_meter_active_power",
+            },
+            grid_power_polarity="export_positive",
+        )
+        c.max_attempts = 1
+        c.retry_base_delay = 0
+        c.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "1500"})
+        )
+        assert c.get_export_power() == 1500.0
+        assert c.get_import_power() == 0.0
+
+    def test_export_positive_polarity_splits_negative_raw_to_import(self):
+        c = HomeAssistantAPIController(
+            ha_url="http://ha.local:8123",
+            token="test-token",
+            sensor_config={
+                "import_power": "sensor.huawei_power_meter_active_power",
+                "export_power": "sensor.huawei_power_meter_active_power",
+            },
+            grid_power_polarity="export_positive",
+        )
+        c.max_attempts = 1
+        c.retry_base_delay = 0
+        c.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "-1500"})
+        )
+        assert c.get_import_power() == 1500.0
+        assert c.get_export_power() == 0.0
+
     def test_separate_entities_unaffected_by_polarity(self, ctrl):
         """A platform with two distinct entities must read them independently,
         even if grid_power_polarity somehow ended up set (defense against a

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -349,6 +349,16 @@ def _huawei_registry(serial: str = "HW2024ABCDEF") -> list[dict]:
             "huawei_solar",
             f"{serial}_grid_accumulated_energy",
         ),
+        _entity(
+            "sensor.huawei_inverter_input_power",
+            "huawei_solar",
+            f"{serial}_input_power",
+        ),
+        _entity(
+            "sensor.huawei_meter_power_meter_active_power",
+            "huawei_solar",
+            f"{serial}_power_meter_active_power",
+        ),
     ]
 
 
@@ -2019,7 +2029,17 @@ class TestHuaweiDiscovery:
         )
         assert result["battery_soc"] == "sensor.huawei_battery_state_of_capacity"
         assert result["huawei_working_mode"] == "select.huawei_battery_working_mode"
-        assert len(result) == 14
+        assert len(result) == 16
+
+    def test_huawei_power_monitoring_sensors_mapped(self):
+        """issue #438: real-time PV power and signed grid power (single
+        power-meter register, split by HAApiController.grid_power_polarity —
+        see #475's mechanism, reused here with export_positive polarity)."""
+        result = self.ctrl._map_registry_entities(
+            _huawei_registry(), ["huawei_solar"], self.ctrl.HUAWEI_SUFFIX_MAP
+        )
+        assert result["pv_power"] == "sensor.huawei_inverter_input_power"
+        assert result["import_power"] == "sensor.huawei_meter_power_meter_active_power"
 
     def test_huawei_lifetime_energy_sensors_mapped(self):
         result = self.ctrl._map_registry_entities(
@@ -2044,3 +2064,23 @@ class TestHuaweiDiscovery:
             result["lifetime_import_from_grid"]
             == "sensor.huawei_meter_grid_accumulated_energy"
         )
+
+    def test_huawei_wired_into_discover_sensors_from_registry(self):
+        """Huawei must be auto-discovered like every other platform.
+
+        HUAWEI_SUFFIX_MAP previously had no caller in
+        discover_sensors_from_registry — every Huawei sensor was manual-entry
+        only. This is the production entry point the setup wizard actually
+        calls (backend/api.py), not _map_registry_entities in isolation.
+        """
+        sensors, platform = self.ctrl.discover_sensors_from_registry(_huawei_registry())
+        assert platform == "huawei_solar_luna2000"
+        assert "huawei_solar_luna2000" in sensors
+        huawei = sensors["huawei_solar_luna2000"]
+
+        assert huawei["battery_soc"] == "sensor.huawei_battery_state_of_capacity"
+        assert huawei["pv_power"] == "sensor.huawei_inverter_input_power"
+        assert huawei["import_power"] == "sensor.huawei_meter_power_meter_active_power"
+        # Single signed power-meter register backs both keys (same pattern
+        # as Solis, #475) — HAApiController splits it via grid_power_polarity.
+        assert huawei["export_power"] == "sensor.huawei_meter_power_meter_active_power"

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -763,18 +763,21 @@ Only slot 1 of each direction is strictly required; slots 2-6 are optional
 | `grid_charge` | switch | `storage_charge_from_grid_function` | Grid charge enable |
 | `huawei_working_mode` | select | `storage_working_mode_settings` | Battery working mode (gating TOU writes) |
 | `local_load_power` | sensor | `active_power` | Home consumption (W) |
+| `pv_power` | sensor | `input_power` | Real-time solar PV power (W) |
+| `import_power` / `export_power` | sensor | `power_meter_active_power` (separate power-meter device, signed) | Net grid power (W); both keys map to this entity, split by sign at read time (`grid_power_polarity`, `"export_positive"` — issue #438) |
 
-**Lifetime energy (optional):**
+**Lifetime energy (optional):** see `HUAWEI_SUFFIX_MAP` in `ha_api_controller.py`
+for the five lifetime-energy suffixes added in #471/#473 (not reproduced here
+to avoid duplicating a list that will drift — the suffix map is the source of
+truth).
 
-The `huawei_solar` integration does not expose lifetime energy counters for BESS's
-standard usage (battery input/output, solar production, grid import/export). Custom
-register reads via a separate Modbus probe are required; this is not yet
-integrated into BESS.
-
-**Auto-detection:** Presence of `huawei_solar` integration entities with the
-`storage_working_mode_settings` unique_id suffix triggers Huawei platform
-detection; the setup wizard confirms the battery model is LUNA2000 via
-`get_huawei_working_mode_options()` before proceeding.
+**Auto-detection:** `HUAWEI_SUFFIX_MAP` is wired into `discover_sensors_from_registry`
+(the same production entity-registry scan every other platform uses — fixed
+in #438; previously this map had no caller there and every Huawei sensor
+required manual entity entry). Presence of `huawei_solar` integration entities
+with the `storage_working_mode_settings` unique_id suffix triggers Huawei
+platform detection; the setup wizard confirms the battery model is LUNA2000
+via `get_huawei_working_mode_options()` before proceeding.
 
 ---
 

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -484,6 +484,8 @@ export const INTEGRATIONS: IntegrationDef[] = [
         name: 'Power Monitoring',
         sensors: [
           { key: 'local_load_power', label: 'Inverter Active Power', required: false },
+          { key: 'pv_power', label: 'Solar PV Power (Input Power)', required: false },
+          { key: 'import_power', label: 'Grid Power (power meter, net signed)', required: false },
         ],
       },
       {


### PR DESCRIPTION
## Summary
- Discovered and fixed a real pre-existing gap while implementing this: `HUAWEI_SUFFIX_MAP` existed but was never wired into `discover_sensors_from_registry` — the production entity-registry scan the setup wizard actually calls (`backend/api.py`). Every Huawei sensor, not just the ones in this issue, has always been manual-entry only, unlike growatt/solax/solis which all auto-discover. Added the missing Huawei branch, mirroring the existing Solis branch.
- Two new suffix-map entries: `input_power` → `pv_power` (real-time solar), `power_meter_active_power` → `import_power` (real-time grid power — single signed register on a separate power-meter device, no separate import/export entities, same situation Solis had in #475).
- `export_power` is mirrored onto the same entity as `import_power` when present, and `PLATFORM_GRID_POWER_POLARITY["huawei_solar_luna2000"] = "export_positive"` reuses #475's signed-split mechanism unchanged (Huawei's polarity is the opposite of Solis's `import_positive` — confirmed against Huawei's official register description, not just the integration source, which documents no sign convention).
- New `pv_power`/`import_power` fields added to the Huawei sensor group in the setup wizard/settings UI.

## Root cause
Traces back to issue #438 (Huawei EMMA-managed systems need the same richer monitoring Growatt Cloud gets). Investigation found the "improved power flow monitoring" and "battery control" asks were partially pre-existing/out of scope (battery control already worked; `lifetime_load_consumption` is deliberately derived via energy-balance fallback for every platform lacking it, not a gap) — the remaining real gap was real-time PV/grid power, which is genuinely consumed by `SensorCollector` (InfluxDB gap-fill + live power sampling, #387), not just a display field. #475 (Solis) built the signed-split mechanism this reuses.

## Scope assessment
The `discover_sensors_from_registry` wiring is structural (new branch, same shape/owner as the adjacent Solis/Solax branches) but was found necessary, not speculative — without it, "auto-detect" for the two new sensors would be meaningless since nothing auto-detects any Huawei sensor today. Everything else mirrors the #475 precedent exactly. No flags/fallbacks routing around an unrelated problem.

## Test plan
- [x] Fast suite — 1522 passed, 15 skipped
- [x] Slow suite — 391 passed, 3 skipped
- [x] `test_huawei_wired_into_discover_sensors_from_registry` — calls the actual production `discover_sensors_from_registry` entry point (not `_map_registry_entities` in isolation like the pre-existing Huawei tests did), confirming RED (missing branch) before the fix, GREEN after
- [x] `test_huawei_power_monitoring_sensors_mapped`, and mirror `export_positive` polarity tests in `test_ha_api_controller.py` (the `export_positive` branch existed in code since #475 but had no test coverage until now)
- [x] Local verification against a live mock-HA instance over real HTTP: drove `sensor.huawei_power_meter_active_power` to 1500 → observed `export_power=1500.0`, `import_power=0.0`; to -1500 → observed `import_power=1500.0`, `export_power=0.0`; `sensor.huawei_input_power` to 3200 → observed `pv_power=3200.0`

Closes #438