### PR TITLE
fix: align schedule table's display threshold with backend classification

### DIFF
--- a/frontend/src/components/InverterStatusDashboard.tsx
+++ b/frontend/src/components/InverterStatusDashboard.tsx
@@ -829,12 +829,17 @@ const InverterStatusDashboard: React.FC = () => {
                             {group.dominantIntent.replace(/_/g, ' ')}
                           </span>
                         </td>
-                        {/* Solar column: SOLAR_STORAGE and passive IDLE gains */}
+                        {/* Solar column: SOLAR_STORAGE and passive IDLE gains.
+                            Threshold/precision must match the backend's own
+                            classification epsilon (decision_intelligence.py's
+                            0.01 kWh) -- otherwise a period correctly labeled
+                            SOLAR_STORAGE by the backend can display no value
+                            at all, which reads as a label/data contradiction. */}
                         <td className={`${cell} text-center`}>
                           {!isPast && (group.dominantIntent === 'SOLAR_STORAGE' || group.dominantIntent === 'IDLE') &&
-                           group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                           group.socDeltaKwh != null && group.socDeltaKwh > 0.01 ? (
                             <span className="text-amber-500 dark:text-amber-400 font-medium">
-                              +{group.socDeltaKwh.toFixed(1)} kWh
+                              +{group.socDeltaKwh.toFixed(2)} kWh
                             </span>
                           ) : (
                             <span className="text-gray-300 dark:text-gray-600">—</span>
@@ -843,13 +848,13 @@ const InverterStatusDashboard: React.FC = () => {
                         {/* Grid / Discharge column */}
                         <td className={`${cell} text-center`}>
                           {!isPast && group.dominantIntent === 'GRID_CHARGING' &&
-                           group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                           group.socDeltaKwh != null && group.socDeltaKwh > 0.01 ? (
                             <span className="text-green-600 dark:text-green-400 font-medium">
-                              +{group.socDeltaKwh.toFixed(1)} kWh
+                              +{group.socDeltaKwh.toFixed(2)} kWh
                             </span>
-                          ) : !isPast && group.totalActionKwh !== undefined && group.totalActionKwh < -0.05 ? (
+                          ) : !isPast && group.totalActionKwh !== undefined && group.totalActionKwh < -0.01 ? (
                             <span className="text-orange-500 dark:text-orange-400 font-medium">
-                              {group.totalActionKwh.toFixed(1)} kWh
+                              {group.totalActionKwh.toFixed(2)} kWh
                             </span>
                           ) : (
                             <span className="text-gray-300 dark:text-gray-600">—</span>
@@ -936,12 +941,14 @@ const InverterStatusDashboard: React.FC = () => {
                                   {group.dominantIntent.replace(/_/g, ' ')}
                                 </span>
                               </td>
-                              {/* Solar column */}
+                              {/* Solar column -- threshold/precision must match
+                                  the backend's own classification epsilon,
+                                  same reasoning as the today block above */}
                               <td className={`${cell} text-center`}>
                                 {(group.dominantIntent === 'SOLAR_STORAGE' || group.dominantIntent === 'IDLE') &&
-                                 group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                                 group.socDeltaKwh != null && group.socDeltaKwh > 0.01 ? (
                                   <span className="text-amber-500 dark:text-amber-400 font-medium">
-                                    +{group.socDeltaKwh.toFixed(1)} kWh
+                                    +{group.socDeltaKwh.toFixed(2)} kWh
                                   </span>
                                 ) : (
                                   <span className="text-gray-300 dark:text-gray-600">—</span>
@@ -950,13 +957,13 @@ const InverterStatusDashboard: React.FC = () => {
                               {/* Grid / Discharge column */}
                               <td className={`${cell} text-center`}>
                                 {group.dominantIntent === 'GRID_CHARGING' &&
-                                 group.socDeltaKwh != null && group.socDeltaKwh > 0.1 ? (
+                                 group.socDeltaKwh != null && group.socDeltaKwh > 0.01 ? (
                                   <span className="text-green-600 dark:text-green-400 font-medium">
-                                    +{group.socDeltaKwh.toFixed(1)} kWh
+                                    +{group.socDeltaKwh.toFixed(2)} kWh
                                   </span>
-                                ) : group.totalActionKwh !== undefined && group.totalActionKwh < -0.05 ? (
+                                ) : group.totalActionKwh !== undefined && group.totalActionKwh < -0.01 ? (
                                   <span className="text-orange-500 dark:text-orange-400 font-medium">
-                                    {group.totalActionKwh.toFixed(1)} kWh
+                                    {group.totalActionKwh.toFixed(2)} kWh
                                   </span>
                                 ) : (
                                   <span className="text-gray-300 dark:text-gray-600">—</span>


### PR DESCRIPTION
## Summary
`InverterStatusDashboard.tsx`'s schedule table only showed a `+X.X kWh` amount when `socDeltaKwh > 0.1` — 10x coarser than the backend's own `0.01` kWh classification threshold (`decision_intelligence.py`) that produces the SOLAR_STORAGE/GRID_CHARGING/LOAD_SUPPORT label in the first place. Any period between 0.01 and 0.1 kWh showed a correctly-labeled row with its value hidden as "—", reading as a data contradiction.

Note: the intent **classification** itself was already correctly single-sourced from the backend (fetched via `periodGroups`, never re-derived client-side) — this was purely a mismatched display cutoff, not a duplicate classification system.

Aligned both thresholds to 0.01 kWh, and switched display precision from 1 to 2 decimals so small-but-real values don't themselves round to a misleading "+0.0 kWh".

## Test plan
- [x] `npm run lint:fix` — 0 errors (pre-existing warnings elsewhere unrelated)
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)