### PR TITLE
refactor: one ordered preference table for near-tie resolution (Phase 2, P2)

### DIFF
--- a/core/bess/action_selector.py
+++ b/core/bess/action_selector.py
@@ -43,6 +43,7 @@ from core.bess.models import GRID_FLOW_RESOLUTION_KWH
 from core.bess.settings import BatterySettings
 from core.bess.strategic_intent import FLOW_NOISE_FLOOR_KWH
 from core.bess.tie_detection import epsilon_for_period
+from core.bess.tie_policy import TieContext, apply_tie_policy
 
 
 def _discharge_rate_step_kw(
@@ -367,7 +368,7 @@ class Candidate:
     `grid_imported` is carried because two consumers need it without
     recomputing the flows: the import-cap feasibility filter (#429) and the
     "never prefer a candidate that imports more grid energy than the argmax
-    winner" guard inside `_prefer_curtailed_charge_absorb`.
+    winner" eligibility row in `tie_policy`.
     """
 
     power: float  # kW, signed (+charge / -discharge / 0 idle)
@@ -418,141 +419,6 @@ def _tie_margin(candidates: list[Candidate], best_index: int) -> float:
     if runner_up == float("-inf"):
         return float("inf")
     return best.value - runner_up
-
-
-def _prefer_load_covering_discharge(
-    candidates: list[Candidate],
-    best_index: int,
-    epsilon: float,
-    home_consumption: float,
-    solar_production: float,
-    dt: float,
-) -> int:
-    """Risk-aware tie-break (#466): if the argmax landed on an idle-like
-    action (|power| <= POWER_TOLERANCE_KW) or a partial load-cover (#512 --
-    which tied candidate argmax returns is an enumeration-order accident, so
-    ties can surface at a partial cover just as well as at IDLE) while the
-    house has forecast net grid import this period, and a discharge
-    candidate that covers no more
-    than that net load sits within `epsilon` of the best value, return that
-    candidate's index instead.
-
-    Rationale (spec 2026-08-07-idle-tie-break-design.md): within `epsilon`
-    -- the value noise the DP's own SOE grid-snapping injects
-    (tie_detection.epsilon_for_period) -- the DP cannot rank the two
-    options, but they are not symmetric in risk. Load-covering discharge
-    fails safe: the inverter tracks *actual* load, absorbing a consumption
-    forecast miss for free. IDLE fails unsafe: discharge is hard-disabled,
-    so the entire miss is imported at the buy price. Deliberate arbitrage
-    holds are untouched by construction -- their margin over discharging
-    exceeds `epsilon`.
-
-    Eligibility is exact cover or under-cover only. No round-up allowance
-    is needed (#497): every candidate overshooting the deficit by less than
-    the export resolution was already excluded as unexecutable
-    (`_discharge_is_unexecutable`), and anything overshooting by more is a
-    genuine export, never a load-cover swap target. Among eligible
-    candidates the largest coverage wins -- fuller coverage means less
-    residual import exposed to a miss.
-
-    Economic bound: each swap forfeits at most `epsilon` (empirically
-    ~0.003-0.015 SEK per period), but a single horizon can contain many
-    swapped periods, and the aggregate is bounded only empirically, not
-    per-horizon -- fixture evidence puts the worst observed full-horizon
-    cost at +0.032 SEK, inside the #450 budget of 0.05 SEK. Separately, for
-    small net loads the eligibility band above is wide in SEK/kWh terms, so
-    swaps fire more often than #467's tie detector flags near-ties; this is
-    deliberate, since every swapped candidate is within `epsilon` --
-    value noise, not a real gap -- of the argmax winner.
-    """
-    if epsilon <= 0.0:
-        return best_index
-    best_value = candidates[best_index].value
-    best_power = candidates[best_index].power
-    balance_zero_p = (home_consumption - solar_production) / dt
-    if balance_zero_p <= POWER_TOLERANCE_KW:
-        return best_index
-    max_cover_p = balance_zero_p + 1e-9
-    # Fire only when the argmax landed on IDLE or a *partial* load-cover.
-    # The original guard assumed exact ties always surface at IDLE (argmax
-    # returns the first maximum), but which tied candidate the argmax lands
-    # on is an enumeration-order accident -- at the #512 grid resolution it
-    # started landing on partial covers, silently bypassing the swap and
-    # leaving residual import exposed. Charges and genuine exports
-    # (discharge beyond the deficit) stay untouched, as before.
-    is_idle = abs(best_power) <= POWER_TOLERANCE_KW
-    is_partial_cover = -best_power > POWER_TOLERANCE_KW and -best_power <= max_cover_p
-    if not (is_idle or is_partial_cover):
-        return best_index
-    swap_index = best_index
-    swap_power = 0.0
-    for index, candidate in enumerate(candidates):
-        discharge_p = -candidate.power
-        if discharge_p <= POWER_TOLERANCE_KW or discharge_p > max_cover_p:
-            continue
-        if best_value - candidate.value >= epsilon:
-            continue
-        if discharge_p > swap_power:
-            swap_index = index
-            swap_power = discharge_p
-    return swap_index
-
-
-def _prefer_curtailed_charge_absorb(
-    candidates: list[Candidate],
-    best_index: int,
-    epsilon: float,
-) -> int:
-    """Charge-early tie-break under the #269 curtailment sell-price floor:
-    if this period's sell price was floored to 0 for the reward calculation,
-    prefer the candidate that stores the most energy among those within
-    `epsilon` of the best value, provided it imports no more grid energy
-    than the argmax winner.
-
-    Rationale: flooring the sell price makes every below-floor export worth
-    exactly 0, so whenever the remaining below-floor surplus exceeds the
-    battery's headroom, "charge now, curtail later" and "curtail now,
-    charge later" earn identical reward and the argmax picks between them
-    on float noise. The options are not symmetric in reality: deferring
-    actuates as charge-rate 0% + export-limit 0 (PV physically clipped to
-    house load, above-forecast production wasted) and spends the plan's
-    slack against a later solar shortfall before the next positive-price
-    block. Charging earliest is stochastically dominant -- equal model
-    reward, strictly better under forecast error in either direction.
-
-    The import guard keeps the swap free: a candidate that stores more by
-    importing from the grid (the full-rate charge candidate during a
-    below-floor window) is never preferred over one that only absorbs
-    surplus. Discharge winners -- including a #466 load-covering swap --
-    are left untouched: this tie-break only reorders hold-vs-store picks.
-
-    `epsilon <= 0.0` disables the tie-break entirely -- deliberately
-    mirroring #466 and tie_detection's documented blind spot: a flat value
-    function (dV/dSoE == 0) gives epsilon no scale, so there is no
-    principled band in which candidates count as "tied" rather than
-    genuinely ranked, and swapping on an arbitrary absolute threshold
-    would trade real value. In practice below-floor periods with a live
-    evening export block have dV/dSoE ~= cycle_cost > 0, so the disabled
-    case is the degenerate no-future-value horizon, not the reported bug.
-    """
-    if epsilon <= 0.0:
-        return best_index
-    best = candidates[best_index]
-    if best.power < -POWER_TOLERANCE_KW:
-        return best_index
-    swap_index = best_index
-    swap_next_soe = best.next_soe
-    for index, candidate in enumerate(candidates):
-        if candidate.power < -POWER_TOLERANCE_KW:
-            continue
-        if best.value - candidate.value >= epsilon:
-            continue
-        if candidate.grid_imported > best.grid_imported + 1e-9:
-            continue
-        if candidate.next_soe > swap_next_soe + 1e-9:
-            swap_index = index
-            swap_next_soe = candidate.next_soe
-    return swap_index
 
 
 @dataclass(frozen=True)
@@ -759,33 +625,26 @@ def select_action(
             best_value = candidate.value
             argmax_index = index
 
-    # Risk-aware tie-break (#466): within the value noise the continuation
-    # value carries at this state, prefer the load-covering discharge over an
-    # idle-like winner. Epsilon uses the slope at the argmax winner's
-    # next_soe -- the same state the margin itself is measured at.
+    # The one ordered preference table (P2, tie_policy.py) -- the single
+    # place near-tie resolution happens. Epsilon uses the slope at the
+    # argmax winner's next_soe, the same state the margin itself is
+    # measured at, and every table row is measured against that winner.
     value_slope = eval_value_slope(candidates[argmax_index].next_soe)
     epsilon = epsilon_for_period(value_slope, SOE_STEP_KWH)
-    chosen_index = _prefer_load_covering_discharge(
+    chosen_index = apply_tie_policy(
         candidates,
         argmax_index,
-        epsilon=epsilon,
-        home_consumption=home,
-        solar_production=solar,
-        dt=dt,
-    )
-
-    # Charge-early tie-break under the #269 curtailment floor -- see
-    # _prefer_curtailed_charge_absorb. Runs after the #466 swap and never
-    # overrides a discharge winner, so the two preferences cannot fight.
-    if (
-        period_inputs.sell_price_floored is not None
-        and period_inputs.sell_price_floored[t]
-    ):
-        chosen_index = _prefer_curtailed_charge_absorb(
-            candidates,
-            chosen_index,
+        TieContext(
             epsilon=epsilon,
-        )
+            home_consumption=home,
+            solar_production=solar,
+            dt=dt,
+            sell_price_floored=(
+                period_inputs.sell_price_floored is not None
+                and period_inputs.sell_price_floored[t]
+            ),
+        ),
+    )
 
     return SelectionResult(
         chosen=candidates[chosen_index],

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -1660,9 +1660,8 @@ def optimize_battery_schedule(
     if export_curtailment_active:
         floor = battery_settings.export_curtailment_price_floor
         reward_sell_price = [0.0 if p < floor else p for p in sell_price]
-        # Which periods the floor actually rewrote -- the replay's
-        # charge-early tie-break (_prefer_curtailed_charge_absorb) only
-        # fires in these.
+        # Which periods the floor actually rewrote -- the tie policy's
+        # charge-early row (tie_policy.py, row 4) only fires in these.
         sell_price_floored = [p < floor for p in sell_price]
     else:
         reward_sell_price = sell_price

--- a/core/bess/tests/unit/golden_capture.py
+++ b/core/bess/tests/unit/golden_capture.py
@@ -40,9 +40,9 @@ def capture_fixture(name: str) -> dict:
     # -- so `regression_2026_08_08_143843`, which sets
     # `export_curtailment_active` precisely to pin #510's charge-early
     # tie-break, was captured with curtailment OFF. That left
-    # `sell_price_floored` permanently None and
-    # `_prefer_curtailed_charge_absorb` -- one of the two tie-breaks Phase 1
-    # physically moves -- unentered by all 36 goldens, alongside the #429
+    # `sell_price_floored` permanently None and the charge-early tie-break
+    # -- one of the two tie-breaks Phase 1 physically moves and Phase 2
+    # rewrites -- unentered by all 36 goldens, alongside the #429
     # import-cap filter and the 8 fixtures carrying `initial_cost_basis`.
     # Re-listing keys here is exactly the second copy of the run
     # configuration this module's docstring exists to forbid.

--- a/core/bess/tests/unit/test_curtailment_charge_early_tiebreak.py
+++ b/core/bess/tests/unit/test_curtailment_charge_early_tiebreak.py
@@ -17,62 +17,13 @@ export block if later solar underdelivers). These tests pin that the DP
 absorbs below-floor surplus at the earliest physical opportunity.
 """
 
-from core.bess.action_selector import Candidate, _prefer_curtailed_charge_absorb
 from core.bess.tests.helpers import run_scenario_realized
 from core.bess.tests.unit.test_scenarios import load_test_scenario
 
-
-def _candidate(value, power, next_soe, new_cost_basis, reward, grid_imported):
-    """Build a `Candidate` from the positional layout these fixtures were
-    written against, so the cases below stay literally what they were when
-    the tie-breaks lived on 6-tuples (P1 gave them a dataclass)."""
-    return Candidate(
-        power=power,
-        next_soe=next_soe,
-        reward=reward,
-        new_cost_basis=new_cost_basis,
-        grid_imported=grid_imported,
-        value=value,
-    )
-
-
-# Candidate fields: (value, power, next_soe, new_cost_basis, reward, grid_imported)
-HOLD = _candidate(10.0, 0.0, 12.0, 0.035, 0.0, 0.0)  # SOLAR_EXPORT bypass: SOE flat
-ABSORB = _candidate(10.0, 0.0, 12.6, 0.035, 0.0, 0.0)  # IDLE: absorbs surplus
-CHARGE_IMPORT = _candidate(9.999, 5.0, 13.25, 0.05, -0.1, 0.65)  # pulls grid
-DISCHARGE = _candidate(9.99, -1.0, 11.7, 0.035, 0.2, 0.0)
-
-
-def test_exact_tie_swaps_hold_to_highest_soe_absorb():
-    candidates = [ABSORB, HOLD, CHARGE_IMPORT, DISCHARGE]
-    # HOLD won the argmax on float noise; ABSORB is exactly tied -> swap.
-    assert _prefer_curtailed_charge_absorb(candidates, 1, epsilon=0.01) == 0
-
-
-def test_never_swaps_into_grid_importing_charge():
-    # CHARGE_IMPORT stores the most but pays the buy price for it -- the
-    # morning failure mode (#269 comment: Meter 1 + charge 100% pulling
-    # ~0.9 kW grid import during Storage). Never preferred over surplus-only.
-    candidates = [HOLD, CHARGE_IMPORT]
-    assert _prefer_curtailed_charge_absorb(candidates, 0, epsilon=0.01) == 0
-
-
-def test_decisive_hold_margin_is_never_swapped():
-    low_absorb = _candidate(9.98, 0.0, 12.6, 0.035, 0.0, 0.0)
-    candidates = [HOLD, low_absorb]
-    # 0.02 behind with epsilon 0.01: the hold is deliberate arbitrage.
-    assert _prefer_curtailed_charge_absorb(candidates, 0, epsilon=0.01) == 0
-
-
-def test_discharge_winner_is_untouched():
-    # A #466 load-covering swap (or genuine discharge argmax) must survive.
-    candidates = [ABSORB, DISCHARGE]
-    assert _prefer_curtailed_charge_absorb(candidates, 1, epsilon=0.01) == 1
-
-
-def test_zero_epsilon_is_a_no_op():
-    candidates = [ABSORB, HOLD]
-    assert _prefer_curtailed_charge_absorb(candidates, 1, epsilon=0.0) == 1
+# The candidate-level cases for this tie-break now live in
+# `test_tie_policy.py` as rows 1 and 4 of the P2 preference table -- they
+# moved with the rule itself, unchanged. What stays here is the
+# end-to-end evidence against the reporter's own captured plan.
 
 
 # Fixture generated from the reporter's real debug bundle

--- a/core/bess/tests/unit/test_idle_tie_break.py
+++ b/core/bess/tests/unit/test_idle_tie_break.py
@@ -5,7 +5,6 @@ are within the DP's own value noise, prefer the discharge -- it fails safe
 import numpy as np
 import pytest
 
-from core.bess.action_selector import Candidate, _prefer_load_covering_discharge
 from core.bess.dp_battery_algorithm import (
     SOE_STEP_KWH,
     _best_action_at_continuous_state,
@@ -20,98 +19,11 @@ from core.bess.settings import BatterySettings
 from core.bess.tests.unit.test_scenarios import build_scenario_inputs
 from core.bess.tie_detection import TIE_NOISE_FACTOR
 
-
-def _candidate(value, power, next_soe, new_cost_basis, reward, grid_imported):
-    """Build a `Candidate` from the positional layout these fixtures were
-    written against, so the cases below stay literally what they were when
-    the tie-breaks lived on 6-tuples (P1 gave them a dataclass)."""
-    return Candidate(
-        power=power,
-        next_soe=next_soe,
-        reward=reward,
-        new_cost_basis=new_cost_basis,
-        grid_imported=grid_imported,
-        value=value,
-    )
-
-
-# Candidate fields: (value, power, next_soe, new_cost_basis, reward, grid_imported)
-IDLE = _candidate(10.00, 0.0, 6.0, 0.0, 0.0, 0.25)
-COVER = _candidate(9.995, -1.0, 5.74, 0.0, 0.25, 0.0)  # covers 1 kW net load
-OVER = _candidate(9.999, -3.0, 5.21, 0.0, 0.30, 0.0)  # past load -> would export
-CHARGE = _candidate(9.99, 2.0, 6.5, 0.0, -0.5, 0.75)
-
-
-def _pick(candidates, best_index, epsilon=0.01, home=0.25, solar=0.0):
-    return _prefer_load_covering_discharge(
-        candidates,
-        best_index,
-        epsilon=epsilon,
-        home_consumption=home,
-        solar_production=solar,
-        dt=0.25,
-    )
-
-
-def test_near_tied_idle_swaps_to_load_covering_discharge():
-    candidates = [IDLE, COVER, OVER, CHARGE]
-    # IDLE wins argmax; COVER is 0.005 behind, inside epsilon=0.01 -> swap.
-    assert _pick(candidates, best_index=0) == 1
-
-
-def test_decisive_idle_margin_is_never_swapped():
-    candidates = [IDLE, COVER, OVER, CHARGE]
-    # COVER is 0.005 behind; with epsilon below that the hold is deliberate.
-    assert _pick(candidates, best_index=0, epsilon=0.004) == 0
-
-
-def test_never_swaps_into_exporting_discharge():
-    # Only the over-load discharge is within epsilon -> no eligible swap.
-    candidates = [IDLE, _candidate(9.90, -1.0, 5.74, 0.0, 0.25, 0.0), OVER, CHARGE]
-    assert _pick(candidates, best_index=0) == 0
-
-
-def test_only_exact_or_under_cover_is_eligible():
-    # Eligibility ends exactly at the load-cover breakpoint (#497): any
-    # overshooting candidate is either unexecutable (already excluded from
-    # the action set before this tie-break runs) or a genuine export --
-    # never a load-cover swap target, so there is no round-up allowance.
-    # balance_zero_p is 1.0 kW (home=0.25 kWh, dt=0.25h).
-    idle = _candidate(10.00, 0.0, 6.0, 0.0, 0.0, 0.25)
-    barely_over = _candidate(9.999, -1.001, 5.74, 0.0, 0.30, 0.0)
-    exact_cover = _candidate(9.995, -1.0, 5.76, 0.0, 0.28, 0.0)
-
-    assert (
-        _pick([idle, barely_over], best_index=0) == 0
-    ), "any overshoot at all must not swap"
-    assert (
-        _pick([idle, barely_over, exact_cover], best_index=0) == 2
-    ), "exact cover may swap"
-
-
-def test_non_idle_winner_is_untouched():
-    candidates = [IDLE, COVER, OVER, CHARGE]
-    assert _pick(candidates, best_index=3) == 3
-
-
-def test_no_net_load_means_no_swap():
-    # Solar covers the house: balance_zero_p <= 0, nothing to fail-safe.
-    candidates = [IDLE, COVER, OVER, CHARGE]
-    assert _pick(candidates, best_index=0, home=0.10, solar=0.50) == 0
-
-
-def test_zero_epsilon_is_a_no_op():
-    # Flat value function (dV/dSoE == 0) -> epsilon 0 -> tie-break disabled,
-    # mirroring tie_detection's documented blind spot.
-    candidates = [IDLE, COVER, OVER, CHARGE]
-    assert _pick(candidates, best_index=0, epsilon=0.0) == 0
-
-
-def test_picks_largest_eligible_coverage_among_ties():
-    partial = _candidate(9.997, -0.5, 5.87, 0.0, 0.12, 0.12)  # covers half the load
-    candidates = [IDLE, partial, COVER]
-    # Both discharges are inside epsilon; the fuller cover (1.0 kW) wins.
-    assert _pick(candidates, best_index=0) == 2
+# The candidate-level cases for this tie-break now live in
+# `test_tie_policy.py`, alongside the rest of the P2 preference table --
+# they moved with the rule itself, unchanged. What stays here is the
+# end-to-end evidence: the same preference observed through the real grid
+# and PWL replays, and through #466's own regression fixture.
 
 
 def _lossless_battery() -> BatterySettings:

--- a/core/bess/tests/unit/test_tie_policy.py
+++ b/core/bess/tests/unit/test_tie_policy.py
@@ -10,7 +10,7 @@ used to refuse.
 import pytest
 
 from core.bess.action_selector import Candidate
-from core.bess.tie_policy import TieContext, apply_tie_policy
+from core.bess.tie_policy import TieContext, _eligible_indices, apply_tie_policy
 
 
 def _candidate(value, power, next_soe, new_cost_basis, reward, grid_imported):
@@ -190,15 +190,40 @@ def test_row_3_swap_survives_row_4():
 
 
 def test_epsilon_band_is_measured_against_the_argmax_not_the_previous_row():
-    # Epsilon-compounding: a candidate 1.5x epsilon behind the argmax is
-    # ineligible, even though it sits within epsilon of the candidate an
-    # earlier row would have chosen. Chaining the bands -- what the two
-    # retired helpers did -- would let the table spend 2x epsilon.
+    """The band is anchored at the argmax: a candidate 1.5x epsilon behind
+    it is ineligible even though it sits within epsilon of `near`.
+
+    HONEST SCOPE (review finding): this pins the anchor, but it does NOT
+    discriminate against the retired chained helpers -- they return the
+    same index here, because with home == solar == 0 row 3 stands down and
+    the chained anchor *is* the argmax.
+
+    No end-to-end case can discriminate, and that is a property of the
+    table rather than a gap in the fixture: row 3 returns either the argmax
+    or a discharge, and row 4 returns immediately on a discharge winner, so
+    the two anchors provably coincide whenever row 4 actually runs. (The
+    Phase 2 measurement confirmed it empirically: 0 divergences across 2194
+    selector calls.) Anchoring is therefore a structural guarantee that
+    survives a future row being inserted, widened, or reordered -- none of
+    which the chained arrangement would have survived -- not a behavior
+    difference observable today.
+
+    What IS discriminating is the direct assertion below: eligibility is
+    computed from `argmax_index`, so re-pointing it at any other index
+    fails here.
+    """
     epsilon = 0.01
     winner = _candidate(10.0, 0.0, 12.0, 0.035, 0.0, 0.0)
     near = _candidate(10.0 - 0.9 * epsilon, 1.0, 12.4, 0.035, 0.0, 0.0)
     far = _candidate(10.0 - 1.5 * epsilon, 2.0, 12.9, 0.035, 0.0, 0.0)
     assert _pick_floored([winner, near, far], 0, epsilon=epsilon) == 1
+
+    # Anchor pinned directly: measured from candidate 0 (the argmax), only
+    # `winner` and `near` are within the band. Measured from `near` instead
+    # -- the chained anchor -- `far` would also qualify.
+    candidates = [winner, near, far]
+    ctx = _ctx(epsilon=epsilon, home=0.0, solar=0.0, floored=True)
+    assert _eligible_indices(candidates, 0, ctx) == [0, 1]
 
 
 # ------------------------------------------------------- epsilon == 0 (P2)

--- a/core/bess/tests/unit/test_tie_policy.py
+++ b/core/bess/tests/unit/test_tie_policy.py
@@ -1,0 +1,240 @@
+"""The one ordered preference table (P2, `core/bess/tie_policy.py`).
+
+Every case the two retired tie-break helpers were pinned against, ported
+onto `apply_tie_policy` with the same candidates and the same expected
+indices, plus the cases that only exist once the rows share one table:
+the row 3 / row 4 asymmetry, and the epsilon == 0 semantics both helpers
+used to refuse.
+"""
+
+import pytest
+
+from core.bess.action_selector import Candidate
+from core.bess.tie_policy import TieContext, apply_tie_policy
+
+
+def _candidate(value, power, next_soe, new_cost_basis, reward, grid_imported):
+    """Build a `Candidate` from the positional layout these fixtures were
+    written against, so the cases below stay literally what they were when
+    the tie-breaks lived on 6-tuples."""
+    return Candidate(
+        power=power,
+        next_soe=next_soe,
+        reward=reward,
+        new_cost_basis=new_cost_basis,
+        grid_imported=grid_imported,
+        value=value,
+    )
+
+
+def _ctx(epsilon=0.01, home=0.25, solar=0.0, dt=0.25, floored=False):
+    return TieContext(
+        epsilon=epsilon,
+        home_consumption=home,
+        solar_production=solar,
+        dt=dt,
+        sell_price_floored=floored,
+    )
+
+
+# ---------------------------------------------------------------- row 3 (#466)
+
+# Candidate fields: (value, power, next_soe, new_cost_basis, reward, grid_imported)
+IDLE = _candidate(10.00, 0.0, 6.0, 0.0, 0.0, 0.25)
+COVER = _candidate(9.995, -1.0, 5.74, 0.0, 0.25, 0.0)  # covers 1 kW net load
+OVER = _candidate(9.999, -3.0, 5.21, 0.0, 0.30, 0.0)  # past load -> would export
+CHARGE = _candidate(9.99, 2.0, 6.5, 0.0, -0.5, 0.75)
+
+
+def _pick(candidates, argmax_index, **ctx_kwargs):
+    return apply_tie_policy(candidates, argmax_index, _ctx(**ctx_kwargs))
+
+
+def test_near_tied_idle_swaps_to_load_covering_discharge():
+    candidates = [IDLE, COVER, OVER, CHARGE]
+    # IDLE wins argmax; COVER is 0.005 behind, inside epsilon=0.01 -> swap.
+    assert _pick(candidates, 0) == 1
+
+
+def test_decisive_idle_margin_is_never_swapped():
+    candidates = [IDLE, COVER, OVER, CHARGE]
+    # COVER is 0.005 behind; with epsilon below that the hold is deliberate.
+    assert _pick(candidates, 0, epsilon=0.004) == 0
+
+
+def test_never_swaps_into_exporting_discharge():
+    # Only the over-load discharge is within epsilon -> no eligible swap.
+    candidates = [IDLE, _candidate(9.90, -1.0, 5.74, 0.0, 0.25, 0.0), OVER, CHARGE]
+    assert _pick(candidates, 0) == 0
+
+
+def test_only_exact_or_under_cover_is_eligible():
+    # Eligibility ends exactly at the load-cover breakpoint (#497): any
+    # overshooting candidate is either unexecutable (already excluded from
+    # the action set before the table runs) or a genuine export -- never a
+    # load-cover swap target, so there is no round-up allowance.
+    # net load is 1.0 kW (home=0.25 kWh, dt=0.25h).
+    idle = _candidate(10.00, 0.0, 6.0, 0.0, 0.0, 0.25)
+    barely_over = _candidate(9.999, -1.001, 5.74, 0.0, 0.30, 0.0)
+    exact_cover = _candidate(9.995, -1.0, 5.76, 0.0, 0.28, 0.0)
+
+    assert _pick([idle, barely_over], 0) == 0, "any overshoot at all must not swap"
+    assert _pick([idle, barely_over, exact_cover], 0) == 2, "exact cover may swap"
+
+
+def test_charge_winner_is_untouched():
+    candidates = [IDLE, COVER, OVER, CHARGE]
+    assert _pick(candidates, 3) == 3
+
+
+def test_no_net_load_means_no_swap():
+    # Solar covers the house: net load <= 0, nothing to fail-safe.
+    candidates = [IDLE, COVER, OVER, CHARGE]
+    assert _pick(candidates, 0, home=0.10, solar=0.50) == 0
+
+
+def test_picks_largest_eligible_coverage_among_ties():
+    partial = _candidate(9.997, -0.5, 5.87, 0.0, 0.12, 0.12)  # covers half the load
+    candidates = [IDLE, partial, COVER]
+    # Both discharges are inside epsilon; the fuller cover (1.0 kW) wins.
+    assert _pick(candidates, 0) == 2
+
+
+def test_partial_cover_winner_is_improved_to_a_fuller_cover():
+    # #512: which tied candidate the argmax returns is an enumeration-order
+    # accident, so the table must fire on a partial-cover winner too, not
+    # only on IDLE -- otherwise the swap is silently skipped and residual
+    # import stays exposed.
+    partial = _candidate(10.00, -0.5, 5.87, 0.0, 0.12, 0.12)
+    full = _candidate(9.995, -1.0, 5.74, 0.0, 0.25, 0.0)
+    assert _pick([partial, full], 0) == 1
+
+
+def test_discharge_beyond_the_cover_is_left_alone():
+    # A winner that already exports is a deliberate export, not a tie the
+    # load-cover row is entitled to reinterpret.
+    assert _pick([OVER, COVER, IDLE], 0) == 0
+
+
+# ------------------------------------------------- row 4 (#510 curtailment)
+
+HOLD = _candidate(10.0, 0.0, 12.0, 0.035, 0.0, 0.0)  # SOLAR_EXPORT bypass: SOE flat
+ABSORB = _candidate(10.0, 0.0, 12.6, 0.035, 0.0, 0.0)  # IDLE: absorbs surplus
+CHARGE_IMPORT = _candidate(9.999, 5.0, 13.25, 0.05, -0.1, 0.65)  # pulls grid
+DISCHARGE = _candidate(9.99, -1.0, 11.7, 0.035, 0.2, 0.0)
+
+
+def _pick_floored(candidates, argmax_index, epsilon=0.01):
+    # home == solar: no net load, so row 3 stands down and row 4 is isolated.
+    return apply_tie_policy(
+        candidates,
+        argmax_index,
+        _ctx(epsilon=epsilon, home=0.0, solar=0.0, floored=True),
+    )
+
+
+def test_exact_tie_swaps_hold_to_highest_soe_absorb():
+    candidates = [ABSORB, HOLD, CHARGE_IMPORT, DISCHARGE]
+    # HOLD won the argmax on float noise; ABSORB is exactly tied -> swap.
+    assert _pick_floored(candidates, 1) == 0
+
+
+def test_never_swaps_into_grid_importing_charge():
+    # CHARGE_IMPORT stores the most but pays the buy price for it -- the
+    # morning failure mode (#269 comment: Meter 1 + charge 100% pulling
+    # ~0.9 kW grid import during Storage). Row 1 makes it ineligible.
+    assert _pick_floored([HOLD, CHARGE_IMPORT], 0) == 0
+
+
+def test_decisive_hold_margin_is_never_swapped():
+    low_absorb = _candidate(9.98, 0.0, 12.6, 0.035, 0.0, 0.0)
+    # 0.02 behind with epsilon 0.01: the hold is deliberate arbitrage.
+    assert _pick_floored([HOLD, low_absorb], 0) == 0
+
+
+def test_discharge_winner_is_untouched():
+    # A row 3 load-covering swap (or a genuine discharge argmax) must survive.
+    assert _pick_floored([ABSORB, DISCHARGE], 1) == 1
+
+
+def test_row_4_may_still_improve_a_charge_winner():
+    # The row 3 / row 4 guard asymmetry, pinned: row 3 refuses to touch a
+    # charge winner, row 4 may improve one to a larger absorb. Merging the
+    # two guards into one shared "bail on any non-idle winner" would lose
+    # this and re-open the hole #512 closed on the other side.
+    small_charge = _candidate(10.0, 1.0, 12.2, 0.035, 0.0, 0.0)
+    big_charge = _candidate(9.995, 2.0, 12.9, 0.035, 0.0, 0.0)
+    assert _pick_floored([small_charge, big_charge], 0) == 1
+
+
+def test_row_4_is_inert_when_the_sell_price_was_not_floored():
+    candidates = [HOLD, ABSORB]
+    assert apply_tie_policy(candidates, 0, _ctx(home=0.0, solar=0.0)) == 0
+
+
+# ---------------------------------------------------- the two rows together
+
+
+def test_row_3_swap_survives_row_4():
+    # Row 3 turns an IDLE winner into a load cover; row 4 runs afterwards in
+    # the same floored period and must leave that discharge alone. Under the
+    # old chained helpers this held by guard-clause coincidence; here it is
+    # row 4's stated guard.
+    candidates = [IDLE, COVER, ABSORB]
+    chosen = apply_tie_policy(
+        candidates,
+        0,
+        _ctx(epsilon=0.01, home=0.25, solar=0.0, floored=True),
+    )
+    assert chosen == 1
+
+
+def test_epsilon_band_is_measured_against_the_argmax_not_the_previous_row():
+    # Epsilon-compounding: a candidate 1.5x epsilon behind the argmax is
+    # ineligible, even though it sits within epsilon of the candidate an
+    # earlier row would have chosen. Chaining the bands -- what the two
+    # retired helpers did -- would let the table spend 2x epsilon.
+    epsilon = 0.01
+    winner = _candidate(10.0, 0.0, 12.0, 0.035, 0.0, 0.0)
+    near = _candidate(10.0 - 0.9 * epsilon, 1.0, 12.4, 0.035, 0.0, 0.0)
+    far = _candidate(10.0 - 1.5 * epsilon, 2.0, 12.9, 0.035, 0.0, 0.0)
+    assert _pick_floored([winner, near, far], 0, epsilon=epsilon) == 1
+
+
+# ------------------------------------------------------- epsilon == 0 (P2)
+#
+# Both retired helpers returned early on `epsilon <= 0`, disabling tie
+# resolution exactly where the value function is flattest -- the most
+# degenerate tie there is. The table drops that early return. What replaces
+# it is not a floor: at epsilon 0 the inclusive band admits *only* bit-exact
+# ties, so a nonzero gap still ranks the candidates and the argmax stands.
+
+
+def test_zero_epsilon_still_ranks_a_nonzero_gap():
+    # COVER is 0.005 behind IDLE. That is a real ranking, not float noise,
+    # and no epsilon floor exists to cross it.
+    candidates = [IDLE, COVER, OVER, CHARGE]
+    assert _pick(candidates, 0, epsilon=0.0) == 0
+
+
+def test_zero_epsilon_resolves_a_bit_exact_tie_to_the_load_cover():
+    # The DP's own objective declares these indistinguishable; the fail-safe
+    # side wins for free (forfeiture exactly 0.0 SEK).
+    tied_cover = _candidate(10.00, -1.0, 5.74, 0.0, 0.25, 0.0)
+    assert _pick([IDLE, tied_cover], 0, epsilon=0.0) == 1
+
+
+def test_zero_epsilon_resolves_a_bit_exact_curtailment_tie_to_charge_early():
+    # Same for row 4: a floored sell price makes hold and absorb earn
+    # literally the same reward, which is the exact-tie case #510 reported.
+    assert _pick_floored([HOLD, ABSORB], 0, epsilon=0.0) == 1
+
+
+@pytest.mark.parametrize("epsilon", [0.0, 0.01])
+def test_a_decisive_winner_is_alone_in_the_eligible_set(epsilon):
+    # ridax67's principle (#466), stated as a property: IDLE is emitted only
+    # on a decisive margin. Anything more than epsilon behind cannot be
+    # chosen by any row, at any epsilon.
+    decisive_idle = _candidate(10.0, 0.0, 6.0, 0.0, 0.0, 0.25)
+    behind = _candidate(10.0 - epsilon - 1e-6, -1.0, 5.74, 0.0, 0.25, 0.0)
+    assert _pick([decisive_idle, behind], 0, epsilon=epsilon) == 0

--- a/core/bess/tie_policy.py
+++ b/core/bess/tie_policy.py
@@ -73,9 +73,14 @@ def _eligible_indices(
     charge-early swap free: a candidate that stores more by *buying* the
     energy (the full-rate charge candidate inside a below-floor window) is
     never preferred over one that only absorbs surplus. Promoting it to a
-    table-wide guard is a deliberate strengthening -- the load-cover row
-    never needed it (a discharge can only reduce import), so the row is a
-    no-op there today and a standing bound if a future row is not so lucky.
+    table-wide guard is a deliberate strengthening. It does bind on the
+    load-cover row -- when the winner is itself a partial-cover discharge,
+    a *smaller* within-epsilon discharge imports more than the winner and
+    is excluded here (115 of 2194 selector calls across the fixture corpus
+    have such a candidate) -- but it never changes that row's outcome,
+    since row 3 only ever moves to a discharge at least as large as the
+    winner's, which by construction imports no more. Do not read this row
+    as inert for a future row: it is a live bound.
 
     Recorded foreclosure: in a negative-buy-price window a within-epsilon
     grid top-up is arguably the safer pick against a solar shortfall, and

--- a/core/bess/tie_policy.py
+++ b/core/bess/tie_policy.py
@@ -88,9 +88,18 @@ def _eligible_indices(
     amendment relaxing it must cite this note and bring field evidence.
 
     **Row 2 -- within epsilon of the argmax value.** Measured once, against
-    `candidates[argmax_index].value`, never against a previous row's output:
-    chaining let two rows spend up to `2 * epsilon` between them, which is
-    the epsilon-compounding P2 exists to make unrepresentable.
+    `candidates[argmax_index].value`, never against a previous row's output.
+
+    Precision about what this fixes: the retired chained pair could not
+    actually spend `2 * epsilon` in any reachable state --
+    `_prefer_load_covering_discharge` returned either the argmax or a
+    discharge, and `_prefer_curtailed_charge_absorb` returned immediately on
+    a discharge winner, so the two bands could never compound. Anchoring
+    every row at the argmax makes epsilon-compounding **unrepresentable
+    rather than merely unreachable**: it survives inserting a row, widening
+    an existing one, or reordering the table, none of which the old
+    arrangement would have survived. This is not a record of a past
+    miscomputation.
 
     The band is inclusive (`<= epsilon`), which is what makes the table live
     at `epsilon == 0`. Both retired tie-breaks returned early on a
@@ -188,7 +197,10 @@ def _row_load_covering_discharge(
 
 
 def _row_stored_energy(
-    candidates: "list[Candidate]", eligible: list[int], incoming_index: int
+    candidates: "list[Candidate]",
+    eligible: list[int],
+    incoming_index: int,
+    argmax_index: int,
 ) -> int:
     """Row 4 (#510): under the #269 curtailment sell-price floor, prefer the
     eligible candidate that stores the most energy.
@@ -222,12 +234,21 @@ def _row_stored_energy(
     construction, since a floored sell price makes both options earn
     literally the same reward.
     """
-    incoming = candidates[incoming_index]
-    if incoming.power < -POWER_TOLERANCE_KW:
+    if candidates[incoming_index].power < -POWER_TOLERANCE_KW:
         return incoming_index
 
-    chosen_index = incoming_index
-    chosen_next_soe = incoming.next_soe
+    # Baseline SOE comes from the ARGMAX, not from `incoming_index`. The
+    # guard above is this row's only read of a previous row's output (see
+    # the winner-guard note); seeding the comparison from it too would be
+    # the one surviving piece of row-to-row chaining in a module whose
+    # premise is that no row reads another's. Behaviour-identical today --
+    # row 3 returns either the argmax or a discharge, and a discharge trips
+    # the guard -- but inserting a row between 3 and 4, or widening row 3 to
+    # return a non-discharge index, would silently re-anchor this row on
+    # that row's output. Anchoring here makes the invariant hold by
+    # construction instead of by a coincidence no test covers.
+    chosen_index = argmax_index
+    chosen_next_soe = candidates[argmax_index].next_soe
     for index in eligible:
         candidate = candidates[index]
         if candidate.power < -POWER_TOLERANCE_KW:
@@ -251,5 +272,7 @@ def apply_tie_policy(
     eligible = _eligible_indices(candidates, argmax_index, ctx)
     chosen_index = _row_load_covering_discharge(candidates, eligible, argmax_index, ctx)
     if ctx.sell_price_floored:
-        chosen_index = _row_stored_energy(candidates, eligible, chosen_index)
+        chosen_index = _row_stored_energy(
+            candidates, eligible, chosen_index, argmax_index
+        )
     return chosen_index

--- a/core/bess/tie_policy.py
+++ b/core/bess/tie_policy.py
@@ -1,0 +1,250 @@
+"""The single ordered preference table that resolves near-tied DP actions
+(principle P2, `docs/agents/optimizer-architecture.md`).
+
+Every near-tie the optimizer has ever mis-resolved was fixed by bolting one
+more bespoke tie-break function onto the selection path (#466, #510, then #512
+widening #466's guard). Each was individually correct and each narrowed the
+next one's room: the two functions ran in a fixed order, the second measured
+its epsilon band against the *first's* output rather than against the argmax,
+and whether they could fight was a property of their guard clauses rather
+than of a stated ordering. P2 replaces that with one table, applied once,
+all rows measured against the argmax winner:
+
+1. **Eligibility (import guard).** A candidate that imports more grid energy
+   than the argmax winner is never preferred.
+2. **Eligibility (within epsilon).** Only candidates the DP genuinely cannot
+   rank -- inside `epsilon_for_period`'s value noise -- are eligible. A
+   decisive winner (every alternative more than epsilon behind) is therefore
+   alone in the set and no row can move it.
+3. **Prefer the largest load-tracking discharge** up to the period's net
+   load (#466).
+4. **Prefer the highest-SOE candidate** when this period's sell price was
+   floored by the #269 curtailment rule (#510).
+5. Otherwise the argmax winner stands.
+
+Rows 3 and 4 keep their own, deliberately *different* winner guards -- see
+their docstrings. A single shared "bail on any non-idle winner" guard cannot
+express the asymmetry and would re-open the hole #512 closed.
+
+Adding a new tie symptom's fix here means adding or reordering a row, with
+its rationale and economic bound in the row's docstring. It does not mean a
+new function on the selection path; `optimizer-architecture.md`'s compliance
+check fails a PR that adds one.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from core.bess.dp_battery_algorithm import POWER_TOLERANCE_KW
+
+if TYPE_CHECKING:  # circular at runtime: action_selector imports this module
+    from core.bess.action_selector import Candidate
+
+
+@dataclass(frozen=True)
+class TieContext:
+    """Everything the table needs about the period being decided.
+
+    `epsilon` comes from `tie_detection.epsilon_for_period` and nowhere else
+    (P5) -- no row re-derives or hand-picks a SEK margin.
+
+    The Phase 2 plan sketch also listed a `rate_step` field for a "+half a
+    rate step" round-up allowance in row 3. That allowance no longer exists:
+    #497 removed it, because every candidate overshooting the deficit by
+    less than the export resolution is now excluded from the candidate set
+    as unexecutable, and anything overshooting by more is a genuine export.
+    Carrying the field would have implied a widening this table does not do.
+    """
+
+    epsilon: float
+    home_consumption: float
+    solar_production: float
+    dt: float
+    sell_price_floored: bool
+
+
+def _eligible_indices(
+    candidates: "list[Candidate]", argmax_index: int, ctx: TieContext
+) -> list[int]:
+    """Rows 1-2: the candidates any preference row is allowed to choose.
+
+    **Row 1 -- never import more grid energy than the argmax winner.**
+    Lifted out of the retired curtailment tie-break, where it kept the
+    charge-early swap free: a candidate that stores more by *buying* the
+    energy (the full-rate charge candidate inside a below-floor window) is
+    never preferred over one that only absorbs surplus. Promoting it to a
+    table-wide guard is a deliberate strengthening -- the load-cover row
+    never needed it (a discharge can only reduce import), so the row is a
+    no-op there today and a standing bound if a future row is not so lucky.
+
+    Recorded foreclosure: in a negative-buy-price window a within-epsilon
+    grid top-up is arguably the safer pick against a solar shortfall, and
+    this row permanently bans it. That codifies today's behavior; an
+    amendment relaxing it must cite this note and bring field evidence.
+
+    **Row 2 -- within epsilon of the argmax value.** Measured once, against
+    `candidates[argmax_index].value`, never against a previous row's output:
+    chaining let two rows spend up to `2 * epsilon` between them, which is
+    the epsilon-compounding P2 exists to make unrepresentable.
+
+    The band is inclusive (`<= epsilon`), which is what makes the table live
+    at `epsilon == 0`. Both retired tie-breaks returned early on a
+    flat value function (dV/dSoE == 0 -> epsilon 0 -> no scale for "tied"),
+    disabling tie resolution in exactly the most degenerate tie there is.
+    At epsilon 0 an inclusive band admits only bit-exact ties -- candidates
+    the DP's own objective declares indistinguishable -- and preferring the
+    fail-safe side of a bit-exact tie forfeits exactly zero model value.
+    Cycle cost already sits inside `_compute_reward`, so the preference is
+    not spending wear it failed to price. No epsilon floor is introduced:
+    a nonzero gap, however small, still ranks the candidates and the argmax
+    winner stands.
+    """
+    winner = candidates[argmax_index]
+    return [
+        index
+        for index, candidate in enumerate(candidates)
+        if candidate.grid_imported <= winner.grid_imported + 1e-9
+        and winner.value - candidate.value <= ctx.epsilon
+    ]
+
+
+def _row_load_covering_discharge(
+    candidates: "list[Candidate]",
+    eligible: list[int],
+    argmax_index: int,
+    ctx: TieContext,
+) -> int:
+    """Row 3 (#466): among the eligible candidates, prefer the largest
+    discharge that covers no more than this period's forecast net load.
+
+    Rationale (spec 2026-08-07-idle-tie-break-design.md): within epsilon --
+    the value noise the DP's own SOE grid-snapping injects -- the DP cannot
+    rank the options, but they are not symmetric in risk. A load-covering
+    discharge fails safe: the inverter tracks *actual* load, absorbing a
+    consumption forecast miss for free. IDLE fails unsafe: discharge is
+    hard-disabled, so the entire miss is imported at the buy price. This is
+    ridax67's principle in code -- IDLE must mean the optimizer WANTS to
+    hold energy (a decisive margin), never that it merely EXPECTS balance
+    (a coin flip). Deliberate arbitrage holds are untouched by construction:
+    their margin over discharging exceeds epsilon, so nothing else is
+    eligible.
+
+    Eligibility is exact cover or under-cover only, with no round-up
+    allowance (#497): every candidate overshooting the deficit by less than
+    the export resolution was already excluded from the candidate set as
+    unexecutable, and anything overshooting by more is a genuine export,
+    never a load-cover swap target. Among eligible candidates the largest
+    coverage wins -- fuller coverage means less residual import exposed to
+    a miss.
+
+    **Winner guard (row 2 of the plan's table, per-preference by design).**
+    This row stands down on a *charge* winner and on a discharge already
+    beyond the load cover; an IDLE winner or a *partial*-cover winner stays
+    eligible so a partial cover can be improved to a fuller one. That last
+    part is #512: which of several tied candidates `argmax` returns is an
+    enumeration-order accident, and at the finer grid it started landing on
+    partial covers, silently skipping the swap and leaving residual import
+    exposed. Charge winners are never flipped to discharges -- a semantic
+    change no phase has declared. Row 4's guard is deliberately different
+    (it bails on discharge winners and may still improve a charge winner),
+    which is why the two guards live on their rows instead of being merged.
+
+    Economic bound: each swap forfeits at most `epsilon` (empirically
+    ~0.003-0.015 SEK per period, and exactly 0 in the epsilon == 0 case row
+    2 newly admits), but a single horizon can contain many swapped periods
+    and the aggregate is bounded only empirically -- fixture evidence puts
+    the worst observed full-horizon cost at +0.032 SEK, inside the #450
+    budget of 0.05 SEK. Separately, for small net loads the eligibility band
+    is wide in SEK/kWh terms, so swaps fire more often than #467's tie
+    detector flags near-ties; deliberate, since every swapped candidate is
+    within epsilon -- value noise, not a real gap -- of the argmax winner.
+    """
+    net_load_p = (ctx.home_consumption - ctx.solar_production) / ctx.dt
+    if net_load_p <= POWER_TOLERANCE_KW:
+        return argmax_index
+    max_cover_p = net_load_p + 1e-9
+
+    winner_power = candidates[argmax_index].power
+    if winner_power > POWER_TOLERANCE_KW:
+        return argmax_index
+    if -winner_power > max_cover_p:
+        return argmax_index
+
+    chosen_index = argmax_index
+    chosen_discharge_p = 0.0
+    for index in eligible:
+        discharge_p = -candidates[index].power
+        if discharge_p <= POWER_TOLERANCE_KW or discharge_p > max_cover_p:
+            continue
+        if discharge_p > chosen_discharge_p:
+            chosen_index = index
+            chosen_discharge_p = discharge_p
+    return chosen_index
+
+
+def _row_stored_energy(
+    candidates: "list[Candidate]", eligible: list[int], incoming_index: int
+) -> int:
+    """Row 4 (#510): under the #269 curtailment sell-price floor, prefer the
+    eligible candidate that stores the most energy.
+
+    Rationale: flooring the sell price makes every below-floor export worth
+    exactly 0, so whenever the remaining below-floor surplus exceeds the
+    battery's headroom, "charge now, curtail later" and "curtail now, charge
+    later" earn identical reward and the argmax picks between them on float
+    noise. The options are not symmetric in reality: deferring actuates as
+    charge-rate 0% + export-limit 0 (PV physically clipped to house load,
+    above-forecast production wasted) and spends the plan's slack against a
+    later solar shortfall before the next positive-price block. Charging
+    earliest is stochastically dominant -- equal model reward, strictly
+    better under forecast error in either direction.
+
+    Row 1 is what keeps the swap free: a candidate that stores more by
+    importing from the grid is not eligible in the first place.
+
+    **Winner guard (per-preference, and deliberately not row 3's).** This row
+    reorders hold-vs-store picks only, so it stands down on a discharge
+    winner -- including a row 3 load-covering swap, which is why the two
+    rows cannot fight -- but it may still improve a *charge* winner to a
+    larger absorb. Note `incoming_index` rather than `argmax_index`: the
+    guard reads the action chosen so far (row 3's output), while eligibility
+    and the epsilon band stay anchored at the argmax. That is the whole of
+    the ordering contract between the two rows.
+
+    Economic bound: at most `epsilon` per period, and exactly 0 in the
+    bit-exact-tie case this row's own reproduction fixture
+    (`regression_2026_08_08_143843`) exhibits -- the tie there is exact by
+    construction, since a floored sell price makes both options earn
+    literally the same reward.
+    """
+    incoming = candidates[incoming_index]
+    if incoming.power < -POWER_TOLERANCE_KW:
+        return incoming_index
+
+    chosen_index = incoming_index
+    chosen_next_soe = incoming.next_soe
+    for index in eligible:
+        candidate = candidates[index]
+        if candidate.power < -POWER_TOLERANCE_KW:
+            continue
+        if candidate.next_soe > chosen_next_soe + 1e-9:
+            chosen_index = index
+            chosen_next_soe = candidate.next_soe
+    return chosen_index
+
+
+def apply_tie_policy(
+    candidates: "list[Candidate]", argmax_index: int, ctx: TieContext
+) -> int:
+    """Resolve this period's near-tie: return the index of the action to
+    emit, given the raw value argmax.
+
+    The whole table, applied once. Rows 1-2 build the eligible set against
+    the argmax winner; rows 3-4 pick within it in order; if neither fires,
+    the argmax winner stands (row 5).
+    """
+    eligible = _eligible_indices(candidates, argmax_index, ctx)
+    chosen_index = _row_load_covering_discharge(candidates, eligible, argmax_index, ctx)
+    if ctx.sell_price_floored:
+        chosen_index = _row_stored_energy(candidates, eligible, chosen_index)
+    return chosen_index

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -487,9 +487,9 @@ Flooring the sell price creates *exact reward ties by construction*:
 whenever the remaining below-floor solar surplus exceeds battery headroom,
 "charge now, curtail later" and "curtail now, charge later" earn identical
 reward (signature in a bundle: `shadow_price == cycle_cost_per_kwh` in
-those periods). The replay therefore applies a charge-early tie-break
-(`_prefer_curtailed_charge_absorb`, mirrored in the PWL tie-window
-replay): among candidates within the #466 epsilon, prefer the highest
+those periods). The replay therefore applies a charge-early tie-break -- the tie
+policy's charge-early row (`tie_policy.py`, row 4), applied once for both
+the grid and PWL replays: among candidates within the #466 epsilon, prefer the highest
 `next_soe`, but never one that imports more grid energy than the argmax
 winner, and never overriding a discharge winner. Charge-early is
 stochastically dominant — equal model reward, strictly better under

--- a/docs/agents/optimizer-architecture.md
+++ b/docs/agents/optimizer-architecture.md
@@ -110,7 +110,9 @@ indifference region it creates (generalizes the #269/#510 invariant in
 `core/bess/tie_policy.py` and is applied once, from
 `action_selector.select_action`. The two bespoke tie-break helpers this
 principle was written against are gone; a repo-wide grep for `_prefer_`
-returns nothing, which is the standing exit gate.
+over the source tree returns nothing, which is the standing exit gate.
+(The migration plan under `docs/superpowers/plans/` still names them,
+describing the code it retired.)
 
 Three things the baseline order above states loosely, as built:
 

--- a/docs/agents/optimizer-architecture.md
+++ b/docs/agents/optimizer-architecture.md
@@ -1,7 +1,7 @@
 # Optimizer Target Architecture — Normative
 
 **Status: normative.** Every change to `core/bess/action_selector.py`,
-`core/bess/dp_battery_algorithm.py`,
+`core/bess/tie_policy.py`, `core/bess/dp_battery_algorithm.py`,
 `core/bess/pwl_window_dp.py`, `core/bess/tie_detection.py`,
 `core/bess/models.py` (flow derivation), `core/bess/strategic_intent.py`,
 or `core/bess/simulation/` must either uphold the principles below or amend
@@ -105,6 +105,32 @@ Reward shaping that flattens the objective (price floors, export-credit
 zeroing) MUST land together with the table row that resolves the
 indifference region it creates (generalizes the #269/#510 invariant in
 `bess-knowledge.md`).
+
+**Status: satisfied as of Phase 2.** The table lives in
+`core/bess/tie_policy.py` and is applied once, from
+`action_selector.select_action`. The two bespoke tie-break helpers this
+principle was written against are gone; a repo-wide grep for `_prefer_`
+returns nothing, which is the standing exit gate.
+
+Three things the baseline order above states loosely, as built:
+
+- Row 2 is **per-preference, not shared**. The load-cover row stands down
+  on a charge winner and on a discharge already past the cover, but keeps
+  a *partial*-cover winner eligible (#512). The curtailment row stands
+  down on a discharge winner and may still improve a charge winner. A
+  single shared non-idle guard cannot express that asymmetry and would
+  re-open the hole #512 closed.
+- "Within epsilon" is measured against the argmax winner for every row,
+  and the band is **inclusive**, so the table is live at `epsilon == 0`
+  where both retired helpers returned early. At epsilon 0 that admits only
+  bit-exact ties. **No epsilon floor exists**, and one may only be
+  introduced with a per-period forfeiture bound in the row docstring,
+  counted against the 0.05 SEK/fixture budget: measured across the whole
+  fixture corpus, the smallest gap the table declines to cross at
+  epsilon 0 is 0.0080 SEK — a real ranking, not value noise.
+- The sunrise/sunset crossover is **not** covered by this principle. #517
+  established the action set there was empty, not tied, and fixed it with
+  a candidate (P3). Crossover regression cover belongs in Phase 4.
 
 ### P3. Candidates are executable commands
 


### PR DESCRIPTION
**This is Phase 2 of the optimizer migration, implementing P2** ("Ties
resolve through one lexicographic preference table") from
`docs/agents/optimizer-architecture.md`. Plan:
`docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md`,
Phase 2. Follows Phase 1 (#521, P1).

## What changed

`core/bess/tie_policy.py` (new) holds one ordered preference table,
applied once from `action_selector.select_action`. The two bespoke
tie-break helpers are deleted; their docstring rationale moved into the
rows. Repo-wide `grep -rn "_prefer_"` returns nothing — P2's exit gate.

### The table as implemented

| # | Kind | Rule | Lineage |
|---|---|---|---|
| 1 | Eligibility | A candidate importing more grid energy than the argmax winner (+1e-9) is never preferred. | lifted out of the curtailment helper; now table-wide |
| 2 | Eligibility | Within `epsilon` of the argmax winner's value, **inclusive**, with `epsilon` from `tie_detection.epsilon_for_period` and nowhere else (P5). Measured against the argmax for every row — never chained. | #450 / P5 |
| 3 | Preference | Prefer the largest load-tracking discharge ≤ this period's net load. Stands down on a **charge** winner and on a discharge **already beyond the cover**; an IDLE **or partial-cover** winner stays eligible. | #466, widened by #512 |
| 4 | Preference | When `sell_price_floored`, prefer the highest-`next_soe` eligible candidate. Stands down on a **discharge** winner (including a row 3 swap) but may still improve a **charge** winner. | #510 / #269 |
| 5 | — | Otherwise the argmax winner stands. | |

Rows 3 and 4 keep their **own** guards, not a shared one. The asymmetry is
deliberate in both directions: a shared "bail on any non-idle winner"
guard would re-open the partial-cover hole #512 closed, and would also
remove row 4's existing ability to improve a charge winner.
`test_row_4_may_still_improve_a_charge_winner` and
`test_partial_cover_winner_is_improved_to_a_fuller_cover` pin the two
sides.

### The two deliberate semantic changes

1. **Epsilon band anchored at the argmax, not chained.** Previously row 4
   received row 3's output and measured its band against it, so the two
   could spend up to `2 * epsilon` between them. Pinned by
   `test_epsilon_band_is_measured_against_the_argmax_not_the_previous_row`.
2. **`epsilon <= 0` early return dropped.** Both helpers disabled
   themselves exactly where the value function is flattest. The band is
   now inclusive, so at `epsilon == 0` it admits only bit-exact ties.

## Epsilon-floor decision: **no floor**, measured

The plan required measuring a real period's margin before writing the RED
test for the `epsilon <= 0` change, and forbade silently introducing a
floor to make a test pass.

Measured across all 36 fixtures (2194 selector calls):

- 234 periods have `epsilon == 0`; 114 of those carry a bit-exact tie at
  the argmax value.
- The table fires on **0** of them. Those exact ties are the known
  IDLE / SOLAR_EXPORT-bypass duplicate pair (identical power, identical
  `next_soe`), never an IDLE-vs-load-cover pair — with a flat V,
  discharging is strictly better or strictly worse, so it does not tie.
- Of the 32 `epsilon == 0` periods where a strictly larger load cover was
  actually available, **the smallest gap to it is 0.0080 SEK**
  (next: 0.0124, 0.0139, 0.0209, 0.0225 …).

0.0080 SEK is a real ranking, not grid-snap noise: a floor large enough to
cross it would trade genuine model value on 32 periods, and per-period
forfeitures of that size compound past the 0.05 SEK/fixture budget. So no
floor is introduced, and the epsilon-0 semantics are pinned at unit level
(`test_zero_epsilon_still_ranks_a_nonzero_gap`,
`test_zero_epsilon_resolves_a_bit_exact_tie_to_the_load_cover`) rather
than against a fixture that cannot exhibit the case.

## Measured deltas: zero

Per-fixture planned cost (`economic_summary.battery_solar_cost`) and
emitted actions were compared against `origin/main` via the Phase 1
goldens:

**0 of 36 fixtures changed. Worst |Δ planned cost| = 0.0000 SEK. 0 actions
differ on any fixture.** Well inside the 0.05 SEK/fixture budget.

Consequently **no `PLAN_EXECUTION_GAP_SEK` pin moves** — the sole pin
(`regression_2026_08_08_143843`: +0.0214) is unchanged and re-verified by
the slow suite.

### Golden regeneration

`scripts/capture_selector_goldens.py` was re-run **from this branch** (as
required for a behavior-changing phase) and all 36 goldens regenerate
**byte-identically** — `git status` on `core/bess/tests/unit/data/golden/`
is empty. `test_action_selector_parity.py` is neither deleted nor skipped
and passes as-is.

This is the plan's first surprise (see below): Phase 2 was expected to
break the goldens by design. It does not.

### #466 evening near-ties (acceptance)

Replaying `regression_2026_08_06_466` (bundle 2026-08-06-110152,
dt=0.25 h), the evening periods resolve to load tracking exactly as
before: periods 32–45 (19:00–22:15) emit `LOAD_SUPPORT` with the winner
already at the exact cover, and periods 46–50 swap a partial cover up to
the fuller one (row 3 firing at epsilon 0.001564). Period 51 sits at
`epsilon == 0` with no larger cover candidate available at all, so nothing
to resolve. #393's overnight-residual regression
(`test_load_support_gate_regression_393.py`) passes unchanged.

## Tests

- New: `core/bess/tests/unit/test_tie_policy.py` — 22 cases. Every case the
  two retired helpers were pinned against, ported with the same candidates
  and expected indices, plus the row 3/row 4 asymmetry, the
  no-epsilon-compounding property, and the epsilon-0 semantics.
- `test_idle_tie_break.py` / `test_curtailment_charge_early_tiebreak.py`:
  candidate-level cases moved to `test_tie_policy.py` with the rule they
  test; the end-to-end replay and fixture tests stay and are unmodified.

```
.venv/bin/pytest -m "not slow"  ->  1677 passed, 14 skipped
.venv/bin/pytest -m slow        ->   457 passed,  3 skipped
.venv/bin/black --check .       ->  200 files unchanged
.venv/bin/ruff check .          ->  All checks passed
```

(`./scripts/quality-check.sh` reports "not installed" warnings because it
looks outside `.venv`; the tools were run directly.)

## Doc amendment

`docs/agents/optimizer-architecture.md`: `tie_policy.py` added to the
scope gate, and P2 marked satisfied with the three things the baseline
order stated loosely (per-preference row 2, inclusive band / no floor with
the 0.0080 SEK measurement, and that the crossover is Phase 4's).

No CHANGELOG entry: measured user-visible effect is exactly zero (repo
policy on pure refactors).

## Explicitly NOT in this PR

- The **P6 splice cost-gate rider** listed as a Phase 2 step. It is a
  separate mechanism in `splice_schedule`, not tie policy, and is not
  needed for P2's exit gate. Needs its own PR.
- The mock-HA crossover replay step — #517 already covers the crossover
  via the candidate space, and the plan itself retracted it as this
  phase's acceptance.
- Answering/closing #466 or #393. Beta graduation first (repo policy); no
  reporter issue is closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
