### PR TITLE
docs: graduate ENTSO-e/Belpex price provider from experimental to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Inverter service domain is now configurable** — a compatible integration exposing the same TOU services under its own domain works as a setting instead of needing a new BESS platform. ([#412](https://github.com/johanzander/bess-manager/pull/412))
 - **Grid connection import capacity modeling** — the DP now caps planned grid import at the house's fuse limit instead of planning unbounded imports, gated on `power_monitoring_enabled`. ([#429](https://github.com/johanzander/bess-manager/issues/429))
 - **Solis inverter platform (`solis_modbus`) is now stable** — confirmed working against real Solis installations by two beta testers, no longer marked experimental. ([#130](https://github.com/johanzander/bess-manager/issues/130))
+- **ENTSO-e / Belpex price provider is now stable** — confirmed working against a real Belgian Belpex/Luminus Dynamic contract over an extended live-test period, no longer marked experimental. ([#126](https://github.com/johanzander/bess-manager/issues/126))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Something look off? The built-in AI Analyst explains every decision in plain lan
 ### Electricity Markets
 - **Nordpool** — Nordic spot market (SE, NO, FI, DK, EE, LT, LV)
 - **Octopus Energy Agile** — UK market with separate import/export rates
-- **ENTSO-e / Belpex** — European day-ahead spot prices via the ENTSO-e Transparency Platform (e.g. Belgian Belpex) *(experimental)*
+- **ENTSO-e / Belpex** — European day-ahead spot prices via the ENTSO-e Transparency Platform (e.g. Belgian Belpex)
 
 ### Optional Integrations
 - **Solcast** or other solar forecast for production predictions

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -275,7 +275,7 @@ For UK users on the Octopus Energy Agile tariff.
 
 #### Provider: ENTSO-e / Belpex (Transparency Platform)
 
-For European users on a day-ahead dynamic tariff that follows the ENTSO-e Transparency Platform — including Belgian **Belpex** prices (Luminus dynamic and others). *Experimental: not yet real-world validated — see [issue #126](https://github.com/johanzander/bess-manager/issues/126).*
+For European users on a day-ahead dynamic tariff that follows the ENTSO-e Transparency Platform — including Belgian **Belpex** prices (Luminus dynamic and others).
 
 - **Prerequisites**: The [ENTSO-e Transparency Platform](https://github.com/JaccoR/hass-entso-e) HACS integration installed and configured with your area (e.g. Belgium). It creates an "Average electricity price" sensor, e.g. `sensor.belpex_h_average_electricity_price`.
 - **How it works**: BESS reads the `prices_today` and `prices_tomorrow` attributes from that single sensor. Each is a list of `{"time", "price"}` entries. Hourly data (PT60M, 24/day) is expanded to the internal 15-minute resolution; native quarterly data (PT15M, 96/day) is used as-is.

--- a/docs/agents/memory/project_platform_maturity.md
+++ b/docs/agents/memory/project_platform_maturity.md
@@ -33,3 +33,17 @@ TOU via solax_modbus — all in production use prior to this file's creation.)
   [#475](https://github.com/johanzander/bess-manager/issues/475)), fixed and
   locked into the `ci-wizard-solis` regression scenario (backend discovery
   test + Playwright wizard E2E).
+- **ENTSO-e / Belpex price provider** (`entsoe_source.py`, added for issue
+  [#126](https://github.com/johanzander/bess-manager/issues/126)) — confirmed
+  working against a real Belgian Belpex/Luminus Dynamic contract by
+  `Frank-Leysen` over an extended live-test period spanning many beta
+  builds. Several real bugs surfaced and were fixed along the way: wizard
+  defaulting to SEK instead of EUR, `ems_discharging_rate` writes
+  overriding Load First mode, and the terminal-value arbitrage cap using
+  an unrelated slot's price as its ceiling
+  ([#422](https://github.com/johanzander/bess-manager/issues/422)/[#425](https://github.com/johanzander/bess-manager/pull/425)).
+  Frank's real (anonymized) config is locked into the regression suite as
+  `ci-wizard-entsoe-frank-126` (backend discovery test + Playwright wizard
+  E2E). Unrelated live-test findings from the same thread were split out
+  into their own issues (#337, #269, #352, #330, #345, #362, #363, #428,
+  #429) rather than tracked here.


### PR DESCRIPTION
## Summary
- ENTSO-e/Belpex has been confirmed working against a real Belgian Belpex/Luminus Dynamic contract by `Frank-Leysen`, over an extended live-test period spanning many beta builds.
- Several real bugs surfaced from that testing and were fixed: wizard currency defaulting to SEK instead of EUR, `ems_discharging_rate` writes overriding Load First mode, and the terminal-value arbitrage cap using an unrelated slot's price as its ceiling (#422/#425).
- Frank's real (anonymized) config is locked into the regression suite as `ci-wizard-entsoe-frank-126` (backend discovery test + Playwright wizard E2E) — already in CI.
- This is `feature-lifecycle` Stage 6: strips the "experimental" marker only — no implementation changes. README, `docs/USER_GUIDE.md`, and `docs/agents/memory/project_platform_maturity.md` updated; CHANGELOG `## [Unreleased]` gets a "now stable" entry.
- Note: the long #126 thread accumulated many unrelated live-test findings over time; those were already split out into their own issues (#337, #269, #352, #330, #345, #362, #363, #428, #429) and are unaffected by this PR.

Closes #126

## Test plan
- [x] `pytest -m "not slow"` on `test_entsoe_source.py` + `test_scenario_discovery.py` — 76 passed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)