### PR TITLE
docs: record why test_flow_coherence.py is absent from main

### DIFF
--- a/docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md
+++ b/docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md
@@ -99,6 +99,21 @@ confusing.
       wrong filename in this doc sent at least one session looking for a
       pin that does not exist. See Phase 3 for what this does to its
       acceptance criteria.
+
+      **No coverage was lost — provenance, so nobody re-opens this.**
+      `9da0f539` (PR #506) added `test_flow_coherence.py`; `33f62129`
+      (PR #511) deleted it *and* migrated its content, in the same commit,
+      into `helpers.py` (+36 lines) and `test_scenarios.py` (+14). That
+      commit's own message states the reason: "All 182 incoherent periods
+      are gone, and **the two invariants that were pinned as debt are
+      ordinary assertions now**." So the standalone pin was retired
+      because it had been promoted, not dropped — and today's
+      `assert_flow_coherence` is a strict superset of it (6 invariants:
+      four source/destination balances, the home-consumption balance, and
+      non-negativity across all 7 named flows). Stale copies of the
+      deleted file survive in unmerged worktrees and branches
+      (`origin/test/period-flow-invariants` among others); finding one
+      there is not evidence that coverage went missing.
 - [x] Land `scripts/bench_pwl_everywhere.py` (PR #515, merged
       2026-08-09) — the #512 sweep gate.
 - [x] PR #511 (#497 executable-discharge fix) merged 2026-08-09; #497


### PR DESCRIPTION
## Why

#527 established that `test_flow_coherence.py` does not exist on `origin/main`, which is correct — but it did not say *why*, and stale copies of the file survive in several unmerged worktrees and branches (`origin/test/period-flow-invariants` among them). The obvious reading of that evidence is "someone deleted our coherence coverage", which is wrong, and acting on it would mean re-adding a pin that was already promoted to something stronger.

This records the provenance so the question closes permanently.

## What actually happened

| Commit | PR | Action |
|---|---|---|
| `9da0f539` | #506 | Added `core/bess/tests/unit/test_flow_coherence.py` |
| `33f62129` | #511 | Deleted it **and** migrated its content — same commit — into `helpers.py` (+36 lines) and `test_scenarios.py` (+14) |

#511's own commit message states the reason:

> All 182 incoherent periods are gone, and **the two invariants that were pinned as debt are ordinary assertions now.**

So the standalone file was retired because its content graduated into the canonical scenario harness, where it now runs over the whole fixture corpus instead of from a file of its own. Today's `assert_flow_coherence` (`helpers.py:288`) is a strict superset of the retired pin — 6 invariants (four source/destination balances, the home-consumption balance, and non-negativity across all 7 named flows) against the pin's 2.

## Verification

`./scripts/quality-check.sh` — markdown checks pass. The one reported error is `Frontend tests failed`, caused by `frontend/node_modules` being absent in a fresh worktree; unrelated to a markdown-only change and reproduces independently of this diff. No code touched.

Follows #527. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGaCVrnR1TyTcpiFRLBaKQ