### PR TITLE
fix: visualize-debug-log zeroed real flows (kWh compared to a kW constant)

### DIFF
--- a/.claude/skills/visualize-debug-log/SKILL.md
+++ b/.claude/skills/visualize-debug-log/SKILL.md
@@ -30,7 +30,8 @@ output, not sensor-derived.
 tooltip shows (which price the shadow price is weighed against, whether it
 clears, breakeven/profit, reward/total value, net savings) is computed once
 in Python (`build_chart.py`'s `compute_decision_view`), reusing the same
-`POWER_CLASSIFICATION_THRESHOLD_KW` core's own code classifies flows with.
+`strategic_intent.FLOW_NOISE_FLOOR_KWH` core's own code classifies flows
+with — the same constant, in the same domain (energy, not power).
 `template_tail.js` only formats the resulting `view` dict per row — it never
 re-derives a threshold or an economic formula from raw numbers. A bug fix or
 behavior change in the real economics only has to happen in Python to reach
@@ -120,6 +121,20 @@ frontend) — this is for a point-in-time bundle snapshot only.
   tooltip needs a new derived number, add it to `compute_decision_view` in
   `build_chart.py` and read it off `r.view` in JS — don't re-derive it from
   raw fields in JavaScript, even for "just this one case."
+- **Re-deriving a threshold in the presentation layer — including in
+  Python.** "Reuse production code" covers the *computation*; it is just as
+  binding on the chart's own thresholds, which feel like display polish but
+  are domain decisions. Import the constant core already owns and apply it
+  in the same domain core applies it. Importing a production constant is
+  NOT the same as reusing production semantics: `_clean_flow` once compared
+  a kWh flow against `POWER_CLASSIFICATION_THRESHOLD_KW`, a *power*
+  constant, zeroing every flow under 0.05 kWh instead of
+  `strategic_intent.FLOW_NOISE_FLOOR_KWH`'s 0.01 kWh. The chart then drew a
+  period labelled LOAD_SUPPORT (label from production) with a zeroed
+  battery flow (suppressed by a rule production never had) — hiding
+  #517's sub-lattice residual covers in the very chart built to show them.
+  If the chart's own filter can contradict the intent label beside it, the
+  filter is wrong.
 - **Forgetting `--title`.** Without it the title is auto-generated from
   period counts only (no bundle date/version) — fine for a quick look, but
   add a real title when publishing something you'll want to find again.

--- a/.claude/skills/visualize-debug-log/scripts/build_chart.py
+++ b/.claude/skills/visualize-debug-log/scripts/build_chart.py
@@ -25,8 +25,8 @@ REPO_ROOT = SCRIPT_DIR.parents[
 ]  # .claude/skills/visualize-debug-log/scripts -> repo root
 sys.path.insert(0, str(REPO_ROOT))
 
-from core.bess.dp_constants import POWER_CLASSIFICATION_THRESHOLD_KW  # noqa: E402
 from core.bess.models import EnergyData, infer_intent_from_flows  # noqa: E402
+from core.bess.strategic_intent import FLOW_NOISE_FLOOR_KWH  # noqa: E402
 
 
 def _extract_json_block(text: str, anchor: str) -> str:
@@ -62,13 +62,22 @@ def parse_bundle(text: str) -> dict:
 def _clean_flow(v: float) -> float:
     """Zero out sub-threshold energy flows.
 
-    Below core's own POWER_CLASSIFICATION_THRESHOLD_KW, a flow value is
-    floating-point/cross-sensor noise, not a real physical transfer (same
-    threshold core.bess.strategic_intent uses to classify flows) --
-    reused here so the chart never displays a phantom "0.00 grid" a raw
-    float epsilon would otherwise trigger.
+    Consumes core's own energy-domain noise floor
+    (`strategic_intent.FLOW_NOISE_FLOOR_KWH`) -- the same constant
+    `classify_strategic_intent` uses to decide whether a flow is a real
+    physical transfer or sensor/float noise. Reused directly so the chart
+    can never disagree with the intent label it renders beside the flow.
+
+    Previously this compared a kWh flow against
+    POWER_CLASSIFICATION_THRESHOLD_KW, a *power* constant (0.05 kW): a unit
+    mismatch that zeroed every flow below 0.05 kWh instead of 0.01 kWh.
+    It hid, among others, the sub-lattice residual-cover discharges #517
+    introduced -- a real 0.0214 kWh battery_to_home rendered as 0.0000
+    while SOE visibly drained, in the very chart meant to show that fix
+    working. Importing a production constant is not the same as reusing
+    production semantics; the domain (power vs energy) has to match too.
     """
-    return v if abs(v) > POWER_CLASSIFICATION_THRESHOLD_KW else 0.0
+    return v if abs(v) > FLOW_NOISE_FLOOR_KWH else 0.0
 
 
 def compute_decision_view(r: dict, cycle_cost: float) -> dict:


### PR DESCRIPTION
## Summary
`_clean_flow` in `build_chart.py` compared an **energy** flow (kWh) against `POWER_CLASSIFICATION_THRESHOLD_KW` — a **power** constant (0.05 kW). Every flow below 0.05 kWh was zeroed instead of below `strategic_intent.FLOW_NOISE_FLOOR_KWH` (0.01 kWh): a 5x over-suppression, in exactly the small-flow domain this chart exists to diagnose.

## How it surfaced
Building the before/after charts for @ridax67's #466 bundle. The "after" chart showed the four sunrise crossover periods labelled `LOAD_SUPPORT` with **battery→home 0.0000**, while SOE visibly drained ~0.02 kWh per period. Checked against real `EnergyData`: `battery_to_home = 0.0214` — the flow was genuine and the chart was wrong.

The failure mode is the notable part: the label came from production (`classify_strategic_intent`), the flow value came from production (`EnergyData`), and the chart's own filter — which is *not* production code — contradicted both. It hid #517's sub-lattice residual covers in the very chart built to show them, and those covers are by construction small, so this filter was guaranteed to suppress them.

## Fix
Import `FLOW_NOISE_FLOOR_KWH` from `core.bess.strategic_intent` and apply it in core's own domain. That is the constant `classify_strategic_intent` uses for "is this flow real", so the chart can no longer disagree with the intent label it renders beside a flow. #517 promoted that literal to a named constant precisely as an anti-drift measure; this consumes it.

`SKILL.md` updated in two places: the "one implementation, not two" section named the wrong constant, and a new **Common Mistakes** entry — *"reuse production code" covers the computation, and is just as binding on the presentation layer's own thresholds.* Importing a production constant is not the same as reusing production semantics; the domain has to match too.

## Verification
Both charts rebuilt from the same bundle. The 06:00 forecast period:

| | intent | battery→home | grid import |
|---|---|---|---|
| before fix (as reported) | IDLE | 0.0000 | 0.0214 |
| after #517 | LOAD_SUPPORT | **0.0214** | 0.0000 |

Previously the second row rendered `battery→home 0.0000`. Solar→home is identical (0.1461) in both, so the contrast is now readable.

## Scope
Skill tooling only — no production code, no test changes. Any bundle containing genuine 0.01–0.05 kWh flows has been under-reporting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)