### PR TITLE
chore: unpin Sonnet so sessions use the Claude Code default model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "model": "sonnet",
   "permissions": {
     "allow": [
       "Read",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,11 +155,12 @@ of `analyzed`.
 The user pays per token. A long Opus session that re-reads a large context after
 every multi-minute wait is what runs up the bill — not the work itself.
 
-- **Default to Sonnet** (set in `.claude/settings.json`). Use Opus only for a
-  genuinely hard reasoning step, say so, and drop back. Don't run routine
-  coordination, iteration, CI-watching, or file edits on Opus.
-- **Never spawn Opus subagents**, and avoid agents for long-running watches
-  entirely; if delegation is truly needed, use a cheap model.
+- **Pick the best-fit model per task.** No model is pinned in
+  `.claude/settings.json`, so sessions start on the Claude Code default.
+  Reach for a stronger model on genuinely hard reasoning, and prefer a
+  cheaper one for routine coordination, iteration, CI-watching, or file edits.
+- **Don't put subagents on an expensive model**, and avoid agents for
+  long-running watches entirely; if delegation is truly needed, use a cheap model.
 - **Don't hold one big session across many long CI/test waits.** The prompt
   cache expires after ~5 min, so each long wait forces a full uncached re-read
   of the entire context. Prefer `/clear` between unrelated chunks, or let the


### PR DESCRIPTION
## What

- Remove `"model": "sonnet"` from `.claude/settings.json`
- Update the stale **Cost Discipline** wording in `CLAUDE.md` to match

## Why

The pin was added in 920f6f45 (2026-06-24) during the Sonnet-only cost-discipline push. That policy has since relaxed to best-fit-model-per-task, but because project settings outrank user settings, the pin silently overrode every contributor's own model default on session start.

With it gone, sessions start on the Claude Code default and anyone who wants Sonnet can set it in their user settings or per-session with `/model`.

## Scope

Config and docs only — no code, no tests touched. The pending `rm` ask-pattern narrowing that was sitting uncommitted in the working tree is deliberately **not** included here; it would have widened unprompted deletes to any single file outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)