### PR TITLE
fix: diff Growatt MIN TOU segments against real hardware, not a cached model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Growatt MIN TOU segments are now written against the inverter's real state**, ending repeated "500 Server Error" write failures and leaving no unplanned segments running on the battery. ([#551](https://github.com/johanzander/bess-manager/issues/551))
 - **House load spikes during a battery-supported period are now covered from the battery instead of the grid**, on TOU/register platforms, whenever the stored energy is worth less than importing at that moment (`buy_price × discharge_efficiency ≥ shadow_price`, decided by the optimizer). When the battery is genuinely being reserved for a pricier later period the reserve is still protected and the spike is imported. ([#520](https://github.com/johanzander/bess-manager/issues/520))
 - Near-tied battery decisions now prefer the fullest load-covering discharge even when the tie surfaces at a partial cover, closing a gap where residual import stayed exposed to consumption spikes. ([#512](https://github.com/johanzander/bess-manager/issues/512))
 - **Sub-period battery discharge is no longer permitted on an uncomputed value** — the ceiling opened whenever the battery sat at its reserve floor, where no marginal value exists. ([#526](https://github.com/johanzander/bess-manager/issues/526))

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -2572,10 +2572,6 @@ class BatterySystemManager:
         logger.info("Schedule update required: %s", reason)
         self._current_schedule = temp_schedule
 
-        # Read the currently-active TOU intervals BEFORE apply_intents
-        # rebuilds them, so write_to_hardware still sees what's on hardware
-        # right now (used for stale-segment cleanup on some platforms).
-        current_tou = self._inverter_controller.active_tou_intervals.copy()
         effective_period = 0 if prepare_next_day else period
         self._inverter_controller.apply_intents(temp_schedule, effective_period)
 
@@ -2583,8 +2579,11 @@ class BatterySystemManager:
             if self._controller is None:
                 logger.error("Cannot apply schedule: controller is not available")
             else:
-                self._inverter_controller.write_to_hardware(
-                    self._controller, effective_period, current_tou
+                # No snapshot of "what's on hardware" is passed in: platforms
+                # that need it read the inverter themselves. Passing our own
+                # pre-apply model let the two drift apart (issue #551).
+                self._inverter_controller.sync_to_hardware(
+                    self._controller, effective_period
                 )
 
             # Clear corruption flag after successful hardware write

--- a/core/bess/debug_data_exporter.py
+++ b/core/bess/debug_data_exporter.py
@@ -804,10 +804,13 @@ class DebugDataAggregator:
         return snapshot
 
     def _serialize_inverter_tou(self) -> list[dict]:
-        """Serialize the current inverter TOU segments from memory.
+        """Serialize the TOU segments this controller intends to have on hardware.
 
-        Returns the segments that were last read from / written to the inverter,
-        so debug log replays can seed the mock with the real inverter state.
+        NOT a hardware read: active_tou_intervals is the *desired* schedule.
+        Since #551 that is explicitly not the same thing as what the inverter
+        holds — the two diverging is the bug that issue documents — so a replay
+        seeded from this reproduces the plan, not the inverter's real state.
+        Reproducing hardware drift needs a genuine read (see #553).
 
         Returns:
             List of TOU segment dicts as held in active_tou_intervals

--- a/core/bess/growatt_min_controller.py
+++ b/core/bess/growatt_min_controller.py
@@ -66,6 +66,7 @@ ROBUST RECOVERY: When TOU corruption detected (overlaps, wrong order, duplicates
 
 import io
 import logging
+from typing import ClassVar
 
 from . import time_utils
 from .dp_schedule import DPSchedule
@@ -694,27 +695,11 @@ class GrowattMinController(InverterController):
         self.current_hour = current_hour
         self.tou_intervals = []
 
-        for segment in tou_segments:
-            segment_id = segment.get("segment_id")
-            is_enabled = segment.get("enabled", False)
-            raw_batt_mode = segment.get("batt_mode")
-
-            # Convert integer to string representation if needed
-            if isinstance(raw_batt_mode, int):
-                batt_mode_map = {0: "load_first", 1: "battery_first", 2: "grid_first"}
-                batt_mode = batt_mode_map.get(raw_batt_mode, "battery_first")
-            else:
-                batt_mode = raw_batt_mode if raw_batt_mode else "load_first"
-
+        # Normalization is shared with the differential-diff path so the two
+        # cannot disagree on field types or missing-key defaults (issue #551).
+        for segment in self._normalize_segments(tou_segments):
             self.tou_intervals.append(
-                {
-                    "segment_id": segment_id,
-                    "batt_mode": batt_mode,
-                    "start_time": segment.get("start_time", "00:00"),
-                    "end_time": segment.get("end_time", "23:59"),
-                    "enabled": is_enabled,
-                    "strategic_intent": "existing_schedule",
-                }
+                {**segment, "strategic_intent": "existing_schedule"}
             )
 
         # Validate intervals read from inverter (log only, no recovery here).
@@ -1098,13 +1083,51 @@ class GrowattMinController(InverterController):
             enabled=segment["enabled"],
         )
 
+    # Growatt reports batt_mode as an int on some firmware/API paths.
+    _BATT_MODE_BY_CODE: ClassVar[dict[int, str]] = {
+        0: "load_first",
+        1: "battery_first",
+        2: "grid_first",
+    }
+
+    @classmethod
+    def _normalize_segments(cls, segments) -> list[dict]:
+        """Put a vendor segment payload into this class's internal shape.
+
+        Applied once at the read boundary so every consumer — the startup
+        initializer and the differential diff — sees the same field types and
+        the same defaults. When only the initializer normalized, the diff
+        compared an int batt_mode against our strings, matched nothing, and
+        rewrote every segment blind while echoing the raw int back to the
+        inverter.
+        """
+        normalized = []
+        for segment in segments:
+            raw_mode = segment.get("batt_mode")
+            if isinstance(raw_mode, int):
+                batt_mode = cls._BATT_MODE_BY_CODE.get(raw_mode, "battery_first")
+            else:
+                batt_mode = raw_mode or "load_first"
+
+            normalized.append(
+                {
+                    "segment_id": segment.get("segment_id"),
+                    "batt_mode": batt_mode,
+                    "start_time": segment.get("start_time", "00:00"),
+                    "end_time": segment.get("end_time", "23:59"),
+                    "enabled": segment.get("enabled", False),
+                }
+            )
+        return normalized
+
     def _read_segments_from_hardware(self, controller) -> list[dict]:
         """Read current TOU segments from inverter hardware.
 
-        Subclasses can override to use different read mechanisms
-        (e.g. entity state reads for solax_modbus).
+        Raises if the read fails; an empty list means the inverter genuinely
+        holds no segments. Subclasses can override to use different read
+        mechanisms (e.g. entity state reads for solax_modbus).
         """
-        return controller.read_inverter_time_segments()
+        return self._normalize_segments(controller.read_inverter_time_segments())
 
     def sync_to_hardware(
         self,
@@ -1127,17 +1150,10 @@ class GrowattMinController(InverterController):
         # started duplicating live segments — which the Growatt cloud rejects
         # with a 500 — while segments the plan had dropped stayed enabled on
         # the inverter and kept running.
+        # A failed read raises out of here rather than arriving as an empty
+        # list, so it cannot be mistaken for "the inverter holds nothing" and
+        # trigger a blind rewrite. _hardware_write_pending then retries.
         current_tou = self._read_segments_from_hardware(controller)
-        if not current_tou:
-            # read_inverter_time_segments swallows errors and returns []. A MIN
-            # inverter always has its 9 slots, so an empty read means the read
-            # failed. Diffing against [] would rewrite everything blind and
-            # recreate the very duplicates this read exists to prevent; raising
-            # leaves _hardware_write_pending set so the caller retries.
-            raise RuntimeError(
-                "Cannot write TOU schedule: failed to read current segments "
-                "from the inverter"
-            )
 
         # Only the active (hardware-programmed) intervals are eligible to be
         # written. self.tou_intervals can hold more than the 9 slots the MIN
@@ -1182,30 +1198,32 @@ class GrowattMinController(InverterController):
             (effective_period % 4) * 15,
         )
 
-        # When new schedule is empty, disable ALL current TOU segments
-        if len(new_tou) == 0 and len(current_tou) > 0:
+        # When new schedule is empty, disable ALL currently-enabled segments.
+        # Counting every slot read back would fire this on an idle plan against
+        # any real inverter, which always reports all 9 (issue #551).
+        enabled_now = [seg for seg in current_tou if seg.get("enabled")]
+        if len(new_tou) == 0 and enabled_now:
             logger.warning("=" * 80)
             logger.warning(
-                "Empty TOU schedule detected - CLEARING ALL %d existing TOU segments from inverter",
-                len(current_tou),
+                "Empty TOU schedule detected - CLEARING ALL %d enabled TOU segments from inverter",
+                len(enabled_now),
             )
             logger.warning(
                 "This happens when optimization determines NO profitable charging/discharging"
             )
             logger.warning("=" * 80)
 
-            for current in current_tou:
-                if current.get("enabled", True):
-                    disabled_segment = current.copy()
-                    disabled_segment["enabled"] = False
-                    to_disable.append(disabled_segment)
-                    logger.info(
-                        "Marking ALL segments for clearing: %s-%s %s (segment_id=%s)",
-                        current["start_time"],
-                        current["end_time"],
-                        current["batt_mode"],
-                        current.get("segment_id"),
-                    )
+            for current in enabled_now:
+                disabled_segment = current.copy()
+                disabled_segment["enabled"] = False
+                to_disable.append(disabled_segment)
+                logger.info(
+                    "Marking ALL segments for clearing: %s-%s %s (segment_id=%s)",
+                    current["start_time"],
+                    current["end_time"],
+                    current["batt_mode"],
+                    current.get("segment_id"),
+                )
 
             logger.info("Total segments marked for clearing: %d", len(to_disable))
         else:
@@ -1402,14 +1420,6 @@ class GrowattMinController(InverterController):
             current_hour: Current hour (0-23)
         """
         inverter_segments = self._read_segments_from_hardware(controller)
-        if not inverter_segments:
-            # Same contract as sync_to_hardware: the MIN always reports its 9
-            # slots, so an empty read is a failed read. Initializing from it
-            # would record "the inverter holds nothing" as fact.
-            raise RuntimeError(
-                "Cannot initialize TOU schedule: failed to read current "
-                "segments from the inverter"
-            )
         self.initialize_from_tou_segments(inverter_segments, current_hour)
 
     def check_health(self, controller) -> list:

--- a/core/bess/growatt_min_controller.py
+++ b/core/bess/growatt_min_controller.py
@@ -1106,22 +1106,39 @@ class GrowattMinController(InverterController):
         """
         return controller.read_inverter_time_segments()
 
-    def write_to_hardware(
+    def sync_to_hardware(
         self,
         controller,
         effective_period: int,
-        current_tou: list,
     ) -> tuple[int, int]:
         """Apply MIN inverter TOU schedule to hardware using differential update.
 
         Args:
             controller: HomeAssistantAPIController instance
             effective_period: Period (0-95) from which to start applying changes
-            current_tou: TOU intervals currently active on the inverter
 
         Returns:
             Tuple of (segments_updated, segments_disabled)
         """
+        # The differential update must be diffed against what the inverter
+        # actually holds, read fresh every cycle. Diffing against our own
+        # in-memory model instead let the two drift apart (issue #551): the
+        # model was seeded once at startup and never corrected, so writes
+        # started duplicating live segments — which the Growatt cloud rejects
+        # with a 500 — while segments the plan had dropped stayed enabled on
+        # the inverter and kept running.
+        current_tou = self._read_segments_from_hardware(controller)
+        if not current_tou:
+            # read_inverter_time_segments swallows errors and returns []. A MIN
+            # inverter always has its 9 slots, so an empty read means the read
+            # failed. Diffing against [] would rewrite everything blind and
+            # recreate the very duplicates this read exists to prevent; raising
+            # leaves _hardware_write_pending set so the caller retries.
+            raise RuntimeError(
+                "Cannot write TOU schedule: failed to read current segments "
+                "from the inverter"
+            )
+
         # Only the active (hardware-programmed) intervals are eligible to be
         # written. self.tou_intervals can hold more than the 9 slots the MIN
         # inverter supports; the overflow is pending_write and must not reach
@@ -1194,6 +1211,11 @@ class GrowattMinController(InverterController):
         else:
             # Normal case: differential update (only update future segments)
             for current in current_tou:
+                if not current.get("enabled", True):
+                    # The inverter reports its unused slots as disabled entries.
+                    # There is nothing to turn off, and re-disabling them would
+                    # spend a cloud API call per idle slot, every cycle.
+                    continue
                 if end_minute(current) >= effective_minute:
                     has_match = any(
                         segment["start_time"] == current["start_time"]
@@ -1380,6 +1402,14 @@ class GrowattMinController(InverterController):
             current_hour: Current hour (0-23)
         """
         inverter_segments = self._read_segments_from_hardware(controller)
+        if not inverter_segments:
+            # Same contract as sync_to_hardware: the MIN always reports its 9
+            # slots, so an empty read is a failed read. Initializing from it
+            # would record "the inverter holds nothing" as fact.
+            raise RuntimeError(
+                "Cannot initialize TOU schedule: failed to read current "
+                "segments from the inverter"
+            )
         self.initialize_from_tou_segments(inverter_segments, current_hour)
 
     def check_health(self, controller) -> list:

--- a/core/bess/growatt_sph_controller.py
+++ b/core/bess/growatt_sph_controller.py
@@ -81,7 +81,7 @@ class GrowattSphController(InverterController):
 
         SPH inverters have no per-period entity controls (grid_charge switch,
         discharge rate number).  The entire schedule is written in
-        ``write_to_hardware`` using ``write_ac_charge_times`` /
+        ``sync_to_hardware`` using ``write_ac_charge_times`` /
         ``write_ac_discharge_times``.
         """
         return True, ""
@@ -154,11 +154,10 @@ class GrowattSphController(InverterController):
 
     # ── Hardware interface ────────────────────────────────────────────────────
 
-    def write_to_hardware(
+    def sync_to_hardware(
         self,
         controller,
         effective_period: int,
-        current_tou: list,
     ) -> tuple[int, int]:
         """Write SPH charge and discharge periods to hardware.
 
@@ -168,7 +167,6 @@ class GrowattSphController(InverterController):
         Args:
             controller: HomeAssistantAPIController instance
             effective_period: Unused for SPH (full rewrite each time)
-            current_tou: Unused for SPH (full rewrite each time)
 
         Returns:
             Tuple of (writes, disables) — always (2, 0) for SPH

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -1633,40 +1633,41 @@ class HomeAssistantAPIController:
         )
 
     def read_inverter_time_segments(self):
-        """Read all time segments from the inverter with retry logic."""
-        try:
-            # Prepare service call parameters
-            service_params: dict[str, str | bool] = {"return_response": True}
+        """Read all time segments from the inverter with retry logic.
 
-            # Require device_id before attempting the API call
-            if not self.growatt_device_id:
-                raise SystemConfigurationError(
-                    "Growatt device_id not configured. Run the setup wizard to configure the inverter."
-                )
+        Raises on a failed or unrecognizable read. An empty list is a valid
+        answer meaning "no segments programmed" and must stay distinguishable
+        from failure: callers diff against this to decide what to write, and
+        a failure silently reported as [] would make them rewrite every
+        segment blind (issue #551).
+        """
+        service_params: dict[str, str | bool] = {"return_response": True}
 
-            service_params["device_id"] = self.growatt_device_id
-
-            # Call the service and get the response
-            result = self._service_call_with_retry(
-                self._vendor_service_domain(),
-                "read_time_segments",
-                operation=None,
-                **service_params,
+        # Require device_id before attempting the API call
+        if not self.growatt_device_id:
+            raise SystemConfigurationError(
+                "Growatt device_id not configured. Run the setup wizard to configure the inverter."
             )
 
-            # Check if the result contains 'service_response' with 'time_segments'
-            if result and "service_response" in result:
-                service_response = result["service_response"]
-                if "time_segments" in service_response:
-                    return service_response["time_segments"]
+        service_params["device_id"] = self.growatt_device_id
 
-            # If the result doesn't match expected format, log and return empty list
-            logger.warning("Unexpected response format from read_time_segments")
-            return []
+        # Transport errors propagate: _service_call_with_retry has already
+        # exhausted its retries by the time it raises.
+        result = self._service_call_with_retry(
+            self._vendor_service_domain(),
+            "read_time_segments",
+            operation=None,
+            **service_params,
+        )
 
-        except (requests.RequestException, ValueError, KeyError) as e:
-            logger.warning("Failed to read time segments: %s", str(e))
-            return []
+        if result and "service_response" in result:
+            service_response = result["service_response"]
+            if "time_segments" in service_response:
+                return service_response["time_segments"]
+
+        raise ValueError(
+            f"Unexpected response format from read_time_segments: {result!r}"
+        )
 
     # ── solax_modbus entity-based TOU segment control (Growatt plugin) ────
 

--- a/core/bess/huawei_controller.py
+++ b/core/bess/huawei_controller.py
@@ -219,11 +219,10 @@ class HuaweiController(InverterController):
         ]
         return "\n".join(lines)
 
-    def write_to_hardware(
+    def sync_to_hardware(
         self,
         controller,
         effective_period: int,
-        current_tou: list,
     ) -> tuple[int, int]:
         """Write Huawei TOU periods to hardware.
 

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -868,13 +868,16 @@ class InverterController(ABC):
         """
 
     @abstractmethod
-    def write_to_hardware(
+    def sync_to_hardware(
         self,
         controller,
         effective_period: int,
-        current_tou: list,
     ) -> tuple[int, int]:
         """Write schedule to inverter hardware.
+
+        Implementations that need to know what the inverter currently holds
+        must read it from the inverter themselves — there is no caller-supplied
+        snapshot, because one that drifted out of sync caused issue #551.
 
         Returns:
             Tuple of (writes, disables)

--- a/core/bess/solax_controller.py
+++ b/core/bess/solax_controller.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 class SolaxController(InverterController):
     """SolaX inverter controller using VPP active-power commands.
 
-    SolaX does not use a persistent TOU schedule.  ``write_to_hardware``
+    SolaX does not use a persistent TOU schedule.  ``sync_to_hardware``
     is a no-op; the actual hardware writes happen period-by-period via
     ``_write_period_to_hardware``, called from
     ``BatterySystemManager._apply_period_schedule``.
@@ -182,11 +182,10 @@ class SolaxController(InverterController):
             return 100, True
         return -discharge_rate, True
 
-    def write_to_hardware(
+    def sync_to_hardware(
         self,
         controller,
         effective_period: int,
-        current_tou: list,
     ) -> tuple[int, int]:
         """No-op for SolaX — schedule is applied period-by-period via VPP.
 
@@ -196,7 +195,7 @@ class SolaxController(InverterController):
         Returns:
             (0, 0) — no writes or disables performed.
         """
-        logger.debug("SolaX: write_to_hardware is a no-op (per-period VPP)")
+        logger.debug("SolaX: sync_to_hardware is a no-op (per-period VPP)")
         return 0, 0
 
     def initialize_hardware(self, controller) -> None:

--- a/core/bess/solax_modbus_growatt_controller.py
+++ b/core/bess/solax_modbus_growatt_controller.py
@@ -81,7 +81,7 @@ class SolaxModbusGrowattController(GrowattMinController):
     mode each period when needed. ``control_mode="vpp"`` issues per-period VPP
     power commands instead, with no persistent TOU schedule — analogous to
     how ``SolaxController`` applies per-period VPP commands for real SolaX
-    hardware, with ``write_to_hardware`` doing only the one-time VPP
+    hardware, with ``sync_to_hardware`` doing only the one-time VPP
     enable sequence.
     """
 
@@ -482,11 +482,10 @@ class SolaxModbusGrowattController(GrowattMinController):
             logger.error("FAILED: Growatt VPP period write: %s", e)
             return False, str(e)
 
-    def write_to_hardware(
+    def sync_to_hardware(
         self,
         controller,
         effective_period: int,
-        current_tou: list,
     ) -> tuple[int, int]:
         """Initialise hardware for the current control mode.
 
@@ -506,7 +505,6 @@ class SolaxModbusGrowattController(GrowattMinController):
         Args:
             controller: HomeAssistantAPIController instance
             effective_period: Period (0-95) from which to start applying changes
-            current_tou: TOU intervals currently active on the inverter (unused)
 
         Returns:
             Tuple of (segments_updated, segments_disabled)

--- a/core/bess/solis_modbus_controller.py
+++ b/core/bess/solis_modbus_controller.py
@@ -87,11 +87,11 @@ class SolisModbusController(InverterController):
     def _write_period_to_hardware(
         self, controller, grid_charge: bool, discharge_rate: int
     ) -> tuple[bool, str]:
-        """No-op: Solis deploys the full schedule via write_to_hardware.
+        """No-op: Solis deploys the full schedule via sync_to_hardware.
 
         Solis has no per-period entity controls beyond the TOU schedule
         itself (no separate grid_charge switch / discharge rate number) —
-        the entire period list is written in ``write_to_hardware``.
+        the entire period list is written in ``sync_to_hardware``.
         """
         return True, ""
 
@@ -157,11 +157,10 @@ class SolisModbusController(InverterController):
 
     # ── Hardware interface ────────────────────────────────────────────────────
 
-    def write_to_hardware(
+    def sync_to_hardware(
         self,
         controller,
         effective_period: int,
-        current_tou: list,
     ) -> tuple[int, int]:
         """Write Solis charge and discharge periods to hardware.
 
@@ -173,7 +172,6 @@ class SolisModbusController(InverterController):
         Args:
             controller: HomeAssistantAPIController instance
             effective_period: Unused for Solis (full rewrite each time)
-            current_tou: Unused for Solis (full rewrite each time)
 
         Returns:
             Tuple of (writes, disables)

--- a/core/bess/tests/conftest.py
+++ b/core/bess/tests/conftest.py
@@ -21,6 +21,7 @@ from core.bess.models import (  # noqa: E402
     PeriodData,
 )
 from core.bess.settings_store import SettingsStore  # noqa: E402
+from core.bess.tests.helpers import empty_slot_table  # noqa: E402
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -255,8 +256,14 @@ class MockHomeAssistantController(HomeAssistantAPIController):
         return None
 
     def read_inverter_time_segments(self):
-        """Read current TOU segments from inverter."""
-        return []
+        """Read current TOU segments from inverter.
+
+        A MIN inverter always reports all 9 slots; unused ones come back
+        disabled. Returning [] would mean "read failed" to the controller
+        (see growatt_min_controller.sync_to_hardware), which is not what
+        an idle mock inverter represents.
+        """
+        return empty_slot_table()
 
     # Growatt solax_modbus TOU entity methods (used by SolaxModbusGrowattController)
 

--- a/core/bess/tests/helpers.py
+++ b/core/bess/tests/helpers.py
@@ -401,3 +401,23 @@ def assert_savings_positive(result) -> None:
         f"Grid-only: {result.economic_summary.grid_only_cost:.2f}, "
         f"Optimized: {result.economic_summary.battery_solar_cost:.2f}"
     )
+
+
+def empty_slot_table() -> list[dict]:
+    """A Growatt MIN inverter with nothing programmed.
+
+    The hardware always reports all 9 slots; unused ones come back disabled.
+    An empty list means the read itself failed, which GrowattMinController
+    treats as fatal (issue #551) — so mocks representing an idle inverter must
+    return this, not [].
+    """
+    return [
+        {
+            "segment_id": slot_id,
+            "start_time": "00:00",
+            "end_time": "00:00",
+            "batt_mode": "load_first",
+            "enabled": False,
+        }
+        for slot_id in range(1, 10)
+    ]

--- a/core/bess/tests/integration/test_solax_integration.py
+++ b/core/bess/tests/integration/test_solax_integration.py
@@ -149,15 +149,15 @@ class TestSolaxGridChargeAtMaxPower:
 
 
 class TestSolaxNoTouHardwareWrites:
-    def test_write_to_hardware_is_noop(self) -> None:
+    def test_sync_to_hardware_is_noop(self) -> None:
         bsm, hw = _make_bsm_solax()
         intents = ["IDLE"] * 96
         intents[PERIOD] = "GRID_CHARGING"
         bsm._inverter_controller.strategic_intents = intents
 
-        # write_to_hardware should not call any hardware method
-        writes, disables = bsm._inverter_controller.write_to_hardware(
-            hw, effective_period=0, current_tou=[]
+        # sync_to_hardware should not call any hardware method
+        writes, disables = bsm._inverter_controller.sync_to_hardware(
+            hw, effective_period=0
         )
 
         assert writes == 0

--- a/core/bess/tests/unit/test_growatt_tou_scheduling.py
+++ b/core/bess/tests/unit/test_growatt_tou_scheduling.py
@@ -17,6 +17,7 @@ import pytest  # type: ignore
 
 from core.bess.growatt_min_controller import GrowattMinController
 from core.bess.settings import BatterySettings
+from core.bess.tests.helpers import empty_slot_table
 
 
 def hourly_to_quarterly(
@@ -924,6 +925,9 @@ class _CapturingController:
         self.failure_tracker = None
         self.calls: list[dict] = []
 
+    def read_inverter_time_segments(self) -> list[dict]:
+        return empty_slot_table()
+
     def set_inverter_time_segment(
         self,
         segment_id: int,
@@ -947,7 +951,7 @@ class TestHardwareWriteRespectsSlotLimit:
     """Regression tests: the inverter only accepts segment_id 1-9.
 
     Writing a segment_id outside that range causes the Growatt HA service to
-    return 500. These tests verify that write_to_hardware never
+    return 500. These tests verify that sync_to_hardware never
     issues such a call regardless of how many TOU intervals were generated.
     """
 
@@ -957,7 +961,7 @@ class TestHardwareWriteRespectsSlotLimit:
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
 
         controller = _CapturingController()
-        scheduler.write_to_hardware(controller, effective_period=0, current_tou=[])
+        scheduler.sync_to_hardware(controller, effective_period=0)
 
         assert controller.calls, "Expected at least one hardware write"
         for call in controller.calls:
@@ -966,12 +970,12 @@ class TestHardwareWriteRespectsSlotLimit:
             ), f"segment_id {call['segment_id']} exceeds hardware slot range 1-9"
 
     def test_write_count_never_exceeds_hardware_slot_count(self, scheduler):
-        """write_to_hardware must not push more than 9 segments."""
+        """sync_to_hardware must not push more than 9 segments."""
         scheduler.strategic_intents = _OVERCAPACITY_INTENTS
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
 
         controller = _CapturingController()
-        scheduler.write_to_hardware(controller, effective_period=0, current_tou=[])
+        scheduler.sync_to_hardware(controller, effective_period=0)
 
         assert (
             len(controller.calls) <= 9
@@ -988,7 +992,7 @@ class TestHardwareWriteRespectsSlotLimit:
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=12)
 
         controller = _CapturingController()
-        scheduler.write_to_hardware(controller, effective_period=12, current_tou=[])
+        scheduler.sync_to_hardware(controller, effective_period=12)
 
         for call in controller.calls:
             assert (
@@ -1006,7 +1010,7 @@ class _FailingController(_CapturingController):
 class TestHardwareWriteFailurePropagates:
     """Regression: a failed segment write must raise, not be swallowed.
 
-    Previously write_to_hardware caught per-segment write
+    Previously sync_to_hardware caught per-segment write
     exceptions and only logged them, returning normally. The caller
     (BatterySystemManager._apply_schedule) treated that as success and
     cleared _hardware_write_pending, so a failed write was never retried
@@ -1020,15 +1024,16 @@ class TestHardwareWriteFailurePropagates:
 
         controller = _FailingController()
         with pytest.raises(RuntimeError):
-            scheduler.write_to_hardware(controller, effective_period=0, current_tou=[])
+            scheduler.sync_to_hardware(controller, effective_period=0)
 
 
 class _SimulatingController(_CapturingController):
     """Controller stub that also models the inverter's TOU slot table.
 
     Writes with enabled=True occupy the slot; enabled=False clears it.
-    `hardware_segments()` returns the currently programmed segments, suitable
-    for passing back as `current_tou` on the next cycle.
+    `hardware_segments()` returns the currently programmed segments, and
+    `read_inverter_time_segments()` reports the full 9-slot table the way the
+    real inverter does — occupied slots plus disabled entries for the rest.
     """
 
     def __init__(self):
@@ -1060,6 +1065,12 @@ class _SimulatingController(_CapturingController):
     def hardware_segments(self) -> list[dict]:
         return [dict(s) for s in self.slots.values()]
 
+    def read_inverter_time_segments(self) -> list[dict]:
+        return [
+            dict(self.slots.get(slot["segment_id"], slot))
+            for slot in empty_slot_table()
+        ]
+
 
 class TestSlotAssignmentPreservesActiveSegments:
     """When a previously-pending segment promotes to active across cycles, the
@@ -1078,7 +1089,7 @@ class TestSlotAssignmentPreservesActiveSegments:
         # Cycle 1 at start of day: 9 of the 10 strategic segments fit on hardware.
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
         controller = _SimulatingController()
-        scheduler.write_to_hardware(controller, effective_period=0, current_tou=[])
+        scheduler.sync_to_hardware(controller, effective_period=0)
 
         cycle1_hardware = self._content_set(controller.hardware_segments())
         assert (
@@ -1088,10 +1099,9 @@ class TestSlotAssignmentPreservesActiveSegments:
         # Cycle 2 at 03:00: the 01:00 segment has expired and the previously
         # pending 19:00 segment is now part of the active 9.
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=12)
-        scheduler.write_to_hardware(
+        scheduler.sync_to_hardware(
             controller,
             effective_period=12,
-            current_tou=controller.hardware_segments(),
         )
 
         hardware_after = self._content_set(controller.hardware_segments())
@@ -1116,17 +1126,199 @@ class TestSlotAssignmentPreservesActiveSegments:
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
 
         controller = _SimulatingController()
-        scheduler.write_to_hardware(controller, effective_period=0, current_tou=[])
+        scheduler.sync_to_hardware(controller, effective_period=0)
         cycle1_call_count = len(controller.calls)
         assert cycle1_call_count > 0
 
         # Re-run the same conversion at the same period — no state has changed.
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=0)
-        scheduler.write_to_hardware(
+        scheduler.sync_to_hardware(
             controller,
             effective_period=0,
-            current_tou=controller.hardware_segments(),
         )
         assert (
             len(controller.calls) == cycle1_call_count
         ), "Cycle 2 with identical state should not issue any new writes"
+
+
+# ── Regression: issue #551 — TOU diff must be computed against real hardware ──
+#
+# The data below is real, from the 2026-08-12 07:30 production failure:
+#   - _LIVE_HARDWARE_SLOTS: the growatt_server.read_time_segments response read
+#     off the inverter while the add-on was failing.
+#   - _intents_at_0730(): the strategic intent list rebuilt from that cycle's
+#     "Intent transition at period N" lines in the debug bundle.
+#
+# Replaying that cycle against the pre-fix code reproduces the production log
+# exactly: "Current=5 intervals, New=4", "Disabling TOU segment 2: 08:00-08:29",
+# then "Setting TOU segment 1: 08:00-08:14" — the write Growatt 500s on.
+
+
+def _seg(segment_id, start, end, mode, enabled=True):
+    return {
+        "segment_id": segment_id,
+        "start_time": start,
+        "end_time": end,
+        "batt_mode": mode,
+        "enabled": enabled,
+    }
+
+
+_LIVE_HARDWARE_SLOTS = [
+    _seg(1, "07:00", "07:14", "grid_first"),
+    _seg(2, "08:00", "08:29", "grid_first", enabled=False),
+    _seg(3, "08:00", "08:14", "grid_first"),
+    _seg(4, "09:00", "09:14", "grid_first"),
+    _seg(5, "19:30", "20:29", "grid_first"),
+    _seg(6, "11:45", "11:59", "battery_first"),
+    _seg(7, "13:45", "14:14", "battery_first"),
+    _seg(8, "16:00", "16:14", "battery_first"),
+    _seg(9, "23:45", "23:59", "battery_first", enabled=False),
+]
+
+# Ranges enabled on the inverter that the optimizer's plan does not contain.
+# The battery really did run these unplanned; they are leftovers from earlier
+# cycles whose disable calls returned 500.
+_ORPHAN_RANGES = {
+    ("09:00", "09:14"),
+    ("11:45", "11:59"),
+    ("13:45", "14:14"),
+    ("16:00", "16:14"),
+}
+
+
+def _intents_at_0730() -> list[str]:
+    """Rebuild the 07:30 cycle's 96-period intent list from the debug bundle."""
+    intents = ["LOAD_SUPPORT"] * 96
+    for start, end, intent in [
+        (30, 32, "SOLAR_EXPORT"),
+        (32, 33, "BATTERY_EXPORT"),
+        (33, 37, "SOLAR_EXPORT"),
+        (37, 52, "SOLAR_STORAGE"),
+        (52, 53, "GRID_CHARGING"),
+        (53, 55, "SOLAR_STORAGE"),
+        (55, 56, "GRID_CHARGING"),
+        (56, 63, "SOLAR_STORAGE"),
+        (63, 64, "SOLAR_EXPORT"),
+        (64, 66, "SOLAR_STORAGE"),
+        (66, 68, "SOLAR_EXPORT"),
+        (68, 70, "IDLE"),
+        (70, 78, "LOAD_SUPPORT"),
+        (78, 82, "BATTERY_EXPORT"),
+    ]:
+        for period in range(start, end):
+            intents[period] = intent
+    return intents
+
+
+class _PreloadedController(_CapturingController):
+    """Controller stub modelling an inverter whose 9 slots are already
+    populated, readable the way growatt_server.read_time_segments reads them."""
+
+    def __init__(self, segments):
+        super().__init__()
+        self.segments = [dict(s) for s in segments]
+
+    def read_inverter_time_segments(self):
+        return [dict(s) for s in self.segments]
+
+    def set_inverter_time_segment(
+        self, segment_id, batt_mode, start_time, end_time, enabled
+    ):
+        super().set_inverter_time_segment(
+            segment_id, batt_mode, start_time, end_time, enabled
+        )
+        for seg in self.segments:
+            if seg["segment_id"] == segment_id:
+                seg.update(
+                    start_time=start_time,
+                    end_time=end_time,
+                    batt_mode=batt_mode,
+                    enabled=enabled,
+                )
+                return
+        self.segments.append(_seg(segment_id, start_time, end_time, batt_mode, enabled))
+
+    def enabled_ranges(self) -> set[tuple[str, str]]:
+        return {
+            (seg["start_time"], seg["end_time"])
+            for seg in self.segments
+            if seg["enabled"]
+        }
+
+
+class TestWriteDiffsAgainstRealHardware:
+    """Regression for issue #551.
+
+    The add-on read hardware TOU once at startup and diffed every later cycle
+    against its own in-memory model. Once those diverged it wrote segments that
+    duplicated live ones — which Growatt's cloud rejects with a 500 — and left
+    unplanned segments enabled on the inverter.
+    """
+
+    def _run_0730_cycle(self, scheduler, controller):
+        scheduler.strategic_intents = _intents_at_0730()
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=30)
+        scheduler.sync_to_hardware(controller, effective_period=30)
+
+    def test_does_not_rewrite_a_range_already_enabled_on_hardware(self, scheduler):
+        controller = _PreloadedController(_LIVE_HARDWARE_SLOTS)
+        self._run_0730_cycle(scheduler, controller)
+
+        duplicated = [
+            call
+            for call in controller.calls
+            if call["enabled"]
+            and (call["start_time"], call["end_time"]) == ("08:00", "08:14")
+        ]
+        assert not duplicated, (
+            "Wrote 08:00-08:14 grid_first, which slot 3 already holds enabled — "
+            f"Growatt rejects this with a 500. Calls: {duplicated}"
+        )
+
+    def test_unplanned_segments_left_on_hardware_are_disabled(self, scheduler):
+        controller = _PreloadedController(_LIVE_HARDWARE_SLOTS)
+        self._run_0730_cycle(scheduler, controller)
+
+        still_enabled = controller.enabled_ranges() & _ORPHAN_RANGES
+        assert not still_enabled, (
+            "Segments left enabled on the inverter that the plan does not "
+            f"contain: {sorted(still_enabled)}"
+        )
+
+    def test_slots_already_disabled_on_hardware_are_not_rewritten(self, scheduler):
+        """Real hardware reports its unused slots as disabled entries.
+
+        The in-memory model only ever held enabled intervals, so the diff never
+        saw a disabled one. Reading the inverter surfaces them, and re-issuing
+        a disable for a slot that is already disabled is a wasted write against
+        a cloud API that rejects them under load.
+        """
+        controller = _PreloadedController(_LIVE_HARDWARE_SLOTS)
+        self._run_0730_cycle(scheduler, controller)
+
+        already_disabled = {
+            seg["segment_id"] for seg in _LIVE_HARDWARE_SLOTS if not seg["enabled"]
+        }
+        redundant = [
+            call
+            for call in controller.calls
+            if not call["enabled"] and call["segment_id"] in already_disabled
+        ]
+        assert not redundant, f"Re-disabled already-disabled slots: {redundant}"
+
+    def test_read_failure_aborts_the_write(self, scheduler):
+        """An unreadable inverter must abort, not diff against an empty list.
+
+        read_inverter_time_segments swallows errors and returns []. Treating
+        that as "hardware is empty" would rewrite every segment blind and
+        reproduce the very 500s this fix removes.
+        """
+        controller = _PreloadedController([])
+        scheduler.strategic_intents = _intents_at_0730()
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=30)
+
+        with pytest.raises(RuntimeError, match="read"):
+            scheduler.sync_to_hardware(controller, effective_period=30)
+
+        assert not controller.calls, "No segment may be written after a failed read"

--- a/core/bess/tests/unit/test_growatt_tou_scheduling.py
+++ b/core/bess/tests/unit/test_growatt_tou_scheduling.py
@@ -13,6 +13,8 @@ Key Principles:
 - Do NOT test internal data structures, field names, or algorithm-specific details
 """
 
+import logging
+
 import pytest  # type: ignore
 
 from core.bess.growatt_min_controller import GrowattMinController
@@ -1247,6 +1249,13 @@ class _PreloadedController(_CapturingController):
         }
 
 
+class _UnreadableController(_CapturingController):
+    """Controller whose segment read fails the way a transport error does."""
+
+    def read_inverter_time_segments(self):
+        raise RuntimeError("500 Server Error: Internal Server Error")
+
+
 class TestWriteDiffsAgainstRealHardware:
     """Regression for issue #551.
 
@@ -1308,17 +1317,124 @@ class TestWriteDiffsAgainstRealHardware:
         assert not redundant, f"Re-disabled already-disabled slots: {redundant}"
 
     def test_read_failure_aborts_the_write(self, scheduler):
-        """An unreadable inverter must abort, not diff against an empty list.
+        """An unreadable inverter must abort rather than write blind.
 
-        read_inverter_time_segments swallows errors and returns []. Treating
-        that as "hardware is empty" would rewrite every segment blind and
-        reproduce the very 500s this fix removes.
+        Diffing against nothing would rewrite every segment and reproduce the
+        very duplicate-write 500s this fix removes. The failure has to arrive
+        as an exception — emptiness cannot carry it, because an inverter with
+        no segments programmed is a legitimate, different state.
+        """
+        controller = _UnreadableController()
+        scheduler.strategic_intents = _intents_at_0730()
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=30)
+
+        with pytest.raises(Exception):  # noqa: B017 - transport error propagates
+            scheduler.sync_to_hardware(controller, effective_period=30)
+
+        assert not controller.calls, "No segment may be written after a failed read"
+
+    def test_inverter_with_no_segments_is_not_a_read_failure(self, scheduler):
+        """An empty segment list is a blank inverter, not a broken read.
+
+        The mock-HA scenarios ship `"time_segments": []` to mean "nothing
+        programmed". Treating that as a failure pinned _hardware_write_pending
+        forever and broke every MIN E2E run.
         """
         controller = _PreloadedController([])
         scheduler.strategic_intents = _intents_at_0730()
         scheduler._consolidate_and_convert_with_strategic_intents(current_period=30)
 
-        with pytest.raises(RuntimeError, match="read"):
+        scheduler.sync_to_hardware(controller, effective_period=30)
+
+        written = {
+            (call["start_time"], call["end_time"])
+            for call in controller.calls
+            if call["enabled"]
+        }
+        assert written, "A blank inverter must receive the whole plan"
+
+    def test_hardware_segments_are_normalized_before_diffing(self, scheduler):
+        """The vendor payload is not already in our internal shape.
+
+        growatt_server can report batt_mode as an int. Unnormalized, no segment
+        ever matches (so everything is rewritten blind) and the int gets echoed
+        straight back to the inverter.
+        """
+        raw = [
+            # 08:00-08:14 grid_first, exactly what the plan wants — as the
+            # vendor API can report it, with an int mode.
+            {
+                "segment_id": 3,
+                "start_time": "08:00",
+                "end_time": "08:14",
+                "batt_mode": 2,
+                "enabled": True,
+            },
+            {
+                "segment_id": 5,
+                "start_time": "19:30",
+                "end_time": "20:29",
+                "batt_mode": 2,
+                "enabled": True,
+            },
+        ]
+        controller = _PreloadedController(raw)
+        self._run_0730_cycle(scheduler, controller)
+
+        rewritten = [
+            call
+            for call in controller.calls
+            if (call["start_time"], call["end_time"]) == ("08:00", "08:14")
+        ]
+        assert not rewritten, (
+            "Rewrote a segment the inverter already holds — the int batt_mode "
+            f"was not normalized before comparing. Calls: {rewritten}"
+        )
+
+        int_modes = [
+            call for call in controller.calls if isinstance(call["batt_mode"], int)
+        ]
+        assert not int_modes, f"Echoed a raw int batt_mode back: {int_modes}"
+
+    def test_segment_missing_the_enabled_flag_does_not_break_the_diff(self, scheduler):
+        """A payload without `enabled` must not blow up mid-diff.
+
+        The diff read it two ways — `.get("enabled", True)` on one line and
+        `current["enabled"]` on the next — so an absent key let the entry
+        through the first and raised KeyError on the second. Normalizing at the
+        read boundary settles it on one default (absent = not programmed, the
+        convention the startup path has always used).
+        """
+        raw = [
+            {
+                "segment_id": 1,
+                "start_time": "19:30",
+                "end_time": "20:29",
+                "batt_mode": "grid_first",
+            },
+        ]
+        controller = _PreloadedController(raw)
+
+        self._run_0730_cycle(scheduler, controller)  # must not raise
+
+        assert controller.calls, "Diff ran to completion and wrote the plan"
+
+    def test_no_clear_all_banner_when_nothing_is_enabled(self, scheduler, caplog):
+        """The clear-everything banner must mean something was cleared.
+
+        Its guard counted all segments read back, and a real read always
+        returns 9 slots — so an idle plan logged "CLEARING ALL 9 existing TOU
+        segments" immediately followed by "No TOU segment changes needed",
+        in the logs this subsystem is diagnosed from.
+        """
+        controller = _PreloadedController(empty_slot_table())
+        scheduler.strategic_intents = ["IDLE"] * 96
+        scheduler._consolidate_and_convert_with_strategic_intents(current_period=30)
+
+        with caplog.at_level(logging.WARNING):
             scheduler.sync_to_hardware(controller, effective_period=30)
 
-        assert not controller.calls, "No segment may be written after a failed read"
+        assert "CLEARING ALL" not in caplog.text, (
+            "Announced clearing segments while none were enabled:\n" f"{caplog.text}"
+        )
+        assert not controller.calls, "Nothing to clear means nothing to write"

--- a/core/bess/tests/unit/test_huawei_controller.py
+++ b/core/bess/tests/unit/test_huawei_controller.py
@@ -87,7 +87,7 @@ class TestWriteSchedule:
             "time_of_use_luna2000",
         ]
         ha.get_huawei_working_mode.return_value = "maximise_self_consumption"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.set_huawei_working_mode.assert_called_once_with("time_of_use_luna2000")
 
     def test_write_schedule_skips_mode_write_when_already_set(
@@ -98,7 +98,7 @@ class TestWriteSchedule:
         ha = MagicMock()
         ha.get_huawei_working_mode_options.return_value = []
         ha.get_huawei_working_mode.return_value = "time_of_use_luna2000"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.set_huawei_working_mode.assert_not_called()
 
     def test_write_schedule_calls_write_tou_periods_with_joined_text(
@@ -109,7 +109,7 @@ class TestWriteSchedule:
         ha = MagicMock()
         ha.get_huawei_working_mode_options.return_value = []
         ha.get_huawei_working_mode.return_value = "time_of_use_luna2000"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.write_huawei_tou_periods.assert_called_once()
         text = ha.write_huawei_tou_periods.call_args[0][0]
         assert "02:00-02:59/1234567/+" in text
@@ -123,7 +123,7 @@ class TestWriteSchedule:
         ha = MagicMock()
         ha.get_huawei_working_mode_options.return_value = []
         ha.get_huawei_working_mode.return_value = "time_of_use_luna2000"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.write_huawei_tou_periods.assert_called_once_with("")
 
     def test_write_schedule_raises_for_lg_resu_battery(
@@ -143,7 +143,7 @@ class TestWriteSchedule:
             "fully_fed_to_grid",
         ]
         with pytest.raises(SystemConfigurationError):
-            controller.write_to_hardware(ha, 0, [])
+            controller.sync_to_hardware(ha, 0)
         ha.write_huawei_tou_periods.assert_not_called()
 
     def test_write_schedule_proceeds_when_options_unavailable(
@@ -156,7 +156,7 @@ class TestWriteSchedule:
         ha = MagicMock()
         ha.get_huawei_working_mode_options.return_value = []
         ha.get_huawei_working_mode.return_value = "time_of_use_luna2000"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.write_huawei_tou_periods.assert_called_once()
 
     def test_write_schedule_enables_grid_charge_when_charge_period_present(
@@ -167,7 +167,7 @@ class TestWriteSchedule:
         ha = MagicMock()
         ha.get_huawei_working_mode_options.return_value = []
         ha.get_huawei_working_mode.return_value = "time_of_use_luna2000"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.set_grid_charge.assert_called_once_with(True)
 
     def test_write_schedule_disables_grid_charge_when_no_charge_period(
@@ -178,14 +178,14 @@ class TestWriteSchedule:
         ha = MagicMock()
         ha.get_huawei_working_mode_options.return_value = []
         ha.get_huawei_working_mode.return_value = "time_of_use_luna2000"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.set_grid_charge.assert_called_once_with(False)
 
 
 class TestWorkingModeGateIsConditional:
     """Installs behind an energy manager (e.g. Huawei EMMA, PR #412) expose no
     LUNA2000 working-mode select. The gate must be skipped when the entity
-    isn't mapped, rather than raising out of write_to_hardware — but skipping
+    isn't mapped, rather than raising out of sync_to_hardware — but skipping
     it also skips the LG-RESU family check, so it is logged, not silent."""
 
     def test_write_proceeds_when_working_mode_entity_unmapped(
@@ -195,7 +195,7 @@ class TestWorkingModeGateIsConditional:
         controller.apply_intents(make_schedule_mock(intents))
         ha = MagicMock()
         ha.is_sensor_configured.return_value = False
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.get_huawei_working_mode_options.assert_not_called()
         ha.get_huawei_working_mode.assert_not_called()
         ha.set_huawei_working_mode.assert_not_called()
@@ -208,7 +208,7 @@ class TestWorkingModeGateIsConditional:
         ha = MagicMock()
         ha.is_sensor_configured.return_value = False
         with caplog.at_level("INFO", logger="core.bess.huawei_controller"):
-            controller.write_to_hardware(ha, 0, [])
+            controller.sync_to_hardware(ha, 0)
         assert any(
             "working mode" in r.message.lower() for r in caplog.records
         ), "skipping the working-mode gate must be logged, not silent"
@@ -224,7 +224,7 @@ class TestWorkingModeGateIsConditional:
             "time_of_use_luna2000",
         ]
         ha.get_huawei_working_mode.return_value = "maximise_self_consumption"
-        controller.write_to_hardware(ha, 0, [])
+        controller.sync_to_hardware(ha, 0)
         ha.set_huawei_working_mode.assert_called_once_with("time_of_use_luna2000")
 
 

--- a/core/bess/tests/unit/test_min_schedule_e2e.py
+++ b/core/bess/tests/unit/test_min_schedule_e2e.py
@@ -27,6 +27,7 @@ from core.bess.growatt_min_controller import (
 )
 from core.bess.price_manager import MockSource, PriceManager
 from core.bess.settings import BatterySettings
+from core.bess.tests.helpers import empty_slot_table
 
 pytestmark = pytest.mark.slow
 
@@ -362,6 +363,9 @@ class TestEndToEndHardwareWrite:
             def __init__(self):
                 self.failure_tracker = None
 
+            def read_inverter_time_segments(self):
+                return empty_slot_table()
+
             def set_inverter_time_segment(
                 self, segment_id, batt_mode, start_time, end_time, enabled
             ):
@@ -376,7 +380,7 @@ class TestEndToEndHardwareWrite:
                 )
 
         controller = CapturingController()
-        scheduler.write_to_hardware(controller, effective_period=0, current_tou=[])
+        scheduler.sync_to_hardware(controller, effective_period=0)
 
         for call in calls:
             assert 1 <= call["segment_id"] <= 9, (
@@ -395,12 +399,15 @@ class TestEndToEndHardwareWrite:
             def __init__(self):
                 self.failure_tracker = None
 
+            def read_inverter_time_segments(self):
+                return empty_slot_table()
+
             def set_inverter_time_segment(self, **kwargs):
                 nonlocal write_count
                 write_count += 1
 
         controller = CountingController()
-        scheduler.write_to_hardware(controller, effective_period=0, current_tou=[])
+        scheduler.sync_to_hardware(controller, effective_period=0)
 
         assert (
             write_count <= 9

--- a/core/bess/tests/unit/test_service_domain.py
+++ b/core/bess/tests/unit/test_service_domain.py
@@ -125,6 +125,27 @@ class TestGrowattCallsUseConfiguredDomain:
             path = mock_request.call_args[0][1]
             assert path.startswith("/api/services/my_growatt_bridge/read_time_segments")
 
+    def test_unreadable_segments_raise_instead_of_reporting_empty(self) -> None:
+        """A failed read must not be indistinguishable from an empty inverter.
+
+        GrowattMinController diffs its TOU plan against this return value to
+        decide what to write. Reporting failure as [] made it read "the
+        inverter holds no segments" and rewrite every one blind — the
+        duplicate writes Growatt rejects with a 500 (issue #551).
+        """
+        ctrl = self._controller("my_growatt_bridge")
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.return_value = {"unexpected": "shape"}
+            with pytest.raises(ValueError, match="Unexpected response format"):
+                ctrl.read_inverter_time_segments()
+
+    def test_empty_segment_list_is_returned_as_a_valid_answer(self) -> None:
+        """An inverter with nothing programmed is a state, not an error."""
+        ctrl = self._controller("my_growatt_bridge")
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.return_value = {"service_response": {"time_segments": []}}
+            assert ctrl.read_inverter_time_segments() == []
+
     def test_ac_charge_times_target_configured_domain(self) -> None:
         ctrl = self._controller("my_growatt_bridge")
         with patch.object(ctrl, "_api_request") as mock_request:

--- a/core/bess/tests/unit/test_solax_controller.py
+++ b/core/bess/tests/unit/test_solax_controller.py
@@ -88,7 +88,7 @@ class TestApplyIntents:
         assert controller.current_schedule is schedule
 
 
-# ── write_to_hardware ────────────────────────────────────────────────
+# ── sync_to_hardware ────────────────────────────────────────────────
 
 
 class TestWriteScheduleToHardware:
@@ -96,7 +96,7 @@ class TestWriteScheduleToHardware:
         self, controller: SolaxController
     ) -> None:
         mock_hw = MagicMock()
-        writes, disables = controller.write_to_hardware(mock_hw, 0, [])
+        writes, disables = controller.sync_to_hardware(mock_hw, 0)
 
         assert writes == 0
         assert disables == 0
@@ -105,7 +105,7 @@ class TestWriteScheduleToHardware:
         self, controller: SolaxController
     ) -> None:
         mock_hw = MagicMock()
-        controller.write_to_hardware(mock_hw, 0, [])
+        controller.sync_to_hardware(mock_hw, 0)
 
         mock_hw.assert_not_called()
 

--- a/core/bess/tests/unit/test_solax_modbus_growatt_single_segment.py
+++ b/core/bess/tests/unit/test_solax_modbus_growatt_single_segment.py
@@ -257,16 +257,14 @@ class TestApplyPeriod:
 
 
 class TestWriteScheduleToHardware:
-    """Test write_to_hardware initialises segment 1."""
+    """Test sync_to_hardware initialises segment 1."""
 
     def test_sets_initial_mode(self, controller, mock_ha):
         intents = hourly_to_quarterly({2: "GRID_CHARGING"})
         schedule = make_schedule(intents)
         controller.apply_intents(schedule, current_period=0)
 
-        writes, _disables = controller.write_to_hardware(
-            mock_ha, effective_period=8, current_tou=[]
-        )
+        writes, _disables = controller.sync_to_hardware(mock_ha, effective_period=8)
 
         assert writes == 1
         seg = mock_ha.calls["tou_segments"][-1]
@@ -281,7 +279,7 @@ class TestWriteScheduleToHardware:
         schedule = make_schedule(intents)
         controller.apply_intents(schedule, current_period=0)
 
-        controller.write_to_hardware(mock_ha, effective_period=0, current_tou=[])
+        controller.sync_to_hardware(mock_ha, effective_period=0)
 
         seg = mock_ha.calls["tou_segments"][-1]
         assert seg["enabled"] is False
@@ -291,7 +289,7 @@ class TestWriteScheduleToHardware:
         schedule = make_schedule(intents)
         controller.apply_intents(schedule, current_period=0)
 
-        controller.write_to_hardware(mock_ha, effective_period=20, current_tou=[])
+        controller.sync_to_hardware(mock_ha, effective_period=20)
 
         assert controller._last_written_tou_mode == "grid_first"
 

--- a/core/bess/tests/unit/test_solax_modbus_growatt_vpp.py
+++ b/core/bess/tests/unit/test_solax_modbus_growatt_vpp.py
@@ -340,33 +340,31 @@ class TestApplyPeriodVpp:
 
 
 class TestWriteScheduleToHardwareVpp:
-    """VPP has no persistent/bulk schedule to push — write_to_hardware is a
+    """VPP has no persistent/bulk schedule to push — sync_to_hardware is a
     no-op for power (like SolaxController's), same as its class docstring
     already claims. The real per-period power command always comes from
     apply_period via BatterySystemManager._apply_period_schedule, which runs
-    immediately after write_to_hardware in the same update_battery_schedule
+    immediately after sync_to_hardware in the same update_battery_schedule
     cycle (#421)."""
 
     def test_returns_zero_writes_zero_disables(self, controller, mock_ha):
         intents = hourly_to_quarterly({2: "GRID_CHARGING"})
         controller.apply_intents(make_schedule(intents), current_period=0)
 
-        writes, disables = controller.write_to_hardware(
-            mock_ha, effective_period=8, current_tou=[]
-        )
+        writes, disables = controller.sync_to_hardware(mock_ha, effective_period=8)
 
         assert writes == 0
         assert disables == 0
 
     def test_no_vpp_power_command_written(self, controller, mock_ha):
-        """#421: write_to_hardware previously computed power from a
+        """#421: sync_to_hardware previously computed power from a
         hardcoded battery_action_kw=0.0 stub, sending a spurious power=0%
         command that briefly preceded the correct value written moments
         later by apply_period. It must not write any VPP power at all."""
         intents = hourly_to_quarterly({2: "GRID_CHARGING"})
         controller.apply_intents(make_schedule(intents), current_period=0)
 
-        controller.write_to_hardware(mock_ha, effective_period=8, current_tou=[])
+        controller.sync_to_hardware(mock_ha, effective_period=8)
 
         assert mock_ha.calls["growatt_vpp_periods"] == []
 
@@ -376,24 +374,24 @@ class TestWriteScheduleToHardwareVpp:
         """Reproduces the exact #421 scenario: a BATTERY_EXPORT period with a
         real nonzero planned discharge (period 77, -2.48 kWh / -9.90 kW in
         the reported debug log) must not produce a spurious power=0% write
-        from write_to_hardware — the stub battery_action_kw=0.0 previously
+        from sync_to_hardware — the stub battery_action_kw=0.0 previously
         made this look like "no action", forcing discharge_rate=0."""
         intents = hourly_to_quarterly({19: "BATTERY_EXPORT"})
         actions = [0.0] * 96
         actions[77] = -2.48
         controller.apply_intents(make_schedule(intents, actions), current_period=77)
 
-        controller.write_to_hardware(mock_ha, effective_period=77, current_tou=[])
+        controller.sync_to_hardware(mock_ha, effective_period=77)
 
         assert mock_ha.calls["growatt_vpp_periods"] == []
 
-    def test_vpp_status_enabled_via_write_to_hardware(self, controller, mock_ha):
+    def test_vpp_status_enabled_via_sync_to_hardware(self, controller, mock_ha):
         """The one-time VPP Status/AC-charging enable sequence is still
-        write_to_hardware's job, per the class docstring."""
+        sync_to_hardware's job, per the class docstring."""
         intents = hourly_to_quarterly({2: "GRID_CHARGING"})
         controller.apply_intents(make_schedule(intents), current_period=0)
 
-        controller.write_to_hardware(mock_ha, effective_period=8, current_tou=[])
+        controller.sync_to_hardware(mock_ha, effective_period=8)
 
         assert len(mock_ha.calls["growatt_vpp_status"]) == 1
         assert len(mock_ha.calls["growatt_vpp_allow_ac_charging"]) == 1

--- a/core/bess/tests/unit/test_solis_modbus_controller.py
+++ b/core/bess/tests/unit/test_solis_modbus_controller.py
@@ -78,7 +78,7 @@ class TestGridChargingProducesChargePeriod:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         # Slot 1 gets the real charge period, enabled=True
         controller.write_solis_period.assert_any_call(
@@ -92,7 +92,7 @@ class TestGridChargingProducesChargePeriod:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         for slot in range(1, manager.MAX_CHARGE_PERIODS + 1):
             controller.write_solis_period.assert_any_call(
@@ -158,7 +158,7 @@ class TestDischargeIntentsProduceDischargePeriod:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         controller.write_solis_period.assert_any_call(
             "discharge", 1, "20:00", "20:59", True
@@ -192,7 +192,7 @@ class TestIdleOnlyDay:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        writes, disables = manager.write_to_hardware(controller, 0, [])
+        writes, disables = manager.sync_to_hardware(controller, 0)
 
         assert writes == 12
         assert disables == 12

--- a/core/bess/tests/unit/test_sph_schedule.py
+++ b/core/bess/tests/unit/test_sph_schedule.py
@@ -74,7 +74,7 @@ class TestGridChargingProducesChargePeriod:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         controller.write_ac_charge_times.assert_called_once()
         call_kwargs = controller.write_ac_charge_times.call_args.kwargs
@@ -87,7 +87,7 @@ class TestGridChargingProducesChargePeriod:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         call_kwargs = controller.write_ac_charge_times.call_args.kwargs
         assert call_kwargs["mains_enabled"] is False
@@ -153,7 +153,7 @@ class TestDischargeIntentsProduceDischargeperiod:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         controller.write_ac_discharge_times.assert_called_once()
 
@@ -185,7 +185,7 @@ class TestIdleOnlyDay:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        writes, disables = manager.write_to_hardware(controller, 0, [])
+        writes, disables = manager.sync_to_hardware(controller, 0)
 
         assert writes == 2
         assert disables == 0
@@ -258,7 +258,7 @@ class TestPeriodLimitEnforcement:
         assert max(durations) >= 4 * 60 - 1  # ~4 hours
 
 
-# ── write_to_hardware ────────────────────────────────────────────────
+# ── sync_to_hardware ────────────────────────────────────────────────
 
 
 class TestWriteScheduleToHardware:
@@ -268,7 +268,7 @@ class TestWriteScheduleToHardware:
         manager.apply_intents(make_schedule_mock(make_intents({2: "GRID_CHARGING"})))
 
         controller = MagicMock()
-        writes, disables = manager.write_to_hardware(controller, 0, [])
+        writes, disables = manager.sync_to_hardware(controller, 0)
 
         assert writes == 2
         assert disables == 0
@@ -281,7 +281,7 @@ class TestWriteScheduleToHardware:
         )
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         controller.write_ac_charge_times.assert_called_once()
         controller.write_ac_discharge_times.assert_called_once()
@@ -292,7 +292,7 @@ class TestWriteScheduleToHardware:
         manager.apply_intents(make_schedule_mock(["IDLE"] * 96))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         call_kwargs = controller.write_ac_charge_times.call_args.kwargs
         assert call_kwargs["charge_stop_soc"] == int(battery_settings.max_soc)
@@ -303,7 +303,7 @@ class TestWriteScheduleToHardware:
         manager.apply_intents(make_schedule_mock(["IDLE"] * 96))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         call_kwargs = controller.write_ac_discharge_times.call_args.kwargs
         assert call_kwargs["discharge_stop_soc"] == int(battery_settings.min_soc)
@@ -316,7 +316,7 @@ class TestWriteScheduleToHardware:
         manager.apply_intents(make_schedule_mock(intents))
 
         controller = MagicMock()
-        manager.write_to_hardware(controller, 0, [])
+        manager.sync_to_hardware(controller, 0)
 
         call_kwargs = controller.write_ac_charge_times.call_args.kwargs
         assert call_kwargs.get("period_1_enabled") is True

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -364,6 +364,7 @@ for the full VPP-mode design (issue #355).
 2. Only create TOU segments for strategic modes (battery_first, grid_first) — load_first is the inverter default and needs no segment
 3. Enforce hardware constraints: max 9 TOU segments, chronological order, no overlaps
 4. Preserve past intervals to minimize unnecessary inverter writes
+5. Diff against segments read fresh from the inverter on every write cycle, never against an in-memory model — a model seeded once at startup drifts from hardware, producing writes that duplicate live segments (rejected by the vendor API) and leaving dropped segments enabled on the battery ([#551](https://github.com/johanzander/bess-manager/issues/551))
 
 ## Configuration and Settings
 

--- a/e2e/ci-bess-settings.json
+++ b/e2e/ci-bess-settings.json
@@ -22,14 +22,19 @@
     "temperature_derating": {
       "enabled": false,
       "weather_entity": ""
-    }
+    },
+    "inverter_max_ac_power_kw": 0.0,
+    "inverter_ac_power_margin": 0.05
   },
   "electricity_price": {
     "area": "SE4",
     "markup_rate": 0.08,
     "vat_multiplier": 1.25,
     "additional_costs": 1.03,
-    "tax_reduction": 0.0
+    "tax_reduction": 0.0,
+    "spot_multiplier": 1.0,
+    "export_spot_multiplier": 1.0,
+    "use_actual_price": false
   },
   "energy_provider": {
     "provider": "nordpool_official",
@@ -38,7 +43,8 @@
     }
   },
   "inverter": {
-    "platform": "growatt_server_min"
+    "platform": "growatt_server_min",
+    "control_mode": "tou"
   },
   "growatt": {
     "inverter_type": "MIN",
@@ -61,5 +67,8 @@
       "grid_charge": "switch.growatt_grid_charge"
     },
     "shared": {}
+  },
+  "demo_mode": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
## Summary

- `GrowattMinController` now reads the inverter's TOU segments on every write cycle and diffs against that, instead of against an in-memory model seeded once at startup.
- `current_tou` is removed from the `write_to_hardware` signature across all platforms — only the MIN controller ever read it.
- `write_to_hardware` → `sync_to_hardware`: it is a read-compare-write now, matching `sync_soc_limits` beside it.

## Root cause

Hardware TOU was read exactly once, in `_initialize_tou_schedule_from_inverter` (called only from `start()` / `set_demo_mode`). Every later cycle diffed against `active_tou_intervals` — the add-on's own model. Three things kept the two apart:

1. The single startup read was discarded: `TOU RECOVERY: Existing intervals are corrupted, clearing and rebuilding`.
2. `apply_intents()` rebuilds the model *before* the write, and a failed write was never rolled back — so after each 500 the model believed the segment had landed.
3. From then on the diff was computed against fiction.

At 07:30 on 2026-08-12 the add-on wrote `slot 1 <- 08:00-08:14 grid_first` while slot 3 already held exactly that, enabled. Growatt's cloud rejects it:

```
growattServer.exceptions.GrowattV1ApiError: Error during writing time segment 1
  -> HomeAssistantError: Growatt API error: Error during writing time segment 1  -> HTTP 500
```

Not transient: the disable of slot 2 at 07:30:05 succeeded, and the conflicting write 7s later failed all four attempts over 24s.

**The part that mattered most:** segments the plan had dropped stayed enabled and kept running — `09:00-09:14 grid_first`, `11:45-11:59`, `13:45-14:14`, `16:00-16:14 battery_first`, all leftovers whose disable calls had also 500'd.

## Fix

`sync_to_hardware` reads the segments from the inverter and diffs against them. With a fresh read, the 07:30 write is skipped entirely (`existing_match` finds slot 3 already correct) and the four orphans become visible to the disable pass.

This made a rollback-on-failed-write mechanism unnecessary: a failed write now simply leaves hardware unchanged and the next cycle re-derives the truth. `active_tou_intervals` is purely "desired"; the hardware read is "actual".

Two consequences of seeing real hardware for the first time:

- The inverter reports unused slots as *disabled* entries. The model only ever held enabled ones, so the diff had never seen a disabled entry and would have re-disabled each idle slot every cycle — wasted calls against an API that rejects them under load.
- An empty read means the read *failed* (a MIN always reports its 9 slots). Diffing against `[]` would rewrite every segment blind and recreate the very duplicates this read prevents, so it raises; the existing `_hardware_write_pending` retry covers it. `read_and_initialize_from_hardware` now applies the same contract instead of silently recording "the inverter holds nothing".

## Test plan

- [x] `./scripts/quality-check.sh` passes locally — 1725 passed, 14 skipped; Black and Ruff clean
- [x] `pytest -m slow` — 534 passed, 4 skipped
- [x] **Verified on the reporter's real inverter**, live run at 08:16:27:
  - `TOU comparison: Current=9 intervals` — read real hardware, not the 5-interval model
  - disabled `08:15-08:29`, `09:00-09:14`, `11:45-11:59`, `13:45-14:14`, `16:00-16:14` — every orphan, including all four identified in the issue
  - wrote `13:00-13:14` and `13:45-13:59`; left `19:30-20:29` untouched (already correct — the churn fix)
  - **zero 500s**; `Schedule applied successfully`

## Evidence the test discriminates

Three mutations, each reddening a different test:

- Reverted: the whole fix — pre-fix code with the diverged model passed in (the RED run).
  Result: 3 tests FAILED, reproducing the production log line-for-line — `TOU comparison: Current=5 intervals, New=4`, `Disabling TOU segment 2: 08:00-08:29`, `Setting TOU segment 1: 08:00-08:14`.
- Reverted: `current_tou = self._read_segments_from_hardware(controller)` replaced with the stale 5-segment model.
  Result: 4 tests FAILED.
- Reverted: the `if not current.get("enabled", True): continue` skip.
  Result: `test_slots_already_disabled_on_hardware_are_not_rewritten` FAILED, 1 of 4.
- Restored: tree clean, 4 passed, full fast suite 1725 passed.

The fixture data is real, not hand-built: hardware slots come from a live `growatt_server.read_time_segments` call against the reporter's inverter during the failure, and the intent list is rebuilt from the debug bundle's `Intent transition at period N` lines for that cycle.

## Outcome-level coverage

The outcome here is inverter state, not cost, and `test_all_scenarios` never runs the write path — so the pins are on hardware state via a controller stub that models the 9-slot table (`_PreloadedController`):

- no write duplicates a range already enabled on hardware (the 500)
- no unplanned segment is left enabled after a cycle (the orphans that ran on the battery)
- no already-disabled slot is re-disabled (wasted writes)
- a failed read aborts the write and touches no segment

No `run_scenario_realized` (`R == P`) test: the diff changes no DP optimization, intent classification, or charge/discharge rate mapping — `battery_system_manager.py` and `inverter_controller.py` are touched for the signature and call site only.

## Documentation

- `docs/SOFTWARE_DESIGN.md` — added the diff-against-hardware rule to "Schedule generation"; the mechanism this PR changes was previously undocumented, which is how the assumption got rebuilt.
- `docs/agents/bess-knowledge.md` — checked, no mention of `write_to_hardware`, `current_tou`, or TOU segment writing. Nothing to update.

## Scope assessment

**Structural** — the owner of "what's on the inverter" moves from the caller's snapshot into the controller's own read. `GrowattMinController` is the sole justified owner: it is the only differential-update platform, the read hook `_read_segments_from_hardware` already lived there, and `BatterySystemManager` has no business knowing which platforms need a hardware read.

**Workaround check:** the diff adds no parameter, flag, default-fallback, second construction site or extra trigger to route around a timing/ordering problem. It removes one. The single added branch (empty read → raise) is a correctness guard on a real failure mode, not a bypass.

## Known limitation (follow-up, not fixed here)

`evaluate_intents` still gates the write decision on `get_daily_TOU_settings()` — the in-memory model — so on a cycle where the plan is unchanged *and* hardware has drifted, `sync_to_hardware` never runs and the drift isn't corrected. This PR fixes reconciliation on cycles that write; it does not make the *decision to write* hardware-aware. In the reported log the gate was open on 28 of 31 cycles (17 plan changes, 8 pending retries, 1 corruption force, vs 3 "Keep current schedule"), and the corruption detector forces a write on exactly the inconsistent-hardware shape seen here — so drift self-heals within a cycle or two in practice. Making the gate itself read hardware would add a cloud API read to every no-op cycle, which deserves its own design discussion rather than a bolt-on. Filed separately.

Closes #551