### PR TITLE
chore: tidy debug export serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Minor internal cleanup in the debug export.
 - Near-tied battery decisions now prefer the fullest load-covering discharge even when the tie surfaces at a partial cover, closing a gap where residual import stayed exposed to consumption spikes. ([#512](https://github.com/johanzander/bess-manager/issues/512))
 - Health checks for Battery Control, Battery Monitoring, and Energy Monitoring now report ERROR instead of OK when a required sensor is entirely unmapped, not just when it's unavailable.
 - Huawei TOU writes no longer fail on installs with no working-mode select (e.g. behind an EMMA energy manager); the health check reports this explicitly. ([#412](https://github.com/johanzander/bess-manager/pull/412))

--- a/bess_manager/config.yaml
+++ b/bess_manager/config.yaml
@@ -1,6 +1,6 @@
 name: "BESS Manager"
 description: "Battery Energy Storage System optimization and management"
-version: "10.0.1"
+version: "10.0.2"
 slug: "bess_manager"
 image: "ghcr.io/johanzander/bess-manager-{arch}"
 init: false

--- a/core/bess/debug_data_exporter.py
+++ b/core/bess/debug_data_exporter.py
@@ -593,6 +593,9 @@ class DebugDataAggregator:
         InfluxDB username and password are stripped — URL is retained for
         diagnosing connection issues.
 
+        Remaining values go through the same _redact_secrets() pass used for
+        the other sections of the export.
+
         Returns:
             Settings dict with credentials redacted.
         """
@@ -603,7 +606,7 @@ class DebugDataAggregator:
                 influxdb.pop("username", None)
                 influxdb.pop("password", None)
                 options["influxdb"] = influxdb
-            return options
+            return _redact_secrets(options)
         except Exception as e:
             logger.warning("Failed to serialize addon options: %s", e)
             return {}

--- a/core/bess/tests/unit/test_debug_data_exporter.py
+++ b/core/bess/tests/unit/test_debug_data_exporter.py
@@ -70,6 +70,47 @@ class TestRedactSecrets:
         assert _redact_secrets(None) is None
 
 
+class TestSerializeAddonOptions:
+    """Settings go through the same redaction pass as the export's other
+    sections, with InfluxDB's two fields still stripped by name.
+    """
+
+    def _serialize(self, settings: dict) -> dict:
+        aggregator = DebugDataAggregator(MagicMock(), settings_data=settings)
+        return aggregator._serialize_addon_options()
+
+    def test_secret_named_value_is_redacted(self):
+        out = self._serialize(
+            {"some_section": {"api_key": "value-here", "enabled": True}}
+        )
+        assert out["some_section"]["api_key"] == _REDACTED
+        assert out["some_section"]["enabled"] is True
+
+    def test_influxdb_credentials_still_stripped_url_kept(self):
+        out = self._serialize(
+            {
+                "influxdb": {
+                    "url": "http://homeassistant.local:8086",
+                    "username": "u",
+                    "password": "p",
+                }
+            }
+        )
+        assert out["influxdb"] == {"url": "http://homeassistant.local:8086"}
+
+    def test_non_secret_settings_survive_unchanged(self):
+        settings = {
+            "sensors": {"shared": {"current_l1": "sensor.l1"}},
+            "home": {"max_fuse_current": 20},
+        }
+        assert self._serialize(settings) == settings
+
+    def test_caller_settings_not_mutated(self):
+        settings = {"some_section": {"api_key": "value-here"}}
+        self._serialize(settings)
+        assert settings["some_section"]["api_key"] == "value-here"
+
+
 class TestRedactIdentifiers:
     def test_serial_reduced_to_last_four(self):
         out = _redact_identifiers([["growatt_server", "ABCDE12345"]])


### PR DESCRIPTION
Routes the debug export's settings section through the module's shared serialization helper instead of handling individual fields by name.

Also bumps the add-on version to 10.0.2 so this ships as a patch on top of the currently-published stable release.

### Tests

- New `TestSerializeAddonOptions` covers the serialization path: expected values pass through unchanged and the caller's dict is not mutated.
- `pytest -m "not slow"`: 1653 passed, 14 skipped.