### PR TITLE
fix: repin numpy to 2.4.6 so the HA add-on image can build

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,14 +12,16 @@ watchdog==3.0.0
 loguru==0.7.3
 pyyaml
 watchdog
-# Pinned (audit Pass 3, F1). The optimizer's cost is a numpy reduction, and
-# its last bits depend on the build: on one commit, numpy 2.5.2 under both
-# py3.12.13 and py3.13 reproduced every action-selector golden exactly, while
-# numpy 2.4.6 under py3.11.15 differed on 27 of 36 fixtures by up to 5.7e-14
-# SEK with the plan bit-identical. The goldens now carry a 1e-9 tolerance so
-# that can no longer redden CI on its own; this pin is the other half, so a
-# silent numpy bump cannot move reported costs at all. Wheels exist for
-# cp312/313/314 on manylinux, musllinux (the Alpine add-on image) and macOS.
-numpy==2.5.2
+# Pinned (audit Pass 3, F1). The optimizer's cost is a numpy reduction and its
+# last bits depend on the build, so a silent numpy bump could move reported
+# costs; the goldens carry a 1e-9 tolerance and this pin is the other half.
+# 2.4.6, not 2.5.x: the HA add-on base (ghcr.io/home-assistant/*-base:3.19)
+# ships Python 3.11, and numpy >=2.5 requires >=3.12 — pinning 2.5.2 broke the
+# supervisor build outright. 2.4.6 has cp311/312/313 wheels on manylinux,
+# musllinux (the Alpine add-on image) and macOS, so add-on, CI and dev all
+# resolve to the same numpy. Measured spread between 2.4.6/py3.11.15 and
+# 2.5.2/py3.12.13 was <=5.7e-14 SEK on 27 of 36 action-selector fixtures with
+# the plan bit-identical — five orders of magnitude inside the tolerance.
+numpy==2.4.6
 pandas
 anthropic>=0.40.0


### PR DESCRIPTION
## Problem

The add-on fails to build in the Home Assistant supervisor:

```
ERROR: Could not find a version that satisfies the requirement numpy==2.5.2
ERROR: No matching distribution found for numpy==2.5.2
```

`numpy==2.5.2` was pinned in #544 to keep the optimizer's cost reduction bit-reproducible. But numpy >= 2.5 requires **Python >= 3.12**, and the add-on base image `ghcr.io/home-assistant/*-base:3.19` ships **Python 3.11.14** (verified by running the image). Only `cp311` wheels are offered there, so pip has nothing to resolve to.

CI didn't catch it because the `Dockerfile` `ARG BUILD_FROM` default is `python:3.13-alpine` — the supervisor overrides it from `build.json`, and only that path hits 3.11.

## Fix

Repin to `numpy==2.4.6` — the newest release with `cp311` wheels, which also covers 3.12/3.13. Add-on, CI and dev now all resolve to the same numpy, which is what the pin was for.

The determinism goal is unharmed: #544's own measurements put the 2.4.6/py3.11 vs 2.5.2/py3.12 spread at **<= 5.7e-14 SEK** on 27 of 36 action-selector fixtures with the plan bit-identical — five orders of magnitude inside the goldens' 1e-9 tolerance. The comment in `requirements.txt` now records the Python-version constraint so the pin doesn't get bumped back.

## Verification

- `pytest -m "not slow"` — 1721 passed, 14 skipped
- `pytest -m slow` — 534 passed, 4 skipped (action-selector goldens included)
- frontend `npm test` — 124 passed
- Replayed the exact failing step in the real base image: `podman run --platform linux/amd64 ghcr.io/home-assistant/amd64-base:3.19` + `pip install -r backend/requirements.txt` → `Successfully installed ... numpy-2.4.6 ...`

No changelog entry: the bad pin landed after the last release and never shipped to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01373swXhcC29MLjMukZewFK