### PR TITLE
docs: graduate Solis (solis_modbus) from experimental to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Optional PV export-limit curtailment on negative sell prices** — when enabled and a period is exporting at a sell price below a configurable floor, Growatt GEN2/GEN3/GEN4 hardware (via solax_modbus, with a grid CT/smart meter) now throttles PV production at the panel instead of paying to export. Off by default. ([#269](https://github.com/johanzander/bess-manager/issues/269))
 - **Inverter service domain is now configurable** — a compatible integration exposing the same TOU services under its own domain works as a setting instead of needing a new BESS platform. ([#412](https://github.com/johanzander/bess-manager/pull/412))
 - **Grid connection import capacity modeling** — the DP now caps planned grid import at the house's fuse limit instead of planning unbounded imports, gated on `power_monitoring_enabled`. ([#429](https://github.com/johanzander/bess-manager/issues/429))
+- **Solis inverter platform (`solis_modbus`) is now stable** — confirmed working against real Solis installations by two beta testers, no longer marked experimental. ([#130](https://github.com/johanzander/bess-manager/issues/130))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Something look off? The built-in AI Analyst explains every decision in plain lan
 - **Growatt MIC/MIN/MOD/MID** — via Growatt Server (cloud) or Modbus (local, TOU or VPP control mode *(VPP experimental)*)
 - **Growatt SPH** — via Growatt Server (cloud) or Modbus (local, VPP control mode *(experimental)*)
 - **SolaX** — via Solax modbus integration
-- **Solis** — via the [solis_modbus](https://github.com/Pho3niX90/solis_modbus) integration (local Modbus) *(experimental)*
+- **Solis** — via the [solis_modbus](https://github.com/Pho3niX90/solis_modbus) integration (local Modbus)
 - **Huawei LUNA2000** *(experimental)* — via huawei_solar integration (local Modbus)
 
 ### Electricity Markets
@@ -64,7 +64,7 @@ Something look off? The built-in AI Analyst explains every decision in plain lan
 - **InfluxDB** for historical data persistence
 - **Tibber** for power monitoring
 
-> **Want support for your inverter?** We're actively looking for testers with GivEnergy, Solis, Huawei, and other systems. [Open an issue](https://github.com/johanzander/bess-manager/issues) or join the discussion! [Sponsoring](https://github.com/johanzander/bess-manager#sponsorship) helps prioritize new hardware support.
+> **Want support for your inverter?** We're actively looking for testers with GivEnergy, Huawei, and other systems. [Open an issue](https://github.com/johanzander/bess-manager/issues) or join the discussion! [Sponsoring](https://github.com/johanzander/bess-manager#sponsorship) helps prioritize new hardware support.
 
 ## Installation
 

--- a/core/bess/solis_modbus_controller.py
+++ b/core/bess/solis_modbus_controller.py
@@ -30,8 +30,7 @@ Solis Intent Mapping (identical semantics to GrowattSphController):
 - BATTERY_EXPORT  → discharge period
 - IDLE            → nothing (inverter default / self-use mode)
 
-EXPERIMENTAL: not yet validated against a real Solis installation — see
-docs/agents/memory/project_platform_maturity.md.
+Real-world validated (issue #130) — see docs/agents/memory/project_platform_maturity.md.
 """
 
 import logging

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -13,7 +13,7 @@ communication.
 | Growatt SPH (Cloud) | Growatt SPH | [Growatt Server](https://www.home-assistant.io/integrations/growatt_server/) | Cloud API | AC charge/discharge periods | — |
 | Growatt MIX/SPH (Local) | Growatt MIX/SPA/SPH | [solax_modbus](https://github.com/wills106/homeassistant-solax-modbus) Growatt plugin | Local Modbus | Mode-specific time slots | GEN3 |
 | SolaX | SolaX hybrid | [solax_modbus](https://github.com/wills106/homeassistant-solax-modbus) | Local Modbus | VPP active-power commands | — |
-| Solis (EXPERIMENTAL) | Solis hybrid | [solis_modbus](https://github.com/Pho3niX90/solis_modbus) | Local Modbus | Grid Time of Use v2 (6 charge + 6 discharge periods) | — |
+| Solis | Solis hybrid | [solis_modbus](https://github.com/Pho3niX90/solis_modbus) | Local Modbus | Grid Time of Use v2 (6 charge + 6 discharge periods) | — |
 | Huawei LUNA2000 (Local) | Huawei LUNA2000 | [huawei_solar](https://github.com/wlcrs/huawei_solar) | Local Modbus | TOU period-list writes | — |
 
 > **solax_modbus generation mapping:** The `wills106/homeassistant-solax-modbus`
@@ -74,7 +74,7 @@ declares which it supports, mapped to BESS sensor keys): **charge window**
 | `solax_modbus_growatt_min` | TX-Modbus | SM-TOU-numbered (single-segment) | `SolaxModbusGrowattController` | `_GROWATT_TOU_MARKER_SUFFIX` (`time_1_enabled`) | `SOLAX_GROWATT_MIN_SUFFIX_MAP` |
 | `solax_modbus_growatt_sph` | TX-Modbus | SM-Mode-slots (GEN3, monitoring-only) | `SolaxModbusGrowattController` | `_GROWATT_GEN3_MARKER_SUFFIX` | `SOLAX_GROWATT_SPH_SUFFIX_MAP` |
 | `solax_modbus_native` | TX-Modbus | SM-Ephemeral (VPP) | `SolaxController` | `_SOLAX_NATIVE_MARKER_SUFFIX` (`remotecontrol_power_control`) | `SOLAX_NATIVE_SUFFIX_MAP` |
-| `solis_modbus` (EXPERIMENTAL) | TX-Modbus | SM-Period-lists (6 charge + 6 discharge) | `SolisModbusController` | `_SOLIS_TOU_MARKER_SUFFIX` (`time_entity_43711`) | `SOLIS_SUFFIX_MAP` + `SOLIS_DICT_EMBEDDED_SUFFIX_MAP` |
+| `solis_modbus` | TX-Modbus | SM-Period-lists (6 charge + 6 discharge) | `SolisModbusController` | `_SOLIS_TOU_MARKER_SUFFIX` (`time_entity_43711`) | `SOLIS_SUFFIX_MAP` + `SOLIS_DICT_EMBEDDED_SUFFIX_MAP` |
 | `huawei_solar_luna2000` | TX-Vendor-service | SM-Period-lists | `HuaweiController` | `_HUAWEI_BATTERY_MARKER_SUFFIX` (`storage_working_mode_settings`) | `HUAWEI_SUFFIX_MAP` |
 
 ### Bring-your-own integration
@@ -409,7 +409,7 @@ button.press(trigger)
 
 **Idle/solar mode:** Disables VPP, inverter reverts to self-use.
 
-### Solis — `solis_modbus` (EXPERIMENTAL)
+### Solis — `solis_modbus`
 
 Solis hybrids, connected via the community
 [`Pho3niX90/solis_modbus`](https://github.com/Pho3niX90/solis_modbus)
@@ -711,7 +711,7 @@ GEN4 above (`limit_grid_export` / `grid_export_limit`, registers 122/123) —
 | `solax_battery_min_soc` | number | `battery_minimum_capacity` | Min battery SOC (%) |
 | `solax_charger_use_mode` | select | `charger_use_mode` | Charger use mode (optional) |
 
-### Solis — `solis_modbus` integration (EXPERIMENTAL)
+### Solis — `solis_modbus` integration
 
 **Monitoring:**
 

--- a/docs/agents/memory/MEMORY.md
+++ b/docs/agents/memory/MEMORY.md
@@ -3,5 +3,5 @@
 - [Worktree sibling location](feedback_worktree_location.md) — Create worktrees as sibling folders, not inside .claude/worktrees/
 - [Parallel release train](feedback_parallel_release.md) — Use concurrent subagents for beta releases; check GitHub releases for version numbers
 - [solax_modbus unique_id format](reference_solax_modbus_unique_ids.md) — unique_id = {user_device_name}_{register_key}; suffix maps must use register key only, never hardcode device name prefix
-- [Inverter platform maturity levels](project_platform_maturity.md) — Only Growatt cloud + GEN4 solax_modbus are real-world tested; GEN3, SolaX VPP, and Solis (solis_modbus) are experimental
+- [Inverter platform maturity levels](project_platform_maturity.md) — Growatt cloud, GEN4 solax_modbus, and Solis (solis_modbus) are real-world tested; GEN3 and SolaX VPP are experimental
 - [Issue #275 investigation status](project_issue_275_investigation_status.md) — real defect fixed in v9.9.0b13 (PR #279); residual proven financially optimal via Bellman-optimality + realized-cost checks; #276/#285 recommended closed

--- a/docs/agents/memory/project_platform_maturity.md
+++ b/docs/agents/memory/project_platform_maturity.md
@@ -16,14 +16,20 @@ file) is the stability flag for this codebase — see `feature-lifecycle` skill.
   scenario.
 - `solax_modbus_growatt_sph` (GEN3) — monitoring-only, schedule control not implemented.
 - `solax_modbus_native` (SolaX VPP).
-- `solis_modbus` (Solis hybrid via Pho3niX90/solis_modbus, added for issue
-  #130) — implementation is source-verified against the real integration
-  (release v4.1.6) but has not been confirmed against a real Solis
-  installation. Do not describe it as validated in user-facing docs or
-  release notes until a beta tester confirms via a debug log.
 
 ## Real-world validated
 
 (Populate as platforms/providers graduate through `feature-lifecycle` Stage 6.
 Candidates not yet formally tracked here: Growatt cloud MIN/SPH, GEN4 Growatt
 TOU via solax_modbus — all in production use prior to this file's creation.)
+
+- `solis_modbus` (Solis hybrid via Pho3niX90/solis_modbus, added for issue
+  [#130](https://github.com/johanzander/bess-manager/issues/130)) — confirmed
+  working against real Solis installations by two beta testers
+  (`tatusbar` on an S6-EH3P10K-NV-YD-L, `andys1802` on an S6-EH3P15K):
+  entities auto-detected, schedule control running successfully. A debug
+  log from the field surfaced one real bug (grid export power never
+  auto-configured,
+  [#475](https://github.com/johanzander/bess-manager/issues/475)), fixed and
+  locked into the `ci-wizard-solis` regression scenario (backend discovery
+  test + Playwright wizard E2E).

--- a/frontend/src/components/settings/SensorConfigSection.tsx
+++ b/frontend/src/components/settings/SensorConfigSection.tsx
@@ -511,8 +511,7 @@ export function SensorConfigSection({ sensors, onChange, inverterForm, onInverte
               <TabsContent value="solis">
                 <p className="text-xs text-gray-500 dark:text-gray-400">
                   Solis hybrid inverter via the Pho3niX90/solis_modbus integration
-                  (Grid Time of Use v2, local Modbus). Experimental — not yet
-                  validated against a real Solis installation.
+                  (Grid Time of Use v2, local Modbus).
                 </p>
               </TabsContent>
 

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -380,7 +380,7 @@ export const INTEGRATIONS: IntegrationDef[] = [
     id: 'solis_modbus',
     name: 'Solis Modbus',
     required: true,
-    description: 'Solis hybrid inverter controlled via the Pho3niX90/solis_modbus integration (local Modbus, Grid Time of Use v2 schedule — 6 charge + 6 discharge periods). Experimental — not yet validated against a real Solis installation.',
+    description: 'Solis hybrid inverter controlled via the Pho3niX90/solis_modbus integration (local Modbus, Grid Time of Use v2 schedule — 6 charge + 6 discharge periods).',
     sensorGroups: [
       {
         name: 'Battery Monitoring',


### PR DESCRIPTION
## Summary
- Solis (`solis_modbus`) has been confirmed working against real hardware by two beta testers (`tatusbar` on an S6-EH3P10K-NV-YD-L, `andys1802` on an S6-EH3P15K) — entities auto-detected, schedule control running.
- A debug log from the field surfaced one real bug (grid export power never auto-configured, #475), which was fixed and locked into the `ci-wizard-solis` regression scenario (backend discovery test + Playwright wizard E2E).
- This is `feature-lifecycle` Stage 6: strips the "experimental" marker only — no implementation changes. README, the setup wizard UI copy, `docs/INVERTER_PLATFORMS.md`, `docs/agents/memory/project_platform_maturity.md`, and the controller docstring all updated; CHANGELOG `## [Unreleased]` gets an "Added — now stable" entry.

Closes #130

## Test plan
- [x] `pytest -m "not slow"` on `test_solis_modbus_controller.py` + `test_scenario_discovery.py` — 80 passed
- [x] `black --check` / `ruff check` on the touched Python file
- [x] `tsc --noEmit` and `npm run lint` on the touched frontend files — 0 errors
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)