### PR TITLE
fix: Dashboard timeline showing stale intent for elapsed hours (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Solis installs now auto-configure grid export power, derived from the same signed sensor as import power. Previously export power was always unconfigured. ([#475](https://github.com/johanzander/bess-manager/issues/475))
 - Huawei LUNA2000 installs now auto-discover all sensors (SOC, battery control, power monitoring) instead of requiring manual entity entry for every field, and gain real-time solar/grid power monitoring. ([#438](https://github.com/johanzander/bess-manager/issues/438))
 - **Growatt VPP Remote Control no longer keeps overriding the inverter after switching away from VPP mode** — switching control mode to TOU, or switching to a different inverter platform entirely, now disables the VPP override automatically. ([#479](https://github.com/johanzander/bess-manager/issues/479))
+- **Dashboard timeline no longer shows a stale intent (e.g. "Selling to Grid") for an elapsed hour that actually executed differently** — the color bar now always reflects true per-quarter data. ([#486](https://github.com/johanzander/bess-manager/issues/486))
 ### Fixed
 
 - The consumption forecast now refreshes intraday like solar already does, instead of caching stale data until the 23:55 job. ([#395](https://github.com/johanzander/bess-manager/issues/395))

--- a/backend/api.py
+++ b/backend/api.py
@@ -389,6 +389,15 @@ def _aggregate_quarterly_to_hourly(
         "IDLE": 1,
     }
 
+    def dominant_intent(intents: list[str]) -> str:
+        """Most common intent among the 4 quarters; ties broken by priority."""
+        intent_counts: dict[str, int] = {}
+        for intent_item in intents:
+            intent_counts[intent_item] = intent_counts.get(intent_item, 0) + 1
+        max_count = max(intent_counts.values())
+        candidates = [i for i, c in intent_counts.items() if c == max_count]
+        return max(candidates, key=lambda x: intent_priority.get(x, 0))
+
     hourly_periods = []
     num_hours = (len(quarterly_periods) + 3) // 4  # Round up to handle DST
 
@@ -406,20 +415,34 @@ def _aggregate_quarterly_to_hourly(
 
         # Determine dominant strategic intent (most common in the 4 periods)
         # If there's a tie, prioritize action over inaction
-        period_intents = [p.strategicIntent for p in quarter_periods]
-        intent_counts = {}
-        for intent_item in period_intents:
-            intent_counts[intent_item] = intent_counts.get(intent_item, 0) + 1
+        dominant_strategic_intent = dominant_intent(
+            [p.strategicIntent for p in quarter_periods]
+        )
 
-        # Find max count, then use priority as tie-breaker
-        max_count = max(intent_counts.values())
-        candidates = [i for i, c in intent_counts.items() if c == max_count]
-        dominant_intent = max(candidates, key=lambda x: intent_priority.get(x, 0))
+        # Observed intent must aggregate across all 4 quarters too, not just
+        # the last one — a re-plan only updates strategicIntent going
+        # forward, so a stale strategicIntent can persist for an elapsed hour
+        # even though most/all of its quarters were genuinely observed
+        # executing something else (#486). dataSource itself stays tied to
+        # the last quarter (unchanged) — actualSavingsSoFar/predictedRemaining
+        # Savings (api_dataclasses.py) bucket a whole hour's summed
+        # hourlySavings by this field, so flipping it to "actual" as soon as
+        # any one quarter is actual would count still-predicted quarters'
+        # costs as realized.
+        actual_quarters = [p for p in quarter_periods if p.dataSource == "actual"]
+        observed_intents = [
+            p.observedIntent for p in actual_quarters if p.observedIntent
+        ]
+        hour_observed_intent = (
+            dominant_intent(observed_intents)
+            if observed_intents
+            else last_period.observedIntent
+        )
 
         # Sum energy values across the 4 quarters
         hourly_period = APIDashboardHourlyData(
             period=hour,
-            dataSource=last_period.dataSource,  # Use last period's data source
+            dataSource=last_period.dataSource,
             timestamp=last_period.timestamp,
             # Sum energy flows
             solarProduction=create_formatted_value(
@@ -570,8 +593,8 @@ def _aggregate_quarterly_to_hourly(
                 sum(p.netSavings.value for p in quarter_periods), "currency", currency
             ),
             # Use dominant strategic intent with tie-breaking (same logic as Growatt schedule)
-            strategicIntent=dominant_intent,
-            observedIntent=last_period.observedIntent,
+            strategicIntent=dominant_strategic_intent,
+            observedIntent=hour_observed_intent,
             directSolar=sum(p.directSolar for p in quarter_periods),
         )
 

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -6,11 +6,12 @@ in _aggregate_quarterly_to_hourly.
 """
 
 import sys
+from dataclasses import replace
 from datetime import date, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
-from api import router
+from api import _aggregate_quarterly_to_hourly, router
 from api_dataclasses import APIDashboardHourlyData, APIDashboardSummary
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -334,6 +335,71 @@ class TestDashboardAvailableDates:
         sys.modules["app"].bess_controller = _unconfigured_controller()
         resp = _client.get("/api/dashboard/available-dates")
         assert resp.status_code == 503
+
+
+def test_aggregate_hourly_uses_observed_intent_from_all_quarters_not_just_last():
+    """Regression test for #486.
+
+    The per-quarter observedIntent captures real execution, but the old
+    aggregation only forwarded the *last* quarter's observedIntent, so if
+    the last quarter's observed execution disagreed with the other 3
+    (all genuinely recorded as "actual"), the majority's real outcome was
+    silently discarded in favor of that one quarter's value.
+    """
+    quarters = []
+    for i in range(4):
+        period = _make_period(i)
+        # All 4 quarters genuinely executed and were recorded as actual;
+        # 3 of them ran LOAD_SUPPORT, only the last ran BATTERY_EXPORT.
+        period = replace(
+            period,
+            data_source="actual",
+            decision=DecisionData(
+                strategic_intent="BATTERY_EXPORT",
+                observed_intent="BATTERY_EXPORT" if i == 3 else "LOAD_SUPPORT",
+            ),
+        )
+        quarters.append(
+            APIDashboardHourlyData.from_internal(
+                period, battery_capacity=15.0, currency="SEK"
+            )
+        )
+
+    [hourly] = _aggregate_quarterly_to_hourly(quarters, 15.0, "SEK")
+
+    # dataSource stays tied to the last quarter (unchanged) — it feeds
+    # actualSavingsSoFar/predictedRemainingSavings bucketing and must not
+    # be widened to "any quarter actual", or a still-predicted quarter's
+    # cost gets counted as realized.
+    assert hourly.dataSource == "actual"
+    assert hourly.observedIntent == "LOAD_SUPPORT"
+
+
+def test_aggregate_hourly_data_source_stays_last_quarter_even_if_earlier_quarters_are_actual():
+    """dataSource must not flip to "actual" just because SOME quarter is —
+    only the last quarter's value counts, matching the pre-existing contract
+    that api_dataclasses.py's actual/predicted savings split relies on.
+    """
+    quarters = []
+    for i in range(4):
+        period = _make_period(i)
+        period = replace(
+            period,
+            data_source="actual" if i < 3 else "predicted",
+            decision=DecisionData(
+                strategic_intent="LOAD_SUPPORT",
+                observed_intent="LOAD_SUPPORT" if i < 3 else None,
+            ),
+        )
+        quarters.append(
+            APIDashboardHourlyData.from_internal(
+                period, battery_capacity=15.0, currency="SEK"
+            )
+        )
+
+    [hourly] = _aggregate_quarterly_to_hourly(quarters, 15.0, "SEK")
+
+    assert hourly.dataSource == "predicted"
 
 
 def test_net_grid_cost_excludes_battery_wear():

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -767,7 +767,7 @@ The system operates on **quarterly resolution (15-minute periods)** throughout t
 - **Storage**: Indexes by period_index (0-95)
 - **InfluxDB**: Queries at 15-minute boundaries
 - **API**: Returns quarterly, aggregates only for display
-- **Frontend**: Displays both resolutions as user preference
+- **Frontend**: Displays both resolutions as user preference, except the Dashboard's intent color timeline (`BatteryModeTimeline`), which always renders at quarter-hourly granularity regardless of that preference — hourly aggregation can average away a genuine intent disagreement between quarters (#486)
 
 
 ## Development and Testing

--- a/frontend/src/components/BatteryModeTimeline.tsx
+++ b/frontend/src/components/BatteryModeTimeline.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { HourlyData } from '../types';
-import { DataResolution } from '../hooks/useUserPreferences';
+import { useDashboardData } from '../hooks/useDashboardData';
+import { DashboardHourlyData } from '../api/scheduleApi';
 import { getIntent, StrategicIntent } from '../utils/intent';
+
+// Refresh cadence matches other components that self-fetch quarter-hourly
+// dashboard data (EnergyFlowCards, SystemStatusCard).
+const REFRESH_INTERVAL_MS = 60000;
 
 // Must match the YAxis width and ComposedChart margin used in EnergyFlowChart and BatteryLevelChart
 // so the timeline bar aligns horizontally with the chart plot areas.
@@ -22,10 +26,7 @@ const INTENT_CONFIG: Record<StrategicIntent, { label: string; color: string; dar
 const INTENT_ORDER: StrategicIntent[] = ['GRID_CHARGING', 'SOLAR_STORAGE', 'LOAD_SUPPORT', 'BATTERY_EXPORT', 'SOLAR_EXPORT', 'IDLE'];
 
 interface BatteryModeTimelineProps {
-  hourlyData: HourlyData[];
-  tomorrowData?: HourlyData[] | null;
   currentHour: number;
-  resolution: DataResolution;
 }
 
 interface Segment {
@@ -35,19 +36,22 @@ interface Segment {
   isTomorrow: boolean;
 }
 
+// Always builds segments at true quarter-hour granularity — the color bar
+// must never go through hourly "dominant intent" aggregation, which can
+// let a stale planned intent outvote what was actually observed (#486).
+const STEP_HOURS = 0.25;
+
 function buildSegments(
-  hourlyData: HourlyData[],
-  tomorrowData: HourlyData[] | null | undefined,
-  resolution: DataResolution
+  hourlyData: DashboardHourlyData[],
+  tomorrowData: DashboardHourlyData[] | null | undefined
 ): Segment[] {
-  const step = resolution === 'quarter-hourly' ? 0.25 : 1;
   const segments: Segment[] = [];
 
   for (let i = 0; i < hourlyData.length; i++) {
     const h = hourlyData[i];
     const intent = getIntent(h);
-    const startHour = resolution === 'quarter-hourly' ? i * 0.25 : i;
-    const endHour = startHour + step;
+    const startHour = i * STEP_HOURS;
+    const endHour = startHour + STEP_HOURS;
 
     const last = segments[segments.length - 1];
     if (last && last.intent === intent && !last.isTomorrow && Math.abs(last.endHour - startHour) < 0.01) {
@@ -60,8 +64,8 @@ function buildSegments(
   if (tomorrowData && tomorrowData.length > 0) {
     for (let i = 0; i < tomorrowData.length; i++) {
       const intent = getIntent(tomorrowData[i]);
-      const startHour = 24 + (resolution === 'quarter-hourly' ? i * 0.25 : i);
-      const endHour = startHour + step;
+      const startHour = 24 + i * STEP_HOURS;
+      const endHour = startHour + STEP_HOURS;
 
       const last = segments[segments.length - 1];
       if (last && last.intent === intent && last.isTomorrow && Math.abs(last.endHour - startHour) < 0.01) {
@@ -82,10 +86,7 @@ function formatHour(hour: number): string {
 }
 
 export const BatteryModeTimeline: React.FC<BatteryModeTimelineProps> = ({
-  hourlyData,
-  tomorrowData,
   currentHour,
-  resolution,
 }) => {
   const [isDarkMode, setIsDarkMode] = useState(
     document.documentElement.classList.contains('dark')
@@ -99,7 +100,31 @@ export const BatteryModeTimeline: React.FC<BatteryModeTimelineProps> = ({
     return () => observer.disconnect();
   }, []);
 
-  const segments = buildSegments(hourlyData, tomorrowData, resolution);
+  const { data, loading, error } = useDashboardData(undefined, 'quarter-hourly', REFRESH_INTERVAL_MS);
+
+  // useDashboardData sets loading=true on every periodic refetch too, not
+  // just the first one — gate the skeleton on "no data yet" so a background
+  // 60s refresh doesn't blank out an already-rendered timeline (#486).
+  if (loading && !data) {
+    return (
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow animate-pulse">
+        <div className="h-9 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow text-red-600 text-center">
+        {error || 'Failed to load schedule'}
+      </div>
+    );
+  }
+
+  const hourlyData = data.hourlyData;
+  const tomorrowData = data.tomorrowData;
+
+  const segments = buildSegments(hourlyData, tomorrowData);
   const hasTomorrow = tomorrowData && tomorrowData.length > 0;
   const maxHour = hasTomorrow ? 48 : 24;
 

--- a/frontend/src/components/__tests__/BatteryModeTimeline.test.tsx
+++ b/frontend/src/components/__tests__/BatteryModeTimeline.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { BatteryModeTimeline } from '../BatteryModeTimeline'
+
+// Regression tests for #486: the timeline color bar must always reflect true
+// quarter-level intent, never an hourly "dominant intent" approximation —
+// that approximation is what let a stale planned BATTERY_EXPORT outvote a
+// genuinely observed LOAD_SUPPORT for an elapsed hour. The component now
+// fetches its own quarter-hourly data instead of receiving page-resolution-
+// dependent hourlyData/resolution props.
+const quarters = [0, 1, 2, 3].map((period) => ({
+  period,
+  dataSource: 'actual',
+  strategicIntent: period < 2 ? 'LOAD_SUPPORT' : 'BATTERY_EXPORT',
+  observedIntent: period < 2 ? 'LOAD_SUPPORT' : 'BATTERY_EXPORT',
+}))
+
+let mockLoading = false
+
+vi.mock('../../hooks/useDashboardData', () => ({
+  useDashboardData: () => ({
+    data: {
+      currentPeriod: 0,
+      hourlyData: quarters,
+      tomorrowData: null,
+      summary: {},
+    },
+    loading: mockLoading,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+describe('BatteryModeTimeline', () => {
+  it('renders each quarter-period as its own segment instead of collapsing a mixed hour into one dominant-intent block', () => {
+    mockLoading = false
+    const { container } = render(<BatteryModeTimeline currentHour={0} />)
+
+    // Two quarters LOAD_SUPPORT followed by two quarters BATTERY_EXPORT
+    // within the same clock hour must render as two distinct colored
+    // segments (one rect each), not merge into a single hour-block.
+    const rects = container.querySelectorAll('rect')
+    expect(rects.length).toBe(2)
+  })
+
+  it('keeps showing the already-loaded timeline during a background refresh instead of blanking to a skeleton', () => {
+    // useDashboardData sets loading=true on every periodic refetch, not just
+    // the very first one. If data from a prior fetch is already available,
+    // the timeline must keep rendering it rather than flashing a skeleton
+    // every 60 seconds.
+    mockLoading = true
+    const { container } = render(<BatteryModeTimeline currentHour={0} />)
+
+    const rects = container.querySelectorAll('rect')
+    expect(rects.length).toBe(2)
+  })
+})

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -397,10 +397,7 @@ export default function DashboardPage({
             <div>
               <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Schedule</h2>
               <BatteryModeTimeline
-                hourlyData={dashboardData.hourlyData as any}
-                tomorrowData={dashboardData.tomorrowData as any}
                 currentHour={currentHour}
-                resolution={dataResolution}
               />
             </div>
 


### PR DESCRIPTION
## Summary
- `backend/api.py`'s `_aggregate_quarterly_to_hourly` now aggregates `observedIntent` via majority vote across all 4 quarters recorded "actual" (matching the tie-break logic `strategicIntent` already used), instead of only forwarding the last quarter's value.
- `BatteryModeTimeline` no longer receives `hourlyData`/`tomorrowData`/`resolution` props tied to the page's display-resolution preference. It now self-fetches its own data at `quarter-hourly` resolution always, so the color bar never goes through hourly aggregation at all — matching the pattern already used by sibling components (`EnergyFlowCards`, `SystemStatusCard`).

## Root cause
Two things combined (full diagnosis in #486):

1. `strategic_intent` for an elapsed period reflects the DP's plan at decision time, not execution — a re-plan (e.g. a TOU-disable event) only plans forward from the current period, so `ScheduleStore.get_period_data_at()` can fall through to a stale earlier plan for an already-elapsed period.
2. The hourly aggregation only forwarded the *last* quarter's `observedIntent`/`dataSource`, so a still-"predicted" trailing quarter within an hour could hide 3 genuinely observed quarters and fall back to the stale `strategicIntent` — this is what produced the reported "Selling to Grid" block for an hour that actually ran `LOAD_SUPPORT` the whole time (see [#381 comment](https://github.com/johanzander/bess-manager/issues/381#issuecomment-5213698837)).

## Fix
- Aggregate `observedIntent` the same way `strategicIntent` already is (majority vote across quarters, extracted into a shared `dominant_intent()` helper), scoped to quarters recorded `"actual"`.
- `dataSource` deliberately stays tied to the last quarter only (unchanged) — it feeds `actualSavingsSoFar`/`predictedRemainingSavings` bucketing in `api_dataclasses.py`, and widening it to "any quarter actual" would count still-predicted quarters' costs as realized. (Caught in code review during this PR's own quality gate — see commit history.)
- Decoupled `BatteryModeTimeline`'s color rendering from the page's `hourly`/`quarter-hourly` display-resolution toggle entirely, since even a *correct* hourly aggregation is still a lossy display approximation of two genuinely different quarters within the same hour. The color bar now always reflects true quarter-level truth.
- Also fixed a flicker introduced by the above: `useDashboardData` sets `loading=true` on every periodic refresh, not just the first — gated the skeleton on "no data yet" so a background 60s refresh doesn't blank an already-rendered timeline.

## Scope assessment
Local — both changes stay within their existing function/component's responsibility (the aggregation helper's existing contract of aggregating 4 quarters into 1 hour; the timeline component's existing responsibility of showing intent). No new fallback, flag, or second construction site.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (fast Python suite, frontend suite, tsc, ESLint)
- [x] `.venv/bin/pytest -m slow` passes locally (411 passed, 3 skipped)
- [x] New backend test `test_aggregate_hourly_uses_observed_intent_from_all_quarters_not_just_last` + `test_aggregate_hourly_data_source_stays_last_quarter_even_if_earlier_quarters_are_actual`, built through the real `PeriodData` → `APIDashboardHourlyData.from_internal` → `_aggregate_quarterly_to_hourly` pipeline
- [x] New frontend test `BatteryModeTimeline.test.tsx` — confirms quarter-level segments render distinctly instead of collapsing, and no skeleton flash on background refresh
- [ ] **Live browser/E2E run not completed.** I stood up the real mock-HA + backend stack (`docker-compose.ci.yml`, `ci-normal-day`) to watch the Dashboard load, but hit a pre-existing, unrelated environment blocker: the schedule never computes (`Configuration error: Solar forecast sensor 'solar_forecast_today' not configured in sensors mapping`), leaving `/api/dashboard` stuck in `"initializing"`. Confirmed `e2e/ci-options.json` is unmodified from `origin/main`, so this is a pre-existing fixture gap, not caused by this diff — but it means this PR has not been visually confirmed working in a live browser. Flagging for reviewer awareness.

## Documentation
Checked `docs/agents/bess-knowledge.md` (no matches) and `docs/SOFTWARE_DESIGN.md` — updated the "Data Flow" section's note that all displays honor the resolution preference, since the intent timeline now deliberately doesn't.

Closes #486