### PR TITLE
chore: build the add-on on HA's Python 3.13 base, and test what ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
               - 'docker-compose.ci.yml'
               - 'docker-compose.prod-test.yml'
               - 'Dockerfile'
+              - 'backend/Dockerfile'
+              - 'build.json'
+              - 'package-addon.sh'
 
       # Algorithm filter uses a script instead of dorny because dorny's
       # negation patterns don't work correctly with the default 'some'
@@ -469,6 +472,26 @@ jobs:
       - name: Stop environment
         if: always()
         run: docker compose -f docker-compose.prod-test.yml down
+
+      # The step above builds ./Dockerfile — what release-addon.yml publishes
+      # to GHCR. A local install goes down a different path entirely:
+      # deploy.sh → package-addon.sh, which ships backend/Dockerfile and lets
+      # the supervisor build it against build.json. That path had no CI
+      # coverage, which is how a base image with Python 3.11 and a numpy pin
+      # needing >=3.12 reached users. Build it here the way the supervisor
+      # does, using the real base from build.json.
+      - name: Build the add-on image the supervisor builds
+        run: |
+          ./package-addon.sh
+          BASE=$(jq -r '.build_from.amd64' build.json)
+          echo "Building build/bess_manager/Dockerfile on $BASE"
+          docker build \
+            --build-arg BUILD_FROM="$BASE" \
+            --build-arg BUILD_VERSION=ci \
+            -t bess-addon-supervisor-test \
+            build/bess_manager
+          docker run --rm --entrypoint /app/venv/bin/python bess-addon-supervisor-test \
+            -c "import sys, numpy, pandas, fastapi; print('py', sys.version.split()[0], 'numpy', numpy.__version__)"
 
   # ── Merge gate: single required check for branch protection ──────
   # Branch protection cannot require the conditional jobs (test-algorithm,

--- a/.github/workflows/release-addon.yml
+++ b/.github/workflows/release-addon.yml
@@ -23,10 +23,10 @@ jobs:
         include:
           - arch: aarch64
             platform: linux/arm64
-            base_image: ghcr.io/home-assistant/aarch64-base:3.19
+            base_image: ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.22
           - arch: amd64
             platform: linux/amd64
-            base_image: ghcr.io/home-assistant/amd64-base:3.19
+            base_image: ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22
 
     steps:
       - uses: actions/checkout@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=python:3.13-alpine
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22
 
 # Build frontend on native amd64 to avoid QEMU npm timeouts on ARM
 FROM --platform=linux/amd64 node:20-alpine AS frontend-builder
@@ -21,7 +21,7 @@ LABEL \
     io.hass.description="Battery Energy Storage System optimization and management" \
     io.hass.version=${BUILD_VERSION} \
     io.hass.type="addon" \
-    io.hass.arch="aarch64,amd64,armv7" \
+    io.hass.arch="aarch64,amd64" \
     maintainer="Johan Zander <johanzander@gmail.com>" \
     org.label-schema.build-date=${BUILD_DATE} \
     org.label-schema.description="Battery Energy Storage System optimization and management" \
@@ -30,10 +30,11 @@ LABEL \
     org.label-schema.vcs-ref=${BUILD_REF} \
     org.label-schema.vcs-url="https://github.com/johanzander/bess-manager"
 
+# Python and pip come from the base image (/usr/local/bin). Do NOT apk add
+# python3/py3-pip here: on the HA base-python images that installs Alpine's
+# own interpreter at /usr/bin alongside it, and which one `python3 -m venv`
+# picks then depends on PATH order. gcc/musl-dev stay for source builds.
 RUN apk add --no-cache \
-    python3 \
-    py3-pip \
-    python3-dev \
     gcc \
     musl-dev \
     bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22
 
-# Build frontend on native amd64 to avoid QEMU npm timeouts on ARM
-FROM --platform=linux/amd64 node:20-alpine AS frontend-builder
+# Build the frontend natively to avoid QEMU npm timeouts: $BUILDPLATFORM is
+# the host doing the build (amd64 on CI runners, arm64 on an Apple Silicon
+# dev machine), never the emulated target. The stage emits plain JS, so its
+# arch does not matter to the image.
+FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend-builder
 ARG BUILD_VERSION
 WORKDIR /tmp/frontend
 RUN echo "Building frontend for version ${BUILD_VERSION}"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ LABEL \
     io.hass.description="Battery Energy Storage System optimization and management" \
     io.hass.version=${BUILD_VERSION} \
     io.hass.type="addon" \
-    io.hass.arch="aarch64,amd64,armhf,armv7,i386" \
+    io.hass.arch="aarch64,amd64" \
     maintainer="Johan Zander <johanzander@gmail.com>" \
     org.label-schema.build-date=${BUILD_DATE} \
     org.label-schema.description="Battery Energy Storage System optimization and management" \
@@ -21,8 +21,12 @@ LABEL \
     org.label-schema.vcs-ref=${BUILD_REF} \
     org.label-schema.vcs-url="https://github.com/johanzander/bess-manager"
 
-# Install requirements for add-on
-RUN apk add --no-cache python3 py3-pip python3-dev gcc musl-dev bash
+# Install requirements for add-on.
+# Python and pip come from the base image (/usr/local/bin). Do NOT apk add
+# python3/py3-pip here: on the HA base-python images that installs Alpine's
+# own interpreter at /usr/bin alongside it, and which one `python3 -m venv`
+# picks then depends on PATH order. gcc/musl-dev stay for source builds.
+RUN apk add --no-cache gcc musl-dev bash
 
 # Set working directory
 WORKDIR /app

--- a/build.json
+++ b/build.json
@@ -1,10 +1,7 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.19",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.19",
-    "armhf": "ghcr.io/home-assistant/armhf-base:3.19",
-    "armv7": "ghcr.io/home-assistant/armv7-base:3.19",
-    "i386": "ghcr.io/home-assistant/i386-base:3.19"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.22",
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22"
   },
   "squash": false,
   "args": {}

--- a/docker-compose.prod-test.yml
+++ b/docker-compose.prod-test.yml
@@ -36,7 +36,17 @@ services:
         # base, and avoids emulating the whole build:
         #   BESS_BUILD_FROM=ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.22
         BUILD_FROM: ${BESS_BUILD_FROM:-ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22}
-    command: ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
+    # with-contenv is required, not decoration: the HA base image's entrypoint
+    # is s6, and s6 does not pass the container environment to its services.
+    # Without it every variable below is invisible to the app, HA_URL falls
+    # back to http://supervisor/core, and startup blocks on retries to a host
+    # that does not exist here.
+    #
+    # The image's own CMD (run.sh) cannot be used instead: bashio is present on
+    # this base, so run.sh would force HA_URL=http://supervisor/core too.
+    command:
+      ["/usr/bin/with-contenv", "python", "-m", "uvicorn", "app:app",
+       "--host", "0.0.0.0", "--port", "8080"]
     environment:
       - HA_URL=http://mock-ha:8123
       - HA_TOKEN=mock_token

--- a/docker-compose.prod-test.yml
+++ b/docker-compose.prod-test.yml
@@ -9,6 +9,18 @@
 #
 # Defaults to port 8081 to avoid conflicting with the dev environment (8080).
 # Override with BESS_PORT=XXXX if needed.
+#
+# On podman, do NOT trust podman-compose's exit code: 1.6.0 exits 0 when the
+# FROM image cannot be resolved, so a failed build reads as a pass (it does
+# propagate RUN failures). Check the log for "Successfully tagged".
+#
+# `docker compose` over podman's socket reports failures correctly and is the
+# implementation CI runs, so prefer it where it works:
+#   export DOCKER_HOST="unix://$(podman machine inspect \
+#     --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
+# On an arm64 host it cannot build this file, though: the frontend stage is
+# pinned to linux/amd64 and buildkit's QEMU emulation fails on `npm run build`
+# where buildah tolerates it.
 
 services:
   bess:
@@ -16,7 +28,14 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        BUILD_FROM: python:3.13-alpine
+        # Must stay a base image from build.json, so this really does test what
+        # ships. Building on the generic python:*-alpine instead is what let
+        # numpy==2.5.2 (needs py>=3.12) pass CI and then fail in the supervisor,
+        # whose base was py3.11. The HA bases are single-arch, so on an arm64
+        # host (Apple Silicon) use the aarch64 one — it is equally a shipped
+        # base, and avoids emulating the whole build:
+        #   BESS_BUILD_FROM=ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.22
+        BUILD_FROM: ${BESS_BUILD_FROM:-ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.22}
     command: ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
     environment:
       - HA_URL=http://mock-ha:8123


### PR DESCRIPTION
Stacked on #546 — review/merge that first. Base branch is `fix/numpy-pin-py311`, so this diff shows only the base-image work.

## Why

The add-on shipped **Python 3.11.14**. `build.json` pinned `ghcr.io/home-assistant/*-base:3.19`, which went EOL in November 2025. Nothing tested that interpreter:

| Environment | Python |
|---|---|
| **Add-on (what users run)** | **3.11.14** |
| CI | 3.13 |
| Dev venv | 3.12.13 |
| Black/Ruff/mypy target | 3.10 |

That gap is how #546's bug shipped: `numpy==2.5.2` needs py>=3.12, resolved fine everywhere it was tested, and only failed in the supervisor.

## What

Move to `ghcr.io/home-assistant/*-base-python:3.13-alpine3.22` — HA's purpose-built Python base, **Python 3.13.14 on Alpine 3.22.4**, matching CI exactly and back on a supported Alpine.

The base image was named in **four** places, which had drifted apart:

| File | Was | Now |
|---|---|---|
| `build.json` (supervisor) | `*-base:3.19` → py3.11 | `*-base-python:3.13-alpine3.22` |
| `release-addon.yml` (published images) | `*-base:3.19` → py3.11 | `*-base-python:3.13-alpine3.22` |
| `docker-compose.prod-test.yml` (CI build test) | `python:3.13-alpine` | `*-base-python:3.13-alpine3.22`, overridable |
| `Dockerfile` ARG default | `python:3.13-alpine` | `*-base-python:3.13-alpine3.22` |

**Row 3 is why CI missed the numpy break.** The "Docker build & boot" job builds the real Dockerfile, but against a generic `python:3.13-alpine` — an image nobody ships. It now builds a base from `build.json`, so that job actually tests what users install.

Also:

- **Dropped `python3`/`py3-pip`/`python3-dev` from the apk layer.** `base-python` ships a source-built interpreter at `/usr/local/bin`; `apk add python3` would install Alpine's own 3.12 at `/usr/bin` beside it, leaving `python3 -m venv` dependent on PATH order. `gcc`/`musl-dev` stay — `watchdog==3.0.0` still builds from source.
- **Removed stale `armhf`/`armv7`/`i386`** from `build.json` and `armv7` from `io.hass.arch`; `config.yaml` supports `aarch64` and `amd64` only.

## Verification

- Full image builds and tags on the real `aarch64-base-python:3.13-alpine3.22`
- venv resolves to `/app/venv/bin/python3` (3.13.14); `numpy`/`pandas`/`fastapi`/`anthropic` all import, installed from musllinux wheels
- `numpy` stays at 2.4.6 from #546 — one version that works on 3.11–3.13 is worth more than matching #544's exact measurements, and it keeps the add-on buildable if the base ever moves again

## Local builds on Apple Silicon

`podman-compose` 1.6.0 **exits 0 when the `FROM` image can't be resolved**, so a failed build reads as a pass (it does propagate `RUN` failures) — worth knowing, since that's exactly the failure class a base-image change produces. `docker compose` over podman's socket reports it correctly, but can't build this file on arm64: the frontend stage is pinned to `linux/amd64` and buildkit's QEMU emulation fails `npm run build` where buildah tolerates it. Both notes are in the compose header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01373swXhcC29MLjMukZewFK
