### PR TITLE
fix: hoist BatteryModeTimeline tooltip hook above conditional returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Near-tied grid-DP decisions could resolve to a suboptimal schedule** — those windows are now re-solved exactly with a windowed piecewise-linear solver instead of relying on the fast DP's approximation alone. ([#450](https://github.com/johanzander/bess-manager/issues/450))
 - The schedule table showed SOLAR_STORAGE/GRID_CHARGING/LOAD_SUPPORT labels with the kWh amount hidden as "--" for small-but-real periods (0.01–0.1 kWh) — the frontend's display threshold is now aligned with the backend's classification threshold. ([#484](https://github.com/johanzander/bess-manager/issues/484))
 - **Power monitoring could be enabled without the phase-current sensors it needs, crash-looping the schedule updater while the health check reported "OK"** — enabling it now requires those sensors to be mapped, at the settings UI, setup wizard, and API layers, and the health check flags the gap if it occurs anyway. ([#492](https://github.com/johanzander/bess-manager/issues/492))
+- Dashboard could crash with "Minified React error #310" during a background data refresh — the timeline's tooltip state hook was declared after two conditional early returns, changing the number of hooks called between renders.
 ### Fixed
 
 - The consumption forecast now refreshes intraday like solar already does, instead of caching stale data until the 23:55 job. ([#395](https://github.com/johanzander/bess-manager/issues/395))

--- a/frontend/src/components/BatteryModeTimeline.tsx
+++ b/frontend/src/components/BatteryModeTimeline.tsx
@@ -102,6 +102,8 @@ export const BatteryModeTimeline: React.FC<BatteryModeTimelineProps> = ({
 
   const { data, loading, error } = useDashboardData(undefined, 'quarter-hourly', REFRESH_INTERVAL_MS);
 
+  const [tooltipData, setTooltipData] = useState<{ segment: Segment; x: number; y: number } | null>(null);
+
   // useDashboardData sets loading=true on every periodic refetch too, not
   // just the first one — gate the skeleton on "no data yet" so a background
   // 60s refresh doesn't blank out an already-rendered timeline (#486).
@@ -139,8 +141,6 @@ export const BatteryModeTimeline: React.FC<BatteryModeTimelineProps> = ({
   const barHeight = 28;
   const tickHeight = 6;
   const svgHeight = barHeight + 20; // bar + tick + label
-
-  const [tooltipData, setTooltipData] = useState<{ segment: Segment; x: number; y: number } | null>(null);
 
   const tickColor = isDarkMode ? '#6b7280' : '#9ca3af';
 


### PR DESCRIPTION
## Summary
- Dashboard crashed with "Minified React error #310" (rendered fewer hooks than expected) during background 60s refreshes of `BatteryModeTimeline`.
- Cause: the loading/error early returns added in #486/#493 sit between `useDashboardData` and the tooltip `useState`, so the hook count differs between the loading/error render and the normal render.
- Fix: hoist the `tooltipData` `useState` above the early returns so hook order is fixed across all renders.

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — no new warnings/errors
- [x] `npm run test` — 116/116 tests pass, including `BatteryModeTimeline.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)