### PR TITLE
test: lock ridax67's real Growatt VPP config into the regression suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,17 @@ jobs:
         if: always() && env.RUN_E2E == 'true'
         run: docker compose -f docker-compose.ci.yml down
 
+      - name: "E2E: Wizard — Growatt VPP (real config, ridax67 / #118)"
+        if: always() && env.RUN_E2E == 'true'
+        run: |
+          echo '{}' > ./e2e/ci-wizard-settings.json
+          SCENARIO=ci-wizard-growatt-vpp-ridax-118 BESS_SETTINGS=./e2e/ci-wizard-settings.json BESS_OPTIONS=./e2e/ci-wizard-options.json docker compose -f docker-compose.ci.yml up -d
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/api/setup/status > /dev/null 2>&1; do sleep 2; done'
+          cd e2e && SCENARIO=ci-wizard-growatt-vpp-ridax-118 npx playwright test --project=wizard
+      - name: "E2E: Stop wizard (Growatt VPP real config)"
+        if: always() && env.RUN_E2E == 'true'
+        run: docker compose -f docker-compose.ci.yml down
+
       - name: "E2E: Wizard — Growatt MIN (GEN4 + SolaX Modbus)"
         if: always() && env.RUN_E2E == 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The "Enable Live Control" pre-flight dialog showed a green check for optional components that were genuinely failing (e.g. a misconfigured InfluxDB), not just ones left unconfigured. Those now show an amber warning — they still never block enabling live control.
 - Settings → Savings History silently displayed "0 days recorded" when the disk-usage request failed, and swallowed errors when clearing the history. Both now surface the actual error.
 
+### Internal
+
+- Locked a real Growatt GEN4 VPP installation's config (`ridax67`) into the discovery regression suite as `ci-wizard-growatt-vpp-ridax-118`, covering a real-world ambiguous case (same `unique_id` suffix exposed on more than one HA domain) the synthetic VPP fixtures didn't exercise. ([#118](https://github.com/johanzander/bess-manager/issues/118))
+
 ## [10.0.1] - 2026-08-02
 
 ### Fixed

--- a/docs/agents/memory/project_platform_maturity.md
+++ b/docs/agents/memory/project_platform_maturity.md
@@ -9,11 +9,25 @@ file) is the stability flag for this codebase — see `feature-lifecycle` skill.
 - **Growatt VPP control mode** (`inverter.control_mode="vpp"`, on top of the
   `solax_modbus_growatt_min` (GEN4) and `solax_modbus_growatt_sph` (GEN3)
   platforms) — shipped per issue
-  [#118](https://github.com/johanzander/bess-manager/issues/118). Not yet
-  confirmed against real hardware; GEN4's existing `"tou"` control mode is
-  unaffected and remains the default there. Move to the validated list below
-  once a beta tester confirms (`feature-lifecycle` Stage 5), naming their
-  scenario.
+  [#118](https://github.com/johanzander/bess-manager/issues/118). Confirmed
+  writing real VPP commands to hardware by multiple testers (`nholmgaard`,
+  `ridax67`, `jdungen`), and several real bugs found in the field have been
+  fixed: LOAD_SUPPORT forcing a fixed rate instead of releasing control
+  ([#413](https://github.com/johanzander/bess-manager/issues/413)), a
+  spurious `power=0%` write on every schedule reload
+  ([#421](https://github.com/johanzander/bess-manager/issues/421)/[#423](https://github.com/johanzander/bess-manager/pull/423)),
+  IDLE periods draining the battery overnight
+  ([#466](https://github.com/johanzander/bess-manager/issues/466)), and VPP
+  Remote Control continuing to override the inverter after switching away
+  from VPP mode
+  ([#479](https://github.com/johanzander/bess-manager/issues/479)). A
+  real-world regression scenario built from `ridax67`'s live config is
+  locked in as `ci-wizard-growatt-vpp-ridax-118` (backend discovery test +
+  Playwright wizard E2E). Still marked experimental: the most recent fix
+  (#479) has only shipped in the beta channel (`v10.1.0b4`) so far, not yet
+  in a stable/prod release, and no tester has given a clean "this now works
+  end-to-end" confirmation since it landed. Move to the validated list below
+  once both happen (`feature-lifecycle` Stage 5/6).
 - `solax_modbus_growatt_sph` (GEN3) — monitoring-only, schedule control not implemented.
 - `solax_modbus_native` (SolaX VPP).
 

--- a/e2e/run-e2e.sh
+++ b/e2e/run-e2e.sh
@@ -88,6 +88,7 @@ if [ "$RUN_WIZARD" = true ]; then
     "ci-wizard-growatt-modbus"
     "ci-wizard-solis"
     "ci-wizard-growatt-vpp"
+    "ci-wizard-growatt-vpp-ridax-118"
   )
 
   for scenario in "${WIZARD_SCENARIOS[@]}"; do

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -268,7 +268,13 @@ test.describe('Setup Wizard', () => {
     const platformsWithoutLocalLoad = ['growatt_server_sph'];
     const platformsWithoutChargeRate = ['growatt_server_sph', 'solax_modbus_native', 'solis_modbus'];
     const expectInfluxDisabled = platformsWithoutLocalLoad.includes(expected.inverterPlatform);
-    const expectFuseDisabled = platformsWithoutChargeRate.includes(expected.inverterPlatform);
+    // Fuse protection also needs phase-current sensors (current_l1/l2/l3) discovered,
+    // independent of the platform's charge-rate-control capability — a platform that
+    // supports charge rate control can still lack phase sensors on an install with no
+    // CT clamps configured. Most fixtures provide both; noPhaseSensors opts a scenario
+    // out explicitly instead of overloading the (separately-purposed) phaseCount field.
+    const expectFuseDisabled =
+      platformsWithoutChargeRate.includes(expected.inverterPlatform) || expected.noPhaseSensors === true;
 
     await page.goto('/setup');
     await expectActiveStep(page, 1);

--- a/e2e/tests/wizard-expectations.ts
+++ b/e2e/tests/wizard-expectations.ts
@@ -215,4 +215,18 @@ export const EXPECTATIONS: Record<string, WizardExpectation> = {
     dischargeInhibitFound: false,
     weatherFound: false,
   },
+  /** Real-world regression from issue #118: ridax67's live Growatt GEN4 VPP installation. */
+  'ci-wizard-growatt-vpp-ridax-118': {
+    growattFound: false,
+    solaxFound: true,
+    inverterPlatform: 'solax_modbus_growatt_min',
+    nordpoolFound: true,
+    octopusFound: false,
+    autoSelectedProvider: 'nordpool_official',
+    phaseCount: null,
+    solcastFound: true,
+    consumptionForecastFound: false,
+    dischargeInhibitFound: false,
+    weatherFound: false,
+  },
 };

--- a/e2e/tests/wizard-expectations.ts
+++ b/e2e/tests/wizard-expectations.ts
@@ -26,6 +26,8 @@ export interface WizardExpectation {
   consumptionForecastFound: boolean;
   dischargeInhibitFound: boolean;
   weatherFound: boolean;
+  /** No current_l1/l2/l3 sensors were discovered (no CT clamps configured) — disables fuse protection regardless of platform capability. Optional, defaults to false. */
+  noPhaseSensors?: boolean;
 }
 
 export const EXPECTATIONS: Record<string, WizardExpectation> = {
@@ -228,5 +230,6 @@ export const EXPECTATIONS: Record<string, WizardExpectation> = {
     consumptionForecastFound: false,
     dischargeInhibitFound: false,
     weatherFound: false,
+    noPhaseSensors: true,
   },
 };

--- a/scripts/mock_ha/scenarios/ci-wizard-growatt-vpp-ridax-118.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-growatt-vpp-ridax-118.json
@@ -1,0 +1,8041 @@
+{
+  "name": "ci-wizard-growatt-vpp-ridax-118",
+  "description": "Real-world regression from issue #118: Growatt GEN4 (solax_modbus_growatt_min) via SolaX Modbus in VPP remote-control mode, from ridax67's live installation (3-phase, 20kWh battery). Sourced from a debug export taken 2026-08-07 on BESS v10.1.0b5 with health OK. Validates GEN4/VPP platform detection and the ambiguous case where the same unique_id suffix (e.g. growatt_vpp_status) is exposed on more than one HA domain (sensor.* and select.*).",
+  "mock_time": "@2026-08-07 23:25:00",
+  "timezone": "Europe/Stockholm",
+  "bess_config": {
+    "battery": {
+      "total_capacity": 20,
+      "min_soc": 10,
+      "max_soc": 100,
+      "max_charge_power_kw": 10,
+      "max_discharge_power_kw": 10,
+      "cycle_cost_per_kwh": 0.4,
+      "charging_power_rate": 40,
+      "efficiency_charge": 0.97,
+      "efficiency_discharge": 0.95,
+      "temperature_derating": {
+        "enabled": false,
+        "weather_entity": "weather.smhi_home"
+      },
+      "inverter_max_ac_power_kw": 11,
+      "inverter_ac_power_margin": 0
+    },
+    "home": {
+      "default_hourly": 0.67,
+      "currency": "SEK",
+      "consumption_strategy": "fixed",
+      "max_fuse_current": 10,
+      "voltage": 230,
+      "safety_margin": 0.5,
+      "phase_count": 3,
+      "power_monitoring_enabled": false
+    },
+    "electricity_price": {
+      "markup_rate": 0.0649,
+      "vat_multiplier": 1.25,
+      "additional_costs": 0.515,
+      "tax_reduction": 0.14,
+      "area": "SE3",
+      "spot_multiplier": 1,
+      "export_spot_multiplier": 1,
+      "use_actual_price": false
+    },
+    "energy_provider": {
+      "provider": "nordpool_official",
+      "nordpool_official": {
+        "config_entry_id": "01K83SXQ68W3952XYRE2YE6JA3"
+      },
+      "nordpool_hacs": {
+        "entity": ""
+      },
+      "octopus": {
+        "import_today_entity": "",
+        "import_tomorrow_entity": "",
+        "export_today_entity": "",
+        "export_tomorrow_entity": ""
+      },
+      "entsoe": {
+        "entity": ""
+      }
+    },
+    "growatt": {
+      "inverter_type": "",
+      "device_id": ""
+    },
+    "inverter": {
+      "platform": "solax_modbus_growatt_min",
+      "device_id": "",
+      "control_mode": "vpp"
+    },
+    "sensors": {
+      "platform": "solax_modbus_growatt_min",
+      "growatt_server_min": {},
+      "growatt_server_sph": {},
+      "solax_modbus_growatt_min": {
+        "tou_time_1_update": "button.growatt_inverter_time_1_update",
+        "tou_time_2_update": "button.growatt_inverter_time_2_update",
+        "tou_time_3_update": "button.growatt_inverter_time_3_update",
+        "tou_time_4_update": "button.growatt_inverter_time_4_update",
+        "tou_time_5_update": "button.growatt_inverter_time_5_update",
+        "tou_time_6_update": "button.growatt_inverter_time_6_update",
+        "tou_time_7_update": "button.growatt_inverter_time_7_update",
+        "tou_time_8_update": "button.growatt_inverter_time_8_update",
+        "tou_time_9_update": "button.growatt_inverter_time_9_update",
+        "battery_discharging_power_rate": "number.growatt_inverter_ems_discharging_rate",
+        "battery_charging_power_rate": "number.growatt_inverter_ems_charging_rate",
+        "battery_charge_stop_soc": "number.growatt_inverter_ems_charging_stop_soc",
+        "battery_discharge_stop_soc": "number.growatt_inverter_ems_discharging_stop_soc_on_grid",
+        "grid_charge": "select.growatt_inverter_allow_grid_charge",
+        "tou_time_1_begin": "select.growatt_inverter_time_1_begin",
+        "tou_time_1_end": "select.growatt_inverter_time_1_end",
+        "tou_time_1_mode": "select.growatt_inverter_time_1_mode",
+        "tou_time_1_enabled": "select.growatt_inverter_time_1_active",
+        "tou_time_2_begin": "select.growatt_inverter_time_2_begin",
+        "tou_time_2_end": "select.growatt_inverter_time_2_end",
+        "tou_time_2_mode": "select.growatt_inverter_time_2_mode",
+        "tou_time_2_enabled": "select.growatt_inverter_time_2_active",
+        "tou_time_3_begin": "select.growatt_inverter_time_3_begin",
+        "tou_time_3_end": "select.growatt_inverter_time_3_end",
+        "tou_time_3_mode": "select.growatt_inverter_time_3_mode",
+        "tou_time_3_enabled": "select.growatt_inverter_time_3_active",
+        "tou_time_4_begin": "select.growatt_inverter_time_4_begin",
+        "tou_time_4_end": "select.growatt_inverter_time_4_end",
+        "tou_time_4_mode": "select.growatt_inverter_time_4_mode",
+        "tou_time_4_enabled": "select.growatt_inverter_time_4_active",
+        "tou_time_5_begin": "select.growatt_inverter_time_5_begin",
+        "tou_time_5_end": "select.growatt_inverter_time_5_end",
+        "tou_time_5_mode": "select.growatt_inverter_time_5_mode",
+        "tou_time_5_enabled": "select.growatt_inverter_time_5_active",
+        "tou_time_6_begin": "select.growatt_inverter_time_6_begin",
+        "tou_time_6_end": "select.growatt_inverter_time_6_end",
+        "tou_time_6_mode": "select.growatt_inverter_time_6_mode",
+        "tou_time_6_enabled": "select.growatt_inverter_time_6_active",
+        "tou_time_7_begin": "select.growatt_inverter_time_7_begin",
+        "tou_time_7_end": "select.growatt_inverter_time_7_end",
+        "tou_time_7_mode": "select.growatt_inverter_time_7_mode",
+        "tou_time_7_enabled": "select.growatt_inverter_time_7_active",
+        "tou_time_8_begin": "select.growatt_inverter_time_8_begin",
+        "tou_time_8_end": "select.growatt_inverter_time_8_end",
+        "tou_time_8_mode": "select.growatt_inverter_time_8_mode",
+        "tou_time_8_enabled": "select.growatt_inverter_time_8_active",
+        "tou_time_9_begin": "select.growatt_inverter_time_9_begin",
+        "tou_time_9_end": "select.growatt_inverter_time_9_end",
+        "tou_time_9_mode": "select.growatt_inverter_time_9_mode",
+        "tou_time_9_enabled": "select.growatt_inverter_time_9_active",
+        "pv_power": "sensor.growatt_inverter_pv_power_total",
+        "import_power": "sensor.growatt_inverter_total_forward_power",
+        "export_power": "sensor.growatt_inverter_total_reverse_power",
+        "local_load_power": "sensor.growatt_inverter_total_load_power",
+        "lifetime_system_production": "sensor.growatt_inverter_total_power_generation",
+        "lifetime_solar_energy": "sensor.growatt_inverter_total_solar_energy",
+        "lifetime_import_from_grid": "sensor.growatt_inverter_total_grid_import",
+        "lifetime_export_to_grid": "sensor.growatt_inverter_total_grid_export",
+        "lifetime_load_consumption": "sensor.growatt_inverter_total_load_energy",
+        "lifetime_battery_discharged": "sensor.growatt_inverter_total_battery_output_energy",
+        "lifetime_battery_charged": "sensor.growatt_inverter_total_battery_input_energy",
+        "battery_soc": "sensor.growatt_inverter_battery_soc",
+        "battery_discharge_power": "sensor.growatt_inverter_battery_discharge_power",
+        "battery_charge_power": "sensor.growatt_inverter_battery_charge_power",
+        "growatt_vpp_time": "number.growatt_inverter_vpp_time",
+        "growatt_vpp_power": "input_number.vpp_bess_power",
+        "growatt_vpp_status": "select.growatt_inverter_vpp_status",
+        "growatt_vpp_remote_control": "select.growatt_inverter_vpp_remote_control",
+        "growatt_vpp_allow_ac_charging": "select.growatt_inverter_vpp_allow_ac_charging"
+      },
+      "solax_modbus_growatt_sph": {},
+      "solax_modbus_native": {},
+      "shared": {
+        "solar_forecast_today": "sensor.solcast_pv_forecast_forecast_today",
+        "solar_forecast_tomorrow": "sensor.solcast_pv_forecast_forecast_tomorrow",
+        "current_l1": "sensor.ada_current_phase_1_l1",
+        "current_l2": "sensor.ada_current_phase_2_l2",
+        "current_l3": "sensor.ada_current_phase_3_l3",
+        "weather_entity": "weather.smhi_home"
+      }
+    },
+    "demo_mode": {
+      "enabled": false
+    }
+  },
+  "sensors": {
+    "select.growatt_inverter_time_3_begin": {
+      "entity_id": "select.growatt_inverter_time_3_begin",
+      "state": "23:00",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 3 Begin"
+      }
+    },
+    "select.growatt_inverter_time_4_active": {
+      "entity_id": "select.growatt_inverter_time_4_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 4 Active"
+      }
+    },
+    "select.growatt_inverter_time_6_active": {
+      "entity_id": "select.growatt_inverter_time_6_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 6 Active"
+      }
+    },
+    "select.growatt_inverter_time_7_end": {
+      "entity_id": "select.growatt_inverter_time_7_end",
+      "state": "16:29",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 7 End"
+      }
+    },
+    "select.growatt_inverter_vpp_status": {
+      "entity_id": "select.growatt_inverter_vpp_status",
+      "state": "Enabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:dip-switch",
+        "friendly_name": "Growatt Inverter VPP Status"
+      }
+    },
+    "select.growatt_inverter_time_6_begin": {
+      "entity_id": "select.growatt_inverter_time_6_begin",
+      "state": "22:00",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 6 Begin"
+      }
+    },
+    "select.growatt_inverter_vpp_allow_ac_charging": {
+      "entity_id": "select.growatt_inverter_vpp_allow_ac_charging",
+      "state": "Enabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:dip-switch",
+        "friendly_name": "Growatt Inverter VPP Allow AC charging"
+      }
+    },
+    "sensor.growatt_inverter_total_load_energy": {
+      "entity_id": "sensor.growatt_inverter_total_load_energy",
+      "state": "6701.3",
+      "attributes": {
+        "state_class": "total_increasing",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "friendly_name": "Growatt Inverter growatt Total Load Energy"
+      }
+    },
+    "button.growatt_inverter_time_6_update": {
+      "entity_id": "button.growatt_inverter_time_6_update",
+      "state": "2026-07-24T19:32:20.789032+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-6-circle",
+        "friendly_name": "Growatt Inverter Time 6 Update"
+      }
+    },
+    "select.growatt_inverter_time_9_mode": {
+      "entity_id": "select.growatt_inverter_time_9_mode",
+      "state": "Battery First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 9 Mode"
+      }
+    },
+    "button.growatt_inverter_time_9_update": {
+      "entity_id": "button.growatt_inverter_time_9_update",
+      "state": "2026-06-09T13:42:07.699465+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-9-circle",
+        "friendly_name": "Growatt Inverter Time 9 Update"
+      }
+    },
+    "sensor.ada_current_phase_2_l2": {
+      "entity_id": "sensor.ada_current_phase_2_l2",
+      "state": "0.400",
+      "attributes": {
+        "icon": "mdi:current-ac",
+        "uid": "http://192.168.8.238:8989/json_ada12_current_phase_l2",
+        "unit_of_measurement": "A",
+        "friendly_name": "ada Current Phase 2 (L2)"
+      }
+    },
+    "button.growatt_inverter_time_2_update": {
+      "entity_id": "button.growatt_inverter_time_2_update",
+      "state": "2026-07-25T05:14:21.249631+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-2-circle",
+        "friendly_name": "Growatt Inverter Time 2 Update"
+      }
+    },
+    "select.growatt_inverter_time_6_mode": {
+      "entity_id": "select.growatt_inverter_time_6_mode",
+      "state": "Grid First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 6 Mode"
+      }
+    },
+    "button.growatt_inverter_time_7_update": {
+      "entity_id": "button.growatt_inverter_time_7_update",
+      "state": "2026-06-24T15:27:07.267921+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-7-circle",
+        "friendly_name": "Growatt Inverter Time 7 Update"
+      }
+    },
+    "sensor.solcast_pv_forecast_forecast_tomorrow": {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow",
+      "state": "37.9629",
+      "attributes": {
+        "state_class": "total",
+        "3cdb_fd46_c0a9_f8f7": 37.9629,
+        "estimate_3cdb_fd46_c0a9_f8f7": 37.9629,
+        "estimate10_3cdb_fd46_c0a9_f8f7": 16.5602,
+        "estimate90_3cdb_fd46_c0a9_f8f7": 57.9111,
+        "estimate": 37.9629,
+        "estimate10": 16.5602,
+        "estimate90": 57.9111,
+        "dayname": "Saturday",
+        "dataCorrect": true,
+        "analysis": {
+          "estimate10_kwh": 16.5602,
+          "estimate90_kwh": 57.9111,
+          "spread_kwh": 41.3509,
+          "confidence": 0.286,
+          "intervals": [
+            {
+              "period_start": "2026-08-08T00:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T00:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T01:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T01:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T02:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T02:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T03:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T03:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T04:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T04:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T05:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T05:30:00+02:00",
+              "spread_kwh": 0.1098,
+              "confidence": 0.1
+            },
+            {
+              "period_start": "2026-08-08T06:00:00+02:00",
+              "spread_kwh": 0.6447,
+              "confidence": 0.0537
+            },
+            {
+              "period_start": "2026-08-08T06:30:00+02:00",
+              "spread_kwh": 1.1121,
+              "confidence": 0.0693
+            },
+            {
+              "period_start": "2026-08-08T07:00:00+02:00",
+              "spread_kwh": 1.5074,
+              "confidence": 0.0996
+            },
+            {
+              "period_start": "2026-08-08T07:30:00+02:00",
+              "spread_kwh": 1.8327,
+              "confidence": 0.1391
+            },
+            {
+              "period_start": "2026-08-08T08:00:00+02:00",
+              "spread_kwh": 2.1297,
+              "confidence": 0.1572
+            },
+            {
+              "period_start": "2026-08-08T08:30:00+02:00",
+              "spread_kwh": 2.4261,
+              "confidence": 0.1564
+            },
+            {
+              "period_start": "2026-08-08T09:00:00+02:00",
+              "spread_kwh": 2.715,
+              "confidence": 0.1473
+            },
+            {
+              "period_start": "2026-08-08T09:30:00+02:00",
+              "spread_kwh": 2.8798,
+              "confidence": 0.1369
+            },
+            {
+              "period_start": "2026-08-08T10:00:00+02:00",
+              "spread_kwh": 2.9539,
+              "confidence": 0.1482
+            },
+            {
+              "period_start": "2026-08-08T10:30:00+02:00",
+              "spread_kwh": 2.9256,
+              "confidence": 0.1812
+            },
+            {
+              "period_start": "2026-08-08T11:00:00+02:00",
+              "spread_kwh": 2.8421,
+              "confidence": 0.2129
+            },
+            {
+              "period_start": "2026-08-08T11:30:00+02:00",
+              "spread_kwh": 2.7202,
+              "confidence": 0.2395
+            },
+            {
+              "period_start": "2026-08-08T12:00:00+02:00",
+              "spread_kwh": 2.5486,
+              "confidence": 0.2665
+            },
+            {
+              "period_start": "2026-08-08T12:30:00+02:00",
+              "spread_kwh": 2.3908,
+              "confidence": 0.2899
+            },
+            {
+              "period_start": "2026-08-08T13:00:00+02:00",
+              "spread_kwh": 2.1869,
+              "confidence": 0.3175
+            },
+            {
+              "period_start": "2026-08-08T13:30:00+02:00",
+              "spread_kwh": 1.9694,
+              "confidence": 0.3455
+            },
+            {
+              "period_start": "2026-08-08T14:00:00+02:00",
+              "spread_kwh": 1.7338,
+              "confidence": 0.3769
+            },
+            {
+              "period_start": "2026-08-08T14:30:00+02:00",
+              "spread_kwh": 1.45,
+              "confidence": 0.4186
+            },
+            {
+              "period_start": "2026-08-08T15:00:00+02:00",
+              "spread_kwh": 1.0186,
+              "confidence": 0.4856
+            },
+            {
+              "period_start": "2026-08-08T15:30:00+02:00",
+              "spread_kwh": 0.6865,
+              "confidence": 0.5895
+            },
+            {
+              "period_start": "2026-08-08T16:00:00+02:00",
+              "spread_kwh": 0.294,
+              "confidence": 0.766
+            },
+            {
+              "period_start": "2026-08-08T16:30:00+02:00",
+              "spread_kwh": 0.05,
+              "confidence": 0.9403
+            },
+            {
+              "period_start": "2026-08-08T17:00:00+02:00",
+              "spread_kwh": 0.0626,
+              "confidence": 0.9047
+            },
+            {
+              "period_start": "2026-08-08T17:30:00+02:00",
+              "spread_kwh": 0.0336,
+              "confidence": 0.9048
+            },
+            {
+              "period_start": "2026-08-08T18:00:00+02:00",
+              "spread_kwh": 0.0201,
+              "confidence": 0.9046
+            },
+            {
+              "period_start": "2026-08-08T18:30:00+02:00",
+              "spread_kwh": 0.0204,
+              "confidence": 0.9046
+            },
+            {
+              "period_start": "2026-08-08T19:00:00+02:00",
+              "spread_kwh": 0.0171,
+              "confidence": 0.9049
+            },
+            {
+              "period_start": "2026-08-08T19:30:00+02:00",
+              "spread_kwh": 0.012,
+              "confidence": 0.9045
+            },
+            {
+              "period_start": "2026-08-08T20:00:00+02:00",
+              "spread_kwh": 0.0295,
+              "confidence": 0.6855
+            },
+            {
+              "period_start": "2026-08-08T20:30:00+02:00",
+              "spread_kwh": 0.0258,
+              "confidence": 0.4273
+            },
+            {
+              "period_start": "2026-08-08T21:00:00+02:00",
+              "spread_kwh": 0.0024,
+              "confidence": 0.0
+            },
+            {
+              "period_start": "2026-08-08T21:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T22:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T22:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T23:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-08T23:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            }
+          ]
+        },
+        "detailedForecast": [
+          {
+            "period_start": "2026-08-08T00:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T00:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T01:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T01:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T02:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T02:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T03:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T03:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T04:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T04:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T05:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T05:30:00+02:00",
+            "pv_estimate": 0.0633,
+            "pv_estimate10": 0.0244,
+            "pv_estimate90": 0.2439,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T06:00:00+02:00",
+            "pv_estimate": 0.2194,
+            "pv_estimate10": 0.0731,
+            "pv_estimate90": 1.3624,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T06:30:00+02:00",
+            "pv_estimate": 0.9491,
+            "pv_estimate10": 0.1656,
+            "pv_estimate90": 2.3898,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T07:00:00+02:00",
+            "pv_estimate": 1.8121,
+            "pv_estimate10": 0.3335,
+            "pv_estimate90": 3.3484,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T07:30:00+02:00",
+            "pv_estimate": 2.5143,
+            "pv_estimate10": 0.5921,
+            "pv_estimate90": 4.2575,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T08:00:00+02:00",
+            "pv_estimate": 2.9538,
+            "pv_estimate10": 0.7943,
+            "pv_estimate90": 5.0536,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T08:30:00+02:00",
+            "pv_estimate": 3.1548,
+            "pv_estimate10": 0.8997,
+            "pv_estimate90": 5.7518,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T09:00:00+02:00",
+            "pv_estimate": 3.2847,
+            "pv_estimate10": 0.938,
+            "pv_estimate90": 6.368,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T09:30:00+02:00",
+            "pv_estimate": 3.3147,
+            "pv_estimate10": 0.9135,
+            "pv_estimate90": 6.6731,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T10:00:00+02:00",
+            "pv_estimate": 3.5818,
+            "pv_estimate10": 1.0275,
+            "pv_estimate90": 6.9352,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T10:30:00+02:00",
+            "pv_estimate": 4.0609,
+            "pv_estimate10": 1.2947,
+            "pv_estimate90": 7.1458,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T11:00:00+02:00",
+            "pv_estimate": 4.3953,
+            "pv_estimate10": 1.5374,
+            "pv_estimate90": 7.2216,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T11:30:00+02:00",
+            "pv_estimate": 4.5947,
+            "pv_estimate10": 1.7135,
+            "pv_estimate90": 7.1538,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T12:00:00+02:00",
+            "pv_estimate": 4.678,
+            "pv_estimate10": 1.8519,
+            "pv_estimate90": 6.9491,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T12:30:00+02:00",
+            "pv_estimate": 4.7046,
+            "pv_estimate10": 1.9525,
+            "pv_estimate90": 6.7341,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T13:00:00+02:00",
+            "pv_estimate": 4.6729,
+            "pv_estimate10": 2.0346,
+            "pv_estimate90": 6.4084,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T13:30:00+02:00",
+            "pv_estimate": 4.5692,
+            "pv_estimate10": 2.0791,
+            "pv_estimate90": 6.0179,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T14:00:00+02:00",
+            "pv_estimate": 4.3714,
+            "pv_estimate10": 2.0972,
+            "pv_estimate90": 5.5649,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T14:30:00+02:00",
+            "pv_estimate": 4.0278,
+            "pv_estimate10": 2.0882,
+            "pv_estimate90": 4.9882,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T15:00:00+02:00",
+            "pv_estimate": 3.3713,
+            "pv_estimate10": 1.9228,
+            "pv_estimate90": 3.96,
+            "dampening_factor": 0.909
+          },
+          {
+            "period_start": "2026-08-08T15:30:00+02:00",
+            "pv_estimate": 3.0225,
+            "pv_estimate10": 1.9721,
+            "pv_estimate90": 3.3451,
+            "dampening_factor": 0.909
+          },
+          {
+            "period_start": "2026-08-08T16:00:00+02:00",
+            "pv_estimate": 2.431,
+            "pv_estimate10": 1.9247,
+            "pv_estimate90": 2.5127,
+            "dampening_factor": 0.873
+          },
+          {
+            "period_start": "2026-08-08T16:30:00+02:00",
+            "pv_estimate": 1.5932,
+            "pv_estimate10": 1.5729,
+            "pv_estimate90": 1.6728,
+            "dampening_factor": 0.738
+          },
+          {
+            "period_start": "2026-08-08T17:00:00+02:00",
+            "pv_estimate": 1.2526,
+            "pv_estimate10": 1.1899,
+            "pv_estimate90": 1.3152,
+            "dampening_factor": 0.89
+          },
+          {
+            "period_start": "2026-08-08T17:30:00+02:00",
+            "pv_estimate": 0.6726,
+            "pv_estimate10": 0.639,
+            "pv_estimate90": 0.7062,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T18:00:00+02:00",
+            "pv_estimate": 0.4014,
+            "pv_estimate10": 0.3813,
+            "pv_estimate90": 0.4215,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T18:30:00+02:00",
+            "pv_estimate": 0.4072,
+            "pv_estimate10": 0.3868,
+            "pv_estimate90": 0.4276,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T19:00:00+02:00",
+            "pv_estimate": 0.3427,
+            "pv_estimate10": 0.3256,
+            "pv_estimate90": 0.3598,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T19:30:00+02:00",
+            "pv_estimate": 0.2393,
+            "pv_estimate10": 0.2273,
+            "pv_estimate90": 0.2513,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T20:00:00+02:00",
+            "pv_estimate": 0.1787,
+            "pv_estimate10": 0.1286,
+            "pv_estimate90": 0.1876,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T20:30:00+02:00",
+            "pv_estimate": 0.0858,
+            "pv_estimate10": 0.0385,
+            "pv_estimate90": 0.0901,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T21:00:00+02:00",
+            "pv_estimate": 0.0048,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0048,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T21:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T22:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T22:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T23:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-08T23:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          }
+        ],
+        "detailedHourly": [
+          {
+            "period_start": "2026-08-08T00:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-08T01:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-08T02:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-08T03:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-08T04:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-08T05:00:00+02:00",
+            "pv_estimate": 0.0316,
+            "pv_estimate10": 0.0122,
+            "pv_estimate90": 0.122
+          },
+          {
+            "period_start": "2026-08-08T06:00:00+02:00",
+            "pv_estimate": 0.5843,
+            "pv_estimate10": 0.1193,
+            "pv_estimate90": 1.8761
+          },
+          {
+            "period_start": "2026-08-08T07:00:00+02:00",
+            "pv_estimate": 2.1632,
+            "pv_estimate10": 0.4628,
+            "pv_estimate90": 3.803
+          },
+          {
+            "period_start": "2026-08-08T08:00:00+02:00",
+            "pv_estimate": 3.0543,
+            "pv_estimate10": 0.847,
+            "pv_estimate90": 5.4027
+          },
+          {
+            "period_start": "2026-08-08T09:00:00+02:00",
+            "pv_estimate": 3.2997,
+            "pv_estimate10": 0.9257,
+            "pv_estimate90": 6.5206
+          },
+          {
+            "period_start": "2026-08-08T10:00:00+02:00",
+            "pv_estimate": 3.8213,
+            "pv_estimate10": 1.1611,
+            "pv_estimate90": 7.0405
+          },
+          {
+            "period_start": "2026-08-08T11:00:00+02:00",
+            "pv_estimate": 4.495,
+            "pv_estimate10": 1.6255,
+            "pv_estimate90": 7.1877
+          },
+          {
+            "period_start": "2026-08-08T12:00:00+02:00",
+            "pv_estimate": 4.6913,
+            "pv_estimate10": 1.9022,
+            "pv_estimate90": 6.8416
+          },
+          {
+            "period_start": "2026-08-08T13:00:00+02:00",
+            "pv_estimate": 4.6211,
+            "pv_estimate10": 2.0568,
+            "pv_estimate90": 6.2132
+          },
+          {
+            "period_start": "2026-08-08T14:00:00+02:00",
+            "pv_estimate": 4.1996,
+            "pv_estimate10": 2.0927,
+            "pv_estimate90": 5.2766
+          },
+          {
+            "period_start": "2026-08-08T15:00:00+02:00",
+            "pv_estimate": 3.1969,
+            "pv_estimate10": 1.9474,
+            "pv_estimate90": 3.6525
+          },
+          {
+            "period_start": "2026-08-08T16:00:00+02:00",
+            "pv_estimate": 2.0121,
+            "pv_estimate10": 1.7488,
+            "pv_estimate90": 2.0928
+          },
+          {
+            "period_start": "2026-08-08T17:00:00+02:00",
+            "pv_estimate": 0.9626,
+            "pv_estimate10": 0.9144,
+            "pv_estimate90": 1.0107
+          },
+          {
+            "period_start": "2026-08-08T18:00:00+02:00",
+            "pv_estimate": 0.4043,
+            "pv_estimate10": 0.3841,
+            "pv_estimate90": 0.4245
+          },
+          {
+            "period_start": "2026-08-08T19:00:00+02:00",
+            "pv_estimate": 0.291,
+            "pv_estimate10": 0.2764,
+            "pv_estimate90": 0.3055
+          },
+          {
+            "period_start": "2026-08-08T20:00:00+02:00",
+            "pv_estimate": 0.1323,
+            "pv_estimate10": 0.0835,
+            "pv_estimate90": 0.1389
+          },
+          {
+            "period_start": "2026-08-08T21:00:00+02:00",
+            "pv_estimate": 0.0024,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0024
+          },
+          {
+            "period_start": "2026-08-08T22:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-08T23:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          }
+        ],
+        "undampened_estimate": 38.8201,
+        "undampened_estimate10": 17.2479,
+        "undampened_estimate90": 58.8378,
+        "unit_of_measurement": "kWh",
+        "attribution": "Data retrieved from Solcast",
+        "device_class": "energy",
+        "friendly_name": "Solcast PV Forecast Forecast Tomorrow"
+      }
+    },
+    "button.growatt_inverter_time_4_update": {
+      "entity_id": "button.growatt_inverter_time_4_update",
+      "state": "2026-07-24T19:37:27.805811+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-4-circle",
+        "friendly_name": "Growatt Inverter Time 4 Update"
+      }
+    },
+    "select.growatt_inverter_time_2_mode": {
+      "entity_id": "select.growatt_inverter_time_2_mode",
+      "state": "Load First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 2 Mode"
+      }
+    },
+    "select.growatt_inverter_time_8_active": {
+      "entity_id": "select.growatt_inverter_time_8_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 8 Active"
+      }
+    },
+    "sensor.growatt_inverter_battery_discharge_power": {
+      "entity_id": "sensor.growatt_inverter_battery_discharge_power",
+      "state": "460.0",
+      "attributes": {
+        "state_class": "measurement",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "friendly_name": "Growatt Inverter growatt Battery Discharge Power"
+      }
+    },
+    "select.growatt_inverter_time_3_mode": {
+      "entity_id": "select.growatt_inverter_time_3_mode",
+      "state": "Load First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 3 Mode"
+      }
+    },
+    "select.growatt_inverter_time_3_end": {
+      "entity_id": "select.growatt_inverter_time_3_end",
+      "state": "23:29",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 3 End"
+      }
+    },
+    "button.growatt_inverter_time_8_update": {
+      "entity_id": "button.growatt_inverter_time_8_update",
+      "state": "2026-06-17T04:56:07.053917+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-8-circle",
+        "friendly_name": "Growatt Inverter Time 8 Update"
+      }
+    },
+    "select.growatt_inverter_time_4_end": {
+      "entity_id": "select.growatt_inverter_time_4_end",
+      "state": "19:44",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 4 End"
+      }
+    },
+    "select.growatt_inverter_time_7_begin": {
+      "entity_id": "select.growatt_inverter_time_7_begin",
+      "state": "15:30",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 7 Begin"
+      }
+    },
+    "select.growatt_inverter_time_2_active": {
+      "entity_id": "select.growatt_inverter_time_2_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 2 Active"
+      }
+    },
+    "sensor.growatt_inverter_total_forward_power": {
+      "entity_id": "sensor.growatt_inverter_total_forward_power",
+      "state": "0.0",
+      "attributes": {
+        "state_class": "measurement",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "friendly_name": "Growatt Inverter growatt Total Import Power"
+      }
+    },
+    "number.growatt_inverter_ems_discharging_rate": {
+      "entity_id": "number.growatt_inverter_ems_discharging_rate",
+      "state": "100",
+      "attributes": {
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "mode": "auto",
+        "unit_of_measurement": "%",
+        "icon": "mdi:battery-arrow-down",
+        "friendly_name": "Growatt Inverter EMS Discharging Rate"
+      }
+    },
+    "select.growatt_inverter_time_1_begin": {
+      "entity_id": "select.growatt_inverter_time_1_begin",
+      "state": "00:00",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 1 Begin"
+      }
+    },
+    "select.growatt_inverter_vpp_remote_control": {
+      "entity_id": "select.growatt_inverter_vpp_remote_control",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:dip-switch",
+        "friendly_name": "Growatt Inverter VPP Remote Control"
+      }
+    },
+    "select.growatt_inverter_time_7_mode": {
+      "entity_id": "select.growatt_inverter_time_7_mode",
+      "state": "Battery First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 7 Mode"
+      }
+    },
+    "select.growatt_inverter_allow_grid_charge": {
+      "entity_id": "select.growatt_inverter_allow_grid_charge",
+      "state": "Enabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-charging",
+        "friendly_name": "Growatt Inverter Allow Grid Charge"
+      }
+    },
+    "select.growatt_inverter_time_3_active": {
+      "entity_id": "select.growatt_inverter_time_3_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 3 Active"
+      }
+    },
+    "sensor.growatt_inverter_total_battery_input_energy": {
+      "entity_id": "sensor.growatt_inverter_total_battery_input_energy",
+      "state": "5507.9",
+      "attributes": {
+        "state_class": "total_increasing",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "icon": "mdi:battery-arrow-up",
+        "friendly_name": "Growatt Inverter growatt Total Battery Input Energy"
+      }
+    },
+    "sensor.growatt_inverter_battery_soc": {
+      "entity_id": "sensor.growatt_inverter_battery_soc",
+      "state": "42",
+      "attributes": {
+        "state_class": "measurement",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "%",
+        "device_class": "battery",
+        "friendly_name": "Growatt Inverter growatt Battery SOC"
+      }
+    },
+    "select.growatt_inverter_time_1_active": {
+      "entity_id": "select.growatt_inverter_time_1_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 1 Active"
+      }
+    },
+    "select.growatt_inverter_time_5_end": {
+      "entity_id": "select.growatt_inverter_time_5_end",
+      "state": "21:14",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 5 End"
+      }
+    },
+    "select.growatt_inverter_time_1_mode": {
+      "entity_id": "select.growatt_inverter_time_1_mode",
+      "state": "Grid First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 1 Mode"
+      }
+    },
+    "select.growatt_inverter_time_7_active": {
+      "entity_id": "select.growatt_inverter_time_7_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 7 Active"
+      }
+    },
+    "sensor.growatt_inverter_total_reverse_power": {
+      "entity_id": "sensor.growatt_inverter_total_reverse_power",
+      "state": "0.0",
+      "attributes": {
+        "state_class": "measurement",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "friendly_name": "Growatt Inverter growatt Total Export Power"
+      }
+    },
+    "number.growatt_inverter_ems_charging_rate": {
+      "entity_id": "number.growatt_inverter_ems_charging_rate",
+      "state": "100",
+      "attributes": {
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "mode": "auto",
+        "unit_of_measurement": "%",
+        "icon": "mdi:battery-arrow-up",
+        "friendly_name": "Growatt Inverter EMS Charging Rate"
+      }
+    },
+    "select.growatt_inverter_time_1_end": {
+      "entity_id": "select.growatt_inverter_time_1_end",
+      "state": "23:59",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 1 End"
+      }
+    },
+    "button.growatt_inverter_time_5_update": {
+      "entity_id": "button.growatt_inverter_time_5_update",
+      "state": "2026-07-24T19:32:15.286827+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-5-circle",
+        "friendly_name": "Growatt Inverter Time 5 Update"
+      }
+    },
+    "select.growatt_inverter_time_9_begin": {
+      "entity_id": "select.growatt_inverter_time_9_begin",
+      "state": "15:00",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 9 Begin"
+      }
+    },
+    "sensor.growatt_inverter_total_load_power": {
+      "entity_id": "sensor.growatt_inverter_total_load_power",
+      "state": "460.0",
+      "attributes": {
+        "state_class": "measurement",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "friendly_name": "Growatt Inverter growatt Total Load Power"
+      }
+    },
+    "select.growatt_inverter_time_9_end": {
+      "entity_id": "select.growatt_inverter_time_9_end",
+      "state": "15:14",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 9 End"
+      }
+    },
+    "number.growatt_inverter_ems_charging_stop_soc": {
+      "entity_id": "number.growatt_inverter_ems_charging_stop_soc",
+      "state": "100",
+      "attributes": {
+        "min": 11,
+        "max": 100,
+        "step": 1,
+        "mode": "auto",
+        "unit_of_measurement": "%",
+        "icon": "mdi:battery",
+        "friendly_name": "Growatt Inverter EMS Charging Stop SOC"
+      }
+    },
+    "sensor.growatt_inverter_total_grid_import": {
+      "entity_id": "sensor.growatt_inverter_total_grid_import",
+      "state": "4442.9",
+      "attributes": {
+        "state_class": "total_increasing",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "icon": "mdi:home-import-outline",
+        "friendly_name": "Growatt Inverter growatt Total Grid Import"
+      }
+    },
+    "sensor.ada_current_phase_3_l3": {
+      "entity_id": "sensor.ada_current_phase_3_l3",
+      "state": "0.700",
+      "attributes": {
+        "icon": "mdi:current-ac",
+        "uid": "http://192.168.8.238:8989/json_ada12_current_phase_l3",
+        "unit_of_measurement": "A",
+        "friendly_name": "ada Current Phase 3 (L3)"
+      }
+    },
+    "number.growatt_inverter_ems_discharging_stop_soc_on_grid": {
+      "entity_id": "number.growatt_inverter_ems_discharging_stop_soc_on_grid",
+      "state": "10",
+      "attributes": {
+        "min": 10,
+        "max": 100,
+        "step": 1,
+        "mode": "auto",
+        "unit_of_measurement": "%",
+        "icon": "mdi:battery-10",
+        "friendly_name": "Growatt Inverter EMS Discharging Stop SOC (on grid)"
+      }
+    },
+    "select.growatt_inverter_time_8_begin": {
+      "entity_id": "select.growatt_inverter_time_8_begin",
+      "state": "04:00",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 8 Begin"
+      }
+    },
+    "sensor.growatt_inverter_total_grid_export": {
+      "entity_id": "sensor.growatt_inverter_total_grid_export",
+      "state": "7547.2",
+      "attributes": {
+        "state_class": "total_increasing",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "icon": "mdi:home-export-outline",
+        "friendly_name": "Growatt Inverter growatt Total Grid Export"
+      }
+    },
+    "select.growatt_inverter_time_5_begin": {
+      "entity_id": "select.growatt_inverter_time_5_begin",
+      "state": "21:00",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 5 Begin"
+      }
+    },
+    "sensor.growatt_inverter_pv_power_total": {
+      "entity_id": "sensor.growatt_inverter_pv_power_total",
+      "state": "0.0",
+      "attributes": {
+        "state_class": "measurement",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "icon": "mdi:solar-power-variant",
+        "friendly_name": "Growatt Inverter growatt PV Power Total"
+      }
+    },
+    "select.growatt_inverter_time_2_begin": {
+      "entity_id": "select.growatt_inverter_time_2_begin",
+      "state": "07:00",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 2 Begin"
+      }
+    },
+    "sensor.growatt_inverter_battery_charge_power": {
+      "entity_id": "sensor.growatt_inverter_battery_charge_power",
+      "state": "0.0",
+      "attributes": {
+        "state_class": "measurement",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "friendly_name": "Growatt Inverter growatt Battery Charge Power"
+      }
+    },
+    "input_number.vpp_bess_power": {
+      "entity_id": "input_number.vpp_bess_power",
+      "state": "0.0",
+      "attributes": {
+        "min": -100.0,
+        "max": 100.0,
+        "step": 1.0,
+        "mode": "slider",
+        "initial": null,
+        "editable": true,
+        "unit_of_measurement": "%",
+        "friendly_name": "vpp_bess_power"
+      }
+    },
+    "select.growatt_inverter_time_5_mode": {
+      "entity_id": "select.growatt_inverter_time_5_mode",
+      "state": "Grid First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 5 Mode"
+      }
+    },
+    "sensor.ada_current_phase_1_l1": {
+      "entity_id": "sensor.ada_current_phase_1_l1",
+      "state": "0.500",
+      "attributes": {
+        "icon": "mdi:current-ac",
+        "uid": "http://192.168.8.238:8989/json_ada12_current_phase_l1",
+        "unit_of_measurement": "A",
+        "friendly_name": "ada Current Phase 1 (L1)"
+      }
+    },
+    "weather.smhi_home": {
+      "entity_id": "weather.smhi_home",
+      "state": "clear-night",
+      "attributes": {
+        "temperature": 15.0,
+        "temperature_unit": "\u00b0C",
+        "humidity": 74,
+        "cloud_coverage": 50,
+        "pressure": 1017.6,
+        "pressure_unit": "hPa",
+        "wind_bearing": 267,
+        "wind_gust_speed": 38.52,
+        "wind_speed": 21.96,
+        "wind_speed_unit": "km/h",
+        "visibility": 21.0,
+        "visibility_unit": "km",
+        "precipitation_unit": "mm",
+        "thunder_probability": 1,
+        "attribution": "Swedish weather institute (SMHI)",
+        "friendly_name": "Home",
+        "supported_features": 7
+      }
+    },
+    "button.growatt_inverter_time_1_update": {
+      "entity_id": "button.growatt_inverter_time_1_update",
+      "state": "2026-08-06T17:46:10.879954+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-1-circle",
+        "friendly_name": "Growatt Inverter Time 1 Update"
+      }
+    },
+    "select.growatt_inverter_time_4_begin": {
+      "entity_id": "select.growatt_inverter_time_4_begin",
+      "state": "18:45",
+      "attributes": {
+        "options": [
+          "00:00",
+          "00:15",
+          "00:30",
+          "00:45",
+          "01:00",
+          "01:15",
+          "01:30",
+          "01:45",
+          "02:00",
+          "02:15",
+          "02:30",
+          "02:45",
+          "03:00",
+          "03:15",
+          "03:30",
+          "03:45",
+          "04:00",
+          "04:15",
+          "04:30",
+          "04:45",
+          "05:00",
+          "05:15",
+          "05:30",
+          "05:45",
+          "06:00",
+          "06:15",
+          "06:30",
+          "06:45",
+          "07:00",
+          "07:15",
+          "07:30",
+          "07:45",
+          "08:00",
+          "08:15",
+          "08:30",
+          "08:45",
+          "09:00",
+          "09:15",
+          "09:30",
+          "09:45",
+          "10:00",
+          "10:15",
+          "10:30",
+          "10:45",
+          "11:00",
+          "11:15",
+          "11:30",
+          "11:45",
+          "12:00",
+          "12:15",
+          "12:30",
+          "12:45",
+          "13:00",
+          "13:15",
+          "13:30",
+          "13:45",
+          "14:00",
+          "14:15",
+          "14:30",
+          "14:45",
+          "15:00",
+          "15:15",
+          "15:30",
+          "15:45",
+          "16:00",
+          "16:15",
+          "16:30",
+          "16:45",
+          "17:00",
+          "17:15",
+          "17:30",
+          "17:45",
+          "18:00",
+          "18:15",
+          "18:30",
+          "18:45",
+          "19:00",
+          "19:15",
+          "19:30",
+          "19:45",
+          "20:00",
+          "20:15",
+          "20:30",
+          "20:45",
+          "21:00",
+          "21:15",
+          "21:30",
+          "21:45",
+          "22:00",
+          "22:15",
+          "22:30",
+          "22:45",
+          "23:00",
+          "23:15",
+          "23:30",
+          "23:45"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 4 Begin"
+      }
+    },
+    "select.growatt_inverter_time_4_mode": {
+      "entity_id": "select.growatt_inverter_time_4_mode",
+      "state": "Load First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 4 Mode"
+      }
+    },
+    "select.growatt_inverter_time_5_active": {
+      "entity_id": "select.growatt_inverter_time_5_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 5 Active"
+      }
+    },
+    "select.growatt_inverter_time_8_mode": {
+      "entity_id": "select.growatt_inverter_time_8_mode",
+      "state": "Battery First",
+      "attributes": {
+        "options": [
+          "Load First",
+          "Battery First",
+          "Grid First"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 8 Mode"
+      }
+    },
+    "select.growatt_inverter_time_2_end": {
+      "entity_id": "select.growatt_inverter_time_2_end",
+      "state": "09:29",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 2 End"
+      }
+    },
+    "sensor.growatt_inverter_total_power_generation": {
+      "entity_id": "sensor.growatt_inverter_total_power_generation",
+      "state": "10987.7",
+      "attributes": {
+        "state_class": "total_increasing",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "icon": "mdi:solar-power",
+        "friendly_name": "Growatt Inverter growatt Total Power Generation"
+      }
+    },
+    "button.growatt_inverter_time_3_update": {
+      "entity_id": "button.growatt_inverter_time_3_update",
+      "state": "2026-07-24T19:37:39.382834+00:00",
+      "attributes": {
+        "icon": "mdi:numeric-3-circle",
+        "friendly_name": "Growatt Inverter Time 3 Update"
+      }
+    },
+    "sensor.growatt_inverter_total_solar_energy": {
+      "entity_id": "sensor.growatt_inverter_total_solar_energy",
+      "state": "9688.1",
+      "attributes": {
+        "state_class": "total_increasing",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "icon": "mdi:solar-power",
+        "friendly_name": "Growatt Inverter growatt Total Solar Energy"
+      }
+    },
+    "select.growatt_inverter_time_6_end": {
+      "entity_id": "select.growatt_inverter_time_6_end",
+      "state": "22:14",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 6 End"
+      }
+    },
+    "select.growatt_inverter_time_9_active": {
+      "entity_id": "select.growatt_inverter_time_9_active",
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Disabled",
+          "Enabled"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 9 Active"
+      }
+    },
+    "sensor.growatt_inverter_total_battery_output_energy": {
+      "entity_id": "sensor.growatt_inverter_total_battery_output_energy",
+      "state": "5625.4",
+      "attributes": {
+        "state_class": "total_increasing",
+        "ed_mapping_present": false,
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "icon": "mdi:battery-arrow-down",
+        "friendly_name": "Growatt Inverter growatt Total Battery Output Energy"
+      }
+    },
+    "select.growatt_inverter_time_8_end": {
+      "entity_id": "select.growatt_inverter_time_8_end",
+      "state": "07:14",
+      "attributes": {
+        "options": [
+          "00:14",
+          "00:29",
+          "00:44",
+          "00:59",
+          "01:14",
+          "01:29",
+          "01:44",
+          "01:59",
+          "02:14",
+          "02:29",
+          "02:44",
+          "02:59",
+          "03:14",
+          "03:29",
+          "03:44",
+          "03:59",
+          "04:14",
+          "04:29",
+          "04:44",
+          "04:59",
+          "05:14",
+          "05:29",
+          "05:44",
+          "05:59",
+          "06:14",
+          "06:29",
+          "06:44",
+          "06:59",
+          "07:14",
+          "07:29",
+          "07:44",
+          "07:59",
+          "08:14",
+          "08:29",
+          "08:44",
+          "08:59",
+          "09:14",
+          "09:29",
+          "09:44",
+          "09:59",
+          "10:14",
+          "10:29",
+          "10:44",
+          "10:59",
+          "11:14",
+          "11:29",
+          "11:44",
+          "11:59",
+          "12:14",
+          "12:29",
+          "12:44",
+          "12:59",
+          "13:14",
+          "13:29",
+          "13:44",
+          "13:59",
+          "14:14",
+          "14:29",
+          "14:44",
+          "14:59",
+          "15:14",
+          "15:29",
+          "15:44",
+          "15:59",
+          "16:14",
+          "16:29",
+          "16:44",
+          "16:59",
+          "17:14",
+          "17:29",
+          "17:44",
+          "17:59",
+          "18:14",
+          "18:29",
+          "18:44",
+          "18:59",
+          "19:14",
+          "19:29",
+          "19:44",
+          "19:59",
+          "20:14",
+          "20:29",
+          "20:44",
+          "20:59",
+          "21:14",
+          "21:29",
+          "21:44",
+          "21:59",
+          "22:14",
+          "22:29",
+          "22:44",
+          "22:59",
+          "23:14",
+          "23:29",
+          "23:44",
+          "23:59"
+        ],
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter Time 8 End"
+      }
+    },
+    "number.growatt_inverter_vpp_time": {
+      "entity_id": "number.growatt_inverter_vpp_time",
+      "state": "20",
+      "attributes": {
+        "min": 0,
+        "max": 1440,
+        "step": 5,
+        "mode": "auto",
+        "unit_of_measurement": "min",
+        "icon": "mdi:battery-clock",
+        "friendly_name": "Growatt Inverter VPP Time"
+      }
+    },
+    "sensor.solcast_pv_forecast_forecast_today": {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_today",
+      "state": "44.438",
+      "attributes": {
+        "state_class": "total",
+        "3cdb_fd46_c0a9_f8f7": 44.438,
+        "estimate_3cdb_fd46_c0a9_f8f7": 44.438,
+        "estimate10_3cdb_fd46_c0a9_f8f7": 28.9623,
+        "estimate90_3cdb_fd46_c0a9_f8f7": 58.3142,
+        "estimate": 44.438,
+        "estimate10": 28.9623,
+        "estimate90": 58.3142,
+        "dayname": "Friday",
+        "dataCorrect": true,
+        "analysis": {
+          "estimate10_kwh": 28.9623,
+          "estimate90_kwh": 58.3143,
+          "spread_kwh": 29.352,
+          "confidence": 0.4967,
+          "intervals": [
+            {
+              "period_start": "2026-08-07T00:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T00:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T01:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T01:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T02:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T02:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T03:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T03:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T04:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T04:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T05:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T05:30:00+02:00",
+              "spread_kwh": 0.0602,
+              "confidence": 0.2905
+            },
+            {
+              "period_start": "2026-08-07T06:00:00+02:00",
+              "spread_kwh": 0.5501,
+              "confidence": 0.1043
+            },
+            {
+              "period_start": "2026-08-07T06:30:00+02:00",
+              "spread_kwh": 1.0496,
+              "confidence": 0.0849
+            },
+            {
+              "period_start": "2026-08-07T07:00:00+02:00",
+              "spread_kwh": 0.4313,
+              "confidence": 0.7306
+            },
+            {
+              "period_start": "2026-08-07T07:30:00+02:00",
+              "spread_kwh": 0.8179,
+              "confidence": 0.6356
+            },
+            {
+              "period_start": "2026-08-07T08:00:00+02:00",
+              "spread_kwh": 1.6302,
+              "confidence": 0.3803
+            },
+            {
+              "period_start": "2026-08-07T08:30:00+02:00",
+              "spread_kwh": 2.3313,
+              "confidence": 0.1568
+            },
+            {
+              "period_start": "2026-08-07T09:00:00+02:00",
+              "spread_kwh": 2.9741,
+              "confidence": 0.0824
+            },
+            {
+              "period_start": "2026-08-07T09:30:00+02:00",
+              "spread_kwh": 1.3361,
+              "confidence": 0.5604
+            },
+            {
+              "period_start": "2026-08-07T10:00:00+02:00",
+              "spread_kwh": 1.9559,
+              "confidence": 0.3951
+            },
+            {
+              "period_start": "2026-08-07T10:30:00+02:00",
+              "spread_kwh": 2.8603,
+              "confidence": 0.2207
+            },
+            {
+              "period_start": "2026-08-07T11:00:00+02:00",
+              "spread_kwh": 2.7583,
+              "confidence": 0.1533
+            },
+            {
+              "period_start": "2026-08-07T11:30:00+02:00",
+              "spread_kwh": 3.2333,
+              "confidence": 0.1076
+            },
+            {
+              "period_start": "2026-08-07T12:00:00+02:00",
+              "spread_kwh": 1.0353,
+              "confidence": 0.7222
+            },
+            {
+              "period_start": "2026-08-07T12:30:00+02:00",
+              "spread_kwh": 1.3531,
+              "confidence": 0.6293
+            },
+            {
+              "period_start": "2026-08-07T13:00:00+02:00",
+              "spread_kwh": 1.5796,
+              "confidence": 0.547
+            },
+            {
+              "period_start": "2026-08-07T13:30:00+02:00",
+              "spread_kwh": 1.8174,
+              "confidence": 0.4424
+            },
+            {
+              "period_start": "2026-08-07T14:00:00+02:00",
+              "spread_kwh": 0.2645,
+              "confidence": 0.8955
+            },
+            {
+              "period_start": "2026-08-07T14:30:00+02:00",
+              "spread_kwh": 0.3832,
+              "confidence": 0.8543
+            },
+            {
+              "period_start": "2026-08-07T15:00:00+02:00",
+              "spread_kwh": 0.3401,
+              "confidence": 0.8357
+            },
+            {
+              "period_start": "2026-08-07T15:30:00+02:00",
+              "spread_kwh": 0.2793,
+              "confidence": 0.8383
+            },
+            {
+              "period_start": "2026-08-07T16:00:00+02:00",
+              "spread_kwh": 0.115,
+              "confidence": 0.9127
+            },
+            {
+              "period_start": "2026-08-07T16:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T17:00:00+02:00",
+              "spread_kwh": 0.0599,
+              "confidence": 0.9048
+            },
+            {
+              "period_start": "2026-08-07T17:30:00+02:00",
+              "spread_kwh": 0.0326,
+              "confidence": 0.9047
+            },
+            {
+              "period_start": "2026-08-07T18:00:00+02:00",
+              "spread_kwh": 0.0274,
+              "confidence": 0.9047
+            },
+            {
+              "period_start": "2026-08-07T18:30:00+02:00",
+              "spread_kwh": 0.0298,
+              "confidence": 0.9045
+            },
+            {
+              "period_start": "2026-08-07T19:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T19:30:00+02:00",
+              "spread_kwh": 0.0118,
+              "confidence": 0.9046
+            },
+            {
+              "period_start": "2026-08-07T20:00:00+02:00",
+              "spread_kwh": 0.0135,
+              "confidence": 0.8727
+            },
+            {
+              "period_start": "2026-08-07T20:30:00+02:00",
+              "spread_kwh": 0.0183,
+              "confidence": 0.6336
+            },
+            {
+              "period_start": "2026-08-07T21:00:00+02:00",
+              "spread_kwh": 0.0024,
+              "confidence": 0.0
+            },
+            {
+              "period_start": "2026-08-07T21:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T22:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T22:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T23:00:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            },
+            {
+              "period_start": "2026-08-07T23:30:00+02:00",
+              "spread_kwh": 0.0,
+              "confidence": 1.0
+            }
+          ]
+        },
+        "detailedForecast": [
+          {
+            "period_start": "2026-08-07T00:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T00:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T01:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T01:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T02:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T02:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T03:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T03:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T04:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T04:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T05:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T05:30:00+02:00",
+            "pv_estimate": 0.0788,
+            "pv_estimate10": 0.0493,
+            "pv_estimate90": 0.1697,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T06:00:00+02:00",
+            "pv_estimate": 0.5975,
+            "pv_estimate10": 0.1281,
+            "pv_estimate90": 1.2283,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T06:30:00+02:00",
+            "pv_estimate": 1.2922,
+            "pv_estimate10": 0.1948,
+            "pv_estimate90": 2.294,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T07:00:00+02:00",
+            "pv_estimate": 2.9023,
+            "pv_estimate10": 2.3392,
+            "pv_estimate90": 3.2018,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T07:30:00+02:00",
+            "pv_estimate": 4.16,
+            "pv_estimate10": 2.8536,
+            "pv_estimate90": 4.4895,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T08:00:00+02:00",
+            "pv_estimate": 4.2379,
+            "pv_estimate10": 2.0013,
+            "pv_estimate90": 5.2618,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T08:30:00+02:00",
+            "pv_estimate": 3.4516,
+            "pv_estimate10": 0.8671,
+            "pv_estimate90": 5.5297,
+            "dampening_factor": 0.934
+          },
+          {
+            "period_start": "2026-08-07T09:00:00+02:00",
+            "pv_estimate": 3.1906,
+            "pv_estimate10": 0.5341,
+            "pv_estimate90": 6.4824,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T09:30:00+02:00",
+            "pv_estimate": 4.9862,
+            "pv_estimate10": 3.4073,
+            "pv_estimate90": 6.0796,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T10:00:00+02:00",
+            "pv_estimate": 4.4577,
+            "pv_estimate10": 2.5549,
+            "pv_estimate90": 6.4667,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T10:30:00+02:00",
+            "pv_estimate": 4.2887,
+            "pv_estimate10": 1.6198,
+            "pv_estimate90": 7.3403,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T11:00:00+02:00",
+            "pv_estimate": 3.3791,
+            "pv_estimate10": 0.9991,
+            "pv_estimate90": 6.5157,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T11:30:00+02:00",
+            "pv_estimate": 3.6542,
+            "pv_estimate10": 0.7798,
+            "pv_estimate90": 7.2464,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T12:00:00+02:00",
+            "pv_estimate": 6.6676,
+            "pv_estimate10": 5.3832,
+            "pv_estimate90": 7.4538,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T12:30:00+02:00",
+            "pv_estimate": 6.2069,
+            "pv_estimate10": 4.5934,
+            "pv_estimate90": 7.2996,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T13:00:00+02:00",
+            "pv_estimate": 5.5704,
+            "pv_estimate10": 3.8154,
+            "pv_estimate90": 6.9746,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T13:30:00+02:00",
+            "pv_estimate": 5.0167,
+            "pv_estimate10": 2.8835,
+            "pv_estimate90": 6.5184,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T14:00:00+02:00",
+            "pv_estimate": 4.8251,
+            "pv_estimate10": 4.5313,
+            "pv_estimate90": 5.0602,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T14:30:00+02:00",
+            "pv_estimate": 4.8755,
+            "pv_estimate10": 4.4931,
+            "pv_estimate90": 5.2595,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T15:00:00+02:00",
+            "pv_estimate": 3.8844,
+            "pv_estimate10": 3.4593,
+            "pv_estimate90": 4.1395,
+            "dampening_factor": 0.89
+          },
+          {
+            "period_start": "2026-08-07T15:30:00+02:00",
+            "pv_estimate": 3.25,
+            "pv_estimate10": 2.8958,
+            "pv_estimate90": 3.4545,
+            "dampening_factor": 0.899
+          },
+          {
+            "period_start": "2026-08-07T16:00:00+02:00",
+            "pv_estimate": 2.5509,
+            "pv_estimate10": 2.4044,
+            "pv_estimate90": 2.6343,
+            "dampening_factor": 0.865
+          },
+          {
+            "period_start": "2026-08-07T16:30:00+02:00",
+            "pv_estimate": 1.5911,
+            "pv_estimate10": 1.5911,
+            "pv_estimate90": 1.5911,
+            "dampening_factor": 0.739
+          },
+          {
+            "period_start": "2026-08-07T17:00:00+02:00",
+            "pv_estimate": 1.1978,
+            "pv_estimate10": 1.138,
+            "pv_estimate90": 1.2577,
+            "dampening_factor": 0.903
+          },
+          {
+            "period_start": "2026-08-07T17:30:00+02:00",
+            "pv_estimate": 0.6514,
+            "pv_estimate10": 0.6188,
+            "pv_estimate90": 0.684,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T18:00:00+02:00",
+            "pv_estimate": 0.5476,
+            "pv_estimate10": 0.5202,
+            "pv_estimate90": 0.575,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T18:30:00+02:00",
+            "pv_estimate": 0.5946,
+            "pv_estimate10": 0.5648,
+            "pv_estimate90": 0.6244,
+            "dampening_factor": 0.873
+          },
+          {
+            "period_start": "2026-08-07T19:00:00+02:00",
+            "pv_estimate": 0.2316,
+            "pv_estimate10": 0.2316,
+            "pv_estimate90": 0.2316,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T19:30:00+02:00",
+            "pv_estimate": 0.2357,
+            "pv_estimate10": 0.2239,
+            "pv_estimate90": 0.2475,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T20:00:00+02:00",
+            "pv_estimate": 0.202,
+            "pv_estimate10": 0.1851,
+            "pv_estimate90": 0.2121,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T20:30:00+02:00",
+            "pv_estimate": 0.0951,
+            "pv_estimate10": 0.0633,
+            "pv_estimate90": 0.0999,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T21:00:00+02:00",
+            "pv_estimate": 0.0049,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0049,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T21:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T22:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T22:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T23:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          },
+          {
+            "period_start": "2026-08-07T23:30:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0,
+            "dampening_factor": 1.0
+          }
+        ],
+        "detailedHourly": [
+          {
+            "period_start": "2026-08-07T00:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-07T01:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-07T02:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-07T03:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-07T04:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-07T05:00:00+02:00",
+            "pv_estimate": 0.0394,
+            "pv_estimate10": 0.0246,
+            "pv_estimate90": 0.0848
+          },
+          {
+            "period_start": "2026-08-07T06:00:00+02:00",
+            "pv_estimate": 0.9448,
+            "pv_estimate10": 0.1614,
+            "pv_estimate90": 1.7611
+          },
+          {
+            "period_start": "2026-08-07T07:00:00+02:00",
+            "pv_estimate": 3.5312,
+            "pv_estimate10": 2.5964,
+            "pv_estimate90": 3.8457
+          },
+          {
+            "period_start": "2026-08-07T08:00:00+02:00",
+            "pv_estimate": 3.8447,
+            "pv_estimate10": 1.4342,
+            "pv_estimate90": 5.3957
+          },
+          {
+            "period_start": "2026-08-07T09:00:00+02:00",
+            "pv_estimate": 4.0884,
+            "pv_estimate10": 1.9707,
+            "pv_estimate90": 6.281
+          },
+          {
+            "period_start": "2026-08-07T10:00:00+02:00",
+            "pv_estimate": 4.3732,
+            "pv_estimate10": 2.0873,
+            "pv_estimate90": 6.9035
+          },
+          {
+            "period_start": "2026-08-07T11:00:00+02:00",
+            "pv_estimate": 3.5167,
+            "pv_estimate10": 0.8895,
+            "pv_estimate90": 6.8811
+          },
+          {
+            "period_start": "2026-08-07T12:00:00+02:00",
+            "pv_estimate": 6.4373,
+            "pv_estimate10": 4.9883,
+            "pv_estimate90": 7.3767
+          },
+          {
+            "period_start": "2026-08-07T13:00:00+02:00",
+            "pv_estimate": 5.2935,
+            "pv_estimate10": 3.3495,
+            "pv_estimate90": 6.7465
+          },
+          {
+            "period_start": "2026-08-07T14:00:00+02:00",
+            "pv_estimate": 4.8503,
+            "pv_estimate10": 4.5122,
+            "pv_estimate90": 5.1599
+          },
+          {
+            "period_start": "2026-08-07T15:00:00+02:00",
+            "pv_estimate": 3.5672,
+            "pv_estimate10": 3.1776,
+            "pv_estimate90": 3.797
+          },
+          {
+            "period_start": "2026-08-07T16:00:00+02:00",
+            "pv_estimate": 2.071,
+            "pv_estimate10": 1.9977,
+            "pv_estimate90": 2.1127
+          },
+          {
+            "period_start": "2026-08-07T17:00:00+02:00",
+            "pv_estimate": 0.9246,
+            "pv_estimate10": 0.8784,
+            "pv_estimate90": 0.9708
+          },
+          {
+            "period_start": "2026-08-07T18:00:00+02:00",
+            "pv_estimate": 0.5711,
+            "pv_estimate10": 0.5425,
+            "pv_estimate90": 0.5997
+          },
+          {
+            "period_start": "2026-08-07T19:00:00+02:00",
+            "pv_estimate": 0.2336,
+            "pv_estimate10": 0.2278,
+            "pv_estimate90": 0.2395
+          },
+          {
+            "period_start": "2026-08-07T20:00:00+02:00",
+            "pv_estimate": 0.1486,
+            "pv_estimate10": 0.1242,
+            "pv_estimate90": 0.156
+          },
+          {
+            "period_start": "2026-08-07T21:00:00+02:00",
+            "pv_estimate": 0.0024,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0024
+          },
+          {
+            "period_start": "2026-08-07T22:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          },
+          {
+            "period_start": "2026-08-07T23:00:00+02:00",
+            "pv_estimate": 0.0,
+            "pv_estimate10": 0.0,
+            "pv_estimate90": 0.0
+          }
+        ],
+        "undampened_estimate": 45.5702,
+        "undampened_estimate10": 29.9402,
+        "undampened_estimate90": 59.5589,
+        "unit_of_measurement": "kWh",
+        "attribution": "Data retrieved from Solcast",
+        "device_class": "energy",
+        "friendly_name": "Solcast PV Forecast Forecast Today"
+      }
+    }
+  },
+  "config_entries": [
+    {
+      "entry_id": "01K83SXQ68W3952XYRE2YE6JA3",
+      "domain": "nordpool",
+      "title": "***",
+      "state": "loaded",
+      "version": null,
+      "options": {},
+      "data": {}
+    },
+    {
+      "entry_id": "01K83V748EZ38F6Z7R2S1N776G",
+      "domain": "solax_modbus",
+      "title": "***",
+      "state": "loaded",
+      "version": null,
+      "options": {},
+      "data": {}
+    },
+    {
+      "entry_id": "01K8J6N9QG9SRE9GJMTA11PAWB",
+      "domain": "template",
+      "title": "***",
+      "state": "loaded",
+      "version": null,
+      "options": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      },
+      "data": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      }
+    },
+    {
+      "entry_id": "01K8J6YQC7QJ3MV9R81XXY2C74",
+      "domain": "template",
+      "title": "***",
+      "state": "loaded",
+      "version": null,
+      "options": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      },
+      "data": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      }
+    },
+    {
+      "entry_id": "01K8KQDWNQHNGVX0ZAFC7C1Z4E",
+      "domain": "template",
+      "title": "***",
+      "state": "loaded",
+      "version": null,
+      "options": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      },
+      "data": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      }
+    },
+    {
+      "entry_id": "01K8KS1K9MVQGNA3XYFDAPVFP2",
+      "domain": "template",
+      "title": "***",
+      "state": "loaded",
+      "version": null,
+      "options": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      },
+      "data": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      }
+    },
+    {
+      "entry_id": "01KAPY9YXX24E3CPDWSY1A68CM",
+      "domain": "solcast_solar",
+      "title": "***",
+      "state": "loaded",
+      "version": null,
+      "options": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      },
+      "data": {
+        "<filtered>": "0 keys (domain not allowlisted)"
+      }
+    }
+  ],
+  "entity_registry": [
+    {
+      "entity_id": "sensor.nord_pool_se3_last_updated",
+      "unique_id": "SE3-updated_at",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Senast uppdaterad",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_currency",
+      "unique_id": "SE3-currency",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Valuta",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_exchange_rate",
+      "unique_id": "SE3-exchange_rate",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "V\u00e4xelkurs",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_current_price",
+      "unique_id": "SE3-current_price",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Aktuellt pris"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_previous_price",
+      "unique_id": "SE3-last_price",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "F\u00f6reg\u00e5ende pris"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_next_price",
+      "unique_id": "SE3-next_price",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "N\u00e4sta pris"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_lowest_price",
+      "unique_id": "SE3-lowest_price",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "L\u00e4gsta pris"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_highest_price",
+      "unique_id": "SE3-highest_price",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "H\u00f6gsta pris"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_daily_average",
+      "unique_id": "SE3-daily_average",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Dagligt genomsnitt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_1_average",
+      "unique_id": "off_peak_1-SE3-block_average",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 1 genomsnitt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_1_lowest_price",
+      "unique_id": "off_peak_1-SE3-block_min",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 1 l\u00e4gsta pris",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_1_highest_price",
+      "unique_id": "off_peak_1-SE3-block_max",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 1 h\u00f6gsta pris",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_1_time_from",
+      "unique_id": "off_peak_1-SE3-block_start_time",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 1 fr\u00e5n tid",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_1_time_until",
+      "unique_id": "off_peak_1-SE3-block_end_time",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 1 tills tid",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_peak_average",
+      "unique_id": "peak-SE3-block_average",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Peak genomsnitt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_peak_lowest_price",
+      "unique_id": "peak-SE3-block_min",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Peak l\u00e4gsta pris",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_peak_highest_price",
+      "unique_id": "peak-SE3-block_max",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Peak h\u00f6gsta pris",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_peak_time_from",
+      "unique_id": "peak-SE3-block_start_time",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Peak fr\u00e5n tid",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_peak_time_until",
+      "unique_id": "peak-SE3-block_end_time",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Peak tills tid",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_2_average",
+      "unique_id": "off_peak_2-SE3-block_average",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 2 genomsnitt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_2_lowest_price",
+      "unique_id": "off_peak_2-SE3-block_min",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 2 l\u00e4gsta pris",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_2_highest_price",
+      "unique_id": "off_peak_2-SE3-block_max",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 2 h\u00f6gsta pris",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_2_time_from",
+      "unique_id": "off_peak_2-SE3-block_start_time",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 2 fr\u00e5n tid",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_off_peak_2_time_until",
+      "unique_id": "off_peak_2-SE3-block_end_time",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Off-peak 2 tills tid",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "update.solax_inverter_modbus_update",
+      "unique_id": "***",
+      "platform": "hacs",
+      "device_id": "7e76f2ab9dabbf3f1810c39cf44a0a62",
+      "original_name": "Update",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "switch.solax_inverter_modbus_pre_release",
+      "unique_id": "***",
+      "platform": "hacs",
+      "device_id": "7e76f2ab9dabbf3f1810c39cf44a0a62",
+      "original_name": "Pre-release",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "button.growatt_inverter_active_power_not_limited",
+      "unique_id": "growatt_active_power_not_limited",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Active Power Not Limited"
+    },
+    {
+      "entity_id": "button.growatt_inverter_reactive_power_not_limited",
+      "unique_id": "growatt_reactive_power_not_limited",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Reactive Power Not Limited"
+    },
+    {
+      "entity_id": "button.growatt_inverter_sync_rtc",
+      "unique_id": "growatt_sync_rtc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Sync RTC"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_1_update",
+      "unique_id": "growatt_time_1_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_2_update",
+      "unique_id": "growatt_time_2_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_3_update",
+      "unique_id": "growatt_time_3_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_4_update",
+      "unique_id": "growatt_time_4_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_5_update",
+      "unique_id": "growatt_time_5_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_6_update",
+      "unique_id": "growatt_time_6_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_7_update",
+      "unique_id": "growatt_time_7_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_8_update",
+      "unique_id": "growatt_time_8_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_9_update",
+      "unique_id": "growatt_time_9_update",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 Update"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_1_clear",
+      "unique_id": "growatt_time_1_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_2_clear",
+      "unique_id": "growatt_time_2_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_3_clear",
+      "unique_id": "growatt_time_3_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_4_clear",
+      "unique_id": "growatt_time_4_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_5_clear",
+      "unique_id": "growatt_time_5_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_6_clear",
+      "unique_id": "growatt_time_6_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_7_clear",
+      "unique_id": "growatt_time_7_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_8_clear",
+      "unique_id": "growatt_time_8_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "button.growatt_inverter_time_9_clear",
+      "unique_id": "growatt_time_9_clear",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 Clear",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "number.growatt_inverter_active_power_limit",
+      "unique_id": "growatt_active_power_limit",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Active Power Limit"
+    },
+    {
+      "entity_id": "number.growatt_inverter_reactive_power_limit",
+      "unique_id": "growatt_reactive_power_limit",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Reactive Power Limit"
+    },
+    {
+      "entity_id": "number.growatt_inverter_grid_export_limit",
+      "unique_id": "growatt_grid_export_limit",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Grid Export Limit"
+    },
+    {
+      "entity_id": "number.growatt_inverter_ems_discharging_rate",
+      "unique_id": "growatt_ems_discharging_rate",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "EMS Discharging Rate",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_ems_discharging_stop_soc_off_grid",
+      "unique_id": "growatt_ems_discharging_stop_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "EMS Discharging Stop SOC (off grid)",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_ems_charging_rate",
+      "unique_id": "growatt_ems_charging_rate",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "EMS Charging Rate",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_ems_charging_stop_soc",
+      "unique_id": "growatt_ems_charging_stop_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "EMS Charging Stop SOC",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_ems_discharging_stop_soc_on_grid",
+      "unique_id": "growatt_ems_discharging_stop_soc_on_grid",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "EMS Discharging Stop SOC (on grid)",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_switch",
+      "unique_id": "growatt_inverter_switch",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Switch"
+    },
+    {
+      "entity_id": "select.growatt_inverter_select_baud_rate",
+      "unique_id": "growatt_select_baud_rate",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Select baud rate",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_limit_grid_export",
+      "unique_id": "growatt_limit_grid_export",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Limit Grid Export"
+    },
+    {
+      "entity_id": "select.growatt_inverter_allow_grid_charge",
+      "unique_id": "growatt_charger_switch",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Allow Grid Charge"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_1_begin",
+      "unique_id": "growatt_time_1_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_1_end",
+      "unique_id": "growatt_time_1_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_1_mode",
+      "unique_id": "growatt_time_1_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_1_active",
+      "unique_id": "growatt_time_1_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_2_begin",
+      "unique_id": "growatt_time_2_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_2_end",
+      "unique_id": "growatt_time_2_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_2_mode",
+      "unique_id": "growatt_time_2_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_2_active",
+      "unique_id": "growatt_time_2_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_3_begin",
+      "unique_id": "growatt_time_3_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_3_end",
+      "unique_id": "growatt_time_3_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_3_mode",
+      "unique_id": "growatt_time_3_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_3_active",
+      "unique_id": "growatt_time_3_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_4_begin",
+      "unique_id": "growatt_time_4_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_4_end",
+      "unique_id": "growatt_time_4_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_4_mode",
+      "unique_id": "growatt_time_4_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_4_active",
+      "unique_id": "growatt_time_4_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_5_begin",
+      "unique_id": "growatt_time_5_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_5_end",
+      "unique_id": "growatt_time_5_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_5_mode",
+      "unique_id": "growatt_time_5_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_5_active",
+      "unique_id": "growatt_time_5_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_6_begin",
+      "unique_id": "growatt_time_6_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_6_end",
+      "unique_id": "growatt_time_6_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_6_mode",
+      "unique_id": "growatt_time_6_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_6_active",
+      "unique_id": "growatt_time_6_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_7_begin",
+      "unique_id": "growatt_time_7_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_7_end",
+      "unique_id": "growatt_time_7_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_7_mode",
+      "unique_id": "growatt_time_7_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_7_active",
+      "unique_id": "growatt_time_7_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_8_begin",
+      "unique_id": "growatt_time_8_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_8_end",
+      "unique_id": "growatt_time_8_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_8_mode",
+      "unique_id": "growatt_time_8_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_8_active",
+      "unique_id": "growatt_time_8_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_9_begin",
+      "unique_id": "growatt_time_9_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_9_end",
+      "unique_id": "growatt_time_9_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_9_mode",
+      "unique_id": "growatt_time_9_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 Mode",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_time_9_active",
+      "unique_id": "growatt_time_9_enabled",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 Active",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_firmware_version",
+      "unique_id": "growatt_firmware_version",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Firmware Version",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_firmware_control_version",
+      "unique_id": "growatt_firmware_control_version",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Firmware Control Version",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_language",
+      "unique_id": "growatt_language",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Language",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_rtc",
+      "unique_id": "growatt_rtc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt RTC",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_isolation_resistance",
+      "unique_id": "growatt_pv_isolation_resistance",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Isolation Resistance",
+      "disabled_by": "user",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_serial_number",
+      "unique_id": "growatt_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_battery_type",
+      "unique_id": "growatt_battery_type",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Battery Type",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_power_total",
+      "unique_id": "growatt_pv_power_total",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Power Total"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_output_power",
+      "unique_id": "growatt_output_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Output Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_work_time_hours",
+      "unique_id": "growatt_total_work_time_hours",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Work Time Hours",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_priority",
+      "unique_id": "growatt_priority",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Priority"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_battery_combined_power",
+      "unique_id": "growatt_battery_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Battery Combined Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_inverter_state",
+      "unique_id": "growatt_inverter_state",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Run State",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_run_mode",
+      "unique_id": "growatt_run_mode",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Machine Status",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_pv_power",
+      "unique_id": "growatt_total_pv_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total PV Power",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_voltage_1",
+      "unique_id": "growatt_pv_voltage_1",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Voltage 1",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_current_1",
+      "unique_id": "growatt_pv_current_1",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Current 1",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_power_1",
+      "unique_id": "growatt_pv_power_1",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Power 1"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_voltage_2",
+      "unique_id": "growatt_pv_voltage_2",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Voltage 2",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_current_2",
+      "unique_id": "growatt_pv_current_2",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Current 2",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_pv_power_2",
+      "unique_id": "growatt_pv_power_2",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt PV Power 2"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_power_total",
+      "unique_id": "growatt_total_grid_power_va",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Power Total"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_grid_power",
+      "unique_id": "growatt_total_grid_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Grid Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_frequency",
+      "unique_id": "growatt_grid_frequency",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Frequency"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_voltage_l1",
+      "unique_id": "growatt_grid_voltage_l1",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Voltage L1"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_current_l1",
+      "unique_id": "growatt_grid_current_l1",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Current L1",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_power_l1",
+      "unique_id": "growatt_grid_power_l1",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Power L1",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_voltage_l2",
+      "unique_id": "growatt_grid_voltage_l2",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Voltage L2",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_current_l2",
+      "unique_id": "growatt_grid_current_l2",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Current L2",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_power_l2",
+      "unique_id": "growatt_grid_power_l2",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Power L2",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_voltage_l3",
+      "unique_id": "growatt_grid_voltage_l3",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Voltage L3",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_current_l3",
+      "unique_id": "growatt_grid_current_l3",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Current L3",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_grid_power_l3",
+      "unique_id": "growatt_grid_power_l3",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Power L3",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_forward_power",
+      "unique_id": "growatt_total_forward_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Import Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_reverse_power",
+      "unique_id": "growatt_total_reverse_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Export Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_load_power",
+      "unique_id": "growatt_total_load_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Load Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_power_generation",
+      "unique_id": "growatt_today_s_power_generation",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's Power Generation"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_power_generation",
+      "unique_id": "growatt_total_power_generation",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Power Generation"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_solar_energy",
+      "unique_id": "growatt_total_solar_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Solar Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_pv1_solar_energy",
+      "unique_id": "growatt_today_s_pv1_solar_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's PV1 Solar Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_pv1_solar_energy",
+      "unique_id": "growatt_total_pv1_solar_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total PV1 Solar Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_pv2_solar_energy",
+      "unique_id": "growatt_today_s_pv2_solar_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's PV2 Solar Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_pv2_solar_energy",
+      "unique_id": "growatt_total_pv2_solar_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total PV2 Solar Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_grid_import",
+      "unique_id": "growatt_today_s_grid_import",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's Grid Import"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_grid_import",
+      "unique_id": "growatt_total_grid_import",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Grid Import"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_grid_export",
+      "unique_id": "growatt_today_s_grid_export",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's Grid Export"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_grid_export",
+      "unique_id": "growatt_total_grid_export",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Grid Export"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_load_energy",
+      "unique_id": "growatt_today_s_yield",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's Load Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_load_energy",
+      "unique_id": "growatt_total_yield",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Load Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_solar_energy",
+      "unique_id": "growatt_today_s_solar_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's Solar Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_inverter_temperature",
+      "unique_id": "growatt_inverter_temperature",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Temperature",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_ipm_inverter_temperature",
+      "unique_id": "growatt_ipm_inverter_temperature",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt IPM Inverter Temperature",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_boost_temperature",
+      "unique_id": "growatt_boost_temperature",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Boost Temperature",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_communication_board_temperature",
+      "unique_id": "growatt_communication_board_temperature",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Communication Board Temperature",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_battery_output_energy",
+      "unique_id": "growatt_today_s_battery_output_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's Battery Output Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_battery_output_energy",
+      "unique_id": "growatt_total_battery_output_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Battery Output Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_today_s_battery_input_energy",
+      "unique_id": "growatt_today_s_battery_input_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Today's Battery Input Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_total_battery_input_energy",
+      "unique_id": "growatt_total_battery_input_energy",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Total Battery Input Energy"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_work_mode_priority",
+      "unique_id": "growatt_work_mode_priority",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Work Mode - Priority"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_battery_voltage",
+      "unique_id": "growatt_battery_voltage",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Battery Voltage"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_battery_current",
+      "unique_id": "growatt_battery_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Battery Current"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_battery_soc",
+      "unique_id": "growatt_battery_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Battery SOC"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_battery_discharge_power",
+      "unique_id": "growatt_battery_discharge_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Battery Discharge Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_battery_charge_power",
+      "unique_id": "growatt_battery_charge_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Battery Charge Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_1_begin_read",
+      "unique_id": "growatt_time_1_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 1 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_1_mode_read",
+      "unique_id": "growatt_time_1_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 1 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_1_active_read",
+      "unique_id": "growatt_time_1_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 1 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_1_end_read",
+      "unique_id": "growatt_time_1_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 1 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_2_begin_read",
+      "unique_id": "growatt_time_2_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 2 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_2_mode_read",
+      "unique_id": "growatt_time_2_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 2 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_2_active_read",
+      "unique_id": "growatt_time_2_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 2 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_2_end_read",
+      "unique_id": "growatt_time_2_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 2 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_3_begin_read",
+      "unique_id": "growatt_time_3_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 3 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_3_mode_read",
+      "unique_id": "growatt_time_3_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 3 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_3_active_read",
+      "unique_id": "growatt_time_3_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 3 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_3_end_read",
+      "unique_id": "growatt_time_3_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 3 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_4_begin_read",
+      "unique_id": "growatt_time_4_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 4 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_4_mode_read",
+      "unique_id": "growatt_time_4_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 4 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_4_active_read",
+      "unique_id": "growatt_time_4_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 4 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_4_end_read",
+      "unique_id": "growatt_time_4_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 4 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_5_begin_read",
+      "unique_id": "growatt_time_5_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 5 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_5_mode_read",
+      "unique_id": "growatt_time_5_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 5 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_5_active_read",
+      "unique_id": "growatt_time_5_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 5 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_5_end_read",
+      "unique_id": "growatt_time_5_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 5 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_6_begin_read",
+      "unique_id": "growatt_time_6_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 6 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_6_mode_read",
+      "unique_id": "growatt_time_6_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 6 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_6_active_read",
+      "unique_id": "growatt_time_6_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 6 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_6_end_read",
+      "unique_id": "growatt_time_6_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 6 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_7_begin_read",
+      "unique_id": "growatt_time_7_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 7 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_7_mode_read",
+      "unique_id": "growatt_time_7_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 7 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_7_active_read",
+      "unique_id": "growatt_time_7_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 7 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_7_end_read",
+      "unique_id": "growatt_time_7_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 7 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_8_begin_read",
+      "unique_id": "growatt_time_8_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 8 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_8_mode_read",
+      "unique_id": "growatt_time_8_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 8 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_8_active_read",
+      "unique_id": "growatt_time_8_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 8 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_8_end_read",
+      "unique_id": "growatt_time_8_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 8 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_9_begin_read",
+      "unique_id": "growatt_time_9_begin_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 9 Begin (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_9_mode_read",
+      "unique_id": "growatt_time_9_mode_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 9 Mode (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_9_active_read",
+      "unique_id": "growatt_time_9_enabled_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 9 Active (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_time_9_end_read",
+      "unique_id": "growatt_time_9_end_read",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Time 9 End (read)",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_inverter_warning_text",
+      "unique_id": "growatt_inverter_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Warning Text",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_inverter_fault_text",
+      "unique_id": "growatt_inverter_fault_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Fault Text",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_peak_shaving_active",
+      "unique_id": "growatt_peak_shaving_enable",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Peak Shaving Active",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_reserved_soc_for_peak_shaving_active",
+      "unique_id": "growatt_reserved_soc_peak_shaving_enable",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Reserved SoC for Peak Shaving Active",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_inverter_total_module_count",
+      "unique_id": "growatt_inverter_total_module_count",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Total Module Count",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_s_connected",
+      "unique_id": "growatt_bmss_connceted",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS's Connected",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_serial_number",
+      "unique_id": "growatt_bms_1_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_charge_power",
+      "unique_id": "growatt_bms_1_charge_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Charge Power",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_discharge_power",
+      "unique_id": "growatt_bms_1_discharge_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Discharge Power",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_temp_a",
+      "unique_id": "growatt_bms_1_temp_a",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Temp A",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_temp_b",
+      "unique_id": "growatt_bms_1_temp_b",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Temp B",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_count",
+      "unique_id": "growatt_bms_1_module_count",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module Count",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_status",
+      "unique_id": "growatt_bms_1_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Status"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_awake_modules",
+      "unique_id": "growatt_bms_1_awake_modules",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Awake Modules"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_monitoring_version",
+      "unique_id": "growatt_bms_1_monitoring_version",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Monitoring Version",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_total_output_energy",
+      "unique_id": "growatt_bms_1_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_soc",
+      "unique_id": "growatt_bms_1_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_soh",
+      "unique_id": "growatt_bms_1_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_status",
+      "unique_id": "growatt_bms_1_module_1_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_soc",
+      "unique_id": "growatt_bms_1_module_1_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_soh",
+      "unique_id": "growatt_bms_1_module_1_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_volt",
+      "unique_id": "growatt_bms_1_module_1_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_combined_current",
+      "unique_id": "growatt_bms_1_module_1_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_combined_power",
+      "unique_id": "growatt_bms_1_module_1_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Combined Power"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_total_output_energy",
+      "unique_id": "growatt_bms_1_module_1_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_max_cell_temp",
+      "unique_id": "growatt_bms_1_module_1_max_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Max Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_min_cell_temp",
+      "unique_id": "growatt_bms_1_module_1_min_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Min Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_warning_text",
+      "unique_id": "growatt_bms_1_module_1_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_charge_cycles",
+      "unique_id": "growatt_bms_1_module_1_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_1_serial_number",
+      "unique_id": "growatt_bms_1_module_1_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 1 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_status",
+      "unique_id": "growatt_bms_1_module_2_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_soc",
+      "unique_id": "growatt_bms_1_module_2_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_soh",
+      "unique_id": "growatt_bms_1_module_2_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_volt",
+      "unique_id": "growatt_bms_1_module_2_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_combined_current",
+      "unique_id": "growatt_bms_1_module_2_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_combined_power",
+      "unique_id": "growatt_bms_1_module_2_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_total_output_energy",
+      "unique_id": "growatt_bms_1_module_2_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_max_cell_temp",
+      "unique_id": "growatt_bms_1_module_2_max_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Max Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_min_cell_temp",
+      "unique_id": "growatt_bms_1_module_2_min_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Min Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_warning_text",
+      "unique_id": "growatt_bms_1_module_2_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_charge_cycles",
+      "unique_id": "growatt_bms_1_module_2_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_2_serial_number",
+      "unique_id": "growatt_bms_1_module_2_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 2 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_status",
+      "unique_id": "growatt_bms_1_module_3_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_soc",
+      "unique_id": "growatt_bms_1_module_3_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_soh",
+      "unique_id": "growatt_bms_1_module_3_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_volt",
+      "unique_id": "growatt_bms_1_module_3_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_combined_current",
+      "unique_id": "growatt_bms_1_module_3_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_combined_power",
+      "unique_id": "growatt_bms_1_module_3_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_total_output_energy",
+      "unique_id": "growatt_bms_1_module_3_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_max_cell_temp",
+      "unique_id": "growatt_bms_1_module_3_max_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Max Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_min_cell_temp",
+      "unique_id": "growatt_bms_1_module_3_min_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Min Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_warning_text",
+      "unique_id": "growatt_bms_1_module_3_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_charge_cycles",
+      "unique_id": "growatt_bms_1_module_3_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_3_serial_number",
+      "unique_id": "growatt_bms_1_module_3_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 3 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_status",
+      "unique_id": "growatt_bms_1_module_4_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_soc",
+      "unique_id": "growatt_bms_1_module_4_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_soh",
+      "unique_id": "growatt_bms_1_module_4_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_volt",
+      "unique_id": "growatt_bms_1_module_4_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_combined_current",
+      "unique_id": "growatt_bms_1_module_4_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_combined_power",
+      "unique_id": "growatt_bms_1_module_4_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_total_output_energy",
+      "unique_id": "growatt_bms_1_module_4_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_max_cell_temp",
+      "unique_id": "growatt_bms_1_module_4_max_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Max Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_min_cell_temp",
+      "unique_id": "growatt_bms_1_module_4_min_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Min Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_warning_text",
+      "unique_id": "growatt_bms_1_module_4_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_charge_cycles",
+      "unique_id": "growatt_bms_1_module_4_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_4_serial_number",
+      "unique_id": "growatt_bms_1_module_4_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 4 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_status",
+      "unique_id": "growatt_bms_1_module_5_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_soc",
+      "unique_id": "growatt_bms_1_module_5_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_soh",
+      "unique_id": "growatt_bms_1_module_5_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_volt",
+      "unique_id": "growatt_bms_1_module_5_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_combined_current",
+      "unique_id": "growatt_bms_1_module_5_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_combined_power",
+      "unique_id": "growatt_bms_1_module_5_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_total_output_energy",
+      "unique_id": "growatt_bms_1_module_5_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_max_cell_temp",
+      "unique_id": "growatt_bms_1_module_5_max_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Max Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_min_cell_temp",
+      "unique_id": "growatt_bms_1_module_5_min_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Min Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_warning_text",
+      "unique_id": "growatt_bms_1_module_5_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_charge_cycles",
+      "unique_id": "growatt_bms_1_module_5_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_5_serial_number",
+      "unique_id": "growatt_bms_1_module_5_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 5 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_status",
+      "unique_id": "growatt_bms_1_module_6_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_soc",
+      "unique_id": "growatt_bms_1_module_6_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_soh",
+      "unique_id": "growatt_bms_1_module_6_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_volt",
+      "unique_id": "growatt_bms_1_module_6_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_combined_current",
+      "unique_id": "growatt_bms_1_module_6_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_combined_power",
+      "unique_id": "growatt_bms_1_module_6_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_total_output_energy",
+      "unique_id": "growatt_bms_1_module_6_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_max_cell_temp",
+      "unique_id": "growatt_bms_1_module_6_max_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Max Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_min_cell_temp",
+      "unique_id": "growatt_bms_1_module_6_min_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Min Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_warning_text",
+      "unique_id": "growatt_bms_1_module_6_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_charge_cycles",
+      "unique_id": "growatt_bms_1_module_6_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_1_module_6_serial_number",
+      "unique_id": "growatt_bms_1_module_6_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 1 Module 6 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_charge_power",
+      "unique_id": "growatt_bms_2_charge_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Charge Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_discharge_power",
+      "unique_id": "growatt_bms_2_discharge_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Discharge Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_temp_a",
+      "unique_id": "growatt_bms_2_temp_a",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Temp A",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_temp_b",
+      "unique_id": "growatt_bms_2_temp_b",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Temp B",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_count",
+      "unique_id": "growatt_bms_2_module_count",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module Count",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_status",
+      "unique_id": "growatt_bms_2_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_awake_modules",
+      "unique_id": "growatt_bms_2_awake_modules",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Awake Modules",
+      "disabled_by": "user"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_serial_number",
+      "unique_id": "growatt_bms_2_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_monitoring_version",
+      "unique_id": "growatt_bms_2_monitoring_version",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Monitoring Version",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_total_output_energy",
+      "unique_id": "growatt_bms_2_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_soc",
+      "unique_id": "growatt_bms_2_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_soh",
+      "unique_id": "growatt_bms_2_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_status",
+      "unique_id": "growatt_bms_2_module_1_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_soc",
+      "unique_id": "growatt_bms_2_module_1_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_soh",
+      "unique_id": "growatt_bms_2_module_1_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_volt",
+      "unique_id": "growatt_bms_2_module_1_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_combined_current",
+      "unique_id": "growatt_bms_2_module_1_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_combined_power",
+      "unique_id": "growatt_bms_2_module_1_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_total_output_energy",
+      "unique_id": "growatt_bms_2_module_1_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_max_cell_temp",
+      "unique_id": "growatt_bms_2_module_1_max_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Max Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_min_cell_temp",
+      "unique_id": "growatt_bms_2_module_1_min_cell_temp",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Min Cell Temp",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_warning_text",
+      "unique_id": "growatt_bms_2_module_1_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_charge_cycles",
+      "unique_id": "growatt_bms_2_module_1_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_1_serial_number",
+      "unique_id": "growatt_bms_2_module_1_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 1 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_status",
+      "unique_id": "growatt_bms_2_module_2_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_soc",
+      "unique_id": "growatt_bms_2_module_2_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_soh",
+      "unique_id": "growatt_bms_2_module_2_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_volt",
+      "unique_id": "growatt_bms_2_module_2_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_combined_current",
+      "unique_id": "growatt_bms_2_module_2_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_combined_power",
+      "unique_id": "growatt_bms_2_module_2_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_total_output_energy",
+      "unique_id": "growatt_bms_2_module_2_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_warning_text",
+      "unique_id": "growatt_bms_2_module_2_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_charge_cycles",
+      "unique_id": "growatt_bms_2_module_2_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_2_serial_number",
+      "unique_id": "growatt_bms_2_module_2_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 2 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_status",
+      "unique_id": "growatt_bms_2_module_3_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_soc",
+      "unique_id": "growatt_bms_2_module_3_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_soh",
+      "unique_id": "growatt_bms_2_module_3_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_volt",
+      "unique_id": "growatt_bms_2_module_3_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_combined_current",
+      "unique_id": "growatt_bms_2_module_3_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_combined_power",
+      "unique_id": "growatt_bms_2_module_3_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_total_output_energy",
+      "unique_id": "growatt_bms_2_module_3_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_warning_text",
+      "unique_id": "growatt_bms_2_module_3_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_charge_cycles",
+      "unique_id": "growatt_bms_2_module_3_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_3_serial_number",
+      "unique_id": "growatt_bms_2_module_3_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 3 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_status",
+      "unique_id": "growatt_bms_2_module_4_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_soc",
+      "unique_id": "growatt_bms_2_module_4_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_soh",
+      "unique_id": "growatt_bms_2_module_4_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_volt",
+      "unique_id": "growatt_bms_2_module_4_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_combined_current",
+      "unique_id": "growatt_bms_2_module_4_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_combined_power",
+      "unique_id": "growatt_bms_2_module_4_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_total_output_energy",
+      "unique_id": "growatt_bms_2_module_4_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_warning_text",
+      "unique_id": "growatt_bms_2_module_4_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_charge_cycles",
+      "unique_id": "growatt_bms_2_module_4_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_4_serial_number",
+      "unique_id": "growatt_bms_2_module_4_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 4 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_status",
+      "unique_id": "growatt_bms_2_module_5_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_soc",
+      "unique_id": "growatt_bms_2_module_5_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_soh",
+      "unique_id": "growatt_bms_2_module_5_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_volt",
+      "unique_id": "growatt_bms_2_module_5_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_combined_current",
+      "unique_id": "growatt_bms_2_module_5_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_combined_power",
+      "unique_id": "growatt_bms_2_module_5_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_total_output_energy",
+      "unique_id": "growatt_bms_2_module_5_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_warning_text",
+      "unique_id": "growatt_bms_2_module_5_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_charge_cycles",
+      "unique_id": "growatt_bms_2_module_5_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_5_serial_number",
+      "unique_id": "growatt_bms_2_module_5_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 5 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_status",
+      "unique_id": "growatt_bms_2_module_6_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Status",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_soc",
+      "unique_id": "growatt_bms_2_module_6_soc",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 SoC",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_soh",
+      "unique_id": "growatt_bms_2_module_6_soh",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 SoH",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_volt",
+      "unique_id": "growatt_bms_2_module_6_volt",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Volt",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_combined_current",
+      "unique_id": "growatt_bms_2_module_6_combined_current",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Combined Current",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_combined_power",
+      "unique_id": "growatt_bms_2_module_6_combined_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Combined Power",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_total_output_energy",
+      "unique_id": "growatt_bms_2_module_6_toe",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Total Output Energy",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_warning_text",
+      "unique_id": "growatt_bms_2_module_6_warning_text",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Warning Text",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_charge_cycles",
+      "unique_id": "growatt_bms_2_module_6_charge_cycles",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Charge Cycles",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_2_module_6_serial_number",
+      "unique_id": "growatt_bms_2_module_6_serialnumber",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS 2 Module 6 Serial Number",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "input_select.growatt_tou_radnr",
+      "unique_id": "growatt_tou_radnr",
+      "platform": "input_select",
+      "original_name": "Growatt TOU Radnr"
+    },
+    {
+      "entity_id": "automation.initiera_och_synk_growatt_tider",
+      "unique_id": "tou_init_och_synk",
+      "platform": "automation",
+      "original_name": "Initiera och synk Growatt-tider"
+    },
+    {
+      "entity_id": "switch.growatt_charge_switch",
+      "unique_id": "01K8J6N9QG9SRE9GJMTA11PAWB",
+      "platform": "template",
+      "original_name": "growatt_charge_switch"
+    },
+    {
+      "entity_id": "switch.growatt_discharge_switch",
+      "unique_id": "01K8J6YQC7QJ3MV9R81XXY2C74",
+      "platform": "template",
+      "original_name": "Growatt discharge switch"
+    },
+    {
+      "entity_id": "switch.growatt_export_switch",
+      "unique_id": "01K8KQDWNQHNGVX0ZAFC7C1Z4E",
+      "platform": "template",
+      "original_name": "Growatt export switch"
+    },
+    {
+      "entity_id": "switch.growatt_grid_charge_enable",
+      "unique_id": "01K8KS1K9MVQGNA3XYFDAPVFP2",
+      "platform": "template",
+      "original_name": "Growatt grid charge enable"
+    },
+    {
+      "entity_id": "number.growatt_inverter_peak_import_limit",
+      "unique_id": "growatt_peak_import_limit",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Peak Import Limit",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_peak_export_limit",
+      "unique_id": "growatt_peak_export_limit",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Peak Export Limit",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_reserved_soc_for_peak_shaving",
+      "unique_id": "growatt_reserved_soc_peak_shaving",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Reserved SoC for Peak Shaving",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_max_charge_power_from_grid",
+      "unique_id": "growatt_max_charge_power_from_grid",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Max charge power from grid",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_charge_stop_soc_from_grid",
+      "unique_id": "growatt_charge_stop_soc_from_grid",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Charge Stop SOC from Grid",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_peak_shaving_active",
+      "unique_id": "growatt_peak_shaving_enable",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Peak Shaving Active"
+    },
+    {
+      "entity_id": "select.growatt_inverter_reserved_soc_for_peak_shaving_active",
+      "unique_id": "growatt_reserved_soc_peak_shaving_enable",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Reserved SoC for Peak Shaving Active"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_bms_type",
+      "unique_id": "growatt_bms_type",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt BMS Type",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_vpp_status",
+      "unique_id": "growatt_vpp_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "VPP Status",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "update.solcast_pv_forecast_update",
+      "unique_id": "***",
+      "platform": "hacs",
+      "device_id": "879e0f6475489eca3f49ab1c79d8fff9",
+      "original_name": "Update",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "switch.solcast_pv_forecast_pre_release",
+      "unique_id": "***",
+      "platform": "hacs",
+      "device_id": "879e0f6475489eca3f49ab1c79d8fff9",
+      "original_name": "Pre-release",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "select.solcast_pv_forecast_use_forecast_field",
+      "unique_id": "estimate_mode",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Use Forecast Field",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_api_used",
+      "unique_id": "api_counter",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "API Used",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_api_limit",
+      "unique_id": "api_limit",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "API Limit",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_dampening",
+      "unique_id": "dampen",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Dampening",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_this_hour",
+      "unique_id": "forecast_this_hour",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast This Hour"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_next_x_hours",
+      "unique_id": "forecast_custom_hours",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Next X Hours"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_next_hour",
+      "unique_id": "forecast_next_hour",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Next Hour"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_remaining_today",
+      "unique_id": "get_remaining_today",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Remaining Today"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_api_last_polled",
+      "unique_id": "lastupdated",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "API Last Polled",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_peak_time_today",
+      "unique_id": "peak_w_time_today",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Peak Time Today"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_peak_time_tomorrow",
+      "unique_id": "peak_w_time_tomorrow",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Peak Time Tomorrow"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_peak_forecast_today",
+      "unique_id": "peak_w_today",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Peak Forecast Today"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_peak_forecast_tomorrow",
+      "unique_id": "peak_w_tomorrow",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Peak Forecast Tomorrow"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_power_now",
+      "unique_id": "power_now",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Power Now"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_power_in_1_hour",
+      "unique_id": "power_now_1hr",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Power in 1 Hour"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_power_in_30_minutes",
+      "unique_id": "power_now_30m",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Power in 30 Minutes"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_today",
+      "unique_id": "total_kwh_forecast_today",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Today"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_tomorrow",
+      "unique_id": "total_kwh_forecast_tomorrow",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Tomorrow"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_day_3",
+      "unique_id": "total_kwh_forecast_d3",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Day 3"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_day_4",
+      "unique_id": "total_kwh_forecast_d4",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Day 4"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_day_5",
+      "unique_id": "total_kwh_forecast_d5",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Day 5"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_day_6",
+      "unique_id": "total_kwh_forecast_d6",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Day 6"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_forecast_day_7",
+      "unique_id": "total_kwh_forecast_d7",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Forecast Day 7"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_hard_limit_set",
+      "unique_id": "hard_limit",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Hard Limit Set",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.trebackegatan",
+      "unique_id": "solcast_solcast_api_3cdb-fd46-c0a9-f8f7",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Trebackegatan",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "automation.satt_growatt_till_bdc_on_kl_20_05",
+      "unique_id": "1765219047276",
+      "platform": "automation",
+      "original_name": "S\u00e4tt Growatt BDC"
+    },
+    {
+      "entity_id": "sensor.solcast_pv_forecast_accuracy",
+      "unique_id": "accuracy",
+      "platform": "solcast_solar",
+      "device_id": "ce950d3e365cb31f25a6d8f4e1f5fed2",
+      "original_name": "Accuracy",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "binary_sensor.nord_pool_se3_tomorrow_price_available",
+      "unique_id": "SE3-tomorrow_price_available",
+      "platform": "nordpool",
+      "device_id": "b6772a4eb97a5b17d4b69f49f1c64925",
+      "original_name": "Morgondagens pris tillg\u00e4ngligt",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "number.growatt_inverter_vpp_time",
+      "unique_id": "growatt_vpp_time",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "VPP Time",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "number.growatt_inverter_vpp_power",
+      "unique_id": "growatt_vpp_power",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "VPP Power",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_vpp_status",
+      "unique_id": "growatt_vpp_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "VPP Status",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_vpp_remote_control",
+      "unique_id": "growatt_vpp_remote_control",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "VPP Remote Control",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "select.growatt_inverter_vpp_allow_ac_charging",
+      "unique_id": "growatt_vpp_allow_ac_charging",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "VPP Allow AC charging",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_growatt_grid_status",
+      "unique_id": "growatt_grid_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Grid Status",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_growatt_backup_status",
+      "unique_id": "growatt_backup_status",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "growatt Backup Status",
+      "disabled_by": "user",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_communication_health",
+      "unique_id": "growatt_communication_health",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Communication Health",
+      "disabled_by": "user",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_communication_success_rate",
+      "unique_id": "growatt_communication_success_rate",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Communication Success Rate",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_communication_quarantined_registers",
+      "unique_id": "growatt_communication_quarantined_registers",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Communication Quarantined Registers",
+      "disabled_by": "user",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "switch.growatt_energy_dashboard_enable_pv_variant_detail_sensors",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_pv_variants_enabled",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Enable PV Variant Detail Sensors",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "switch.growatt_energy_dashboard_enable_home_consumption_sensor",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_home_consumption_enabled",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Enable Home Consumption Sensor",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "switch.growatt_energy_dashboard_enable_grid_to_battery_sensors",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_grid_to_battery_enabled",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Enable Grid to Battery Sensors",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "sensor.growatt_energy_dashboard_mode",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_mode",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Mode",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_energy_dashboard_inverter_count",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_inverter_count",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Inverter Count",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_energy_dashboard_last_total_inverter_count",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_last_total_inverter_count",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Last Total Inverter Count",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_energy_dashboard_parallel_setting",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_parallel_setting",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Parallel Setting",
+      "disabled_by": "integration",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "sensor.growatt_energy_dashboard_mapping_summary",
+      "unique_id": "growatt Energy Dashboard_energy_dashboard_mapping_summary",
+      "platform": "solax_modbus",
+      "device_id": "47e18f7decedab12e82b5ce57ba4a0f5",
+      "original_name": "Mapping Summary",
+      "entity_category": "diagnostic"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_1_begin",
+      "unique_id": "growatt_time_1_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 Begin",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_1_end",
+      "unique_id": "growatt_time_1_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 1 End",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_2_begin",
+      "unique_id": "growatt_time_2_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_2_end",
+      "unique_id": "growatt_time_2_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 2 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_3_begin",
+      "unique_id": "growatt_time_3_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_3_end",
+      "unique_id": "growatt_time_3_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 3 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_4_begin",
+      "unique_id": "growatt_time_4_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_4_end",
+      "unique_id": "growatt_time_4_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 4 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_5_begin",
+      "unique_id": "growatt_time_5_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_5_end",
+      "unique_id": "growatt_time_5_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 5 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_6_begin",
+      "unique_id": "growatt_time_6_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_6_end",
+      "unique_id": "growatt_time_6_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 6 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_7_begin",
+      "unique_id": "growatt_time_7_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_7_end",
+      "unique_id": "growatt_time_7_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 7 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_8_begin",
+      "unique_id": "growatt_time_8_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_8_end",
+      "unique_id": "growatt_time_8_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 8 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_9_begin",
+      "unique_id": "growatt_time_9_begin",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 Begin",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "time.growatt_inverter_time_9_end",
+      "unique_id": "growatt_time_9_end",
+      "platform": "solax_modbus",
+      "device_id": "04598ea6595488ee068cd6e9d2dcfe79",
+      "original_name": "Time 9 End",
+      "disabled_by": "integration",
+      "entity_category": "config"
+    },
+    {
+      "entity_id": "input_datetime.growatt_current_start",
+      "unique_id": "growatt_current_start",
+      "platform": "input_datetime",
+      "original_name": "growatt_current_start"
+    },
+    {
+      "entity_id": "input_datetime.growatt_current_end",
+      "unique_id": "growatt_current_end",
+      "platform": "input_datetime",
+      "original_name": "growatt_current_end"
+    },
+    {
+      "entity_id": "input_select.growatt_current_mode",
+      "unique_id": "growatt_current_mode",
+      "platform": "input_select",
+      "original_name": "growatt_current_mode"
+    },
+    {
+      "entity_id": "input_select.growatt_current_active",
+      "unique_id": "growatt_current_active",
+      "platform": "input_select",
+      "original_name": "growatt_current_active"
+    },
+    {
+      "entity_id": "automation.growatt_current_mode_update_schedule",
+      "unique_id": "1786112858126",
+      "platform": "automation",
+      "original_name": "Growatt current mode - update schedule"
+    }
+  ],
+  "inverter_platform": "solax_modbus_growatt_min",
+  "price_data": {
+    "today": [
+      0.02341,
+      0.02319,
+      0.02264,
+      0.02144,
+      0.02067,
+      0.02035,
+      0.02002,
+      0.01947,
+      0.02002,
+      0.02002,
+      0.02002,
+      0.02024,
+      0.01903,
+      0.02002,
+      0.02002,
+      0.02002,
+      0.02002,
+      0.02002,
+      0.02035,
+      0.02078,
+      0.02188,
+      0.02231,
+      0.02549,
+      0.03008,
+      0.03817,
+      0.04441,
+      0.04747,
+      0.05469,
+      0.05436,
+      0.05841,
+      0.05841,
+      0.05611,
+      0.05579,
+      0.05425,
+      0.05382,
+      0.04703,
+      0.05732,
+      0.05458,
+      0.04528,
+      0.05425,
+      0.05502,
+      0.05382,
+      0.04496,
+      0.04474,
+      0.04583,
+      0.05458,
+      0.04682,
+      0.05469,
+      0.04703,
+      0.04518,
+      0.04474,
+      0.04397,
+      0.04408,
+      0.04386,
+      0.04375,
+      0.04375,
+      0.04343,
+      0.04343,
+      0.04332,
+      0.04375,
+      0.04364,
+      0.04397,
+      0.04485,
+      0.04518,
+      0.0396,
+      0.04146,
+      0.04594,
+      0.05502,
+      0.0455,
+      0.05765,
+      0.06749,
+      0.08444,
+      0.06268,
+      0.0956,
+      0.27335,
+      0.22303,
+      0.24207,
+      0.17501,
+      0.44891,
+      0.5385,
+      0.15981,
+      0.21308,
+      0.31185,
+      0.2961,
+      0.45711,
+      0.41566,
+      0.17501,
+      0.23868,
+      0.36392,
+      0.22511,
+      0.16178,
+      0.11704,
+      0.21155,
+      0.15051,
+      0.1037,
+      0.07602
+    ],
+    "tomorrow": [
+      0.15244,
+      0.07206,
+      0.05826,
+      0.0541,
+      0.05629,
+      0.04796,
+      0.04534,
+      0.04271,
+      0.04621,
+      0.0438,
+      0.04304,
+      0.04096,
+      0.04271,
+      0.0392,
+      0.03877,
+      0.038,
+      0.03581,
+      0.03526,
+      0.03307,
+      0.03406,
+      0.03044,
+      0.03165,
+      0.03209,
+      0.0346,
+      0.0346,
+      0.03723,
+      0.03778,
+      0.03723,
+      0.04358,
+      0.04227,
+      0.04085,
+      0.03909,
+      0.04238,
+      0.03625,
+      0.03143,
+      0.0311,
+      0.03154,
+      0.03154,
+      0.03066,
+      0.03044,
+      0.04074,
+      0.03515,
+      0.01719,
+      0.01336,
+      0.02409,
+      0.02256,
+      0.02256,
+      0.02179,
+      0.02004,
+      0.015,
+      0.01117,
+      0.01051,
+      0.00635,
+      0.00569,
+      0.00548,
+      0.00548,
+      0.00613,
+      0.00624,
+      0.00602,
+      0.00646,
+      0.00887,
+      0.01062,
+      0.01007,
+      0.01029,
+      0.00931,
+      0.01467,
+      0.02858,
+      0.04348,
+      0.03066,
+      0.04161,
+      0.06045,
+      0.08487,
+      0.05574,
+      0.07512,
+      0.09221,
+      0.1704,
+      0.15244,
+      0.27366,
+      0.34583,
+      0.40945,
+      0.3328,
+      0.32546,
+      0.34594,
+      0.3501,
+      0.39423,
+      0.3766,
+      0.28845,
+      0.23194,
+      0.27366,
+      0.16853,
+      0.15255,
+      0.07611,
+      0.15955,
+      0.07688,
+      0.07293,
+      0.05771
+    ]
+  },
+  "expected_discovery": {
+    "growatt_found": false,
+    "solax_found": true,
+    "solis_found": false,
+    "huawei_found": false,
+    "nordpool_found": true,
+    "nordpool_config_entry_id": "01K83SXQ68W3952XYRE2YE6JA3",
+    "octopus_found": false,
+    "entsoe_found": false,
+    "solax_has_growatt_tou": true,
+    "solax_has_growatt_gen3": false,
+    "detected_platform": "solax_modbus_growatt_min",
+    "required_sensors": [
+      "battery_soc",
+      "battery_charge_power",
+      "battery_discharge_power",
+      "pv_power",
+      "import_power",
+      "export_power",
+      "local_load_power",
+      "grid_charge",
+      "growatt_vpp_status",
+      "growatt_vpp_remote_control",
+      "growatt_vpp_allow_ac_charging",
+      "growatt_vpp_time",
+      "growatt_vpp_power"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Relates to #118 (Growatt VPP control mode) — this is `feature-lifecycle` Stage 3 groundwork, not a graduation. VPP mode stays marked experimental; the most recent fix (#479) has only shipped in beta (`v10.1.0b4`), and no tester has confirmed against it yet.
- Built `ci-wizard-growatt-vpp-ridax-118` from a real debug export `ridax67` posted on 2026-08-07 (BESS v10.1.0b5, health OK) — Growatt GEN4 (`solax_modbus_growatt_min`) via `solax_modbus`, VPP remote-control mode, 3-phase, 20kWh battery.
- Their real entity registry surfaces a case the synthetic `ci-wizard-growatt-vpp` / `ci-growatt-vpp` fixtures never exercised: the same `unique_id` suffix (`growatt_vpp_status`) is exposed on both a `sensor.*` and a `select.*` entity in their installation. The discovery pipeline resolves it to `select.growatt_inverter_vpp_status`, now pinned via `expected_discovery`.
- Wired into `test_scenario_discovery.py` (automatic — any scenario file with an `expected_discovery` key is picked up, no test-file edit needed) and the Playwright wizard E2E (`wizard-expectations.ts`, `run-e2e.sh`, `.github/workflows/ci.yml`).
- No BESS implementation changes — fixture + CI wiring only.

## Scope assessment
Test-fixture/regression-lock work, not a bug fix — no diagnosis or workaround check applies. The fixture's `unique_id` values use the debug export's own `unique_id_suffix` field (serial redacted, immutable suffix preserved) rather than the display-redacted `unique_id`, matching the pattern the exporter documents for building test scenarios from real data.

## Test plan
- [x] `pytest -m "not slow"` — full suite, 1612 passed
- [x] `test_scenario_discovery.py -k ridax` — 4 passed, 1 skipped; confirmed the pin actually discriminates (temporarily flipped `detected_platform` to a wrong value, watched it fail, reverted)
- [ ] Playwright wizard E2E for `ci-wizard-growatt-vpp-ridax-118` — verified the mock-HA/backend stack serves the scenario correctly (wizard-needed status confirmed against the real discovery pipeline), but couldn't complete the actual Playwright run locally due to a Chromium browser-cache version mismatch across worktrees on this machine. Wired into `ci.yml`; will run in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)