### PR TITLE
docs: add the missing #510 changelog entry, fix Unreleased structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,24 +45,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **"-0.00" no longer displays for values that round to zero** — e.g. a curtailed period's export revenue now shows as "0.00".
 - **Reported cost and savings no longer include a phantom charge for periods that will actually be curtailed at runtime by PV export-limit curtailment.** ([#502](https://github.com/johanzander/bess-manager/issues/502))
 - **Growatt VPP installs with AC charging disabled at the inverter now get it re-enabled on restart** — an inverter reporting VPP Status enabled but AC charging disabled was treated as fully configured, so planned grid-charging periods silently drew nothing from the grid. Each of the two registers is now checked and repaired on its own, so a drifted one is fixed without rewriting the healthy one. ([#539](https://github.com/johanzander/bess-manager/issues/539))
-### Fixed
-
+- **With PV export-limit curtailment enabled, the battery now fills from below-floor surplus solar instead of deferring the charge** — the sell-price floor makes every below-floor export worth exactly 0 to the optimizer, so charge-now and curtail-now tied on float noise and the deferred pick clipped PV to house load while multi-kWh of battery headroom sat unused. ([#510](https://github.com/johanzander/bess-manager/issues/510))
 - The consumption forecast now refreshes intraday like solar already does, instead of caching stale data until the 23:55 job. ([#395](https://github.com/johanzander/bess-manager/issues/395))
 - Inverter schedule display no longer shows a fictional TOU mode label for VPP/period-list-controlled installs. ([#415](https://github.com/johanzander/bess-manager/issues/415))
 - **A silently dropped quarterly schedule-update tick permanently lost a period's actuals with no trace it ever happened** — the missed tick is now logged and surfaced as a runtime failure. ([#403](https://github.com/johanzander/bess-manager/issues/403))
+- The "Enable Live Control" pre-flight dialog showed a green check for optional components that were genuinely failing (e.g. a misconfigured InfluxDB), not just ones left unconfigured. Those now show an amber warning — they still never block enabling live control.
+- Settings → Savings History silently displayed "0 days recorded" when the disk-usage request failed, and swallowed errors when clearing the history. Both now surface the actual error.
 
 ### Removed
 
 - **"Min Action Profit" setting** — the DP optimizer stopped reading it when the profitability gate was replaced by pure backward induction (v10.0.0), but the field stayed in Settings → Battery and the setup wizard, still describing behaviour ("the optimizer skips cycles where the expected gain is below this value") that no longer happened. Removed from the UI, the settings schema, and the API. Existing configs are migrated automatically; no action needed.
-
-### Fixed
-
-- The "Enable Live Control" pre-flight dialog showed a green check for optional components that were genuinely failing (e.g. a misconfigured InfluxDB), not just ones left unconfigured. Those now show an amber warning — they still never block enabling live control.
-- Settings → Savings History silently displayed "0 days recorded" when the disk-usage request failed, and swallowed errors when clearing the history. Both now surface the actual error.
-
-### Internal
-
-- Locked a real Growatt GEN4 VPP installation's config (`ridax67`) into the discovery regression suite as `ci-wizard-growatt-vpp-ridax-118`, covering a real-world ambiguous case (same `unique_id` suffix exposed on more than one HA domain) the synthetic VPP fixtures didn't exercise. ([#118](https://github.com/johanzander/bess-manager/issues/118))
 
 ## [10.0.2] - 2026-08-10
 


### PR DESCRIPTION
Changelog-only prep for the `v10.1.0b7` beta, found while reviewing what the release should announce.

## Three things

**Structure.** `Unreleased` had accumulated three separate `### Fixed` headings with a `### Removed` interleaved between them — successive PRs each appended their own rather than merging into the existing block. Now one `Fixed`, with `Removed` last.

**A real gap: #510.** It merged with no changelog entry at all. It is user-facing, from a live report on #269: with PV export-limit curtailment enabled, the sell-price floor makes every below-floor export worth exactly 0 to the DP, so charge-now and curtail-now earn identical reward and the replay argmax picked between them on float noise. The deferred pick actuates as charge rate 0% + export limit, physically clipping PV to house load while multi-kWh of battery headroom sits unused.

**Dropped the `### Internal` fixture bullet.** The ridax67 discovery regression fixture (#118) has no user-visible effect. Prior `Internal` sections (v10.0.0) listed things a user could actually notice — the 115x DP backward-induction speedup, debug-bundle export changes — so this is consistent with that precedent, not a break from it.

## Not added, deliberately

Reviewing the 39 commits since `v10.1.0b6` found 28 internal (13 docs/plan, 3 optimizer refactor phases, 5 test/bench, 7 chore). Three could be mistaken for user-facing and are intentionally omitted:

- **#546** (numpy repin so the add-on image builds) — #544 *introduced* that break, also post-b6. It never reached a user, so it is pre-release iteration, not a fix.
- **#548** (12 npm audit vulnerabilities) — all build/dev-time: dev Dockerfiles, lockfile, one dead dep. No shipped runtime code. Deliberately *not* written up as a security fix.
- **#541** (#539 VPP) — the post-b6 #539 commits are the simulation harness and its docs only; the AC-charging repair itself shipped in an earlier beta and is already listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01373swXhcC29MLjMukZewFK