### PR TITLE
fix: stop the setup wizard accepting configuration it cannot make work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,28 @@ jobs:
         if: always() && env.RUN_E2E == 'true'
         run: docker compose -f docker-compose.ci.yml down
 
+      - name: "E2E: Wizard — SolaX with disabled lifetime counters (#549)"
+        if: always() && env.RUN_E2E == 'true'
+        run: |
+          echo '{}' > ./e2e/ci-wizard-settings.json
+          SCENARIO=ci-wizard-solax-disabled-lifetime BESS_SETTINGS=./e2e/ci-wizard-settings.json BESS_OPTIONS=./e2e/ci-wizard-options.json docker compose -f docker-compose.ci.yml up -d
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/api/setup/status > /dev/null 2>&1; do sleep 2; done'
+          cd e2e && SCENARIO=ci-wizard-solax-disabled-lifetime npx playwright test --project=wizard
+      - name: "E2E: Stop wizard (disabled lifetime counters)"
+        if: always() && env.RUN_E2E == 'true'
+        run: docker compose -f docker-compose.ci.yml down
+
+      - name: "E2E: Wizard — no price provider installed (#549)"
+        if: always() && env.RUN_E2E == 'true'
+        run: |
+          echo '{}' > ./e2e/ci-wizard-settings.json
+          SCENARIO=ci-wizard-no-price-provider BESS_SETTINGS=./e2e/ci-wizard-settings.json BESS_OPTIONS=./e2e/ci-wizard-options.json docker compose -f docker-compose.ci.yml up -d
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/api/setup/status > /dev/null 2>&1; do sleep 2; done'
+          cd e2e && SCENARIO=ci-wizard-no-price-provider npx playwright test --project=wizard
+      - name: "E2E: Stop wizard (no price provider)"
+        if: always() && env.RUN_E2E == 'true'
+        run: docker compose -f docker-compose.ci.yml down
+
       - name: "E2E: Wizard — Full integrations"
         if: always() && env.RUN_E2E == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
         if: always() && env.RUN_E2E == 'true'
         run: |
           echo '{}' > ./e2e/ci-wizard-settings.json
-          SCENARIO=ci-wizard-no-price-provider BESS_SETTINGS=./e2e/ci-wizard-settings.json BESS_OPTIONS=./e2e/ci-wizard-options.json docker compose -f docker-compose.ci.yml up -d
+          SCENARIO=ci-wizard-no-price-provider BESS_SETTINGS=./e2e/ci-wizard-settings.json BESS_OPTIONS=./e2e/ci-wizard-options-no-pricing.json docker compose -f docker-compose.ci.yml up -d
           timeout 120 bash -c 'until curl -sf http://localhost:8080/api/setup/status > /dev/null 2>&1; do sleep 2; done'
           cd e2e && SCENARIO=ci-wizard-no-price-provider npx playwright test --project=wizard
       - name: "E2E: Stop wizard (no price provider)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **The setup wizard no longer completes with a configuration that cannot work** — it now blocks on inverter sensors whose Home Assistant entity is disabled (naming them so you can enable them) and on a price provider that isn't configured, instead of reporting "SYSTEM DEGRADED" afterwards. ([#549](https://github.com/johanzander/bess-manager/issues/549))
 - **Growatt MIN TOU segments are now written against the inverter's real state**, ending repeated "500 Server Error" write failures and leaving no unplanned segments running on the battery. ([#551](https://github.com/johanzander/bess-manager/issues/551))
 - **House load spikes during a battery-supported period are now covered from the battery instead of the grid**, on TOU/register platforms, whenever the stored energy is worth less than importing at that moment (`buy_price × discharge_efficiency ≥ shadow_price`, decided by the optimizer). When the battery is genuinely being reserved for a pricier later period the reserve is still protected and the spike is imported. ([#520](https://github.com/johanzander/bess-manager/issues/520))
 - Near-tied battery decisions now prefer the fullest load-covering discharge even when the tie surfaces at a partial cover, closing a gap where residual import stayed exposed to consumption spikes. ([#512](https://github.com/johanzander/bess-manager/issues/512))

--- a/backend/api.py
+++ b/backend/api.py
@@ -43,6 +43,16 @@ from core.bess.time_utils import get_period_count
 
 router = APIRouter()
 
+#: The wizard payload field each energy provider cannot work without.
+#: Mirrors BatterySystemManager._create_price_source, which needs exactly
+#: these to construct a usable PriceSource (#549).
+_PROVIDER_REQUIRED_FIELD: dict[str, str] = {
+    "nordpool_official": "nordpoolConfigEntryId",
+    "nordpool_hacs": "nordpoolEntity",
+    "octopus": "octopusImportTodayEntity",
+    "entsoe": "entsoeEntity",
+}
+
 
 def _get_hourly_settings_from_periods(schedule_manager, hour: int) -> dict:
     """Build hourly settings from period-level data.
@@ -2837,9 +2847,13 @@ async def run_setup_discovery():
 
         # Registry-based discovery (robust against entity renaming)
         registry = ha.fetch_entity_registry()
-        platform_sensors, detected_platform = ha.discover_sensors_from_registry(
-            registry
-        )
+        (
+            platform_sensors,
+            detected_platform,
+            platform_disabled,
+        ) = ha.discover_sensors_from_registry(registry)
+        disabled_sensors: dict[str, str] = {}
+        platform_disabled_sensors: dict[str, dict[str, str]] = platform_disabled
         if platform_sensors:
             # When local modbus is detected alongside cloud, use modbus as
             # the primary sensor source (it provides TOU control entities).
@@ -2857,6 +2871,7 @@ async def run_setup_discovery():
             ):
                 effective_platform = "solax_modbus_growatt_sph"
             sensors = dict(platform_sensors.get(effective_platform, {}))
+            disabled_sensors = dict(platform_disabled.get(effective_platform, {}))
             _suffix_maps = {
                 "growatt_server_min": ha.GROWATT_MIN_SUFFIX_MAP,
                 "growatt_server_sph": ha.GROWATT_SPH_SUFFIX_MAP,
@@ -2873,7 +2888,14 @@ async def run_setup_discovery():
                     for k in all_bess_keys
                     if not (k.startswith("tou_time_") and k[9:10] in "23456789")
                 ]
-            missing_sensors = [k for k in all_bess_keys if k not in sensors]
+            # A disabled sensor is not "missing" — the entity exists and the
+            # user only has to switch it on.  Keep the two conditions apart
+            # so the wizard can give the actionable message (#549).
+            missing_sensors = [
+                k
+                for k in all_bess_keys
+                if k not in sensors and k not in disabled_sensors
+            ]
 
         current_sensors = ha.discover_current_sensors(states)
         for phase_key, entity_id in current_sensors.items():
@@ -2929,6 +2951,14 @@ async def run_setup_discovery():
         # Attach sensor dicts without key conversion
         result["sensors"] = sensors
         result["platformSensors"] = platform_sensors
+        # Sensor keys left unmapped because their only registry match is
+        # disabled in HA — the wizard blocks on these and names the entity
+        # to enable, rather than persisting a mapping that 404s (#549).
+        # Per-platform like platformSensors, because the user can switch the
+        # inverter tab away from the auto-detected platform and the gate has
+        # to follow that choice.
+        result["disabledSensors"] = disabled_sensors
+        result["platformDisabledSensors"] = platform_disabled_sensors
         # Suggested spot-multiplier defaults for the auto-detected provider —
         # already camelCase, attach after conversion to avoid double-conversion.
         result["pricingDefaults"] = _pricing_defaults_for_discovery(integrations)
@@ -2952,6 +2982,24 @@ async def setup_complete(payload: APISetupCompletePayload):
     from app import bess_controller
 
     try:
+        # A provider without its own required configuration can never fetch
+        # a price, so the whole optimizer aborts every cycle with "No price
+        # data available".  Reject it here rather than persisting a config
+        # that is guaranteed to fail (#549).  This runs before
+        # apply_discovered_config below, which persists on its own.
+        if payload.provider is not None:
+            required_field = _PROVIDER_REQUIRED_FIELD.get(payload.provider)
+            if required_field and not getattr(payload, required_field, None):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Energy provider '{payload.provider}' requires "
+                        f"'{required_field}', which is empty. Select the "
+                        f"provider you actually have configured in Home "
+                        f"Assistant, or install the integration first."
+                    ),
+                )
+
         sections: dict = {}
 
         # --- sensors & discovery ---

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -263,6 +263,7 @@ class TestSetupCompleteLegacy:
             json={
                 "sensors": {"battery_soc": "sensor.growatt_battery_soc"},
                 "provider": "nordpool_official",
+                "nordpoolConfigEntryId": "entry-abc",
                 "currency": "SEK",
                 "nordpoolArea": "SE4",
             },
@@ -283,6 +284,7 @@ class TestSetupCompleteLegacy:
             json={
                 "sensors": {},
                 "provider": "nordpool_official",
+                "nordpoolConfigEntryId": "entry-abc",
                 "totalCapacity": 30.0,
                 "minSoc": 15,
                 "maxSoc": 95,
@@ -434,6 +436,7 @@ class TestSetupComplete:
         """spotMultiplier/exportSpotMultiplier must reach electricity_price, not be dropped."""
         payload = _full_wizard_payload(
             provider="entsoe",
+            entsoeEntity="sensor.entsoe_average_electricity_price",
             spotMultiplier=1.0175,
             exportSpotMultiplier=1.018,
         )
@@ -699,6 +702,7 @@ class TestSetupComplete:
         default 1.0 until the addon restarts."""
         payload = _full_wizard_payload(
             provider="entsoe",
+            entsoeEntity="sensor.entsoe_average_electricity_price",
             spotMultiplier=1.0175,
             exportSpotMultiplier=1.018,
         )
@@ -918,7 +922,7 @@ class TestDiscoverLocaleDefaults:
         ha = ctrl.ha_controller
         ha.discover_integrations.return_value = (integrations, [])
         ha.fetch_entity_registry.return_value = [] if registry is None else registry
-        ha.discover_sensors_from_registry.return_value = ({}, None)
+        ha.discover_sensors_from_registry.return_value = ({}, None, {})
         ha.discover_current_sensors.return_value = {}
         ha.discover_optional_sensors.return_value = {}
         ha.discover_octopus_entities.return_value = {}
@@ -1097,6 +1101,114 @@ class TestDiscoverLocaleDefaults:
         )
 
 
+class TestDiscoverReportsDisabledSensors:
+    """POST /api/setup/discover must tell the wizard which sensors are
+    unmapped because their entity is disabled in HA (#549).
+
+    Without this the wizard cannot distinguish "no such entity" from
+    "entity exists but is switched off", and the user is left to decode a
+    runtime 404 that claims the sensor is missing.
+    """
+
+    def _run_discover(self, ctrl, platform_sensors, platform_disabled, platform):
+        ha = ctrl.ha_controller
+        ha.discover_integrations.return_value = (
+            {
+                "growatt_found": False,
+                "growatt_device_id": None,
+                "solax_found": True,
+                "nordpool_found": False,
+                "nordpool_area": None,
+                "nordpool_custom_area": None,
+                "nordpool_custom_entity": None,
+                "nordpool_config_entry_id": None,
+                "octopus_found": False,
+                "detected_inverter_platforms": ["solax_modbus_growatt_min"],
+                "detected_phase_count": None,
+                "currency": None,
+                "vat_multiplier": None,
+            },
+            [],
+        )
+        ha.fetch_entity_registry.return_value = []
+        ha.discover_sensors_from_registry.return_value = (
+            platform_sensors,
+            platform,
+            platform_disabled,
+        )
+        ha.discover_current_sensors.return_value = {}
+        ha.discover_optional_sensors.return_value = {}
+        ha.discover_octopus_entities.return_value = {}
+        ha.SOLAX_GROWATT_MIN_SUFFIX_MAP = {"soc": "battery_soc"}
+        sys.modules["app"].bess_controller = ctrl
+        return _client.post("/api/setup/discover")
+
+    def test_disabled_sensors_returned_for_active_platform(self):
+        """The reporter's exact case: solax_modbus ships Total * disabled."""
+        ctrl = _make_discover_controller(deepcopy(_PRE_EXISTING_STORE))
+        disabled = {
+            "lifetime_import_from_grid": (
+                "sensor.solaxgrowatt_inverter_total_grid_import"
+            ),
+            "lifetime_export_to_grid": (
+                "sensor.solaxgrowatt_inverter_total_grid_export"
+            ),
+        }
+
+        resp = self._run_discover(
+            ctrl,
+            {"solax_modbus_growatt_min": {"battery_soc": "sensor.soc"}},
+            {"solax_modbus_growatt_min": disabled},
+            "solax_modbus_growatt_min",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["disabledSensors"] == disabled
+
+    def test_disabled_sensors_returned_per_platform(self):
+        """The wizard lets the user switch inverter tabs, so the gate needs
+        every platform's disabled set — not just the auto-detected one.
+
+        The #549 reporter had both a Growatt cloud entry and a solax_modbus
+        entry, so this is their configuration, not a hypothetical.
+        """
+        ctrl = _make_discover_controller(deepcopy(_PRE_EXISTING_STORE))
+        per_platform = {
+            "solax_modbus_growatt_min": {
+                "lifetime_import_from_grid": "sensor.solax_total_grid_import"
+            },
+            "growatt_server_min": {
+                "lifetime_solar_energy": "sensor.growatt_total_solar"
+            },
+        }
+
+        resp = self._run_discover(
+            ctrl,
+            {
+                "solax_modbus_growatt_min": {"battery_soc": "sensor.soc"},
+                "growatt_server_min": {"battery_soc": "sensor.cloud_soc"},
+            },
+            per_platform,
+            "solax_modbus_growatt_min",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["platformDisabledSensors"] == per_platform
+
+    def test_disabled_sensors_empty_when_everything_enabled(self):
+        ctrl = _make_discover_controller(deepcopy(_PRE_EXISTING_STORE))
+
+        resp = self._run_discover(
+            ctrl,
+            {"solax_modbus_growatt_min": {"battery_soc": "sensor.soc"}},
+            {"solax_modbus_growatt_min": {}},
+            "solax_modbus_growatt_min",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["disabledSensors"] == {}
+
+
 class TestDiscoverPricingDefaults:
     """POST /api/setup/discover must suggest provider-aware pricing defaults.
 
@@ -1109,7 +1221,7 @@ class TestDiscoverPricingDefaults:
         ha = ctrl.ha_controller
         ha.discover_integrations.return_value = (integrations, [])
         ha.fetch_entity_registry.return_value = []
-        ha.discover_sensors_from_registry.return_value = ({}, None)
+        ha.discover_sensors_from_registry.return_value = ({}, None, {})
         ha.discover_current_sensors.return_value = {}
         ha.discover_optional_sensors.return_value = {}
         ha.discover_octopus_entities.return_value = {}
@@ -1174,6 +1286,46 @@ class TestDiscoverPricingDefaults:
 # ===========================================================================
 # POST /api/setup/complete — demo mode TOU reinitialization
 # ===========================================================================
+
+
+class TestSetupCompleteRejectsUnusableProvider:
+    """POST /api/setup/complete must refuse a provider it cannot read prices
+    from (#549).
+
+    The reporter finished the wizard with provider=nordpool_official and an
+    empty config_entry_id because Home Assistant had no Nordpool integration
+    at all.  Every optimization cycle then aborted with "No price data
+    available".  Persisting that config is a silent failure — reject it.
+    """
+
+    @pytest.mark.parametrize(
+        ("provider", "overrides"),
+        [
+            ("nordpool_official", {"nordpoolConfigEntryId": ""}),
+            ("nordpool_hacs", {"nordpoolEntity": ""}),
+            ("entsoe", {"entsoeEntity": ""}),
+            ("octopus", {"octopusImportTodayEntity": ""}),
+        ],
+    )
+    def test_provider_without_its_required_config_is_rejected(
+        self, complete_controller, provider, overrides
+    ):
+        payload = _full_wizard_payload(provider=provider, **overrides)
+
+        resp = _client.post("/api/setup/complete", json=payload)
+
+        assert resp.status_code == 400
+        assert provider in resp.json()["detail"]
+        complete_controller.settings_store.save_all.assert_not_called()
+
+    def test_provider_with_its_required_config_is_accepted(self, complete_controller):
+        payload = _full_wizard_payload(
+            provider="nordpool_hacs", nordpoolEntity="sensor.nordpool_kwh_se4"
+        )
+
+        resp = _client.post("/api/setup/complete", json=payload)
+
+        assert resp.status_code == 200
 
 
 class TestSetupCompleteDemoMode:

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -3713,7 +3713,7 @@ class HomeAssistantAPIController:
         entities: list[dict],
         platforms: list[str],
         suffix_map: dict[str, str],
-    ) -> dict[str, str]:
+    ) -> tuple[dict[str, str], dict[str, str]]:
         """Map entity registry entries to BESS sensor keys using unique_id.
 
         Filters entities belonging to the given platforms, then matches

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -3282,7 +3282,9 @@ class HomeAssistantAPIController:
         result: dict[str, str] = {}
 
         if entity_registry is not None:
-            solcast = self._map_registry_entities(
+            # Solcast forecast sensors are optional — a disabled one is
+            # simply left unconfigured, nothing to report to the wizard.
+            solcast, _solcast_disabled = self._map_registry_entities(
                 entity_registry, ["solcast_solar"], self.SOLCAST_SUFFIX_MAP
             )
             result.update(solcast)
@@ -3406,7 +3408,7 @@ class HomeAssistantAPIController:
 
     def _match_solis_dict_embedded_entities(
         self, entities: list[dict]
-    ) -> dict[str, str]:
+    ) -> tuple[dict[str, str], dict[str, str]]:
         """Map Solis monitoring entities affected by the dict-embedded unique_id bug.
 
         Scoped to the ``solis_modbus`` platform only — never touches
@@ -3421,8 +3423,13 @@ class HomeAssistantAPIController:
         the key appearing as a fragment of some other field's value.
 
         Enabled entities are preferred over disabled ones, mirroring
-        ``_map_registry_entities``'s deferral behavior — a disabled match is
-        only used if no enabled entity matches the same key.
+        ``_map_registry_entities``: a disabled entity is never mapped (it
+        has no state, so reading it 404s), and keys whose only match is
+        disabled are returned separately for the caller to report (#549).
+
+        Returns:
+            Tuple of (mapped, disabled), each mapping
+            bess_sensor_key -> entity_id.  The two never share a key.
         """
         result: dict[str, str] = {}
         disabled_matches: dict[str, str] = {}
@@ -3447,18 +3454,22 @@ class HomeAssistantAPIController:
                 result[bess_key] = entity_id
                 break
 
-        for bess_key, entity_id in disabled_matches.items():
-            if bess_key not in result:
-                result[bess_key] = entity_id
-                logger.warning(
-                    "Solis dict-embedded sensor %s only matched a disabled "
-                    "entity %s",
-                    bess_key,
-                    entity_id,
-                )
+        disabled_only = {
+            bess_key: entity_id
+            for bess_key, entity_id in disabled_matches.items()
+            if bess_key not in result
+        }
+        for bess_key, entity_id in disabled_only.items():
+            logger.warning(
+                "Solis dict-embedded sensor %s not mapped: its only match "
+                "%s is disabled in Home Assistant — enable it, then re-run "
+                "discovery",
+                bess_key,
+                entity_id,
+            )
 
         logger.info("Mapped %d Solis dict-embedded monitoring entities", len(result))
-        return result
+        return result, disabled_only
 
     def _has_solax_entity_suffix(
         self,
@@ -3541,7 +3552,7 @@ class HomeAssistantAPIController:
 
     def discover_sensors_from_registry(
         self, entities: list[dict] | None = None
-    ) -> tuple[dict[str, dict[str, str]], str | None]:
+    ) -> tuple[dict[str, dict[str, str]], str | None, dict[str, dict[str, str]]]:
         """Discover sensor entity IDs for all detected inverter platforms.
 
         Uses the ``platform`` field to identify integration entities, then maps
@@ -3553,34 +3564,42 @@ class HomeAssistantAPIController:
             entities: Pre-fetched entity registry list, or None to fetch.
 
         Returns:
-            Tuple of (platform_sensors, detected_platform) where
-            platform_sensors maps platform name to its sensor dict
-            (e.g. ``{"growatt": {bess_key: entity_id, ...}, "solax": {...}}``)
-            and detected_platform is ``"growatt"``, ``"solax"``, or None.
-            Growatt takes priority when both are present.
+            Tuple of (platform_sensors, detected_platform, platform_disabled)
+            where platform_sensors maps platform name to its sensor dict
+            (e.g. ``{"growatt": {bess_key: entity_id, ...}, "solax": {...}}``),
+            detected_platform is ``"growatt"``, ``"solax"``, or None (Growatt
+            takes priority when both are present), and platform_disabled maps
+            platform name to the sensor keys left unmapped because their only
+            registry match is disabled in Home Assistant (#549).
         """
         if entities is None:
             entities = self.fetch_entity_registry()
 
         inverter_detected = self.detect_inverter_integrations(entities)
         platform_sensors: dict[str, dict[str, str]] = {}
+        platform_disabled: dict[str, dict[str, str]] = {}
         detected_platform: str | None = None
 
         if inverter_detected.get("growatt"):
-            min_sensors = self._map_registry_entities(
+            min_sensors, min_disabled = self._map_registry_entities(
                 entities,
                 ["growatt_server"],
                 self.GROWATT_MIN_SUFFIX_MAP,
             )
-            sph_sensors = self._map_registry_entities(
+            sph_sensors, sph_disabled = self._map_registry_entities(
                 entities,
                 ["growatt_server"],
                 self.GROWATT_SPH_SUFFIX_MAP,
             )
-            if min_sensors:
+            # Include a platform whose every match is disabled: its sensor
+            # dict is empty, but dropping it would hide the "enable these
+            # entities" report that is the only way out of that state.
+            if min_sensors or min_disabled:
                 platform_sensors["growatt_server_min"] = min_sensors
-            if sph_sensors:
+                platform_disabled["growatt_server_min"] = min_disabled
+            if sph_sensors or sph_disabled:
                 platform_sensors["growatt_server_sph"] = sph_sensors
+                platform_disabled["growatt_server_sph"] = sph_disabled
             # Pick the platform that matched more sensors
             if len(min_sensors) >= len(sph_sensors):
                 detected_platform = "growatt_server_min"
@@ -3591,44 +3610,47 @@ class HomeAssistantAPIController:
             solax_platforms = ["solax_modbus", "solax"]
             if self._has_growatt_tou_entities(entities):
                 # GEN4: Growatt MIN/MOD/MID with numbered TOU slots
-                solax_sensors = self._map_registry_entities(
+                solax_sensors, solax_disabled = self._map_registry_entities(
                     entities, solax_platforms, self.SOLAX_GROWATT_MIN_SUFFIX_MAP
                 )
                 platform_sensors["solax_modbus_growatt_min"] = solax_sensors
+                platform_disabled["solax_modbus_growatt_min"] = solax_disabled
                 if not detected_platform:
                     detected_platform = "solax_modbus_growatt_min"
             elif self._has_growatt_gen3_entities(entities):
                 # GEN3: Growatt MIX/SPA/SPH with mode-specific time slots
-                solax_sensors = self._map_registry_entities(
+                solax_sensors, solax_disabled = self._map_registry_entities(
                     entities, solax_platforms, self.SOLAX_GROWATT_SPH_SUFFIX_MAP
                 )
                 platform_sensors["solax_modbus_growatt_sph"] = solax_sensors
+                platform_disabled["solax_modbus_growatt_sph"] = solax_disabled
                 if not detected_platform:
                     detected_platform = "solax_modbus_growatt_sph"
             else:
-                solax_sensors = self._map_registry_entities(
+                solax_sensors, solax_disabled = self._map_registry_entities(
                     entities, solax_platforms, self.SOLAX_NATIVE_SUFFIX_MAP
                 )
                 platform_sensors["solax_modbus_native"] = solax_sensors
+                platform_disabled["solax_modbus_native"] = solax_disabled
                 if not detected_platform:
                     detected_platform = "solax_modbus_native"
 
         if inverter_detected.get("solis"):
             solis_platforms = ["solis_modbus"]
-            solis_sensors = self._map_registry_entities(
+            solis_sensors, solis_disabled = self._map_registry_entities(
                 entities, solis_platforms, self.SOLIS_SUFFIX_MAP
             )
             # Dict-embedded-unique_id monitoring entities need a separate,
             # Solis-scoped matcher (see SOLIS_DICT_EMBEDDED_SUFFIX_MAP) —
             # merge them in without touching _map_registry_entities.
+            embedded, embedded_disabled = self._match_solis_dict_embedded_entities(
+                entities
+            )
             solis_sensors.update(
-                {
-                    k: v
-                    for k, v in self._match_solis_dict_embedded_entities(
-                        entities
-                    ).items()
-                    if k not in solis_sensors
-                }
+                {k: v for k, v in embedded.items() if k not in solis_sensors}
+            )
+            solis_disabled.update(
+                {k: v for k, v in embedded_disabled.items() if k not in solis_disabled}
             )
             # Solis has no separate export_power entity — grid_power_net is
             # a single signed sensor (see SOLIS_SUFFIX_MAP comment). Point
@@ -3643,6 +3665,7 @@ class HomeAssistantAPIController:
             # Solis install must not be silently promoted to "detected"
             # like a fully-controllable one.
             platform_sensors["solis_modbus"] = solis_sensors
+            platform_disabled["solis_modbus"] = solis_disabled
             if self._has_solis_tou_v2_entities(entities):
                 if not detected_platform:
                     detected_platform = "solis_modbus"
@@ -3655,7 +3678,7 @@ class HomeAssistantAPIController:
                 )
 
         if inverter_detected.get("huawei"):
-            huawei_sensors = self._map_registry_entities(
+            huawei_sensors, huawei_disabled = self._map_registry_entities(
                 entities, ["huawei_solar"], self.HUAWEI_SUFFIX_MAP
             )
             # power_meter_active_power is a single signed register — Huawei
@@ -3669,10 +3692,21 @@ class HomeAssistantAPIController:
             ):
                 huawei_sensors["export_power"] = huawei_sensors["import_power"]
             platform_sensors["huawei_solar_luna2000"] = huawei_sensors
+            platform_disabled["huawei_solar_luna2000"] = huawei_disabled
             if not detected_platform:
                 detected_platform = "huawei_solar_luna2000"
 
-        return platform_sensors, detected_platform
+        # A key that some other path did map (a derived alias, the Solis
+        # signed-sensor aliasing above) is configured, not disabled — the
+        # two dicts must never overlap, or the wizard would block on a
+        # sensor it actually has.
+        for platform, disabled in platform_disabled.items():
+            mapped = platform_sensors.get(platform, {})
+            for bess_key in list(disabled):
+                if bess_key in mapped:
+                    del disabled[bess_key]
+
+        return platform_sensors, detected_platform, platform_disabled
 
     def _map_registry_entities(
         self,
@@ -3687,9 +3721,11 @@ class HomeAssistantAPIController:
         is assigned by the integration and never changes regardless of
         user entity renaming — this is the only reliable matching strategy.
 
-        Enabled entities are preferred over disabled ones.  If the only
-        match for a sensor key is a disabled entity, it is still returned
-        (the caller can read its state) but a warning is logged.
+        Enabled entities are preferred over disabled ones.  A disabled
+        entity is never mapped: it has no state in Home Assistant, so any
+        read of it 404s.  Keys whose only match is disabled are returned
+        separately so the caller can tell the user which entities to
+        enable, instead of persisting a mapping that cannot work (#549).
 
         Args:
             entities: Full entity registry list.
@@ -3697,7 +3733,8 @@ class HomeAssistantAPIController:
             suffix_map: Maps entity suffix -> BESS sensor key.
 
         Returns:
-            dict mapping bess_sensor_key -> entity_id.
+            Tuple of (mapped, disabled), each mapping
+            bess_sensor_key -> entity_id.  The two never share a key.
         """
         result: dict[str, str] = {}
         disabled_matches: dict[str, str] = {}
@@ -3734,20 +3771,26 @@ class HomeAssistantAPIController:
                             result[bess_key] = entity_id
                     break
 
-        # Fill gaps with disabled entities and warn
-        for bess_key, entity_id in disabled_matches.items():
-            if bess_key not in result:
-                result[bess_key] = entity_id
-                logger.warning(
-                    "Sensor '%s' mapped to disabled entity %s — "
-                    "enable it in Home Assistant for reliable operation",
-                    bess_key,
-                    entity_id,
-                )
+        # Keys whose only match is disabled stay unmapped — reading a
+        # disabled entity 404s, so mapping one just defers the failure to
+        # runtime.  Report them instead (#549).
+        disabled_only = {
+            bess_key: entity_id
+            for bess_key, entity_id in disabled_matches.items()
+            if bess_key not in result
+        }
+        for bess_key, entity_id in disabled_only.items():
+            logger.warning(
+                "Sensor '%s' not mapped: its only match %s is disabled in "
+                "Home Assistant — enable it, then re-run discovery",
+                bess_key,
+                entity_id,
+            )
 
         logger.info(
-            "Mapped %d entities from registry (platforms=%s)",
+            "Mapped %d entities from registry (platforms=%s, %d disabled)",
             len(result),
             platforms,
+            len(disabled_only),
         )
-        return result
+        return result, disabled_only

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -859,7 +859,7 @@ class TestMapRegistryEntities:
 
     def test_growatt_standard_entities(self):
         """Standard Growatt entities match via unique_id suffix."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _growatt_registry(),
             ["growatt_server"],
             self.ctrl.GROWATT_MIN_SUFFIX_MAP,
@@ -891,7 +891,7 @@ class TestMapRegistryEntities:
             "growatt_server",
             "rkm0d7n04x_battery_discharge_soc_limit",
         )
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             [off_grid_entity],
             ["growatt_server"],
             self.ctrl.GROWATT_MIN_SUFFIX_MAP,
@@ -900,7 +900,7 @@ class TestMapRegistryEntities:
 
     def test_growatt_sph_entities(self):
         """SPH entities match via mix_* unique_id sensor keys."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _growatt_sph_registry(),
             ["growatt_server"],
             self.ctrl.GROWATT_SPH_SUFFIX_MAP,
@@ -939,7 +939,7 @@ class TestMapRegistryEntities:
 
     def test_min_map_does_not_match_sph_entities(self):
         """MIN suffix map should not match SPH mix_* unique_ids."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _growatt_sph_registry(),
             ["growatt_server"],
             self.ctrl.GROWATT_MIN_SUFFIX_MAP,
@@ -953,7 +953,7 @@ class TestMapRegistryEntities:
 
     def test_sph_map_does_not_match_min_entities(self):
         """SPH suffix map should not match MIN tlx_* unique_ids."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _growatt_registry(),
             ["growatt_server"],
             self.ctrl.GROWATT_SPH_SUFFIX_MAP,
@@ -965,7 +965,7 @@ class TestMapRegistryEntities:
 
     def test_growatt_renamed_entities_still_match(self):
         """User-renamed entity IDs still match via unique_id."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _growatt_renamed_registry(),
             ["growatt_server"],
             self.ctrl.GROWATT_MIN_SUFFIX_MAP,
@@ -979,7 +979,7 @@ class TestMapRegistryEntities:
 
     def test_solax_native_entities(self):
         """Native SolaX entities match via SOLAX_NATIVE_SUFFIX_MAP."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _solax_native_registry(),
             ["solax_modbus", "solax"],
             self.ctrl.SOLAX_NATIVE_SUFFIX_MAP,
@@ -1007,7 +1007,7 @@ class TestMapRegistryEntities:
             "solax_modbus",
             "solax_battery_minimum_capacity",
         )
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             [off_grid_entity],
             ["solax_modbus", "solax"],
             self.ctrl.SOLAX_NATIVE_SUFFIX_MAP,
@@ -1016,7 +1016,7 @@ class TestMapRegistryEntities:
 
     def test_solax_growatt_entities(self):
         """Growatt GEN4 inverter via solax_modbus matches via SOLAX_GROWATT_MIN_SUFFIX_MAP."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _solax_growatt_registry(),
             ["solax_modbus", "solax"],
             self.ctrl.SOLAX_GROWATT_MIN_SUFFIX_MAP,
@@ -1066,7 +1066,7 @@ class TestMapRegistryEntities:
             "solax_modbus",
             "solax_ems_discharging_stop_soc",
         )
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             [off_grid_entity],
             ["solax_modbus", "solax"],
             self.ctrl.SOLAX_GROWATT_MIN_SUFFIX_MAP,
@@ -1075,7 +1075,7 @@ class TestMapRegistryEntities:
 
     def test_platform_filter_excludes_other_integrations(self):
         """Entities from non-matching platforms are excluded."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _growatt_registry(),
             ["solax_modbus"],
             self.ctrl.GROWATT_MIN_SUFFIX_MAP,
@@ -1084,7 +1084,7 @@ class TestMapRegistryEntities:
 
     def test_nordpool_entity_not_matched(self):
         """Nordpool entities are excluded by platform filter."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _growatt_registry(),
             ["growatt_server"],
             self.ctrl.GROWATT_MIN_SUFFIX_MAP,
@@ -1092,7 +1092,7 @@ class TestMapRegistryEntities:
         assert "nordpool_kwh_se4_sek" not in result.values()
 
     def test_empty_registry(self):
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             [],
             ["growatt_server"],
             self.ctrl.GROWATT_MIN_SUFFIX_MAP,
@@ -1126,7 +1126,7 @@ class TestMapRegistryEntities:
                 "solax_total_reverse_power",
             ),
         ]
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             entities,
             ["solax_modbus"],
             self.ctrl.SOLAX_GROWATT_MIN_SUFFIX_MAP,
@@ -1151,7 +1151,7 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_growatt_min_only(self):
         """MIN registry → detected_platform is growatt_server_min, MIN has more sensors."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
             _growatt_registry()
         )
         assert platform == "growatt_server_min"
@@ -1165,7 +1165,7 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_growatt_sph_only(self):
         """SPH registry → detected_platform is growatt_server_sph, all 12 sensors mapped."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
             _growatt_sph_registry()
         )
         assert platform == "growatt_server_sph"
@@ -1181,7 +1181,7 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_solax_native_only(self):
         """When only native SolaX entities exist, detected_platform is solax."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
             _solax_native_registry()
         )
         assert platform == "solax_modbus_native"
@@ -1190,7 +1190,7 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_solax_growatt_min(self):
         """Growatt GEN4 inverter via solax_modbus with TOU slots → solax_modbus_growatt_min."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
             _solax_growatt_tou_registry()
         )
         assert platform == "solax_modbus_growatt_min"
@@ -1205,7 +1205,7 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_solax_growatt_with_tou(self):
         """Growatt with TOU entities detected as solax_modbus_growatt_min platform."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
             _solax_growatt_tou_registry()
         )
         assert platform == "solax_modbus_growatt_min"
@@ -1224,7 +1224,9 @@ class TestDiscoverSensorsFromRegistry:
     def test_both_growatt_and_solax_native_present(self):
         """When both integrations exist, both are mapped; growatt_server_min is primary."""
         combined = _growatt_registry() + _solax_native_registry()
-        sensors, platform = self.ctrl.discover_sensors_from_registry(combined)
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            combined
+        )
         assert platform == "growatt_server_min"
         assert "growatt_server_min" in sensors
         assert "solax_modbus_native" in sensors
@@ -1232,7 +1234,7 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_renamed_growatt_entities_discovered(self):
         """User-renamed entities still discovered via unique_id."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
             _growatt_renamed_registry()
         )
         assert platform == "growatt_server_min"
@@ -1241,7 +1243,7 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_solax_growatt_gen3(self):
         """GEN3 Growatt (MIX/SPA/SPH) detected as solax_modbus_growatt_sph platform."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
             _solax_growatt_gen3_registry()
         )
         assert platform == "solax_modbus_growatt_sph"
@@ -1267,7 +1269,9 @@ class TestDiscoverSensorsFromRegistry:
 
     def test_solis_modbus_only(self):
         """Solis hybrid via solis_modbus → detected_platform is solis_modbus."""
-        sensors, platform = self.ctrl.discover_sensors_from_registry(_solis_registry())
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            _solis_registry()
+        )
         assert platform == "solis_modbus"
         assert "solis_modbus" in sensors
         solis = sensors["solis_modbus"]
@@ -1341,7 +1345,9 @@ class TestDiscoverSensorsFromRegistry:
             ),
         ]
 
-        sensors, platform = self.ctrl.discover_sensors_from_registry(monitoring_only)
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            monitoring_only
+        )
 
         assert "solis_modbus" in sensors
         assert sensors["solis_modbus"]["battery_soc"] == "sensor.solis_battery_soc"
@@ -1361,15 +1367,20 @@ class TestDiscoverSensorsFromRegistry:
             _solis_dict_embedded_unique_id("solis_modbus_inverter_battery_soc"),
         )
 
-        mapped = self.ctrl._match_solis_dict_embedded_entities(
+        mapped, disabled = self.ctrl._match_solis_dict_embedded_entities(
             [disabled_entity, enabled_entity]
         )
 
         assert mapped["battery_soc"] == "sensor.solis_battery_soc"
+        assert "battery_soc" not in disabled
 
-    def test_solis_dict_embedded_matcher_falls_back_to_disabled_if_only_match(self):
-        """A disabled-only match is still returned (with a warning), per the
-        same deferral behavior as _map_registry_entities."""
+    def test_solis_dict_embedded_matcher_reports_disabled_only_match(self):
+        """A disabled-only match is reported, never mapped (#549).
+
+        Mapping it would persist an entity that has no state, so every
+        later read 404s — the same failure this matcher's sibling
+        ``_map_registry_entities`` used to produce.
+        """
         disabled_entity = _entity(
             "sensor.solis_battery_soc_old",
             "solis_modbus",
@@ -1377,9 +1388,12 @@ class TestDiscoverSensorsFromRegistry:
         )
         disabled_entity["disabled_by"] = "user"
 
-        mapped = self.ctrl._match_solis_dict_embedded_entities([disabled_entity])
+        mapped, disabled = self.ctrl._match_solis_dict_embedded_entities(
+            [disabled_entity]
+        )
 
-        assert mapped["battery_soc"] == "sensor.solis_battery_soc_old"
+        assert "battery_soc" not in mapped
+        assert disabled["battery_soc"] == "sensor.solis_battery_soc_old"
 
     def test_solax_growatt_gen4_vpp_entities_discovered(self):
         """GEN4 VPP entities are mapped alongside TOU entities (issue #118).
@@ -1388,7 +1402,9 @@ class TestDiscoverSensorsFromRegistry:
         control_mode BESS uses — detection still keys off the TOU marker.
         """
         registry = _solax_growatt_tou_registry() + _solax_growatt_vpp_entities()
-        sensors, platform = self.ctrl.discover_sensors_from_registry(registry)
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            registry
+        )
         assert platform == "solax_modbus_growatt_min"
         growatt_min = sensors["solax_modbus_growatt_min"]
         assert (
@@ -1416,7 +1432,9 @@ class TestDiscoverSensorsFromRegistry:
     def test_solax_growatt_gen3_vpp_entities_discovered(self):
         """GEN3 VPP entities are mapped — GEN3's only working control path."""
         registry = _solax_growatt_gen3_registry() + _solax_growatt_vpp_entities()
-        sensors, platform = self.ctrl.discover_sensors_from_registry(registry)
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            registry
+        )
         assert platform == "solax_modbus_growatt_sph"
         growatt_sph = sensors["solax_modbus_growatt_sph"]
         assert (
@@ -1433,7 +1451,9 @@ class TestDiscoverSensorsFromRegistry:
         registry = (
             _solax_growatt_tou_registry() + _solax_growatt_export_limit_entities()
         )
-        sensors, platform = self.ctrl.discover_sensors_from_registry(registry)
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            registry
+        )
         assert platform == "solax_modbus_growatt_min"
         growatt_min = sensors["solax_modbus_growatt_min"]
         assert (
@@ -1451,7 +1471,9 @@ class TestDiscoverSensorsFromRegistry:
         registry = (
             _solax_growatt_gen3_registry() + _solax_growatt_export_limit_entities()
         )
-        sensors, platform = self.ctrl.discover_sensors_from_registry(registry)
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            registry
+        )
         assert platform == "solax_modbus_growatt_sph"
         growatt_sph = sensors["solax_modbus_growatt_sph"]
         assert (
@@ -1486,6 +1508,79 @@ class TestDiscoverSensorsFromRegistry:
             ),
         ]
         assert self.ctrl._has_growatt_tou_entities(entities) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: Disabled entities are reported, never mapped (issue #549)
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledEntitiesAreNotMapped:
+    """A disabled entity has no state in HA, so mapping one guarantees a 404.
+
+    Issue #549: solax_modbus ships its ``Total *`` lifetime counters
+    disabled_by=integration.  The mapper used to map them anyway (warning
+    only), which sailed through the wizard's non-empty check and surfaced
+    at runtime as "Sensor not found (404)" plus SYSTEM DEGRADED.
+    """
+
+    SUFFIX_MAP: ClassVar[dict[str, str]] = {
+        "total_grid_import": "lifetime_import_from_grid",
+    }
+
+    def setup_method(self):
+        self.ctrl = _make_controller()
+
+    def _disabled(self, entity_id: str, unique_id: str) -> dict:
+        entity = _entity(entity_id, "solax_modbus", unique_id)
+        entity["disabled_by"] = "integration"
+        return entity
+
+    def test_disabled_only_match_is_reported_not_mapped(self):
+        entity = self._disabled(
+            "sensor.solaxgrowatt_inverter_total_grid_import",
+            "SolaxGrowatt_total_grid_import",
+        )
+
+        mapped, disabled = self.ctrl._map_registry_entities(
+            [entity], ["solax_modbus"], self.SUFFIX_MAP
+        )
+
+        assert "lifetime_import_from_grid" not in mapped
+        assert (
+            disabled["lifetime_import_from_grid"]
+            == "sensor.solaxgrowatt_inverter_total_grid_import"
+        )
+
+    def test_enabled_match_wins_and_is_not_reported_disabled(self):
+        entities = [
+            self._disabled("sensor.old_total_grid_import", "Old_total_grid_import"),
+            _entity(
+                "sensor.new_total_grid_import",
+                "solax_modbus",
+                "New_total_grid_import",
+            ),
+        ]
+
+        mapped, disabled = self.ctrl._map_registry_entities(
+            entities, ["solax_modbus"], self.SUFFIX_MAP
+        )
+
+        assert mapped["lifetime_import_from_grid"] == "sensor.new_total_grid_import"
+        assert "lifetime_import_from_grid" not in disabled
+
+    def test_discover_reports_disabled_sensors_per_platform(self):
+        """The wizard needs the disabled keys per platform, not just a log line."""
+        registry = _solax_growatt_tou_registry()
+        for entity in registry:
+            if entity["unique_id"].endswith("_total_grid_import"):
+                entity["disabled_by"] = "integration"
+
+        _sensors, _platform, disabled = self.ctrl.discover_sensors_from_registry(
+            registry
+        )
+
+        assert "lifetime_import_from_grid" in disabled["solax_modbus_growatt_min"]
 
 
 # ---------------------------------------------------------------------------
@@ -1805,6 +1900,21 @@ class TestDiscoverEntsoeEntity:
 # Frontend ↔ backend sensor key consistency
 # ---------------------------------------------------------------------------
 
+#: Frontend integration IDs in sensorDefinitions.ts that are inverter
+#: platforms — everything else there is an auxiliary integration
+#: (pricing, forecast, phase current, weather) with no suffix map.
+_INVERTER_PLATFORM_IDS: frozenset[str] = frozenset(
+    {
+        "growatt_server_min",
+        "growatt_server_sph",
+        "solax_modbus_native",
+        "solax_modbus_growatt_min",
+        "solax_modbus_growatt_sph",
+        "solis_modbus",
+        "huawei_solar_luna2000",
+    }
+)
+
 
 class TestFrontendSensorKeysMatchBackend:
     """Every sensor key shown in the frontend UI must exist in the backend suffix map.
@@ -1962,6 +2072,126 @@ class TestFrontendSensorKeysMatchBackend:
             )
 
 
+class TestEnergyFlowSensorsRequiredOnEveryPlatform:
+    """The sensors that energy-flow calculation reads must be required
+    everywhere the wizard offers them, and the derived one must not be.
+
+    Issue #549: the flags were exactly inverted.  All five flow sensors
+    were ``required: false`` on every modbus platform, so the wizard
+    happily completed without them and the runtime then reported
+    "Energy Monitoring [ERROR] — SYSTEM DEGRADED".  Meanwhile
+    ``lifetime_load_consumption`` — which ``get_load_consumption_lifetime``
+    derives as ``solar + grid_import - grid_export`` when unmapped
+    (ha_api_controller.py) — was ``required: true`` on both cloud
+    platforms, demanding a sensor BESS can compute for itself.
+    """
+
+    #: Read directly by energy-flow calculation; no derivation exists.
+    FLOW_SENSORS: ClassVar[set[str]] = {
+        "lifetime_solar_energy",
+        "lifetime_import_from_grid",
+        "lifetime_export_to_grid",
+        "lifetime_battery_charged",
+        "lifetime_battery_discharged",
+    }
+
+    #: Derived from the three grid/solar flow sensors when unmapped.
+    DERIVED_SENSORS: ClassVar[set[str]] = {"lifetime_load_consumption"}
+
+    @staticmethod
+    def _parse_required_flags() -> dict[str, dict[str, bool]]:
+        """Parse sensorDefinitions.ts into platform_id -> {key: required}."""
+        import re
+        from pathlib import Path
+
+        ts_path = (
+            Path(__file__).parents[4]
+            / "frontend"
+            / "src"
+            / "lib"
+            / "sensorDefinitions.ts"
+        )
+        source = ts_path.read_text()
+
+        def _flags(text: str) -> dict[str, bool]:
+            return {
+                key: required == "true"
+                for key, required in re.findall(
+                    r"key:\s*'([^']+)'[^\n]*?required:\s*(true|false)", text
+                )
+            }
+
+        result: dict[str, dict[str, bool]] = {}
+        blocks = re.split(r"\{\s*\n\s*id:\s*'", source)
+        for block in blocks[1:]:
+            platform_match = re.match(r"([^']+)'", block)
+            if not platform_match:
+                continue
+            platform_id = platform_match.group(1)
+            if platform_id not in _INVERTER_PLATFORM_IDS:
+                continue
+
+            groups_ref = re.search(r"sensorGroups:\s*(\w+)", block)
+            search_text = block
+            if groups_ref:
+                const_match = re.search(
+                    rf"const\s+{groups_ref.group(1)}.*?=\s*\[(.*?)\];",
+                    source,
+                    re.DOTALL,
+                )
+                if const_match:
+                    search_text = const_match.group(1)
+                    for ref in re.findall(
+                        r"\b([A-Z_]+(?:_MONITORING|_LIFETIME))\b", search_text
+                    ):
+                        ref_match = re.search(
+                            rf"const\s+{ref}.*?sensors:\s*\[(.*?)\]",
+                            source,
+                            re.DOTALL,
+                        )
+                        if ref_match:
+                            search_text += ref_match.group(1)
+
+            flags = _flags(search_text)
+            if flags:
+                result[platform_id] = flags
+        return result
+
+    def test_flow_sensors_are_required_on_every_platform_offering_them(self):
+        flags = self._parse_required_flags()
+        assert flags, "No platforms parsed — parser broken?"
+
+        optional_anywhere = {
+            f"{platform}.{key}"
+            for platform, keys in flags.items()
+            for key in self.FLOW_SENSORS & keys.keys()
+            if not keys[key]
+        }
+
+        assert not optional_anywhere, (
+            "Energy-flow sensors must be required — the optimizer cannot "
+            "derive them and the runtime health check treats Energy "
+            "Monitoring as a required component: "
+            f"{sorted(optional_anywhere)}"
+        )
+
+    def test_derived_load_consumption_is_never_required(self):
+        flags = self._parse_required_flags()
+
+        required_anywhere = {
+            f"{platform}.{key}"
+            for platform, keys in flags.items()
+            for key in self.DERIVED_SENSORS & keys.keys()
+            if keys[key]
+        }
+
+        assert not required_anywhere, (
+            "lifetime_load_consumption is derived from solar + grid_import - "
+            "grid_export when unmapped, so requiring it blocks the wizard on "
+            f"a sensor BESS can compute itself: {sorted(required_anywhere)}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Solcast entity-registry discovery (#218): unique_id matching instead of
 # entity_id substrings, so detection survives non-English HA locale renames.
@@ -2025,7 +2255,7 @@ class TestHuaweiDiscovery:
         assert detected["huawei"] is True
 
     def test_huawei_map_matches_registry(self):
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _huawei_registry(), ["huawei_solar"], self.ctrl.HUAWEI_SUFFIX_MAP
         )
         assert result["battery_soc"] == "sensor.huawei_battery_state_of_capacity"
@@ -2036,14 +2266,14 @@ class TestHuaweiDiscovery:
         """issue #438: real-time PV power and signed grid power (single
         power-meter register, split by HAApiController.grid_power_polarity —
         see #475's mechanism, reused here with export_positive polarity)."""
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _huawei_registry(), ["huawei_solar"], self.ctrl.HUAWEI_SUFFIX_MAP
         )
         assert result["pv_power"] == "sensor.huawei_inverter_input_power"
         assert result["import_power"] == "sensor.huawei_meter_power_meter_active_power"
 
     def test_huawei_lifetime_energy_sensors_mapped(self):
-        result = self.ctrl._map_registry_entities(
+        result, _disabled = self.ctrl._map_registry_entities(
             _huawei_registry(), ["huawei_solar"], self.ctrl.HUAWEI_SUFFIX_MAP
         )
         assert (
@@ -2074,7 +2304,9 @@ class TestHuaweiDiscovery:
         only. This is the production entry point the setup wizard actually
         calls (backend/api.py), not _map_registry_entities in isolation.
         """
-        sensors, platform = self.ctrl.discover_sensors_from_registry(_huawei_registry())
+        sensors, platform, _disabled = self.ctrl.discover_sensors_from_registry(
+            _huawei_registry()
+        )
         assert platform == "huawei_solar_luna2000"
         assert "huawei_solar_luna2000" in sensors
         huawei = sensors["huawei_solar_luna2000"]

--- a/core/bess/tests/unit/test_scenario_discovery.py
+++ b/core/bess/tests/unit/test_scenario_discovery.py
@@ -123,10 +123,13 @@ class TestScenarioDiscovery:
 
         integrations, states = ctrl.discover_integrations()
         registry = ctrl.fetch_entity_registry()
-        platform_sensors, detected_platform = ctrl.discover_sensors_from_registry(
-            registry
-        )
+        (
+            platform_sensors,
+            detected_platform,
+            platform_disabled,
+        ) = ctrl.discover_sensors_from_registry(registry)
 
+        self._platform_disabled = platform_disabled
         return expected, integrations, platform_sensors, detected_platform, states
 
     # -- Integration detection -----------------------------------------------
@@ -167,6 +170,33 @@ class TestScenarioDiscovery:
         assert not missing, (
             f"{scenario_name}: sensors not discovered for "
             f"{detected_platform!r}: {missing}"
+        )
+
+    # -- Disabled entities (#549) --------------------------------------------
+
+    def test_disabled_sensors_reported_and_not_mapped(self, scenario_name, monkeypatch):
+        """Keys whose only entity is disabled are reported, never mapped.
+
+        A disabled entity has no state, so mapping it guarantees a runtime
+        404 — the failure the reporter of #549 saw as SYSTEM DEGRADED.
+        """
+        expected, _, platform_sensors, detected_platform, _ = self._run(
+            scenario_name, monkeypatch
+        )
+        if "disabled_sensors" not in expected:
+            pytest.skip("no disabled_sensors defined")
+
+        disabled = self._platform_disabled.get(detected_platform, {})
+        sensors = platform_sensors.get(detected_platform, {})
+
+        assert sorted(disabled) == expected["disabled_sensors"], (
+            f"{scenario_name}: disabled sensors for {detected_platform!r} = "
+            f"{sorted(disabled)}, expected {expected['disabled_sensors']}"
+        )
+        still_mapped = [k for k in expected["disabled_sensors"] if k in sensors]
+        assert not still_mapped, (
+            f"{scenario_name}: disabled entities were mapped anyway "
+            f"(guaranteed 404 at runtime): {still_mapped}"
         )
 
     # -- Platform-specific sensor lists ----------------------------------------

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -542,6 +542,8 @@ The mapping uses two layers of filtering:
 
 The result maps each BESS sensor key (e.g. `battery_soc`) to the corresponding HA `entity_id` (e.g. `sensor.rkm0d7n04x_state_of_charge_soc`). This entity_id is what the REST API uses to read state values at runtime.
 
+**Disabled entities are never mapped.** An entity with `disabled_by` set exists in the registry but has no state, so any REST read of it returns 404. Enabled matches always win; when a sensor key's *only* match is disabled, the key is left unmapped and returned in a second dict (`platform_disabled`, surfaced by `/api/setup/discover` as `disabledSensors` / `platformDisabledSensors`). The wizard blocks on those and names the entity to enable, rather than persisting a mapping that is guaranteed to fail at runtime. This matters because integrations ship useful entities disabled by default — `solax_modbus` disables all of its `Total *` lifetime energy counters, which is what made issue #549 present as "Sensor not found (404) … SYSTEM DEGRADED" after a wizard run that appeared to succeed.
+
 Renaming entities in the HA UI (friendly name/label) does not affect discovery. However, if a user changes the actual entity_id and removes the original suffix, the `unique_id` still matches — so discovery still works. Only if the integration itself changes its `unique_id` scheme (across versions) would manual remapping via the wizard be needed.
 
 #### Derived Hints
@@ -573,13 +575,13 @@ The setup wizard is a 6-step flow for first-time configuration. It is triggered 
 | `GET /api/setup/status` | Returns `wizard_needed` flag based on whether sensors are configured |
 | `POST /api/setup/discover` | Runs full auto-discovery, returns sensors map, missing sensors, platform hints |
 | `POST /api/setup/confirm` | Persists discovered sensor config to `/data/bess_discovered_config.json` and applies to live controller |
-| `POST /api/setup/complete` | Atomic save of all wizard data across 6 settings sections |
+| `POST /api/setup/complete` | Atomic save of all wizard data across 6 settings sections. Rejects (400) an energy provider whose own required configuration is empty — `nordpool_official` needs `nordpoolConfigEntryId`, `nordpool_hacs`/`entsoe` need their entity, `octopus` needs `octopusImportTodayEntity` — since such a config can never fetch a price |
 
 #### Wizard Steps (Frontend: `SetupWizardPage.tsx`)
 
 1. **Scan** — Calls `/api/setup/discover` to auto-detect integrations and sensors
-2. **Review Sensors** — Displays discovered sensor mappings, allows manual correction, selects inverter platform
-3. **Electricity Pricing** — Configure price area, provider (Nordpool/Octopus), markup, VAT (pre-filled from discovery hints)
+2. **Review Sensors** — Displays discovered sensor mappings, allows manual correction, selects inverter platform. Blocked while a required sensor is unmapped, or while a required sensor's only entity is disabled in HA (the entities to enable are listed by name)
+3. **Electricity Pricing** — Configure price area, provider (Nordpool/Octopus), markup, VAT (pre-filled from discovery hints). Blocked until the selected provider's required configuration is filled in, mirroring the server-side check on `/api/setup/complete`
 4. **Battery** — Set capacity, SOC limits, power rating, cycle cost
 5. **Home** — Set consumption, fuse current, voltage, phase count (pre-filled from detected phase count)
 6. **Complete** — Calls `/api/setup/complete` for atomic save

--- a/e2e/ci-wizard-options-no-pricing.json
+++ b/e2e/ci-wizard-options-no-pricing.json
@@ -1,0 +1,35 @@
+{
+  "battery": {
+    "total_capacity": 10.0,
+    "min_soc": 10,
+    "max_soc": 100,
+    "max_charge_power_kw": 5.0,
+    "max_discharge_power_kw": 5.0,
+    "cycle_cost_per_kwh": 0.4
+  },
+  "electricity_price": {
+    "area": "SE4",
+    "markup_rate": 0.08,
+    "vat_multiplier": 1.25,
+    "additional_costs": 1.03,
+    "tax_reduction": 0.0
+  },
+  "home": {
+    "default_hourly": 1.5,
+    "currency": "SEK",
+    "max_fuse_current": 25,
+    "voltage": 230,
+    "safety_margin": 1.0,
+    "phase_count": 3,
+    "consumption_strategy": "fixed",
+    "power_monitoring_enabled": false
+  },
+  "energy_provider": {
+    "provider": "nordpool_official",
+    "nordpool_official": {
+      "config_entry_id": ""
+    }
+  },
+  "growatt": {},
+  "sensors": {}
+}

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -40,7 +40,26 @@ const PROVIDER_LABEL: Record<string, string> = {
 // Tests
 // ---------------------------------------------------------------------------
 
+/**
+ * Some scenarios exist to prove a wizard gate holds (#549), so the step
+ * they block is unreachable by design. Call these as the first line of any
+ * test that navigates past that step.
+ */
+function skipIfSensorStepBlocked() {
+  test.skip(
+    !!expected.sensorStepBlocked,
+    'scenario deliberately blocks the sensor step (disabled entities)',
+  );
+}
+function skipIfPricingStepBlocked() {
+  test.skip(
+    !!expected.sensorStepBlocked || !!expected.pricingBlocked,
+    'scenario deliberately blocks the sensor or pricing step',
+  );
+}
+
 test.describe('Setup Wizard', () => {
+
   test('redirects to /setup when no sensors are configured', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveURL('/setup', { timeout: 15_000 });
@@ -59,6 +78,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('auto-selects correct pricing provider', async ({ page }) => {
+    skipIfSensorStepBlocked()
     await page.goto('/setup');
     await expectActiveStep(page, 1);
 
@@ -113,6 +133,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('provider-specific fields shown correctly', async ({ page }) => {
+    skipIfSensorStepBlocked()
     await page.goto('/setup');
     await expectActiveStep(page, 1);
 
@@ -147,6 +168,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('can switch provider when both are available', async ({ page }) => {
+    skipIfSensorStepBlocked()
     // Only meaningful when both providers are detected
     test.skip(!expected.nordpoolFound || !expected.octopusFound,
       'Scenario has only one provider');
@@ -176,6 +198,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('completes full wizard flow end-to-end', async ({ page }) => {
+    skipIfPricingStepBlocked()
     await page.goto('/setup');
 
     // Step 0 → 1: Scan
@@ -213,6 +236,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('can navigate back and forth without losing state', async ({ page }) => {
+    skipIfSensorStepBlocked()
     await page.goto('/setup');
     await expectActiveStep(page, 1);
 
@@ -233,6 +257,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('edited battery values appear in summary', async ({ page }) => {
+    skipIfPricingStepBlocked()
     await page.goto('/setup');
     await expectActiveStep(page, 1);
 
@@ -264,6 +289,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('home step gates features by platform capabilities', async ({ page }) => {
+    skipIfPricingStepBlocked()
     // SPH lacks local_load_power; SolaX native has it (as house_load)
     const platformsWithoutLocalLoad = ['growatt_server_sph'];
     const platformsWithoutChargeRate = ['growatt_server_sph', 'solax_modbus_native', 'solis_modbus'];
@@ -305,6 +331,7 @@ test.describe('Setup Wizard', () => {
   });
 
   test('partial phase-current discovery does not auto-enable fuse protection or seed an invalid phase count', async ({ page }) => {
+    skipIfPricingStepBlocked()
     // Regression test: discovery finding only 2 of the 3 current_l1/l2/l3
     // sensors (detectedPhaseCount === 2) must not auto-enable fuse
     // protection (current_l3 is missing, so real-time monitoring would
@@ -413,5 +440,49 @@ test.describe('Setup Wizard', () => {
     // the 1-phase option was not selected either.
     await expect(page.getByRole('radio', { name: '3-phase' })).toBeChecked();
     await expect(page.getByRole('radio', { name: '1-phase' })).not.toBeChecked();
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #549: the wizard must refuse configuration it cannot make work
+  // -------------------------------------------------------------------------
+
+  test('blocks the sensor step when a required entity is disabled in HA', async ({ page }) => {
+    test.skip(!expected.disabledEntities, 'scenario has no disabled entities');
+
+    await page.goto('/setup');
+    await expectActiveStep(page, 1);
+
+    // The user is told which entities to switch on — not that they are
+    // "missing", which is what the old runtime 404 claimed.
+    const warning = page.getByTestId('disabled-entities-warning');
+    await expect(warning).toBeVisible();
+    for (const entityId of expected.disabledEntities!) {
+      await expect(warning).toContainText(entityId);
+    }
+
+    // And setup cannot proceed with a mapping that would 404 at runtime.
+    await expect(
+      page.getByRole('button', { name: /Next: Electricity Pricing/i }),
+    ).toBeDisabled();
+  });
+
+  test('blocks the pricing step when the selected provider is unconfigured', async ({ page }) => {
+    test.skip(!expected.pricingBlocked, 'scenario has a usable price provider');
+
+    await page.goto('/setup');
+    await expectActiveStep(page, 1);
+    await page.getByRole('button', { name: /Next: Electricity Pricing/i }).click();
+    await expectActiveStep(page, 2);
+
+    // No Nord Pool integration exists, so the defaulted provider has an
+    // empty config entry — completing here would persist a config that can
+    // never fetch a price and abort every optimizer cycle.
+    await expect(page.getByTestId('pricing-incomplete-warning')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Next: Battery/i })).toBeDisabled();
+
+    // Supplying the missing field releases the gate.
+    await fieldByLabel(page, /Config Entry ID/).fill('entry-nordpool-manual');
+    await expect(page.getByTestId('pricing-incomplete-warning')).toBeHidden();
+    await expect(page.getByRole('button', { name: /Next: Battery/i })).toBeEnabled();
   });
 });

--- a/e2e/tests/wizard-expectations.ts
+++ b/e2e/tests/wizard-expectations.ts
@@ -28,6 +28,22 @@ export interface WizardExpectation {
   weatherFound: boolean;
   /** No current_l1/l2/l3 sensors were discovered (no CT clamps configured) — disables fuse protection regardless of platform capability. Optional, defaults to false. */
   noPhaseSensors?: boolean;
+
+  /**
+   * Entity IDs that exist in HA but are disabled, so the sensor step must
+   * block and name them (#549). Optional — absent means nothing disabled.
+   */
+  disabledEntities?: string[];
+  /**
+   * The selected provider has no usable configuration, so the pricing step
+   * must block (#549). Optional, defaults to false.
+   */
+  pricingBlocked?: boolean;
+  /**
+   * The sensor step cannot be passed in this scenario (disabled entities),
+   * so every later step is unreachable. Tests that navigate past it skip.
+   */
+  sensorStepBlocked?: boolean;
 }
 
 export const EXPECTATIONS: Record<string, WizardExpectation> = {
@@ -231,5 +247,50 @@ export const EXPECTATIONS: Record<string, WizardExpectation> = {
     dischargeInhibitFound: false,
     weatherFound: false,
     noPhaseSensors: true,
+  },
+  /**
+   * Real-world regression from issue #549: solax_modbus ships its Total *
+   * lifetime counters disabled_by=integration, and this HA has no Nord Pool
+   * integration at all. Both wizard gates must hold.
+   */
+  'ci-wizard-solax-disabled-lifetime': {
+    growattFound: false,
+    solaxFound: true,
+    inverterPlatform: 'solax_modbus_growatt_min',
+    nordpoolFound: false,
+    octopusFound: false,
+    autoSelectedProvider: 'nordpool_official',
+    phaseCount: 3,
+    solcastFound: false,
+    consumptionForecastFound: false,
+    dischargeInhibitFound: false,
+    weatherFound: false,
+    disabledEntities: [
+      'sensor.growatt_inverter_solax_total_grid_import',
+      'sensor.growatt_inverter_solax_total_grid_export',
+      'sensor.growatt_inverter_solax_total_solar_energy',
+      'sensor.growatt_inverter_solax_total_battery_input_energy',
+      'sensor.growatt_inverter_solax_total_battery_output_energy',
+    ],
+    sensorStepBlocked: true,
+  },
+  /**
+   * Issue #549, second half: all inverter sensors enabled, but HA has no
+   * price integration at all — the pricing step must block rather than
+   * persist the defaulted nordpool_official with an empty config entry.
+   */
+  'ci-wizard-no-price-provider': {
+    growattFound: false,
+    solaxFound: true,
+    inverterPlatform: 'solax_modbus_growatt_min',
+    nordpoolFound: false,
+    octopusFound: false,
+    autoSelectedProvider: 'nordpool_official',
+    phaseCount: 3,
+    solcastFound: false,
+    consumptionForecastFound: false,
+    dischargeInhibitFound: false,
+    weatherFound: false,
+    pricingBlocked: true,
   },
 };

--- a/frontend/src/components/settings/SensorConfigSection.tsx
+++ b/frontend/src/components/settings/SensorConfigSection.tsx
@@ -83,6 +83,18 @@ export interface DiscoveryResult {
   sensors: Record<string, string>;
   platformSensors?: Record<string, Record<string, string>>;
   missingSensors: string[];
+  /**
+   * Sensor keys left unmapped because their only matching HA entity is
+   * disabled (#549).  Distinct from missingSensors: the entity exists, it
+   * just has no state until the user switches it on, so the fix is
+   * "enable it in HA", not "install something".
+   */
+  disabledSensors?: Record<string, string>;
+  /**
+   * Same, but keyed by platform — the user can switch the inverter tab away
+   * from the auto-detected platform, and the gate must follow that choice.
+   */
+  platformDisabledSensors?: Record<string, Record<string, string>>;
   detectedInverterPlatforms?: string[];
   detectedPhaseCount: number | null;
   currency: string | null;

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -117,7 +117,7 @@ const GROWATT_CLOUD_LIFETIME: SensorGroup = {
     { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: true },
     { key: 'lifetime_export_to_grid', label: 'Total Export to Grid', required: true },
     { key: 'lifetime_import_from_grid', label: 'Total Import from Grid', required: true },
-    { key: 'lifetime_load_consumption', label: 'Total Load Consumption', required: true },
+    { key: 'lifetime_load_consumption', label: 'Total Load Consumption', required: false },
   ],
 };
 
@@ -162,7 +162,7 @@ const GROWATT_CLOUD_SPH_LIFETIME: SensorGroup = {
     { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: true },
     { key: 'lifetime_export_to_grid', label: 'Total Export to Grid', required: true },
     { key: 'lifetime_import_from_grid', label: 'Total Import from Grid', required: true },
-    { key: 'lifetime_load_consumption', label: 'Total Load Consumption', required: true },
+    { key: 'lifetime_load_consumption', label: 'Total Load Consumption', required: false },
   ],
 };
 
@@ -220,11 +220,11 @@ export const INTEGRATIONS: IntegrationDef[] = [
       {
         name: 'Lifetime Energy',
         sensors: [
-          { key: 'lifetime_battery_charged', label: 'Battery Input Energy Total', required: false },
-          { key: 'lifetime_battery_discharged', label: 'Battery Output Energy Total', required: false },
-          { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: false },
-          { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: false },
-          { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: false },
+          { key: 'lifetime_battery_charged', label: 'Battery Input Energy Total', required: true },
+          { key: 'lifetime_battery_discharged', label: 'Battery Output Energy Total', required: true },
+          { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: true },
+          { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: true },
+          { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: true },
         ],
       },
       {
@@ -276,11 +276,11 @@ export const INTEGRATIONS: IntegrationDef[] = [
       {
         name: 'Lifetime Energy',
         sensors: [
-          { key: 'lifetime_battery_charged', label: 'Battery Input Energy Total', required: false },
-          { key: 'lifetime_battery_discharged', label: 'Battery Output Energy Total', required: false },
-          { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: false },
-          { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: false },
-          { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: false },
+          { key: 'lifetime_battery_charged', label: 'Battery Input Energy Total', required: true },
+          { key: 'lifetime_battery_discharged', label: 'Battery Output Energy Total', required: true },
+          { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: true },
+          { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: true },
+          { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: true },
           { key: 'lifetime_load_consumption', label: 'Total Load Energy', required: false },
         ],
       },
@@ -349,11 +349,11 @@ export const INTEGRATIONS: IntegrationDef[] = [
       {
         name: 'Lifetime Energy',
         sensors: [
-          { key: 'lifetime_battery_charged', label: 'Battery Input Energy Total', required: false },
-          { key: 'lifetime_battery_discharged', label: 'Battery Output Energy Total', required: false },
-          { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: false },
-          { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: false },
-          { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: false },
+          { key: 'lifetime_battery_charged', label: 'Battery Input Energy Total', required: true },
+          { key: 'lifetime_battery_discharged', label: 'Battery Output Energy Total', required: true },
+          { key: 'lifetime_solar_energy', label: 'Total Solar Energy', required: true },
+          { key: 'lifetime_import_from_grid', label: 'Grid Import Total', required: true },
+          { key: 'lifetime_export_to_grid', label: 'Grid Export Total', required: true },
           { key: 'lifetime_load_consumption', label: 'Total Load', required: false },
         ],
       },
@@ -401,11 +401,11 @@ export const INTEGRATIONS: IntegrationDef[] = [
       {
         name: 'Lifetime Energy',
         sensors: [
-          { key: 'lifetime_battery_charged', label: 'Total Battery Charge Energy', required: false },
-          { key: 'lifetime_battery_discharged', label: 'Total Battery Discharge Energy', required: false },
-          { key: 'lifetime_solar_energy', label: 'PV Total Energy Generation', required: false },
-          { key: 'lifetime_import_from_grid', label: 'Total Energy Imported From Grid', required: false },
-          { key: 'lifetime_export_to_grid', label: 'Total Energy Fed Into Grid', required: false },
+          { key: 'lifetime_battery_charged', label: 'Total Battery Charge Energy', required: true },
+          { key: 'lifetime_battery_discharged', label: 'Total Battery Discharge Energy', required: true },
+          { key: 'lifetime_solar_energy', label: 'PV Total Energy Generation', required: true },
+          { key: 'lifetime_import_from_grid', label: 'Total Energy Imported From Grid', required: true },
+          { key: 'lifetime_export_to_grid', label: 'Total Energy Fed Into Grid', required: true },
         ],
       },
       {
@@ -491,11 +491,11 @@ export const INTEGRATIONS: IntegrationDef[] = [
       {
         name: 'Lifetime Energy',
         sensors: [
-          { key: 'lifetime_solar_energy', label: 'Accumulated Yield Energy', required: false },
-          { key: 'lifetime_battery_charged', label: 'Battery Total Charge', required: false },
-          { key: 'lifetime_battery_discharged', label: 'Battery Total Discharge', required: false },
-          { key: 'lifetime_export_to_grid', label: 'Grid Exported Energy (power meter)', required: false },
-          { key: 'lifetime_import_from_grid', label: 'Grid Accumulated Energy (power meter)', required: false },
+          { key: 'lifetime_solar_energy', label: 'Accumulated Yield Energy', required: true },
+          { key: 'lifetime_battery_charged', label: 'Battery Total Charge', required: true },
+          { key: 'lifetime_battery_discharged', label: 'Battery Total Discharge', required: true },
+          { key: 'lifetime_export_to_grid', label: 'Grid Exported Energy (power meter)', required: true },
+          { key: 'lifetime_import_from_grid', label: 'Grid Accumulated Energy (power meter)', required: true },
         ],
       },
     ],

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -449,12 +449,23 @@ const SetupWizardPage: React.FC = () => {
   // Follow the selected inverter tab, not the auto-detected platform — a
   // user with both a cloud and a modbus integration can switch between
   // them, and each has its own set of disabled entities.
+  // platformDisabledSensors only has entries for platforms that were actually
+  // detected, so a miss means "this platform has no disabled entities" — never
+  // fall back to another platform's dict, or the tab would list entity IDs
+  // that belong to a different integration.
   const activeDisabledSensors =
-    discovery?.platformDisabledSensors?.[activeInverterIntegrationId]
-    ?? discovery?.disabledSensors
+    (discovery?.platformDisabledSensors
+      ? discovery.platformDisabledSensors[activeInverterIntegrationId]
+      : discovery?.disabledSensors)
     ?? {};
+  // Compare against the entity ID, not mere presence: a user upgrading from an
+  // older wizard run already has the disabled entity persisted, and handleScan
+  // restores it from the saved settings. Presence alone would suppress the
+  // warning and re-persist the same 404-ing mapping (#549).
   const disabledRequiredEntities = Object.entries(activeDisabledSensors)
-    .filter(([key]) => requiredSensorKeys.has(key) && !activeSensorsFlat[key]);
+    .filter(([key, entityId]) =>
+      requiredSensorKeys.has(key)
+      && (!activeSensorsFlat[key] || activeSensorsFlat[key] === entityId));
 
   const pricingRequiredField = PROVIDER_REQUIRED_FIELD[pricingForm.provider];
   const pricingReady = !pricingRequiredField || !!pricingForm[pricingRequiredField];

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -27,6 +27,18 @@ const CYCLE_COST_BY_CURRENCY: Record<string, number> = { SEK: 0.40, EUR: 0.035, 
 // "not yet user-configured" so a detected currency can safely replace them.
 const UNSET_CYCLE_COST_DEFAULTS = new Set([0.40, 0.50]);
 
+// The pricing field each provider cannot fetch a price without. Mirrors
+// backend/api.py's _PROVIDER_REQUIRED_FIELD, which rejects the same gap
+// server-side (#549). Without this gate the wizard completes with
+// provider=nordpool_official and an empty config entry whenever HA has no
+// Nord Pool integration, and every optimizer cycle then aborts.
+const PROVIDER_REQUIRED_FIELD: Record<string, keyof PricingForm> = {
+  nordpool_official: 'nordpoolConfigEntryId',
+  nordpool_hacs: 'nordpoolEntity',
+  octopus: 'octopusImportTodayEntity',
+  entsoe: 'entsoeEntity',
+};
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -422,6 +434,31 @@ const SetupWizardPage: React.FC = () => {
     );
   });
 
+  // Required sensors whose only HA entity is disabled (#549). The entity
+  // exists but has no state, so BESS cannot read it — the wizard must say
+  // "enable it", not "it's missing", and must not let setup complete with
+  // a mapping that is guaranteed to 404.
+  const requiredSensorKeys = new Set(
+    INTEGRATIONS.flatMap(integration => {
+      if (inverterIntegrationIds.has(integration.id) && integration.id !== activeInverterIntegrationId) return [];
+      return integration.sensorGroups.flatMap(group =>
+        group.sensors.filter(s => s.required).map(s => s.key),
+      );
+    }),
+  );
+  // Follow the selected inverter tab, not the auto-detected platform — a
+  // user with both a cloud and a modbus integration can switch between
+  // them, and each has its own set of disabled entities.
+  const activeDisabledSensors =
+    discovery?.platformDisabledSensors?.[activeInverterIntegrationId]
+    ?? discovery?.disabledSensors
+    ?? {};
+  const disabledRequiredEntities = Object.entries(activeDisabledSensors)
+    .filter(([key]) => requiredSensorKeys.has(key) && !activeSensorsFlat[key]);
+
+  const pricingRequiredField = PROVIDER_REQUIRED_FIELD[pricingForm.provider];
+  const pricingReady = !pricingRequiredField || !!pricingForm[pricingRequiredField];
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col items-center justify-center p-6">
       <div className="w-full max-w-3xl">
@@ -506,7 +543,28 @@ const SetupWizardPage: React.FC = () => {
               discovery={discovery}
             />
 
-            {!allRequiredFilled && (
+            {disabledRequiredEntities.length > 0 && (
+              <div
+                data-testid="disabled-entities-warning"
+                className="p-3 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-lg text-sm text-orange-700 dark:text-orange-300"
+              >
+                <p className="font-semibold">
+                  These entities exist in Home Assistant but are disabled:
+                </p>
+                <ul className="mt-1 ml-4 list-disc font-mono text-xs">
+                  {disabledRequiredEntities.map(([key, entityId]) => (
+                    <li key={key}>{entityId}</li>
+                  ))}
+                </ul>
+                <p className="mt-2">
+                  Enable them on the device page in Home Assistant, then press
+                  Re-scan. BESS cannot read a disabled entity, so leaving them
+                  off would report the system as degraded after setup.
+                </p>
+              </div>
+            )}
+
+            {!allRequiredFilled && disabledRequiredEntities.length === 0 && (
               <div className="p-3 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-lg text-sm text-orange-700 dark:text-orange-300">
                 Some required sensors (marked with <span className="font-semibold">*</span>) are missing. Expand the integration to configure them manually.
               </div>
@@ -522,7 +580,7 @@ const SetupWizardPage: React.FC = () => {
               </button>
               <button
                 onClick={handleConfirm}
-                disabled={!allRequiredFilled}
+                disabled={!allRequiredFilled || disabledRequiredEntities.length > 0}
                 className="flex items-center space-x-2 px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 font-medium disabled:opacity-60"
               >
                 <span>Next: Electricity Pricing</span>
@@ -550,13 +608,26 @@ const SetupWizardPage: React.FC = () => {
 
             <PricingFormSection form={pricingForm} onChange={setPricingForm} />
 
+            {!pricingReady && (
+              <div
+                data-testid="pricing-incomplete-warning"
+                className="p-3 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-lg text-sm text-orange-700 dark:text-orange-300"
+              >
+                This provider is selected but not configured, so BESS cannot
+                fetch any prices and the optimizer will not run. Fill in the
+                field above, or pick the provider you actually have installed
+                in Home Assistant.
+              </div>
+            )}
+
             <div className="flex justify-between pt-2">
               <button onClick={() => setStep(1)}
                 className="flex items-center space-x-1 px-4 py-2 text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
                 <ChevronLeft className="h-4 w-4" /><span>Back</span>
               </button>
               <button onClick={() => setStep(3)}
-                className="flex items-center space-x-2 px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 font-medium">
+                disabled={!pricingReady}
+                className="flex items-center space-x-2 px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 font-medium disabled:opacity-40 disabled:cursor-not-allowed">
                 <span>Next: Battery</span><ChevronRight className="h-4 w-4" />
               </button>
             </div>

--- a/scripts/mock_ha/scenarios/ci-wizard-no-price-provider.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-no-price-provider.json
@@ -1,0 +1,549 @@
+{
+  "name": "ci-wizard-no-price-provider",
+  "description": "Issue #549, second half: every inverter sensor is present and enabled, but Home Assistant has no price integration at all. The wizard defaults to nordpool_official with an empty config entry, so the pricing step must block instead of persisting a config that can never fetch a price.",
+  "mock_time": "@2026-05-21 17:17:48",
+  "timezone": "Europe/Stockholm",
+  "bess_config": {
+    "battery": {
+      "total_capacity": 30.0,
+      "min_soc": 10,
+      "max_soc": 100,
+      "max_charge_power_kw": 15.0,
+      "max_discharge_power_kw": 15.0,
+      "cycle_cost_per_kwh": 0.4,
+      "efficiency_charge": 0.97,
+      "efficiency_discharge": 0.95
+    },
+    "home": {
+      "default_hourly": 4.6,
+      "currency": "SEK",
+      "consumption_strategy": "fixed",
+      "max_fuse_current": 25,
+      "voltage": 230,
+      "safety_margin": 1.0,
+      "phase_count": 1,
+      "power_monitoring_enabled": false
+    },
+    "electricity_price": {
+      "markup_rate": 0.08,
+      "vat_multiplier": 1.25,
+      "additional_costs": 0.773,
+      "tax_reduction": 0.1988,
+      "area": "SE4"
+    },
+    "energy_provider": {
+      "provider": "nordpool_official",
+      "nordpool_official": {
+        "config_entry_id": ""
+      },
+      "nordpool": {
+        "entity": ""
+      },
+      "octopus": {}
+    },
+    "growatt": {
+      "inverter_type": "",
+      "device_id": ""
+    },
+    "inverter": {
+      "platform": "",
+      "device_id": ""
+    },
+    "sensors": {}
+  },
+  "sensors": {
+    "sensor.growatt_inverter_solax_battery_soc": {
+      "state": "45",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "sensor.growatt_inverter_solax_battery_charge_power": {
+      "state": "0",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_battery_discharge_power": {
+      "state": "1200",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_import_power": {
+      "state": "2500",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_export_power": {
+      "state": "0",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_pv_power_total": {
+      "state": "800",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_load_power": {
+      "state": "4500",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_charging_rate": {
+      "state": "100",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_discharging_rate": {
+      "state": "100",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_charging_stop_soc": {
+      "state": "100",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_discharging_stop_soc_on_grid": {
+      "state": "10",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "select.growatt_inverter_solax_inverter_allow_grid_charge": {
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Enabled",
+          "Disabled"
+        ]
+      }
+    },
+    "select.growatt_inverter_solax_inverter_time_1_active": {
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Enabled",
+          "Disabled"
+        ]
+      }
+    },
+    "select.growatt_inverter_solax_inverter_time_1_begin": {
+      "state": "00:00",
+      "attributes": {}
+    },
+    "select.growatt_inverter_solax_inverter_time_1_end": {
+      "state": "00:00",
+      "attributes": {}
+    },
+    "select.growatt_inverter_solax_inverter_time_1_mode": {
+      "state": "Load First",
+      "attributes": {
+        "options": [
+          "Battery First",
+          "Load First",
+          "Grid First"
+        ]
+      }
+    },
+    "button.growatt_inverter_solax_inverter_time_1_update": {
+      "state": "unknown",
+      "attributes": {}
+    },
+    "sensor.growatt_inverter_solax_total_battery_input_energy": {
+      "state": "5000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_battery_output_energy": {
+      "state": "4500",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_solar_energy": {
+      "state": "10000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_grid_import": {
+      "state": "15000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_grid_export": {
+      "state": "3000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_load_energy": {
+      "state": "20000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_power_generation": {
+      "state": "25000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_grid_current_l1": {
+      "state": "3.5",
+      "attributes": {
+        "unit_of_measurement": "A",
+        "device_class": "current"
+      }
+    },
+    "sensor.growatt_inverter_solax_grid_current_l2": {
+      "state": "4.1",
+      "attributes": {
+        "unit_of_measurement": "A",
+        "device_class": "current"
+      }
+    },
+    "sensor.growatt_inverter_solax_grid_current_l3": {
+      "state": "3.8",
+      "attributes": {
+        "unit_of_measurement": "A",
+        "device_class": "current"
+      }
+    },
+    "sensor.nord_pool_se3_current_price": {
+      "state": "0.52",
+      "attributes": {
+        "unit_of_measurement": "SEK/kWh",
+        "price_area": "SE3"
+      }
+    }
+  },
+  "entity_registry": [
+    {
+      "entity_id": "sensor.growatt_inverter_solax_battery_soc",
+      "platform": "solax_modbus",
+      "unique_id": "solax_battery_soc",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_battery_charge_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_battery_charge_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_battery_discharge_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_battery_discharge_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_import_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_forward_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_export_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_reverse_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_pv_power_total",
+      "platform": "solax_modbus",
+      "unique_id": "solax_pv_power_total",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_load_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_load_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_charging_rate",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_charging_rate",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_discharging_rate",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_discharging_rate",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_charging_stop_soc",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_charging_stop_soc",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_discharging_stop_soc_on_grid",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_discharging_stop_soc_on_grid",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_allow_grid_charge",
+      "platform": "solax_modbus",
+      "unique_id": "solax_charger_switch",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_active",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_enabled",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_begin",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_begin",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_end",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_end",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_mode",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_mode",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "button.growatt_inverter_solax_inverter_time_1_update",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_update",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_battery_input_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_battery_input_energy",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_battery_output_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_battery_output_energy",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_solar_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_solar_energy",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_grid_import",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_grid_import",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_grid_export",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_grid_export",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_load_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_yield",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_power_generation",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_power_generation",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_grid_current_l1",
+      "platform": "solax_modbus",
+      "unique_id": "solax_grid_current_l1",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_grid_current_l2",
+      "platform": "solax_modbus",
+      "unique_id": "solax_grid_current_l2",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_grid_current_l3",
+      "platform": "solax_modbus",
+      "unique_id": "solax_grid_current_l3",
+      "device_id": "dev-solax-001"
+    }
+  ],
+  "config_entries": [
+    {
+      "entry_id": "entry-solax-001",
+      "domain": "solax_modbus",
+      "title": "solax",
+      "state": "loaded"
+    }
+  ],
+  "devices": [
+    {
+      "id": "dev-solax-001",
+      "name": "Growatt Inverter",
+      "manufacturer": "Growatt New Energy",
+      "model": null,
+      "identifiers": [],
+      "config_entries": [
+        "entry-solax-001"
+      ]
+    }
+  ],
+  "services": {
+    "growatt_server": {
+      "read_time_segments": {},
+      "update_time_segment": {},
+      "read_ac_charge_times": {},
+      "write_ac_charge_times": {}
+    },
+    "solax_modbus": {
+      "stop_all": {},
+      "stop_hub": {}
+    }
+  },
+  "price_data": {
+    "today": [
+      0.45,
+      0.38,
+      0.32,
+      0.28,
+      0.25,
+      0.3,
+      0.55,
+      0.82,
+      1.05,
+      1.15,
+      1.08,
+      0.95,
+      0.85,
+      0.78,
+      0.72,
+      0.8,
+      0.92,
+      1.25,
+      1.55,
+      1.42,
+      1.1,
+      0.75,
+      0.58,
+      0.48
+    ],
+    "tomorrow": [
+      0.42,
+      0.35,
+      0.3,
+      0.26,
+      0.23,
+      0.28,
+      0.5,
+      0.78,
+      1.0,
+      1.1,
+      1.02,
+      0.9,
+      0.8,
+      0.74,
+      0.68,
+      0.76,
+      0.88,
+      1.2,
+      1.48,
+      1.35,
+      1.05,
+      0.7,
+      0.55,
+      0.45
+    ]
+  },
+  "time_segments": [],
+  "expected_discovery": {
+    "growatt_found": false,
+    "solax_found": true,
+    "solax_has_growatt_tou": true,
+    "solax_has_growatt_gen3": false,
+    "nordpool_found": false,
+    "nordpool_area": null,
+    "nordpool_custom_area": null,
+    "nordpool_config_entry_id": null,
+    "octopus_found": false,
+    "currency": null,
+    "vat_multiplier": null,
+    "detected_platform": "solax_modbus_growatt_min",
+    "required_sensors": [
+      "battery_soc",
+      "battery_charge_power",
+      "battery_discharge_power",
+      "import_power",
+      "export_power",
+      "pv_power",
+      "local_load_power",
+      "battery_charging_power_rate",
+      "battery_discharging_power_rate",
+      "battery_charge_stop_soc",
+      "battery_discharge_stop_soc",
+      "grid_charge",
+      "lifetime_system_production",
+      "lifetime_solar_energy",
+      "lifetime_battery_charged",
+      "lifetime_battery_discharged",
+      "lifetime_import_from_grid",
+      "lifetime_export_to_grid",
+      "lifetime_load_consumption"
+    ],
+    "required_sensors_solax_modbus_growatt_min": [
+      "battery_soc",
+      "battery_charge_power",
+      "battery_discharge_power",
+      "import_power",
+      "export_power",
+      "pv_power",
+      "local_load_power",
+      "battery_charging_power_rate",
+      "battery_discharging_power_rate",
+      "battery_charge_stop_soc",
+      "battery_discharge_stop_soc",
+      "grid_charge",
+      "tou_time_1_enabled",
+      "tou_time_1_begin",
+      "tou_time_1_end",
+      "tou_time_1_mode",
+      "tou_time_1_update",
+      "lifetime_system_production",
+      "lifetime_solar_energy",
+      "lifetime_battery_charged",
+      "lifetime_battery_discharged",
+      "lifetime_import_from_grid",
+      "lifetime_export_to_grid",
+      "lifetime_load_consumption"
+    ],
+    "detected_inverter_platforms": [
+      "solax_modbus_growatt_min"
+    ],
+    "disabled_sensors": []
+  },
+  "inverter_platform": "solax_modbus_growatt_min"
+}

--- a/scripts/mock_ha/scenarios/ci-wizard-nordpool-solax.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-nordpool-solax.json
@@ -53,6 +53,41 @@
         "friendly_name": "SolaX House Load"
       }
     },
+    "sensor.solax_battery_input_energy_total": {
+      "state": "1250.5",
+      "attributes": {
+        "unit_of_measurement": "kWh",
+        "friendly_name": "SolaX Battery Input Energy Total"
+      }
+    },
+    "sensor.solax_battery_output_energy_total": {
+      "state": "1180.2",
+      "attributes": {
+        "unit_of_measurement": "kWh",
+        "friendly_name": "SolaX Battery Output Energy Total"
+      }
+    },
+    "sensor.solax_total_solar_energy": {
+      "state": "8420.7",
+      "attributes": {
+        "unit_of_measurement": "kWh",
+        "friendly_name": "SolaX Total Solar Energy"
+      }
+    },
+    "sensor.solax_grid_import_total": {
+      "state": "5310.4",
+      "attributes": {
+        "unit_of_measurement": "kWh",
+        "friendly_name": "SolaX Grid Import Total"
+      }
+    },
+    "sensor.solax_grid_export_total": {
+      "state": "3105.9",
+      "attributes": {
+        "unit_of_measurement": "kWh",
+        "friendly_name": "SolaX Grid Export Total"
+      }
+    },
     "select.solax_remotecontrol_power_control": {
       "state": "Enabled - Remote Control",
       "attributes": {
@@ -233,6 +268,36 @@
       "unique_id": "solax_house_load"
     },
     {
+      "entity_id": "sensor.solax_battery_input_energy_total",
+      "platform": "solax_modbus",
+      "config_entry_id": "mock_solax_config_entry",
+      "unique_id": "solax_battery_input_energy_total"
+    },
+    {
+      "entity_id": "sensor.solax_battery_output_energy_total",
+      "platform": "solax_modbus",
+      "config_entry_id": "mock_solax_config_entry",
+      "unique_id": "solax_battery_output_energy_total"
+    },
+    {
+      "entity_id": "sensor.solax_total_solar_energy",
+      "platform": "solax_modbus",
+      "config_entry_id": "mock_solax_config_entry",
+      "unique_id": "solax_total_solar_energy"
+    },
+    {
+      "entity_id": "sensor.solax_grid_import_total",
+      "platform": "solax_modbus",
+      "config_entry_id": "mock_solax_config_entry",
+      "unique_id": "solax_grid_import_total"
+    },
+    {
+      "entity_id": "sensor.solax_grid_export_total",
+      "platform": "solax_modbus",
+      "config_entry_id": "mock_solax_config_entry",
+      "unique_id": "solax_grid_export_total"
+    },
+    {
       "entity_id": "select.solax_remotecontrol_power_control",
       "platform": "solax_modbus",
       "config_entry_id": "mock_solax_config_entry",
@@ -343,6 +408,11 @@
       "battery_soc",
       "export_power",
       "import_power",
+      "lifetime_battery_charged",
+      "lifetime_battery_discharged",
+      "lifetime_export_to_grid",
+      "lifetime_import_from_grid",
+      "lifetime_solar_energy",
       "local_load_power",
       "pv_power",
       "solax_active_power",

--- a/scripts/mock_ha/scenarios/ci-wizard-solax-disabled-lifetime.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-solax-disabled-lifetime.json
@@ -1,0 +1,520 @@
+{
+  "name": "ci-wizard-solax-disabled-lifetime",
+  "description": "Reproduces issue #549: solax_modbus ships its Total * lifetime counters disabled_by=integration, and Home Assistant has no Nord Pool integration at all. The wizard must block on both rather than persisting a config that reports SYSTEM DEGRADED after setup.",
+  "mock_time": "@2026-05-21 17:17:48",
+  "timezone": "Europe/Stockholm",
+  "bess_config": {
+    "battery": {
+      "total_capacity": 30.0,
+      "min_soc": 10,
+      "max_soc": 100,
+      "max_charge_power_kw": 15.0,
+      "max_discharge_power_kw": 15.0,
+      "cycle_cost_per_kwh": 0.4,
+      "efficiency_charge": 0.97,
+      "efficiency_discharge": 0.95
+    },
+    "home": {
+      "default_hourly": 4.6,
+      "currency": "SEK",
+      "consumption_strategy": "fixed",
+      "max_fuse_current": 25,
+      "voltage": 230,
+      "safety_margin": 1.0,
+      "phase_count": 1,
+      "power_monitoring_enabled": false
+    },
+    "electricity_price": {
+      "markup_rate": 0.08,
+      "vat_multiplier": 1.25,
+      "additional_costs": 0.773,
+      "tax_reduction": 0.1988,
+      "area": "SE4"
+    },
+    "energy_provider": {
+      "provider": "nordpool_official",
+      "nordpool_official": {
+        "config_entry_id": ""
+      },
+      "nordpool": {
+        "entity": ""
+      },
+      "octopus": {}
+    },
+    "growatt": {
+      "inverter_type": "",
+      "device_id": ""
+    },
+    "inverter": {
+      "platform": "",
+      "device_id": ""
+    },
+    "sensors": {}
+  },
+  "sensors": {
+    "sensor.growatt_inverter_solax_battery_soc": {
+      "state": "45",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "sensor.growatt_inverter_solax_battery_charge_power": {
+      "state": "0",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_battery_discharge_power": {
+      "state": "1200",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_import_power": {
+      "state": "2500",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_export_power": {
+      "state": "0",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_pv_power_total": {
+      "state": "800",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_load_power": {
+      "state": "4500",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_charging_rate": {
+      "state": "100",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_discharging_rate": {
+      "state": "100",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_charging_stop_soc": {
+      "state": "100",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "number.growatt_inverter_solax_inverter_ems_discharging_stop_soc_on_grid": {
+      "state": "10",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "select.growatt_inverter_solax_inverter_allow_grid_charge": {
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Enabled",
+          "Disabled"
+        ]
+      }
+    },
+    "select.growatt_inverter_solax_inverter_time_1_active": {
+      "state": "Disabled",
+      "attributes": {
+        "options": [
+          "Enabled",
+          "Disabled"
+        ]
+      }
+    },
+    "select.growatt_inverter_solax_inverter_time_1_begin": {
+      "state": "00:00",
+      "attributes": {}
+    },
+    "select.growatt_inverter_solax_inverter_time_1_end": {
+      "state": "00:00",
+      "attributes": {}
+    },
+    "select.growatt_inverter_solax_inverter_time_1_mode": {
+      "state": "Load First",
+      "attributes": {
+        "options": [
+          "Battery First",
+          "Load First",
+          "Grid First"
+        ]
+      }
+    },
+    "button.growatt_inverter_solax_inverter_time_1_update": {
+      "state": "unknown",
+      "attributes": {}
+    },
+    "sensor.growatt_inverter_solax_total_load_energy": {
+      "state": "20000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_total_power_generation": {
+      "state": "25000",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.growatt_inverter_solax_grid_current_l1": {
+      "state": "3.5",
+      "attributes": {
+        "unit_of_measurement": "A",
+        "device_class": "current"
+      }
+    },
+    "sensor.growatt_inverter_solax_grid_current_l2": {
+      "state": "4.1",
+      "attributes": {
+        "unit_of_measurement": "A",
+        "device_class": "current"
+      }
+    },
+    "sensor.growatt_inverter_solax_grid_current_l3": {
+      "state": "3.8",
+      "attributes": {
+        "unit_of_measurement": "A",
+        "device_class": "current"
+      }
+    },
+    "sensor.nord_pool_se3_current_price": {
+      "state": "0.52",
+      "attributes": {
+        "unit_of_measurement": "SEK/kWh",
+        "price_area": "SE3"
+      }
+    }
+  },
+  "entity_registry": [
+    {
+      "entity_id": "sensor.growatt_inverter_solax_battery_soc",
+      "platform": "solax_modbus",
+      "unique_id": "solax_battery_soc",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_battery_charge_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_battery_charge_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_battery_discharge_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_battery_discharge_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_import_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_forward_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_export_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_reverse_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_pv_power_total",
+      "platform": "solax_modbus",
+      "unique_id": "solax_pv_power_total",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_load_power",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_load_power",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_charging_rate",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_charging_rate",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_discharging_rate",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_discharging_rate",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_charging_stop_soc",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_charging_stop_soc",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "number.growatt_inverter_solax_inverter_ems_discharging_stop_soc_on_grid",
+      "platform": "solax_modbus",
+      "unique_id": "solax_ems_discharging_stop_soc_on_grid",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_allow_grid_charge",
+      "platform": "solax_modbus",
+      "unique_id": "solax_charger_switch",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_active",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_enabled",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_begin",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_begin",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_end",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_end",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "select.growatt_inverter_solax_inverter_time_1_mode",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_mode",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "button.growatt_inverter_solax_inverter_time_1_update",
+      "platform": "solax_modbus",
+      "unique_id": "solax_time_1_update",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_battery_input_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_battery_input_energy",
+      "device_id": "dev-solax-001",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_battery_output_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_battery_output_energy",
+      "device_id": "dev-solax-001",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_solar_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_solar_energy",
+      "device_id": "dev-solax-001",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_grid_import",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_grid_import",
+      "device_id": "dev-solax-001",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_grid_export",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_grid_export",
+      "device_id": "dev-solax-001",
+      "disabled_by": "integration"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_load_energy",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_yield",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_total_power_generation",
+      "platform": "solax_modbus",
+      "unique_id": "solax_total_power_generation",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_grid_current_l1",
+      "platform": "solax_modbus",
+      "unique_id": "solax_grid_current_l1",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_grid_current_l2",
+      "platform": "solax_modbus",
+      "unique_id": "solax_grid_current_l2",
+      "device_id": "dev-solax-001"
+    },
+    {
+      "entity_id": "sensor.growatt_inverter_solax_grid_current_l3",
+      "platform": "solax_modbus",
+      "unique_id": "solax_grid_current_l3",
+      "device_id": "dev-solax-001"
+    }
+  ],
+  "config_entries": [
+    {
+      "entry_id": "entry-solax-001",
+      "domain": "solax_modbus",
+      "title": "solax",
+      "state": "loaded"
+    }
+  ],
+  "devices": [
+    {
+      "id": "dev-solax-001",
+      "name": "Growatt Inverter",
+      "manufacturer": "Growatt New Energy",
+      "model": null,
+      "identifiers": [],
+      "config_entries": [
+        "entry-solax-001"
+      ]
+    }
+  ],
+  "services": {
+    "growatt_server": {
+      "read_time_segments": {},
+      "update_time_segment": {},
+      "read_ac_charge_times": {},
+      "write_ac_charge_times": {}
+    },
+    "solax_modbus": {
+      "stop_all": {},
+      "stop_hub": {}
+    }
+  },
+  "price_data": {
+    "today": [
+      0.45,
+      0.38,
+      0.32,
+      0.28,
+      0.25,
+      0.3,
+      0.55,
+      0.82,
+      1.05,
+      1.15,
+      1.08,
+      0.95,
+      0.85,
+      0.78,
+      0.72,
+      0.8,
+      0.92,
+      1.25,
+      1.55,
+      1.42,
+      1.1,
+      0.75,
+      0.58,
+      0.48
+    ],
+    "tomorrow": [
+      0.42,
+      0.35,
+      0.3,
+      0.26,
+      0.23,
+      0.28,
+      0.5,
+      0.78,
+      1.0,
+      1.1,
+      1.02,
+      0.9,
+      0.8,
+      0.74,
+      0.68,
+      0.76,
+      0.88,
+      1.2,
+      1.48,
+      1.35,
+      1.05,
+      0.7,
+      0.55,
+      0.45
+    ]
+  },
+  "time_segments": [],
+  "expected_discovery": {
+    "growatt_found": false,
+    "solax_found": true,
+    "solax_has_growatt_tou": true,
+    "solax_has_growatt_gen3": false,
+    "nordpool_found": false,
+    "nordpool_area": null,
+    "nordpool_custom_area": null,
+    "nordpool_config_entry_id": null,
+    "octopus_found": false,
+    "currency": null,
+    "vat_multiplier": null,
+    "detected_platform": "solax_modbus_growatt_min",
+    "required_sensors": [
+      "battery_soc",
+      "battery_charge_power",
+      "battery_discharge_power",
+      "import_power",
+      "export_power",
+      "pv_power",
+      "local_load_power",
+      "battery_charging_power_rate",
+      "battery_discharging_power_rate",
+      "battery_charge_stop_soc",
+      "battery_discharge_stop_soc",
+      "grid_charge",
+      "lifetime_system_production",
+      "lifetime_load_consumption"
+    ],
+    "required_sensors_solax_modbus_growatt_min": [
+      "battery_soc",
+      "battery_charge_power",
+      "battery_discharge_power",
+      "import_power",
+      "export_power",
+      "pv_power",
+      "local_load_power",
+      "battery_charging_power_rate",
+      "battery_discharging_power_rate",
+      "battery_charge_stop_soc",
+      "battery_discharge_stop_soc",
+      "grid_charge",
+      "tou_time_1_enabled",
+      "tou_time_1_begin",
+      "tou_time_1_end",
+      "tou_time_1_mode",
+      "tou_time_1_update",
+      "lifetime_system_production",
+      "lifetime_load_consumption"
+    ],
+    "detected_inverter_platforms": [
+      "solax_modbus_growatt_min"
+    ],
+    "disabled_sensors": [
+      "lifetime_battery_charged",
+      "lifetime_battery_discharged",
+      "lifetime_export_to_grid",
+      "lifetime_import_from_grid",
+      "lifetime_solar_energy"
+    ]
+  },
+  "inverter_platform": "solax_modbus_growatt_min"
+}


### PR DESCRIPTION
## Summary

- Disabled HA entities are never mapped as sensors; they are reported so the wizard can name them
- The five energy-flow sensors are required on every platform; the derived one is required on none
- The pricing step and `/api/setup/complete` both refuse a provider that has no usable configuration

## Root cause

The reporter finished the wizard cleanly and then got "Critical system issues detected" — Energy Monitoring and Electricity Price Data both ERROR, system DEGRADED. Two independent validation gaps.

**1. Disabled entities were mapped anyway.** All five failing sensors exist in the registry with `disabled_by: "integration"` — `solax_modbus` ships its `Total *` lifetime counters disabled by default. `_map_registry_entities` deliberately mapped a disabled entity when it was the only match:

```
00:05:42 | WARNING | ha_api_controller:3564 - Sensor 'lifetime_import_from_grid' mapped to
  disabled entity sensor.solaxgrowatt_inverter_total_grid_import — enable it in Home Assistant
```

A disabled entity has no state, so every REST read 404s. The mapping could only ever fail, just later — and the failure text (`Sensor not found (404). This indicates a missing or misconfigured sensor.`) pointed at the wrong problem. The warning went to the log and nowhere else: `discover_sensors_from_registry` returned only `bess_key → entity_id`, so `/api/setup/discover` never saw it, and the wizard's gate tests `!!activeSensorsFlat[s.key]` — a disabled entity ID is a non-empty string, so it passed.

**2. Required flags were inverted.** The five sensors energy-flow calculation reads were `required: false` on *every* modbus platform, while `lifetime_load_consumption` — which `get_load_consumption_lifetime` derives as `solar + grid_import - grid_export` when unmapped — was `required: true` on both cloud platforms. The wizard demanded a sensor BESS computes for itself and shrugged at five it cannot. `sensor_collector.py:825` meanwhile declares Energy Monitoring `is_required=True`, which is where DEGRADED came from.

**3. No price provider validation.** `provider` defaults to `nordpool_official`; with no Nord Pool integration discovered, `autoProvider` is `undefined` so the default survived with `config_entry_id: ""`. Step 2 had no gate at all, and `/api/setup/complete` guarded only the *entity* fields, never the provider's own config. Every cycle then aborted with `Schedule update aborted: No price data available`.

## Fix

| area | change |
|---|---|
| `ha_api_controller.py` | `_map_registry_entities` returns `(mapped, disabled)` and never maps a disabled-only match. Same fallback removed from `_match_solis_dict_embedded_entities`. `discover_sensors_from_registry` returns per-platform disabled keys, reconciled so the two dicts never overlap |
| `backend/api.py` | `/api/setup/discover` returns `disabledSensors` + `platformDisabledSensors`; `missing_sensors` excludes them (existing ≠ missing). `/api/setup/complete` 400s on a provider whose required config is empty |
| `sensorDefinitions.ts` | 25 flags `false → true` (5 flow sensors × 5 modbus platforms), 2 flags `true → false` (derived load consumption on both cloud platforms) |
| `SetupWizardPage.tsx` | Sensor step blocks on disabled required entities and lists them; pricing step blocks until the provider's required field is filled |

**Deliberately not changed:** the runtime `Sensor not found (404)` text. Making it disabled-aware needs registry access the health-check path doesn't have — `discover_sensors_from_registry` has exactly one non-test caller, the wizard endpoint — and adding a WebSocket registry fetch to enrich an error string is the kind of routing-around `rules.md` forbids. The wizard is the correct owner.

**Also not changed:** `check_energy_health`. `perform_health_check` already tolerates a derived sensor whose primary mapping is `not_configured` (pinned by `test_health_check.py:82-101`), so requiring the *method* is correct — only the wizard's raw-*sensor* requirement was wrong.

## Test plan

- [x] `./scripts/quality-check.sh`, `black --check`, `ruff` clean
- [x] Fast suite: 1756 passed, 29 skipped
- [x] Slow suite: 534 passed, 4 skipped
- [x] `tsc --noEmit` clean; eslint 0 errors
- [x] **Live stack** (`docker-compose.ci.yml` + mock-HA, scenario `ci-wizard-solax-disabled-lifetime`), real HTTP against the real backend:
  - `POST /api/setup/discover` → all **5** disabled counters reported, none leaked into `sensors`:
    ```
    lifetime_battery_charged    -> sensor.growatt_inverter_solax_total_battery_input_energy
    lifetime_battery_discharged -> sensor.growatt_inverter_solax_total_battery_output_energy
    lifetime_export_to_grid     -> sensor.growatt_inverter_solax_total_grid_export
    lifetime_import_from_grid   -> sensor.growatt_inverter_solax_total_grid_import
    lifetime_solar_energy       -> sensor.growatt_inverter_solax_total_solar_energy
    ```
  - `POST /api/setup/complete` with the reporter's exact saved state (`nordpool_official`, empty config entry) → **HTTP 400**, `"Energy provider 'nordpool_official' requires 'nordpoolConfigEntryId', which is empty…"`
  - same payload with a config entry supplied → **HTTP 200**
  - both new UI strings and `platformDisabledSensors` confirmed present in the served JS bundle
- [ ] **The two new Playwright specs were NOT executed locally.** The local Playwright browser install corrupted (empty binary dir beside an `INSTALLATION_COMPLETE` marker, making reinstall a silent no-op — see #556). The specs parse and register under `playwright test --list`, and I fixed one real bug in them found by running the suite (a describe-level `test.skip` used a `(fixtures, testInfo)` callback signature Playwright doesn't pass at that level, which failed all 14 tests). Their assertions are unverified until CI runs them.

## Evidence the test discriminates

Three mutations, tree confirmed clean afterwards:

- Reverted: `_map_registry_entities` restored to mapping disabled entities as a fallback
- Result: **3 FAILED** — `test_disabled_only_match_is_reported_not_mapped`, `test_discover_reports_disabled_sensors_per_platform`, and `test_disabled_sensors_reported_and_not_mapped[ci-wizard-solax-disabled-lifetime]` (the real-data fixture)

- Reverted: `lifetime_import_from_grid` back to `required: false` (7 occurrences)
- Result: **1 FAILED** — `test_flow_sensors_are_required_on_every_platform_offering_them`

- Reverted: provider validation short-circuited to `if False and …`
- Result: **4 FAILED** — every `test_provider_without_its_required_config_is_rejected` case

- Restored: `git status` clean, full fast suite green

## Outcome-level coverage

- `expected_discovery.disabled_sensors` on the new `ci-wizard-solax-disabled-lifetime` fixture, consumed by the auto-discovered `test_scenario_discovery.py` harness — asserts both that the keys are reported *and* that they are absent from the mapped sensors
- `TestEnergyFlowSensorsRequiredOnEveryPlatform` parses `sensorDefinitions.ts` and pins the required/derived invariant across all 7 platforms, so a new platform cannot reintroduce the inversion
- `ci-wizard-no-price-provider` fixture + two CI wizard E2E steps for the gates
- Not applicable: `run_scenario_realized` / `R == P`. This diff touches no DP, intent classification, or control/rate mapping — it is wizard-time validation only.

## Documentation

`docs/SOFTWARE_DESIGN.md` updated in three places its claims were invalidated: Stage 4 sensor mapping (disabled entities are never mapped), the wizard endpoint table (`/api/setup/complete` provider rejection), and the wizard step list (both new gates). `docs/agents/bess-knowledge.md` mentions nothing this diff touches.

Closes #549
