### PR TITLE
Make outcome-based testing and mutation evidence enforceable

### DIFF
--- a/.claude/hooks/optimizer_core_principles.py
+++ b/.claude/hooks/optimizer_core_principles.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""PreToolUse (Edit|Write|NotebookEdit): inject the optimizer core's normative
+principles when the file being edited is part of that core.
+
+Why a hook and not documentation. CLAUDE.md already marks
+`docs/agents/optimizer-architecture.md` normative, and rules.md already says a
+new test must be seen to fail. Both are prompt text an agent may or may not
+have loaded, and the `implement-issue` skill that restates them only fires for
+issue work — an ad-hoc DP edit reaches none of it. This fires on the edit, so
+the constraints arrive when they apply regardless of how the session got here.
+
+Never blocks: emits `additionalContext` and exits 0. The point is that nobody
+edits the DP without being told the rules, not that edits need approval. Any
+unexpected input exits 0 silently — a broken hook must not be able to stop
+work.
+
+Written as Python rather than a shell heredoc deliberately: `python3 - <<'PY'`
+consumes the hook payload on stdin and the script then reads nothing, which is
+how the first version of this silently matched no file at all.
+"""
+
+import json
+import sys
+
+CORE_FILES = (
+    "core/bess/dp_battery_algorithm.py",
+    "core/bess/action_selector.py",
+    "core/bess/pwl_window_dp.py",
+    "core/bess/tie_detection.py",
+    "core/bess/tie_policy.py",
+    "core/bess/dp_constants.py",
+    "core/bess/strategic_intent.py",
+)
+
+CONTEXT = """\
+OPTIMIZER CORE EDIT — docs/agents/optimizer-architecture.md is NORMATIVE here.
+
+The seven principles this file is held to:
+  P1  One selector. No second enumerate/evaluate/select implementation; the
+      grid and PWL replays share `select_action`. Mirrored implementations
+      are the #236 bug class.
+  P2  Ties resolve through one lexicographic preference table, not ad-hoc
+      comparisons at each call site.
+  P3  Candidates are executable commands (Phase 4's target state).
+  P4  One flow record per candidate; noise models live at ingestion only.
+      Reporting must not re-derive physics the objective already priced.
+  P5  One epsilon, one owner.
+  P6  Exactness claims are certified or bounded — never asserted.
+  P7  Point forecasts stay; risk handling is structural, not stochastic.
+
+Before you finish this change:
+  1. A new test must be SEEN TO FAIL without the fix. Write it RED, or revert
+     the fix and watch it break, then report which test failed and how many.
+     "The suite is green" is evidence the suite is satisfied, never that the
+     behaviour holds — three guards in this repo passed while proving nothing.
+  2. Assert the OUTCOME, not the command: realized cost, SoE trajectory, or
+     flows, not the value written to a register. Command-level assertions are
+     legitimate only where no execution model exists, and the test must say so.
+  3. Prefer the existing harnesses over a new standalone test file —
+     `test_scenarios.py` expected_results, the action-selector goldens, and
+     `run_scenario_realized` for R == P.
+  4. The goldens pin `actions`, `strategic_intent`,
+     `intra_period_discharge_allowed` and the SoE trajectory bit-exactly. A
+     reclassification or a gate flip is a golden diff even when no energy
+     moves — regenerate deliberately and state the measured delta.
+"""
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return
+
+    path = (payload.get("tool_input") or {}).get("file_path") or ""
+    normalized = path.replace("\\", "/")
+
+    in_core = any(normalized.endswith(name) for name in CORE_FILES) or (
+        "/core/bess/simulation/" in normalized and normalized.endswith(".py")
+    )
+    if not in_core:
+        return
+
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": CONTEXT,
+            }
+        },
+        sys.stdout,
+    )
+
+
+main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,6 +70,11 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/check-worktree-path.sh"
+          },
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/optimizer_core_principles.py",
+            "statusMessage": "Checking optimizer-core principles"
           }
         ]
       }

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -219,10 +219,34 @@ trusting it. Reserve a standalone test file for what that harness genuinely
 can't express: a private method's internal formula, or plan-faithfulness
 (`R == P`) — `test_all_scenarios` never runs the inverter simulator.
 
+**Adding a fixture also means regenerating two artefacts (since #544).** Two
+meta-tests will fail the moment a new `*.json` lands in
+`core/bess/tests/unit/data/`, by design — they exist so a fixture cannot
+silently escape the pins:
+
+```bash
+.venv/bin/python scripts/capture_selector_goldens.py       # test_every_fixture_has_a_golden
+.venv/bin/python scripts/capture_vpp_baseline.py --add-new # test_every_fixture_has_a_vpp_baseline
+```
+
+`--add-new` records only the new fixture's plan. **Never run a full VPP
+re-baseline to make that test go green** — the script warns about this
+because a full re-baseline regenerates both halves of every entry, collapsing
+the recorded v10.0.2 drift to zero and destroying the signal
+`test_drift_from_the_released_version_is_recorded` exists to hold.
+
+Note what the goldens now pin per period, because it changes what counts as a
+behaviour change: `actions`, `strategic_intent`, `intra_period_discharge_allowed`
+and the SoE trajectory, all bit-exact, plus cost at 1e-9. So a fix that
+reclassifies an intent or flips the discharge gate — without moving a single
+kWh — is a golden diff and must be re-pinned deliberately, with the measured
+delta stated in the PR. That is the intended behaviour, not a broken test.
+
 ### 6. Quality gate + code review (background)
 
 Every PR must pass both the fast and slow suites, plus code review. This is
-the long-wait step (slow suite is ~30min) — per `CLAUDE.md`'s Cost
+the long-wait step (slow suite ~4 min, measured 2026-08-11; the "~30 min"
+this used to claim predates the vectorized backward pass) — per `CLAUDE.md`'s Cost
 Discipline, do NOT hold the session open watching it run. Always a
 background `Agent` — this is not a choice to put to the user; asking
 "subagent or inline?" is itself the thing to stop doing (no `isolation` —
@@ -331,8 +355,33 @@ go straight to executing Option 2, do not present its 3-option menu, body:
 - [ ] `./scripts/quality-check.sh` passes locally (already done)
 - [ ] <what you actually observed in Step 8 — be concrete>
 
+## Evidence the test discriminates
+<REQUIRED. Not "the suite passes". The mutation you ran and what broke:>
+- Reverted: <the exact line/behaviour you undid>
+- Result: `<test name>` FAILED, <N> test(s) total
+- Restored: tree clean
+
+## Outcome-level coverage
+<REQUIRED. Which outcome pin now covers this behaviour:>
+- <expected_results on fixture X | intents/gate in the goldens | R == P via
+  run_scenario_realized | none, because …>
+
 Closes #<n>
 ```
+
+**These two sections are the point of the PR, not paperwork.** A reviewer
+cannot tell a real guard from a vacuous one by reading it — three times in
+this codebase a test has passed while proving nothing (#399 asserted an
+internal flag instead of a write count; #302 asserted nothing at all; a
+gate-outcome test written during the 2026-08-11 audit went green on its first
+run while catching neither of the two mutations it claimed to catch). Every
+one of those looked fine in review. The mutation result is the only cheap
+thing that separates them, so it is stated where the reviewer reads, not left
+in a terminal scrollback.
+
+If you cannot produce a mutation that reddens your test, you have not
+demonstrated the bug — say so in the PR and stop, rather than filling the
+section in with the suite result.
 
 ### 10. Hard constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ interface for managing battery schedules and monitoring energy flows.
 
 ```bash
 .venv/bin/pytest -m "not slow"           # fast tests (~3s, recommended)
-.venv/bin/pytest -m slow                 # algorithm/integration tests (~30min)
+.venv/bin/pytest -m slow                 # algorithm/integration tests (~4min)
 .venv/bin/pytest                         # run all tests
 .venv/bin/black . && .venv/bin/ruff check --fix .  # format and lint
 ./scripts/quality-check.sh               # full quality gate


### PR DESCRIPTION
Follow-up to #544. The audit's most repeated finding was tests passing while proving less than claimed — #399 asserted an internal flag instead of a write count, #302 asserted nothing at all, and a gate-outcome test written *during* the audit went green on its first run while catching neither mutation it claimed to catch.

The guidance against all three already existed, in `rules.md` and in the `implement-issue` skill. **Guidance was never the gap. Evidence was.** Every one of those looked fine in review.

## What changes

**Two required PR-body sections** in `implement-issue`, neither satisfiable by a green suite:

- *Evidence the test discriminates* — the mutation you ran, the test that failed, the count, the tree restored.
- *Outcome-level coverage* — which pin now covers the behaviour (`expected_results`, the goldens, or R == P), or an explicit "none, because…".

**A PreToolUse hook** (`.claude/hooks/optimizer_core_principles.py`) on `Edit|Write|NotebookEdit` that injects P1–P7 plus those requirements whenever the edited file is in the optimizer core. The skill only fires for issue work, so an ad-hoc DP edit reached none of it; the hook fires on the edit itself, whatever route the session took.

It never blocks — emits `additionalContext`, exits 0, and exits 0 silently on unexpected input, because a broken hook must not be able to stop work. Appended to the existing `Edit|Write|NotebookEdit` block; `check-worktree-path.sh` is untouched.

## Two corrections found while writing it

- **Adding a fixture now also needs the goldens regenerated and a VPP baseline entry via `--add-new`** (both meta-tests fail otherwise, by design). Documented *why* a full VPP re-baseline is the wrong remedy: it regenerates both halves of every entry, collapsing the recorded v10.0.2 drift to zero and destroying the signal `test_drift_from_the_released_version_is_recorded` exists to hold.
- **The slow suite is ~4 min, not ~30 min.** Both `CLAUDE.md` and the skill claimed 30, and that figure drives the "treat it as a session boundary" cost advice — so it was telling people to clear context for a four-minute wait.

## Verification

Every branch of the hook pipe-tested against synthesized payloads: core file emits, `simulation/*.py` emits, non-core silent, non-`.py` in `simulation/` silent, malformed JSON and `{}` both exit 0. `jq -e` confirms both hooks on the matcher.

The first version was a shell heredoc — `python3 - <<'PY'` consumed the hook payload on stdin, so it matched **no file at all** while looking correct. It was caught by pipe-testing, which is the same lesson as the rest of this PR and is now noted in the script's docstring.

**Not proven firing in-session:** hooks added after session start are not picked up until `/hooks` is opened or the session restarts, and this edits a worktree's settings. Contract is validated against the schema and every path is tested, but the live fire is unverified — worth one DP edit after merge to confirm.

Docs, skill and hook only; no production code.