### PR TITLE
chore: make the worktree the permission boundary so agent runs stop stalling

### DIFF
--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -21,12 +21,20 @@
 # prompted, and every new command shape needed another entry. Inverting it
 # removes that whole class of stall.
 #
-# Two exceptions never get auto-allowed:
+# Every check below therefore fails CLOSED: where a pattern list is
+# unavoidable it enumerates what is SAFE, so a shape nobody thought of
+# costs one prompt rather than a silent auto-allow.
 #
-#   1. Globally-scoped actions (sudo, podman machine rm, gh release, ...) --
-#      matched at command-word position, not as a bare substring, so that
+# Three exceptions never get auto-allowed:
+#
+#   1. Globally-scoped actions (sudo, the shared podman VM, anything
+#      touching GitHub, a push that can move a shared ref) -- matched at
+#      command-word position, not as a bare substring, so that
 #      `grep "sudo " docs/` is not mistaken for running sudo.
-#   2. Commands that can reach OUTSIDE the worktree. Those are put through
+#   2. Mutations of state SHARED with the main checkout. A linked worktree
+#      has its own working tree but ONE object database and ONE ref
+#      namespace with every other checkout (see mutates_shared_state).
+#   3. Commands that can reach OUTSIDE the worktree. Those are put through
 #      a stricter check (see needs_scrutiny / escapes_worktree below).
 #
 # THREAT MODEL: accidents, not an adversary. The damage this prevents is a
@@ -53,25 +61,67 @@ fi
 # `grep "sudo " docs/` as running sudo and reintroduce the prompt.
 CMD_START='(^|[;&|(]|&&|\|\||\n)[[:space:]]*'
 
+# --- Hard denials -------------------------------------------------------
+#
+# `podman machine rm` / `podman system reset` are `deny` entries in
+# settings.json -- a hard block on destroying the shared podman VM every
+# worktree's E2E stack runs on. A hook decision SUPERSEDES a settings rule,
+# so answering "ask" here would quietly downgrade that block to a single
+# keystroke. Re-emit the deny instead of weakening it.
+is_hard_denied() {
+  printf '%s' "$1" | grep -qE "${CMD_START}podman[[:space:]]+(machine[[:space:]]+(rm|reset)|system[[:space:]]+reset)"
+}
+
 # --- Globally-scoped actions -------------------------------------------
 #
-# Effects that no worktree can contain: elevated privileges, the shared
-# podman VM every worktree's E2E stack runs on, a GitHub mutation, or a
-# push that moves a shared ref.
+# Effects that no worktree can contain: elevated privileges, anything that
+# reaches GitHub, or a push that can move a shared ref.
 #
-# These get an explicit "ask" rather than a fall-through. Falling through
-# would be wrong in both directions: settings.json ALLOWS `Bash(git push *)`,
-# so a shared-ref push would sail through unprompted, while `podman machine
-# rm` would hit a deny it can no longer reach once any allow is in play.
+# These get an explicit "ask" rather than a fall-through, because
+# settings.json ALLOWS `Bash(git push *)` and `Bash(gh *)` -- falling
+# through would let them run unprompted rather than prompt.
 is_globally_scoped() {
   printf '%s' "$1" | grep -qE "${CMD_START}sudo[[:space:]]" && return 0
-  printf '%s' "$1" | grep -qE "${CMD_START}podman[[:space:]]+(machine[[:space:]]+(rm|reset)|system[[:space:]]+reset)" && return 0
-  printf '%s' "$1" | grep -qE "${CMD_START}gh[[:space:]]+(pr[[:space:]]+merge|release|repo[[:space:]]+(delete|archive))" && return 0
-  # Any push that can move a shared ref: main/beta branches, tags, --all,
-  # --mirror. NOTE these must be an explicit deny, not a fall-through --
-  # settings.json allow-lists `Bash(git push *)`, so falling through would
-  # allow them outright rather than prompt.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+push([[:space:]]|$).*([[:space:]](main|beta)([[:space:]]|$)|--all|--mirror|--tags|[[:space:]]v[0-9])" && return 0
+
+  # `gh` reaches GitHub, which no worktree contains. Enumerating destructive
+  # subcommands fails the wrong way: `gh api -X DELETE repos/...` is the
+  # general form of every entry such a list could hold, and `gh workflow
+  # run` / `gh secret set` / `gh repo edit` are not obviously "destructive"
+  # names. So invert -- every `gh` asks unless it is a read-only query.
+  # Counting both forms catches a compound `gh pr view && gh pr merge`,
+  # where matching only the first invocation would clear the whole command.
+  local gh_all gh_readonly
+  # `grep -c` counts LINES, and a command is normally one line, so both
+  # counts would be 1 for that compound. Count occurrences with -o | wc -l.
+  gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh[[:space:]]" | wc -l | tr -d ' ' || true)
+  gh_readonly=$(printf '%s' "$1" | grep -oE "${CMD_START}gh[[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status)|issue[[:space:]]+(view|list)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+view|workflow[[:space:]]+(view|list)|label[[:space:]]+list|search|auth[[:space:]]+status)([[:space:]]|$)" | wc -l | tr -d ' ' || true)
+  [ "$gh_all" -ne "$gh_readonly" ] && return 0
+
+  # Any push that can move a shared ref. The ref has to be matched in every
+  # refspec form -- `main`, `HEAD:main`, `br:refs/heads/main`, `+main` --
+  # not just as a bare word, since the bare word is the spelling least
+  # likely to appear when something force-updates a ref. Force pushes ask
+  # unconditionally: settings.json already asks for them, and this hook's
+  # explicit allow would otherwise override that.
+  if printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+push([[:space:]]|$)"; then
+    printf '%s' "$1" | grep -qE "(--force|--force-with-lease|[[:space:]]-f([[:space:]]|$)|--all|--mirror|--tags)" && return 0
+    printf '%s' "$1" | grep -qE "(^|[[:space:]:+])(refs/heads/)?(main|beta)([[:space:]]|:|$)" && return 0
+    printf '%s' "$1" | grep -qE "(^|[[:space:]:+])(refs/tags/)?v[0-9]" && return 0
+  fi
+  return 1
+}
+
+# --- Shared repository state --------------------------------------------
+#
+# A linked worktree has its own working tree, but shares ONE object
+# database and ONE ref namespace with the main checkout and every other
+# worktree. So these reach far outside the worktree even without `-C`:
+# deleting a branch another agent is on, expiring the reflog that would
+# have recovered it, or removing another agent's checkout outright.
+mutates_shared_state() {
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(branch|tag)[[:space:]]+(.*[[:space:]])?(-D|-d|--delete)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|update-ref[[:space:]]+-d|filter-branch)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+(remove|prune)([[:space:]]|$)" && return 0
   return 1
 }
 
@@ -100,8 +150,20 @@ if [ -z "$main_root" ] || [ "$session_root" = "$main_root" ]; then
   exit 0
 fi
 
-if is_globally_scoped "$command"; then
-  reason="Not auto-allowed: this command's effect is global (elevated privileges, the shared podman VM, a GitHub mutation, or a shared git ref), so being inside a disposable worktree does not contain it. Confirm it explicitly."
+if is_hard_denied "$command"; then
+  reason="Denied: this destroys the shared podman VM every worktree's E2E stack runs on. settings.json denies it outright; a worktree does not make it recoverable, and this hook must not downgrade that block to a prompt."
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+fi
+
+if is_globally_scoped "$command" || mutates_shared_state "$command"; then
+  reason="Not auto-allowed: this command's effect reaches outside the worktree -- elevated privileges, GitHub, a shared git ref, or the object database and ref namespace this worktree shares with the main checkout. Being inside a disposable worktree does not contain it. Confirm it explicitly."
   jq -n --arg reason "$reason" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -115,16 +177,28 @@ fi
 # --- Containment check --------------------------------------------------
 #
 # Only commands that can actually write outside the worktree are scrutinized.
-# Read-only and build commands (pytest, npm ci, ruff, git status) skip this
-# entirely, which is what keeps the autonomy this hook exists to provide.
+# Purely relative, purely in-tree commands (pytest, npm ci, ruff, git status)
+# skip this entirely, which is what keeps the autonomy this hook exists to
+# provide.
 #
-# `git` is scrutinized only when given an explicit repo redirect (-C,
-# --git-dir, --work-tree) -- without one it operates on the cwd's repo,
-# which is this worktree by definition.
+# The trigger is deliberately NOT a list of writing verbs. That list is the
+# same enumeration bug as before, only inverted: on this side a miss is a
+# silent auto-allow, not an extra prompt, and the misses were the commonest
+# in-place writers there are -- `sed -i` into the main checkout, `touch`,
+# `mkdir -p`, `python3 -c "shutil.rmtree(...)"`. Trigger instead on the
+# thing that actually makes a command dangerous here: naming a path that
+# could sit outside the worktree. escapes_worktree then decides.
+#
+# The verb list survives only for the indirection case -- `rm -rf $HOME/x`
+# names no literal path but still resolves to one.
 needs_scrutiny() {
-  printf '%s' "$1" | grep -qE "${CMD_START}(rm|mv|cp|ln|dd|tee|shred|install|truncate|chmod|chown|rsync|find|xargs)([[:space:]]|$)" && return 0
+  # Any absolute path, any `..` traversal, any `~`.
+  printf '%s' "$1" | grep -qE '(^|[[:space:]"'\''=:(])(/|~|\.\.(/|[[:space:]]|$))' && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}(rm|mv|cp|ln|dd|tee|shred|install|truncate|chmod|chown|rsync|find|xargs|sed|touch|mkdir)([[:space:]]|$)" && return 0
   printf '%s' "$1" | grep -qE "(^|[[:space:]])(-C|--git-dir|--work-tree)([[:space:]]|=)" && return 0
-  printf '%s' "$1" | grep -qE '>[[:space:]]*/' && return 0
+  # Any redirect, not just one to an absolute path: `> ../../repo/README.md`
+  # leaves the worktree just as surely, and is the likelier accident.
+  printf '%s' "$1" | grep -qE '>' && return 0
   return 1
 }
 
@@ -141,21 +215,34 @@ escapes_worktree() {
   # traverses out THROUGH an allowed temp prefix and passes the check below.
   printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''=:/])\.\.(/|[[:space:]]|$)' && return 0
   printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''=:])~' && return 0
-  printf '%s' "$cmd" | grep -qE '[$`]' && return 0
+
+  # A variable or substitution is "unresolvable" only when it could actually
+  # BE a path. Rejecting every `$` and backtick was far too blunt once
+  # needs_scrutiny started firing on any redirect: `git show X 2>/dev/null |
+  # grep "case \"$command\""` is read-only, names no path, and still
+  # prompted. So reject command substitution (which can expand to anything),
+  # and a variable spliced into a path (`$HOME/GitHub/...`, `"$root"/x`) --
+  # but not a bare `$word` with no `/` around it, which is `$?`, `$1`, or a
+  # literal `$name` inside a search pattern.
+  printf '%s' "$cmd" | grep -qE '(\$\(|\$\{|`)' && return 0
+  printf '%s' "$cmd" | grep -qE '(\$[A-Za-z_][A-Za-z0-9_]*/|/[^[:space:]"'\'']*\$[A-Za-z_{])' && return 0
 
   # Absolute paths must resolve under the worktree (or a disposable temp
-  # area). Quotes are stripped first -- a leading `"` used to make the token
-  # not start with `/`, which silently skipped the whole check.
+  # area). Quotes, parens, commas and `=` are turned into SEPARATORS first,
+  # not deleted: deleting them left `shutil.rmtree('/Users/x')` as the single
+  # token `shutil.rmtree(/Users/x)`, which does not start with `/`, so the
+  # check below never saw the path at all. Separating yields `/Users/x` as
+  # its own token. An ordinary `sed s/a/b/` is unaffected -- it still forms
+  # one token that does not begin with `/`.
   # Word-split deliberately, but with globbing off: an unquoted `*` in the
   # command would otherwise be pathname-expanded against the hook's own cwd
   # before we ever inspect it.
-  local token stripped
+  local token
   set -f
-  for token in $cmd; do
-    stripped=$(printf '%s' "$token" | tr -d "\"'")
-    case "$stripped" in
+  for token in $(printf '%s' "$cmd" | tr "\"'(),=" "      "); do
+    case "$token" in
       /*)
-        case "$stripped" in
+        case "$token" in
           "$session_root" | "$session_root"/*) ;;
           /tmp/* | /private/tmp/* | /private/var/folders/* | /dev/null) ;;
           *) set +f; return 0 ;;

--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -21,10 +21,23 @@
 # prompted, and every new command shape needed another entry. Inverting it
 # removes that whole class of stall.
 #
-# The escape list below is the exception: commands whose blast radius
-# LEAVES the worktree are never auto-allowed, no matter where they run.
-# Keep it narrow and justified -- everything added here reintroduces a
-# prompt inside worktrees.
+# Two exceptions never get auto-allowed:
+#
+#   1. Globally-scoped actions (sudo, podman machine rm, gh release, ...) --
+#      matched at command-word position, not as a bare substring, so that
+#      `grep "sudo " docs/` is not mistaken for running sudo.
+#   2. Commands that can reach OUTSIDE the worktree. Those are put through
+#      a stricter check (see needs_scrutiny / escapes_worktree below).
+#
+# THREAT MODEL: accidents, not an adversary. The damage this prevents is a
+# stale absolute path left over from before a worktree switch, or a `../..`
+# counted from the wrong cwd -- the Bash-side counterpart of what
+# check-worktree-path.sh blocks for Edit/Write. A command that deliberately
+# hides its target behind an unexpanded variable, an alias, or a here-doc
+# can still get through: a hook sees the command STRING, not the syscalls
+# it will make. Do not treat this as a sandbox. The real containment is
+# that a worktree is disposable; this guard only keeps ordinary mistakes
+# from reaching the shared checkout.
 set -euo pipefail
 
 input=$(cat)
@@ -35,33 +48,32 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
-# --- Escape list: blast radius outside this worktree -----------------
+# Anchored at command-word position: start of string, or after a shell
+# separator (; & | && || newline). A bare substring match would treat
+# `grep "sudo " docs/` as running sudo and reintroduce the prompt.
+CMD_START='(^|[;&|(]|&&|\|\||\n)[[:space:]]*'
+
+# --- Globally-scoped actions -------------------------------------------
 #
-# These must keep hitting the normal permission rules (including the deny
-# entries in settings.json). A PreToolUse "allow" decision bypasses the
-# permission system entirely, so anything matched here that we allowed
-# would render those deny rules dead.
+# Effects that no worktree can contain: elevated privileges, the shared
+# podman VM every worktree's E2E stack runs on, a GitHub mutation, or a
+# push that moves a shared ref.
 #
-#   podman machine rm / system reset -> destroys the shared podman VM that
-#     every worktree's E2E stack runs on (settings.json denies these).
-#   gh pr merge / gh release / gh repo -> mutates GitHub, not the checkout.
-#   git push to a non-feature ref     -> touches a shared remote branch.
-#   sudo                              -> escapes the user account entirely.
-#   rm/mv targeting an absolute path outside the worktree root.
-is_escaped() {
-  case "$1" in
-    *"sudo "*) return 0 ;;
-    *"podman machine rm"*|*"podman system reset"*|*"podman machine reset"*) return 0 ;;
-    *"gh pr merge"*|*"gh release"*|*"gh repo delete"*|*"gh repo archive"*) return 0 ;;
-    *"git push"*"main"*|*"git push"*"beta"*) return 0 ;;
-  esac
+# These get an explicit "ask" rather than a fall-through. Falling through
+# would be wrong in both directions: settings.json ALLOWS `Bash(git push *)`,
+# so a shared-ref push would sail through unprompted, while `podman machine
+# rm` would hit a deny it can no longer reach once any allow is in play.
+is_globally_scoped() {
+  printf '%s' "$1" | grep -qE "${CMD_START}sudo[[:space:]]" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}podman[[:space:]]+(machine[[:space:]]+(rm|reset)|system[[:space:]]+reset)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}gh[[:space:]]+(pr[[:space:]]+merge|release|repo[[:space:]]+(delete|archive))" && return 0
+  # Any push that can move a shared ref: main/beta branches, tags, --all,
+  # --mirror. NOTE these must be an explicit deny, not a fall-through --
+  # settings.json allow-lists `Bash(git push *)`, so falling through would
+  # allow them outright rather than prompt.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+push([[:space:]]|$).*([[:space:]](main|beta)([[:space:]]|$)|--all|--mirror|--tags|[[:space:]]v[0-9])" && return 0
   return 1
 }
-
-if is_escaped "$command"; then
-  echo '{"continue": true}'
-  exit 0
-fi
 
 session_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [ -z "$session_root" ]; then
@@ -73,36 +85,100 @@ fi
 # worktree (the original clone); every other entry is a linked worktree.
 # (Capture to a variable before awk -- piping directly into `awk 'exit'`
 # can SIGPIPE the git process under `set -o pipefail`.)
+# Strip the "worktree " prefix rather than taking $2 -- awk's $2 truncates
+# at the first space, so a checkout path containing a space would yield a
+# short main_root, the "am I the main checkout?" test below would wrongly
+# say no, and the hook would auto-allow everything IN THE MAIN CHECKOUT.
 worktree_list=$(git worktree list --porcelain)
-main_root=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{print $2; exit}')
+main_root=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{sub(/^worktree /, ""); print; exit}')
 
+# Everything below applies ONLY inside a linked worktree. In the main
+# checkout the hook stays completely silent, so that shared checkout keeps
+# every ask/deny rule in settings.json exactly as configured.
 if [ -z "$main_root" ] || [ "$session_root" = "$main_root" ]; then
   echo '{"continue": true}'
   exit 0
 fi
 
-# Destructive verbs aimed at an absolute path outside this worktree are the
-# one in-worktree shape that can still damage something shared -- a stale
-# absolute path from before a worktree switch is exactly the cross-checkout
-# confusion that check-worktree-path.sh guards for Edit/Write.
-case "$command" in
-  *"rm "*|*"mv "*|*"chmod "*|*"chown "*|*"truncate "*)
-    for token in $command; do
-      case "$token" in
-        /*)
-          case "$token" in
-            "$session_root"/*|"$session_root") ;;
-            /private/tmp/claude-*|/tmp/*|/private/var/folders/*) ;;
-            *)
-              echo '{"continue": true}'
-              exit 0
-              ;;
-          esac
-          ;;
-      esac
-    done
-    ;;
-esac
+if is_globally_scoped "$command"; then
+  reason="Not auto-allowed: this command's effect is global (elevated privileges, the shared podman VM, a GitHub mutation, or a shared git ref), so being inside a disposable worktree does not contain it. Confirm it explicitly."
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+fi
+
+# --- Containment check --------------------------------------------------
+#
+# Only commands that can actually write outside the worktree are scrutinized.
+# Read-only and build commands (pytest, npm ci, ruff, git status) skip this
+# entirely, which is what keeps the autonomy this hook exists to provide.
+#
+# `git` is scrutinized only when given an explicit repo redirect (-C,
+# --git-dir, --work-tree) -- without one it operates on the cwd's repo,
+# which is this worktree by definition.
+needs_scrutiny() {
+  printf '%s' "$1" | grep -qE "${CMD_START}(rm|mv|cp|ln|dd|tee|shred|install|truncate|chmod|chown|rsync|find|xargs)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "(^|[[:space:]])(-C|--git-dir|--work-tree)([[:space:]]|=)" && return 0
+  printf '%s' "$1" | grep -qE '>[[:space:]]*/' && return 0
+  return 1
+}
+
+# A scrutinized command must be transparently contained. Anything that hides
+# its target -- `..`, `~`, a variable, a command substitution -- cannot be
+# resolved from the command string, so it is not auto-allowed. These are
+# rare in generated commands and common in the accidents we care about
+# (`rm -rf ../../..`, `$HOME/GitHub/bess-manager`).
+escapes_worktree() {
+  local cmd="$1"
+
+  # Unresolvable indirection.
+  # `/` must be in the leading class too: without it, `/tmp/../Users/...`
+  # traverses out THROUGH an allowed temp prefix and passes the check below.
+  printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''=:/])\.\.(/|[[:space:]]|$)' && return 0
+  printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''=:])~' && return 0
+  printf '%s' "$cmd" | grep -qE '[$`]' && return 0
+
+  # Absolute paths must resolve under the worktree (or a disposable temp
+  # area). Quotes are stripped first -- a leading `"` used to make the token
+  # not start with `/`, which silently skipped the whole check.
+  # Word-split deliberately, but with globbing off: an unquoted `*` in the
+  # command would otherwise be pathname-expanded against the hook's own cwd
+  # before we ever inspect it.
+  local token stripped
+  set -f
+  for token in $cmd; do
+    stripped=$(printf '%s' "$token" | tr -d "\"'")
+    case "$stripped" in
+      /*)
+        case "$stripped" in
+          "$session_root" | "$session_root"/*) ;;
+          /tmp/* | /private/tmp/* | /private/var/folders/* | /dev/null) ;;
+          *) set +f; return 0 ;;
+        esac
+        ;;
+    esac
+  done
+  set +f
+
+  return 1
+}
+
+if needs_scrutiny "$command" && escapes_worktree "$command"; then
+  reason="Not auto-allowed: this command can write outside '${session_root}' -- it names an absolute path beyond the worktree, or hides its target behind '..', '~', a variable, or a command substitution. This is the Bash-side counterpart of the cross-checkout path confusion check-worktree-path.sh blocks for Edit/Write. Re-derive the path from \`pwd\` if that was unintended."
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+fi
 
 reason="Auto-allowed: cwd '${session_root}' is a linked git worktree (main checkout is '${main_root}'). A worktree is disposable, so commands scoped to it need no confirmation per CLAUDE.md's Worktree Conventions. Commands whose blast radius leaves the worktree are excluded and still prompt."
 jq -n --arg reason "$reason" '{

--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -59,7 +59,28 @@ fi
 # Anchored at command-word position: start of string, or after a shell
 # separator (; & | && || newline). A bare substring match would treat
 # `grep "sudo " docs/` as running sudo and reintroduce the prompt.
-CMD_START='(^|[;&|(]|&&|\|\||\n)[[:space:]]*'
+#
+# The anchor must also step over anything that sits BEFORE the command word
+# without being it. Without this, one env assignment defeated every guard in
+# this file at once -- `PODMAN=1 podman machine rm` was auto-allowed,
+# silently upgrading a settings.json `deny` to an unprompted allow. Env
+# prefixes are ordinary generated-command shape (`PYTHONPATH=. ...`,
+# `TZ=UTC ...`), so that was an accident-class miss, not just an
+# adversarial one.
+CMD_PREFIX='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(nohup|time|command|exec|env)[[:space:]]+)*'
+CMD_START="(^|[;&|(]|&&|\\|\\||\\n)[[:space:]]*${CMD_PREFIX}"
+
+# `git` accepts global options between the program name and the subcommand,
+# so a literal `git`+space+`push` match is trivially sidestepped by
+# `git -C sub push origin main` or `git --git-dir=... push origin main`.
+# Strip those options once, up front, and match against the normalised
+# string. Spaces are squeezed too so `git   push` matches the same way.
+# This is for MATCHING only -- the command that runs is untouched.
+normalise_git() {
+  printf '%s' "$1" | sed -E \
+    -e 's/(^|[[:space:]])git([[:space:]]+(-c[[:space:]]+[^[:space:]]+|-C[[:space:]]+[^[:space:]]+|--git-dir=[^[:space:]]+|--work-tree=[^[:space:]]+|--exec-path=[^[:space:]]*|--no-pager|--paginate|--bare|--literal-pathspecs))+/\1git/g' \
+    | tr -s ' '
+}
 
 # --- Hard denials -------------------------------------------------------
 #
@@ -102,8 +123,11 @@ is_globally_scoped() {
   local gh_all gh_safe
   # `grep -c` counts LINES, and a command is normally one line, so both
   # counts would be 1 for that compound. Count occurrences with -o | wc -l.
-  gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh[[:space:]]" | wc -l | tr -d ' ' || true)
-  gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh[[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+view|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|search|auth[[:space:]]+status)([[:space:]]|$)" | wc -l | tr -d ' ' || true)
+  # `gh[[:space:]]` missed a bare `gh` at end of string -- it matched neither
+  # counter, so both stayed 0 and the command was allowed. Anchor on
+  # ([[:space:]]|$) so the totals cannot silently agree at zero.
+  gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]|$)" | wc -l | tr -d ' ' || true)
+  gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready|checkout)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+(view|clone)|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|search|auth[[:space:]]+status|--version|--help|-h)|([[:space:]]|$))([[:space:]]|$)" | wc -l | tr -d ' ' || true)
   [ "$gh_all" -ne "$gh_safe" ] && return 0
 
   # Any push that can move a shared ref. The ref has to be matched in every
@@ -117,13 +141,26 @@ is_globally_scoped() {
   # Step 4 merge, so asking costs a stall on every run. Bare `--force`/`-f`
   # keeps asking -- that one overwrites unconditionally. Order matters
   # below: test the lease form first, or `--force` matches its prefix.
-  if printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+push([[:space:]]|$)"; then
-    if ! printf '%s' "$1" | grep -qE '\-\-force-with-lease'; then
-      printf '%s' "$1" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
+  # Both tests are scoped to the push's OWN arguments, not the whole command
+  # string. Scanning the whole string made any `main` anywhere in a compound
+  # turn a safe push into a prompt -- including `git push -u origin feat/x &&
+  # gh pr create --base main ...`, which is implement-issue's closing step,
+  # i.e. exactly the stall this hook exists to remove.
+  local norm push_args
+  norm=$(normalise_git "$1")
+  if printf '%s' "$norm" | grep -qE "${CMD_START}git[[:space:]]+push([[:space:]]|$)"; then
+    push_args=${norm#*git push}
+    push_args=${push_args%%&&*}
+    push_args=${push_args%%||*}
+    push_args=${push_args%%;*}
+    push_args=${push_args%%|*}
+
+    if ! printf '%s' "$push_args" | grep -qE '\-\-force-with-lease'; then
+      printf '%s' "$push_args" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
     fi
-    printf '%s' "$1" | grep -qE "(--all|--mirror|--tags)" && return 0
-    printf '%s' "$1" | grep -qE "(^|[[:space:]:+])(refs/heads/)?(main|beta)([[:space:]]|:|$)" && return 0
-    printf '%s' "$1" | grep -qE "(^|[[:space:]:+])(refs/tags/)?v[0-9]" && return 0
+    printf '%s' "$push_args" | grep -qE "(--all|--mirror|--tags)" && return 0
+    printf '%s' "$push_args" | grep -qE "(^|[[:space:]:+])(refs/heads/)?(main|beta)([[:space:]]|:|$)" && return 0
+    printf '%s' "$push_args" | grep -qE "(^|[[:space:]:+])(refs/tags/)?v[0-9]" && return 0
   fi
   return 1
 }
@@ -148,6 +185,19 @@ mutates_shared_state() {
   # a release is addressed, and nothing refuses to delete one.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+tag[[:space:]]+(.*[[:space:]])?(-d|--delete)([[:space:]]|$)" && return 0
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|update-ref[[:space:]]+-d|filter-branch)([[:space:]]|$)" && return 0
+
+  # The stash is ONE `refs/stash` shared by every worktree, so these discard
+  # work stashed from the main checkout or another agent's session. Same
+  # class as the reflog/gc cases above, and this project leans on `git stash`
+  # for branch isolation, which makes the shared stack a live hazard rather
+  # than a theoretical one.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash[[:space:]]+(clear|drop|pop)([[:space:]]|$)" && return 0
+
+  # A linked worktree shares `.git/config` with the main checkout, and
+  # `--global` reaches `~/.gitconfig`, outside every worktree. Repointing or
+  # removing `origin` changes where every checkout pushes.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+config[[:space:]]+(.*[[:space:]])?(--global|--system)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+remote[[:space:]]+(set-url|remove|rm|rename|add)([[:space:]]|$)" && return 0
   # Same upstream-protection argument as `git branch -D`: plain `git worktree
   # remove` REFUSES a worktree holding uncommitted or untracked files
   # (verified: "contains modified or untracked files, use --force to delete
@@ -300,12 +350,56 @@ escapes_worktree() {
 # worktree holding uncommitted or untracked files, so this cannot discard
 # work; `rm -rf <other worktree>` gets no such exemption, because nothing
 # protects it.
+# --- Read-only inspection -----------------------------------------------
+#
+# needs_scrutiny fires on any absolute path or `~`, whether or not the
+# command can write. That made ordinary inspection outside the worktree
+# prompt -- `cat ~/Downloads/bess-debug.json` is the first step of
+# visualize-debug-log, and `head $MAIN/CHANGELOG.md` is routine -- trading
+# one stall class for another. The containment guard is about WRITES, so a
+# command that cannot write is exempt from it.
+#
+# This is an allowlist, so it fails closed: an unrecognised program (or
+# `python3 -c ...`, or `sed -i`) is not read-only and stays scrutinised.
+READ_ONLY_CMDS='cat|head|tail|less|more|grep|egrep|fgrep|rg|ag|ls|stat|file|wc|diff|jq|yq|sort|uniq|cut|tr|column|basename|dirname|realpath|readlink|echo|printf|pwd|date|which|type|shasum|md5sum|true|test'
+READ_ONLY_GIT='log|show|diff|status|rev-parse|ls-files|describe|blame|shortlog|cat-file|for-each-ref|check-ignore'
+
+is_read_only() {
+  local cleaned seg first sub
+  # Discard the harmless redirects first; any OTHER redirect writes a file,
+  # so the command is not read-only.
+  cleaned=$(printf '%s' "$1" | sed -E 's/2>&1//g; s/[0-9]?>[[:space:]]*\/dev\/null//g')
+  printf '%s' "$cleaned" | grep -q '>' && return 1
+
+  while IFS= read -r seg; do
+    seg=$(printf '%s' "$seg" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+    [ -z "$seg" ] && continue
+    # Step over the same prefixes CMD_START skips.
+    seg=$(printf '%s' "$seg" | sed -E "s/^${CMD_PREFIX}//")
+    first=${seg%% *}
+    case "$first" in
+      git)
+        sub=$(printf '%s' "$seg" | awk '{print $2}')
+        printf '%s' "$sub" | grep -qE "^(${READ_ONLY_GIT})$" || return 1
+        ;;
+      *)
+        printf '%s' "$first" | grep -qE "^(${READ_ONLY_CMDS})$" || return 1
+        ;;
+    esac
+  done <<EOF
+$(printf '%s' "$cleaned" | tr ';|&' '\n')
+EOF
+  return 0
+}
+
 is_lone_worktree_removal() {
   printf '%s' "$1" | grep -qE '^[[:space:]]*git[[:space:]]+worktree[[:space:]]+remove[[:space:]]+[^;&|]+$' &&
     ! printf '%s' "$1" | grep -qE '(--force|[[:space:]]-f([[:space:]]|$))'
 }
 
-if ! is_lone_worktree_removal "$command" && needs_scrutiny "$command" && escapes_worktree "$command"; then
+if ! is_read_only "$command" &&
+   ! is_lone_worktree_removal "$command" &&
+   needs_scrutiny "$command" && escapes_worktree "$command"; then
   reason="Not auto-allowed: this command can write outside '${session_root}' -- it names an absolute path beyond the worktree, or hides its target behind '..', '~', a variable, or a command substitution. This is the Bash-side counterpart of the cross-checkout path confusion check-worktree-path.sh blocks for Edit/Write. Re-derive the path from \`pwd\` if that was unintended."
   jq -n --arg reason "$reason" '{
     hookSpecificOutput: {

--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -1,20 +1,30 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash.
 #
-# Several destructive-looking commands (rm -rf, git reset --hard, git
-# rebase, git merge, git push --force) are in settings.json's "ask" list
-# because they're dangerous in the SHARED main checkout. But agents doing
-# feature work almost always run them inside a disposable git worktree
-# (.claude/worktrees/* or a sibling worktree per CLAUDE.md's Worktree
-# Conventions), where blast radius is contained to that one checkout and
-# there is nothing to protect -- the whole point of a worktree is that it
-# can be blown away and recreated. Prompting there just stalls otherwise
-# autonomous work (e.g. implement-issue rebuilding a venv).
+# The worktree IS the safety boundary. A linked git worktree
+# (.claude/worktrees/* or a sibling per CLAUDE.md's Worktree Conventions)
+# is disposable by construction: it can be blown away and recreated, and
+# nothing in it is shared with the main checkout or with another agent.
+# Inside one, a permission prompt protects nothing -- it just stalls
+# otherwise autonomous work (implement-issue rebuilding a venv, pruning a
+# scenario fixture, merging origin/main before a PR).
 #
-# This hook auto-allows those specific command shapes when the session's
-# cwd resolves to a LINKED worktree, and falls through (no decision) so
-# the normal ask/deny rules in settings.json apply everywhere else,
-# including the main checkout.
+# So this hook AUTO-ALLOWS Bash commands when the session's cwd resolves to
+# a linked worktree, and falls through (no decision) everywhere else, so
+# the normal ask/deny rules in settings.json still guard the shared main
+# checkout.
+#
+# It deliberately does NOT enumerate destructive command shapes. The
+# previous version did -- an allowlist of `rm -rf`, `git reset --hard`,
+# `git rebase`, `git merge`, `git push --force` -- and the enumeration was
+# the bug: a plain `rm -f <file>` fell through to `ask: Bash(rm *)` and
+# prompted, and every new command shape needed another entry. Inverting it
+# removes that whole class of stall.
+#
+# The escape list below is the exception: commands whose blast radius
+# LEAVES the worktree are never auto-allowed, no matter where they run.
+# Keep it narrow and justified -- everything added here reintroduces a
+# prompt inside worktrees.
 set -euo pipefail
 
 input=$(cat)
@@ -25,15 +35,33 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
-# Only consider commands that would otherwise hit an "ask" rule.
-case "$command" in
-  *"rm -r "*|*"rm -R "*|*"rm -rf "*|*"rm -Rf "*|*"rm -fr "*|*"rm -fR "*|*"rm --recursive"*) ;;
-  *"git reset --hard"*) ;;
-  *"git rebase"*) ;;
-  *"git merge"*) ;;
-  *"git push --force"*|*"git push -f "*|*"git push -f")  ;;
-  *) echo '{"continue": true}'; exit 0 ;;
-esac
+# --- Escape list: blast radius outside this worktree -----------------
+#
+# These must keep hitting the normal permission rules (including the deny
+# entries in settings.json). A PreToolUse "allow" decision bypasses the
+# permission system entirely, so anything matched here that we allowed
+# would render those deny rules dead.
+#
+#   podman machine rm / system reset -> destroys the shared podman VM that
+#     every worktree's E2E stack runs on (settings.json denies these).
+#   gh pr merge / gh release / gh repo -> mutates GitHub, not the checkout.
+#   git push to a non-feature ref     -> touches a shared remote branch.
+#   sudo                              -> escapes the user account entirely.
+#   rm/mv targeting an absolute path outside the worktree root.
+is_escaped() {
+  case "$1" in
+    *"sudo "*) return 0 ;;
+    *"podman machine rm"*|*"podman system reset"*|*"podman machine reset"*) return 0 ;;
+    *"gh pr merge"*|*"gh release"*|*"gh repo delete"*|*"gh repo archive"*) return 0 ;;
+    *"git push"*"main"*|*"git push"*"beta"*) return 0 ;;
+  esac
+  return 1
+}
+
+if is_escaped "$command"; then
+  echo '{"continue": true}'
+  exit 0
+fi
 
 session_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [ -z "$session_root" ]; then
@@ -48,16 +76,39 @@ fi
 worktree_list=$(git worktree list --porcelain)
 main_root=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{print $2; exit}')
 
-if [ -n "$main_root" ] && [ "$session_root" != "$main_root" ]; then
-  reason="Auto-allowed: cwd '${session_root}' is a linked git worktree (main checkout is '${main_root}'), so this destructive command is scoped to a disposable checkout per CLAUDE.md's Worktree Conventions."
-  jq -n --arg reason "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "allow",
-      permissionDecisionReason: $reason
-    }
-  }'
+if [ -z "$main_root" ] || [ "$session_root" = "$main_root" ]; then
+  echo '{"continue": true}'
   exit 0
 fi
 
-echo '{"continue": true}'
+# Destructive verbs aimed at an absolute path outside this worktree are the
+# one in-worktree shape that can still damage something shared -- a stale
+# absolute path from before a worktree switch is exactly the cross-checkout
+# confusion that check-worktree-path.sh guards for Edit/Write.
+case "$command" in
+  *"rm "*|*"mv "*|*"chmod "*|*"chown "*|*"truncate "*)
+    for token in $command; do
+      case "$token" in
+        /*)
+          case "$token" in
+            "$session_root"/*|"$session_root") ;;
+            /private/tmp/claude-*|/tmp/*|/private/var/folders/*) ;;
+            *)
+              echo '{"continue": true}'
+              exit 0
+              ;;
+          esac
+          ;;
+      esac
+    done
+    ;;
+esac
+
+reason="Auto-allowed: cwd '${session_root}' is a linked git worktree (main checkout is '${main_root}'). A worktree is disposable, so commands scoped to it need no confirmation per CLAUDE.md's Worktree Conventions. Commands whose blast radius leaves the worktree are excluded and still prompt."
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "allow",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -87,24 +87,41 @@ is_globally_scoped() {
   # subcommands fails the wrong way: `gh api -X DELETE repos/...` is the
   # general form of every entry such a list could hold, and `gh workflow
   # run` / `gh secret set` / `gh repo edit` are not obviously "destructive"
-  # names. So invert -- every `gh` asks unless it is a read-only query.
+  # names. So invert -- every `gh` asks unless it is on the safe list.
   # Counting both forms catches a compound `gh pr view && gh pr merge`,
   # where matching only the first invocation would clear the whole command.
-  local gh_all gh_readonly
+  #
+  # The safe list covers reads AND authoring, not reads alone. A read-only
+  # list looks tighter but defeats the point of the hook: `gh pr create` is
+  # the closing step of implement-issue, so a run that no longer stalls on
+  # `rm -f` would instead stall at the finish line, and `gh issue comment`
+  # would stall it in the middle. Authoring a PR/issue on this repo IS the
+  # work product. What stays behind a prompt is everything that publishes,
+  # merges, or reconfigures: pr merge, release, repo edit/delete, secret,
+  # workflow run, and any non-GET `gh api`.
+  local gh_all gh_safe
   # `grep -c` counts LINES, and a command is normally one line, so both
   # counts would be 1 for that compound. Count occurrences with -o | wc -l.
   gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh[[:space:]]" | wc -l | tr -d ' ' || true)
-  gh_readonly=$(printf '%s' "$1" | grep -oE "${CMD_START}gh[[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status)|issue[[:space:]]+(view|list)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+view|workflow[[:space:]]+(view|list)|label[[:space:]]+list|search|auth[[:space:]]+status)([[:space:]]|$)" | wc -l | tr -d ' ' || true)
-  [ "$gh_all" -ne "$gh_readonly" ] && return 0
+  gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh[[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+view|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|search|auth[[:space:]]+status)([[:space:]]|$)" | wc -l | tr -d ' ' || true)
+  [ "$gh_all" -ne "$gh_safe" ] && return 0
 
   # Any push that can move a shared ref. The ref has to be matched in every
   # refspec form -- `main`, `HEAD:main`, `br:refs/heads/main`, `+main` --
   # not just as a bare word, since the bare word is the spelling least
-  # likely to appear when something force-updates a ref. Force pushes ask
-  # unconditionally: settings.json already asks for them, and this hook's
-  # explicit allow would otherwise override that.
+  # likely to appear when something force-updates a ref.
+  #
+  # `--force-with-lease` is exempt: it is the one force form that REFUSES to
+  # clobber an update it has not seen, which is exactly the accident a
+  # prompt here would be guarding against. It is also routine after the
+  # Step 4 merge, so asking costs a stall on every run. Bare `--force`/`-f`
+  # keeps asking -- that one overwrites unconditionally. Order matters
+  # below: test the lease form first, or `--force` matches its prefix.
   if printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+push([[:space:]]|$)"; then
-    printf '%s' "$1" | grep -qE "(--force|--force-with-lease|[[:space:]]-f([[:space:]]|$)|--all|--mirror|--tags)" && return 0
+    if ! printf '%s' "$1" | grep -qE '\-\-force-with-lease'; then
+      printf '%s' "$1" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
+    fi
+    printf '%s' "$1" | grep -qE "(--all|--mirror|--tags)" && return 0
     printf '%s' "$1" | grep -qE "(^|[[:space:]:+])(refs/heads/)?(main|beta)([[:space:]]|:|$)" && return 0
     printf '%s' "$1" | grep -qE "(^|[[:space:]:+])(refs/tags/)?v[0-9]" && return 0
   fi
@@ -119,9 +136,28 @@ is_globally_scoped() {
 # deleting a branch another agent is on, expiring the reflog that would
 # have recovered it, or removing another agent's checkout outright.
 mutates_shared_state() {
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(branch|tag)[[:space:]]+(.*[[:space:]])?(-D|-d|--delete)([[:space:]]|$)" && return 0
+  # `git branch -D` is deliberately NOT here. implement-issue Step 4 prunes
+  # merged worktrees in a loop, so asking turns one cleanup step into dozens
+  # of prompts -- and the danger it would be guarding is already handled
+  # upstream: git itself REFUSES to delete a branch checked out in another
+  # worktree ("error: cannot delete branch 'x' used by worktree at ...",
+  # exit 1), so it cannot cut another agent out from under itself. What is
+  # left is an unchecked-out branch, whose SHA git prints on delete and
+  # which stays reachable -- protected because `reflog expire`, `gc` and
+  # `filter-branch` below keep asking. `git tag -d` DOES stay: a tag is how
+  # a release is addressed, and nothing refuses to delete one.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+tag[[:space:]]+(.*[[:space:]])?(-d|--delete)([[:space:]]|$)" && return 0
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|update-ref[[:space:]]+-d|filter-branch)([[:space:]]|$)" && return 0
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+(remove|prune)([[:space:]]|$)" && return 0
+  # Same upstream-protection argument as `git branch -D`: plain `git worktree
+  # remove` REFUSES a worktree holding uncommitted or untracked files
+  # (verified: "contains modified or untracked files, use --force to delete
+  # it", exit 128), so it cannot destroy unsaved work, and a clean worktree
+  # has nothing to lose -- its branch survives. Step 4 removes merged
+  # worktrees in a loop, so asking here meant ~24 prompts in one step. Only
+  # `--force`, which is what actually discards the work, still asks.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+remove([[:space:]]|$)" &&
+    printf '%s' "$1" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+prune([[:space:]]|$)" && return 0
   return 1
 }
 
@@ -255,7 +291,21 @@ escapes_worktree() {
   return 1
 }
 
-if needs_scrutiny "$command" && escapes_worktree "$command"; then
+# Pruning a merged worktree necessarily names a path outside this one, so
+# the containment check below would ask on every iteration of Step 4's
+# cleanup loop -- ~24 prompts for the step whose whole purpose is unattended
+# tidying. Exempt exactly that command and nothing else: a lone `git
+# worktree remove` with no `--force` (matched above in mutates_shared_state)
+# and no second invocation chained after it. git refuses to remove a
+# worktree holding uncommitted or untracked files, so this cannot discard
+# work; `rm -rf <other worktree>` gets no such exemption, because nothing
+# protects it.
+is_lone_worktree_removal() {
+  printf '%s' "$1" | grep -qE '^[[:space:]]*git[[:space:]]+worktree[[:space:]]+remove[[:space:]]+[^;&|]+$' &&
+    ! printf '%s' "$1" | grep -qE '(--force|[[:space:]]-f([[:space:]]|$))'
+}
+
+if ! is_lone_worktree_removal "$command" && needs_scrutiny "$command" && escapes_worktree "$command"; then
   reason="Not auto-allowed: this command can write outside '${session_root}' -- it names an absolute path beyond the worktree, or hides its target behind '..', '~', a variable, or a command substitution. This is the Bash-side counterpart of the cross-checkout path confusion check-worktree-path.sh blocks for Edit/Write. Re-derive the path from \`pwd\` if that was unintended."
   jq -n --arg reason "$reason" '{
     hookSpecificOutput: {

--- a/.claude/hooks/link-worktree-local-settings.sh
+++ b/.claude/hooks/link-worktree-local-settings.sh
@@ -44,7 +44,10 @@ if [ -z "$worktree_list" ]; then
   exit 0
 fi
 
-roots=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{print $2}')
+# Strip the prefix rather than taking $2 -- awk's $2 truncates at the first
+# space, so a checkout path containing one would yield a short root and be
+# silently skipped.
+roots=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{sub(/^worktree /, ""); print}')
 main_root=$(printf '%s\n' "$roots" | head -n 1)
 source_file="${main_root}/.claude/settings.local.json"
 
@@ -66,7 +69,10 @@ printf '%s\n' "$roots" | tail -n +2 | while IFS= read -r root; do
     continue
   fi
 
-  ln -sfn "$source_file" "$target"
+  # Never let one unwritable or racing worktree abort the sweep: under
+  # `set -e` a single ln failure would kill the script before `exit 0`, and
+  # as a SessionStart hook that surfaces an error on every new session.
+  ln -sfn "$source_file" "$target" 2>/dev/null || true
 done
 
 exit 0

--- a/.claude/hooks/link-worktree-local-settings.sh
+++ b/.claude/hooks/link-worktree-local-settings.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# WorktreeCreate hook.
+#
+# `.claude/settings.local.json` is gitignored (globally, via
+# `**/.claude/settings.local.json`), so it exists ONLY in the main checkout.
+# `.claude/settings.json` and everything under `.claude/hooks/` are tracked
+# and travel into a worktree for free -- local settings do not.
+#
+# The asymmetry is silent and it bites hard: the moment a session enters a
+# worktree it loses every permission rule and mode set in local settings,
+# while the tracked `ask:` list keeps applying. A run that was fully
+# autonomous in the main checkout starts prompting inside the worktree, for
+# rules the user thought they had already relaxed.
+#
+# This symlinks the main checkout's local settings into every linked
+# worktree that lacks them. A symlink (not a copy) so later edits in the
+# main checkout apply everywhere without re-running anything.
+#
+# It sweeps all linked worktrees rather than trusting a payload field for
+# "the worktree that was just created": the sweep is idempotent, needs no
+# assumption about the hook's stdin shape, and self-heals worktrees that
+# predate this hook.
+#
+# Registered on two events, because there are two ways a worktree appears:
+#   WorktreeCreate -- native creation (EnterWorktree / --worktree). Fires
+#     before the session enters, so the link is in place when settings load.
+#   SessionStart   -- covers `git worktree add`, the git fallback path in
+#     superpowers:using-git-worktrees, which fires no WorktreeCreate at all.
+#     Settings are already loaded by the time SessionStart runs, so a
+#     fallback-created worktree picks its link up on its NEXT session; the
+#     fleet-wide sweep is what makes that self-correcting rather than
+#     permanent.
+#
+# Scope note: .venv and frontend/node_modules have the same
+# doesn't-travel problem, but they are scripts/worktree-setup.sh's job
+# (issue #556). This hook stays limited to the permissions concern.
+set -euo pipefail
+
+# Drain stdin so the caller never sees EPIPE; the payload is not needed.
+cat >/dev/null 2>&1 || true
+
+worktree_list=$(git worktree list --porcelain 2>/dev/null || true)
+if [ -z "$worktree_list" ]; then
+  exit 0
+fi
+
+roots=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{print $2}')
+main_root=$(printf '%s\n' "$roots" | head -n 1)
+source_file="${main_root}/.claude/settings.local.json"
+
+if [ ! -f "$source_file" ]; then
+  exit 0
+fi
+
+printf '%s\n' "$roots" | tail -n +2 | while IFS= read -r root; do
+  [ -n "$root" ] || continue
+  [ -d "$root/.claude" ] || continue
+  target="$root/.claude/settings.local.json"
+
+  # Leave a real file alone -- a worktree may intentionally carry its own.
+  if [ -e "$target" ] && [ ! -L "$target" ]; then
+    continue
+  fi
+  # Already pointing where we want.
+  if [ -L "$target" ] && [ "$(readlink "$target")" = "$source_file" ]; then
+    continue
+  fi
+
+  ln -sfn "$source_file" "$target"
+done
+
+exit 0

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Regression tests for .claude/hooks/auto-allow-worktree-destructive.sh.
+#
+# The hook decides between "allow", "ask" and "deny" from a command STRING,
+# and both directions of a wrong answer hurt: a missed containment case
+# silently writes into the shared main checkout, while an over-broad match
+# reintroduces the prompt-stall the hook exists to remove. Every case below
+# is one or the other.
+#
+# Runs against a throwaway repo + linked worktree in a temp dir, so it needs
+# no particular checkout layout and leaves nothing behind.
+#
+#   bash .claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+set -uo pipefail
+
+HOOK=$(cd "$(dirname "$0")/.." && pwd)/auto-allow-worktree-destructive.sh
+[ -f "$HOOK" ] || { echo "hook not found: $HOOK" >&2; exit 1; }
+
+# Deliberately NOT under mktemp's default root: the hook counts /tmp and
+# the macOS $TMPDIR as disposable, so a fixture there would be auto-allowed
+# and the "reaches the main checkout" cases could not be expressed at all.
+# `pwd -P` because `git rev-parse --show-toplevel` reports a resolved path
+# and the hook compares the two as strings.
+TMP=$(mktemp -d "${HOME}/.cache/bess-hook-test-XXXXXX") || exit 1
+TMP=$(cd "$TMP" && pwd -P)
+trap 'rm -rf "$TMP"' EXIT
+
+MAIN="$TMP/main"
+WT="$TMP/wt"
+git init -q "$MAIN"
+git -C "$MAIN" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$MAIN" worktree add -q -b testwt "$WT"
+
+failures=0
+
+# Asserts the hook's decision for a command run from inside the worktree.
+run() {
+  local expected="$1" cmd="$2" out got
+  out=$(printf '%s' "$cmd" | jq -Rn '{tool_input: {command: input}}' | (cd "$WT" && bash "$HOOK") 2>&1)
+  got=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // (if .continue then "fallthrough" else "unparseable" end)' 2>/dev/null) \
+    || got="unparseable: $out"
+  if [ "$got" = "$expected" ]; then
+    printf 'ok    %-5s %s\n' "$got" "$cmd"
+  else
+    printf 'FAIL  got=%-12s want=%-6s %s\n' "$got" "$expected" "$cmd"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "== pushes that can move a shared ref =="
+# The bare `main` spelling is the one an accidental force-update is LEAST
+# likely to use, so every refspec form has to be matched.
+run ask "git push origin main"
+run ask "git push origin HEAD:main"
+run ask "git push origin mybr:refs/heads/main"
+run ask "git push origin +main"
+run ask "git push --force origin HEAD:refs/heads/main"
+run ask "git push -f origin mybr"
+run ask "git push origin v10.1.0"
+run ask "git push --tags"
+run ask "git push beta main"
+run allow "git push origin feat/issue-561-thing"
+run allow "git push -u origin feat/main-ish"
+
+echo "== writes that reach the main checkout =="
+run ask "sed -i '' s/a/b/ $MAIN/backend/app.py"
+run ask "touch $MAIN/x"
+run ask "mkdir -p $MAIN/x"
+run ask "cp somefile $MAIN/somefile"
+# Absolute path quoted inside an argument, not at token start.
+run ask "python3 -c \"import shutil; shutil.rmtree('$MAIN')\""
+# Relative traversal, redirect and rm alike.
+run ask "echo x > ../../main/README.md"
+run ask "rm -rf ../../main"
+# Traversal out THROUGH an allowed temp prefix.
+run ask "rm -rf /tmp/../$MAIN"
+run ask "git -C $MAIN reset --hard"
+run ask "tar -C $MAIN -xf x.tar"
+
+echo "== state shared with the main checkout =="
+# A linked worktree has its own working tree but ONE object database and
+# ONE ref namespace, so these escape it even without -C.
+run ask "git branch -D some-branch"
+run ask "git branch --delete some-branch"
+run ask "git tag -d v1.0.0"
+run ask "git gc --prune=now"
+run ask "git reflog expire --expire=now --all"
+run ask "git worktree remove $TMP/other"
+run ask "git worktree prune"
+run allow "git branch --show-current"
+run allow "git status --short"
+
+echo "== gh reaches GitHub, which no worktree contains =="
+run ask "gh api -X DELETE repos/o/r"
+run ask "gh api repos/o/r"
+run ask "gh workflow run issue-fix.yml"
+run ask "gh secret set FOO"
+run ask "gh repo edit --visibility private"
+run ask "gh pr close 561"
+run ask "gh pr merge 561"
+# A read-only first invocation must not clear the rest of a compound.
+run ask "gh pr view 561 && gh pr merge 561"
+run allow "gh pr view 561 --json title"
+run allow "gh pr list"
+run allow "gh run watch 123"
+
+echo "== settings.json denials stay denials =="
+# A hook decision supersedes a settings rule, so "ask" here would downgrade
+# a hard block on destroying the shared podman VM to one keystroke.
+run deny "podman machine rm"
+run deny "podman system reset"
+run allow "podman ps"
+
+echo "== elevated privileges =="
+run ask "sudo rm -rf /"
+run allow "grep -rn 'sudo ' docs/"
+
+echo "== autonomy inside the worktree is preserved =="
+run allow ".venv/bin/pytest -m 'not slow'"
+run allow "rm -rf .venv && python3 -m venv .venv"
+run allow "npm ci"
+run allow "git merge origin/main"
+run allow "git reset --hard HEAD~1"
+run allow "git rebase origin/main"
+run allow "pytest 2>&1 | tee test.log"
+run allow "npm run build > /dev/null"
+run allow "cd $WT/frontend && npm run lint"
+run allow "sed -i '' s/a/b/ backend/app.py"
+run allow "mkdir -p docs/newdir"
+run allow "echo hi > out.txt"
+run allow "rm -rf /tmp/scratch"
+
+echo "== the main checkout keeps its own rules =="
+# In the main checkout the hook must stay silent so settings.json applies
+# unchanged -- an allow there would be the worst possible failure.
+main_decision=$(printf '%s' "rm -rf .venv" | jq -Rn '{tool_input: {command: input}}' \
+  | (cd "$MAIN" && bash "$HOOK") | jq -r 'if .continue then "fallthrough" else "DECIDED" end')
+if [ "$main_decision" = "fallthrough" ]; then
+  printf 'ok    %-5s %s\n' "none" "rm -rf .venv (from the main checkout)"
+else
+  printf 'FAIL  got=%-12s want=%-6s %s\n' "$main_decision" "none" "rm -rf .venv (from the main checkout)"
+  failures=$((failures + 1))
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "all checks passed"
+else
+  echo "$failures check(s) failed"
+fi
+exit $((failures > 0))

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -61,6 +61,15 @@ run ask "git push --tags"
 run ask "git push beta main"
 run allow "git push origin feat/issue-561-thing"
 run allow "git push -u origin feat/main-ish"
+# --force-with-lease is the one force form that REFUSES to clobber an
+# update it has not seen -- the accident a prompt here would guard. It is
+# routine after the Step 4 merge, so asking would stall every run. Bare
+# --force still asks (pinned above), including when both could match.
+run allow "git push --force-with-lease origin HEAD"
+run allow "git push --force-with-lease origin feat/issue-561-thing"
+# ...but never onto a shared ref, lease or not.
+run ask "git push --force-with-lease origin main"
+run ask "git push --force-with-lease origin HEAD:refs/heads/beta"
 
 echo "== writes that reach the main checkout =="
 run ask "sed -i '' s/a/b/ $MAIN/backend/app.py"
@@ -80,12 +89,27 @@ run ask "tar -C $MAIN -xf x.tar"
 echo "== state shared with the main checkout =="
 # A linked worktree has its own working tree but ONE object database and
 # ONE ref namespace, so these escape it even without -C.
-run ask "git branch -D some-branch"
-run ask "git branch --delete some-branch"
+# `git branch -D` is allowed on purpose. implement-issue Step 4 prunes
+# merged worktrees in a loop, and the danger is already handled upstream:
+# git REFUSES to delete a branch checked out in another worktree (verified:
+# "error: cannot delete branch 'x' used by worktree at ...", exit 1). An
+# unchecked-out branch stays reachable by the SHA git prints, which is why
+# reflog expire / gc / filter-branch below must keep asking.
+run allow "git branch -D some-branch"
+run allow "git branch --delete some-branch"
+# A tag is how a release is addressed and nothing refuses to delete one.
 run ask "git tag -d v1.0.0"
 run ask "git gc --prune=now"
 run ask "git reflog expire --expire=now --all"
-run ask "git worktree remove $TMP/other"
+# Plain `remove` refuses a worktree with uncommitted or untracked files
+# (verified: exit 128), so only --force can actually discard work.
+run allow "git worktree remove $TMP/other"
+run ask "git worktree remove --force $TMP/other"
+run ask "git worktree remove -f $TMP/other"
+# The exemption is for a LONE removal only -- it must not carry an
+# unprotected second command through with it.
+run ask "git worktree remove $TMP/other && rm -rf $MAIN"
+run ask "rm -rf $TMP/other"
 run ask "git worktree prune"
 run allow "git branch --show-current"
 run allow "git status --short"
@@ -102,6 +126,17 @@ run ask "gh pr merge 561"
 run ask "gh pr view 561 && gh pr merge 561"
 run allow "gh pr view 561 --json title"
 run allow "gh pr list"
+# Authoring a PR/issue on this repo IS the work product -- `gh pr create` is
+# the closing step of implement-issue, so a read-only-only safe list would
+# move the stall from `rm -f` to the finish line. Publishing, merging and
+# reconfiguring stay behind a prompt (pinned above).
+run allow "gh pr create --draft --base main --title x --body-file /tmp/b.md"
+run allow "gh pr edit 561 --body-file /tmp/b.md"
+run allow "gh pr ready 561"
+run allow "gh issue comment 558 --body 'working on it'"
+run allow "gh issue edit 558 --add-label analyzed"
+# Authoring first must still not clear a publishing invocation after it.
+run ask "gh pr create --draft --title x && gh pr merge 561"
 run allow "gh run watch 123"
 
 echo "== settings.json denials stay denials =="

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -21,6 +21,10 @@ HOOK=$(cd "$(dirname "$0")/.." && pwd)/auto-allow-worktree-destructive.sh
 # and the "reaches the main checkout" cases could not be expressed at all.
 # `pwd -P` because `git rev-parse --show-toplevel` reports a resolved path
 # and the hook compares the two as strings.
+# ~/.cache is absent on a fresh macOS install and on most CI runners, where
+# mktemp would fail with only its own stderr -- indistinguishable from a
+# real test failure.
+mkdir -p "${HOME}/.cache" || exit 1
 TMP=$(mktemp -d "${HOME}/.cache/bess-hook-test-XXXXXX") || exit 1
 TMP=$(cd "$TMP" && pwd -P)
 trap 'rm -rf "$TMP"' EXIT
@@ -164,6 +168,58 @@ run allow "sed -i '' s/a/b/ backend/app.py"
 run allow "mkdir -p docs/newdir"
 run allow "echo hi > out.txt"
 run allow "rm -rf /tmp/scratch"
+
+echo "== a command prefix must not shift the command word out of the guards =="
+# One env assignment used to defeat EVERY anchored guard at once, turning a
+# settings.json deny into a silent allow.
+run deny "PODMAN=1 podman machine rm"
+run deny "env podman system reset"
+run ask  "GIT_SSH_COMMAND=ssh git push origin main"
+run ask  "nohup gh pr merge 561"
+run ask  "time sudo rm -rf /"
+run ask  "PYTHONPATH=. sudo rm -rf /"
+# ...while an env prefix on ordinary work stays allowed.
+run allow "PYTHONPATH=. .venv/bin/pytest -q"
+run allow "TZ=UTC .venv/bin/pytest -q"
+
+echo "== git global options must not slip past the push guard =="
+run ask "git -C sub push origin main"
+run ask "git --git-dir=sub/.git push origin main"
+run ask "git -c push.default=matching push origin main"
+run allow "git -C sub push origin feat/x"
+
+echo "== the refspec scan is scoped to the push's own arguments =="
+# A `main` elsewhere in a compound must not turn a safe push into a prompt.
+run allow "git push -u origin feat/x && gh pr create --draft --base main --title x"
+run allow "git commit -m 'fix main crash' && git push origin feat/x"
+run ask   "git commit -m 'x' && git push origin main"
+
+echo "== state shared across worktrees: stash, config, remotes =="
+# ONE refs/stash for every worktree; this project leans on stash for
+# branch isolation, so the shared stack is a live hazard.
+run ask "git stash clear"
+run ask "git stash drop"
+run ask "git stash pop"
+run allow "git stash list"
+run allow "git stash push -u -m wip"
+run ask "git config --global user.email x@y.z"
+run ask "git remote set-url origin git@github.com:other/repo.git"
+run ask "git remote remove origin"
+run allow "git config --get user.email"
+
+echo "== reading outside the worktree is not a write =="
+# visualize-debug-log opens a user's bundle from ~/Downloads; the
+# containment guard is about writes, so reads must not prompt.
+run allow "cat $TMP/outside.json"
+run allow "head -50 $MAIN/CHANGELOG.md"
+run allow "ls ~/Downloads"
+run allow "grep -rn foo /usr/local/lib"
+run allow "git log --oneline -5"
+run allow "cat $MAIN/x.json | jq .a"
+# ...but anything that can write is still scrutinised.
+run ask "python3 -c \"import shutil; shutil.rmtree('$MAIN')\""
+run ask "sed -i '' s/a/b/ $MAIN/app.py"
+run ask "cat x.json > $MAIN/out.json"
 
 echo "== the main checkout keeps its own rules =="
 # In the main checkout the hook must stay silent so settings.json applies

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,6 +79,27 @@
         ]
       }
     ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/link-worktree-local-settings.sh",
+            "statusMessage": "Linking local settings into the worktree"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/link-worktree-local-settings.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@ venv/
 
 # Node.js dependencies
 node_modules/
+# A worktree gets this as a symlink to the main checkout (see
+# .claude/hooks/link-worktree-local-settings.sh). Ignoring it only via a
+# personal ~/.config/git/ignore means another clone -- or CI -- would see an
+# untracked symlink holding an absolute path from one machine, and `git add
+# -A` would commit it.
+.claude/settings.local.json
 
 # Logs
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,11 @@ main checkout. A session that enters a worktree silently loses every rule and
 mode set there while the tracked `ask:` list keeps applying — that asymmetry is
 why an autonomous run in the main checkout starts prompting mid-worktree.
 `.claude/hooks/link-worktree-local-settings.sh` symlinks it into every linked
-worktree. The same doesn't-travel problem applies to `.venv` and
+worktree. Note what that does **not** buy you: a hook decision supersedes a
+settings rule, so a Bash `deny`/`ask` you add to local settings is overridden
+inside a worktree by the auto-allow. `defaultMode` and non-Bash rules survive
+the trip; a Bash restriction has to go in the hook's own escape lists to have
+any effect there. The same doesn't-travel problem applies to `.venv` and
 `frontend/node_modules` (see `scripts/worktree-setup.sh`, issue #556).
 
 ## Home Assistant Integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,20 @@ pushes moving `main`/`beta`/tags), and commands that **reach outside the
 worktree** — an absolute path beyond its root, or a target hidden behind `..`,
 `~`, a variable, or a command substitution.
 
+**Don't add a prompt where git already refuses.** `git branch -D`, plain `git
+worktree remove` and `git push --force-with-lease` are auto-allowed on purpose:
+git itself blocks the dangerous case (it won't delete a branch checked out in
+another worktree, won't remove a worktree holding uncommitted or untracked
+files, and `--force-with-lease` won't clobber an update it hasn't seen). A
+second prompt there buys nothing and costs a stall on every run — Step 4's
+prune loop alone would have hit ~24 of them. The forcing variants (`--force`,
+`-f`, `git tag -d`, `reflog expire`, `gc`) still ask, because those are the
+ones that actually discard recoverable state. Likewise `gh` allows *authoring*
+(`pr create`/`edit`/`comment`, `issue comment`) — that's the work product, and
+`gh pr create` is the closing step of `implement-issue` — while publishing and
+reconfiguring (`pr merge`, `release`, `repo edit`, `secret`, `workflow run`,
+non-GET `gh api`) still ask.
+
 That second check guards against *accidents* — a stale absolute path from before
 a worktree switch, a `../..` counted from the wrong cwd — and is the Bash-side
 counterpart of `check-worktree-path.sh`. It is **not a sandbox**: a hook sees the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,10 +200,20 @@ Bash commands whose cwd is a linked worktree, and falls through everywhere else
 so the shared main checkout keeps its `ask`/`deny` rules. Do not "fix" a prompt
 by adding the offending command to an allowlist — an `ask` rule beats an `allow`
 rule, so that never works, and enumerating command shapes is what the inverted
-hook exists to replace. The only additions that belong in that hook are the
-*escape* list: commands whose blast radius leaves the worktree (`sudo`,
-`podman machine rm`, `gh pr merge`, pushes to `main`/`beta`, absolute paths
-outside the worktree root).
+hook exists to replace.
+
+Two classes still prompt inside a worktree: **globally-scoped** actions no
+worktree can contain (`sudo`, `podman machine rm`, `gh pr merge`/`release`,
+pushes moving `main`/`beta`/tags), and commands that **reach outside the
+worktree** — an absolute path beyond its root, or a target hidden behind `..`,
+`~`, a variable, or a command substitution.
+
+That second check guards against *accidents* — a stale absolute path from before
+a worktree switch, a `../..` counted from the wrong cwd — and is the Bash-side
+counterpart of `check-worktree-path.sh`. It is **not a sandbox**: a hook sees the
+command string, not the syscalls, so indirection can defeat it. The real
+containment is that a worktree is disposable. Don't extend it as if it were a
+security boundary, and don't weaken it on the grounds that it isn't one.
 
 **Only tracked files travel into a worktree.** `.claude/settings.json` and
 `.claude/hooks/*` are tracked and follow automatically;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,29 @@ same. Choose by how you want to reach an agent's work:
 Find any session's worktree path by peeking/attaching it in Agent View, or via
 `claude agents --json` (the `cwd` field).
 
+### Permissions inside a worktree
+
+**The worktree is the safety boundary.** A linked worktree is disposable by
+construction, so `.claude/hooks/auto-allow-worktree-destructive.sh` auto-allows
+Bash commands whose cwd is a linked worktree, and falls through everywhere else
+so the shared main checkout keeps its `ask`/`deny` rules. Do not "fix" a prompt
+by adding the offending command to an allowlist — an `ask` rule beats an `allow`
+rule, so that never works, and enumerating command shapes is what the inverted
+hook exists to replace. The only additions that belong in that hook are the
+*escape* list: commands whose blast radius leaves the worktree (`sudo`,
+`podman machine rm`, `gh pr merge`, pushes to `main`/`beta`, absolute paths
+outside the worktree root).
+
+**Only tracked files travel into a worktree.** `.claude/settings.json` and
+`.claude/hooks/*` are tracked and follow automatically;
+`.claude/settings.local.json` is gitignored and therefore exists only in the
+main checkout. A session that enters a worktree silently loses every rule and
+mode set there while the tracked `ask:` list keeps applying — that asymmetry is
+why an autonomous run in the main checkout starts prompting mid-worktree.
+`.claude/hooks/link-worktree-local-settings.sh` symlinks it into every linked
+worktree. The same doesn't-travel problem applies to `.venv` and
+`frontend/node_modules` (see `scripts/worktree-setup.sh`, issue #556).
+
 ## Home Assistant Integration
 
 - **Sensors**: battery SOC/power, solar production, grid import/export, pricing

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -151,6 +151,28 @@ else
 fi
 
 echo ""
+echo "📋 Checking permission-hook decisions..."
+echo "-------------------------------------------"
+
+# The hook decides, per Bash command, whether an agent is prompted or runs
+# unattended -- including re-emitting the settings.json denials. Its
+# expectation matrix only protects that if something actually runs it.
+HOOK_TEST=".claude/hooks/tests/auto-allow-worktree-destructive.test.sh"
+if [ -f "$HOOK_TEST" ]; then
+    if bash "$HOOK_TEST" > /tmp/hook-test-out.txt 2>&1; then
+        echo "✅ Worktree permission hook behaves as pinned"
+    else
+        echo "❌ Worktree permission hook changed behaviour:"
+        grep "^FAIL" /tmp/hook-test-out.txt || tail -20 /tmp/hook-test-out.txt
+        ERRORS=$((ERRORS + 1))
+    fi
+    rm -f /tmp/hook-test-out.txt
+else
+    echo "⚠️  $HOOK_TEST not found"
+    WARNINGS=$((WARNINGS + 1))
+fi
+
+echo ""
 echo "📋 Checking scenario discovery coverage..."
 echo "-------------------------------------------"
 


### PR DESCRIPTION
Long autonomous runs — `implement-issue` especially — kept halting on permission
prompts *inside a worktree*, for commands the setup was supposed to have already
cleared. Two independent causes, both silent.

## 1. The auto-allow hook was an enumeration, and enumerations lose

`auto-allow-worktree-destructive.sh` listed destructive command shapes (`rm -rf`,
`git reset --hard`, `git rebase`, `git merge`, `git push --force`) and auto-allowed
only those inside a linked worktree. Everything else fell through to
`ask: Bash(rm *)` in `settings.json`.

So `rm -f scripts/mock_ha/scenarios/bess-debug-huawei.json && .venv/bin/pytest …`
prompted — and **no allowlist entry could ever have fixed it**, because an `ask`
rule beats an `allow` rule. Each new command shape needed another hook entry, which
left the list permanently one command behind.

**Inverted.** cwd in a linked worktree now auto-allows Bash. A worktree is
disposable by construction; a prompt there protects nothing. Two classes still
prompt:

- **Globally scoped** — no worktree contains these: `sudo`, `podman machine
  rm`/`system reset` (the shared VM every worktree's E2E stack uses), `gh pr
  merge`/`release`/`repo delete`, and any push that moves a shared ref
  (`main`/`beta`, `--all`, `--mirror`, `--tags`, version tags).
- **Reaches outside the worktree** — an absolute path beyond its root, or a target
  hidden behind `..`, `~`, a variable, or a command substitution.

Both emit an explicit `ask`. Falling through would have been wrong in both
directions: `settings.json` *allow*-lists `Bash(git push *)`, so a shared-ref push
would sail through unprompted, while `podman machine rm` would hit a deny it can no
longer reach once any allow is in play.

The main checkout is untouched — the hook returns before any of this when cwd isn't
a linked worktree, so it keeps every `ask`/`deny` rule exactly as configured.

## 2. Local settings never travel into a worktree

Only *tracked* files follow a worktree. `.claude/settings.json` and
`.claude/hooks/*` do; `.claude/settings.local.json` is gitignored and so exists
**only in the main checkout**.

A session entering a worktree therefore drops every rule and mode set there —
including `defaultMode` — while the tracked `ask:` list keeps applying. A run that
was fully autonomous in the main checkout starts prompting the moment it moves.
**24 of 25 linked worktrees on this machine were missing the file.**

`link-worktree-local-settings.sh` symlinks it in, sweeping *all* linked worktrees so
the pass is idempotent, payload-agnostic, and self-healing for worktrees predating
it. Registered on `WorktreeCreate` (native creation; fires before settings load) and
`SessionStart` (covers `git worktree add`, the `using-git-worktrees` fallback, which
fires no `WorktreeCreate` — settings are already loaded by then, so such a worktree
picks its link up on its *next* session; the fleet-wide sweep is what makes that
self-correcting rather than permanent).

## What the first revision got wrong

The original version of this PR claimed the escape list excluded "commands whose
blast radius leaves the worktree." **That claim was false**, and `/code-review`
demonstrated it. The guard inspected only tokens beginning with `/`, so all of these
were auto-allowed from inside a worktree — each reproduced against the real hook:

| Auto-allowed (should not have been) | Why it slipped |
|---|---|
| `rm -rf ../../../../bess-manager-sibling` | relative traversal, never checked |
| `rm -rf "/Users/…/bess-manager/.venv"` | leading quote meant the token didn't start with `/` |
| `rm -rf $HOME/GitHub/bess-manager` | unexpanded variable |
| `rm -rf /tmp/../Users/…/.venv` | matched the `/tmp/*` allowance, then traversed out |
| `git -C /Users/…/bess-manager reset --hard` | not an `rm`/`mv` verb, so never scrutinized |
| `cp secrets.txt /Users/…/leak.txt`, `find /Users/… -delete` | same |

Also fixed from that review: the escape list matched bare substrings, so `grep
"sudo " docs/` and `git push origin fix/mainpage-bug` were wrongly pushed back to a
prompt (now anchored at command-word position); and `awk '/^worktree /{print $2}'`
truncates a checkout path at its first space — in `auto-allow` that **inverted the
boundary**, making the "am I the main checkout?" test fail *in the main checkout*
and auto-allowing everything there.

## Honest limits

The containment check guards **accidents** — a stale absolute path from before a
worktree switch, a `../..` from the wrong cwd — as the Bash-side counterpart of
`check-worktree-path.sh`. It is **not a sandbox**: a hook sees the command string,
not the syscalls, so indirection can defeat it. The real containment is that a
worktree is disposable. CLAUDE.md says so, so this isn't re-litigated as either a
security boundary or a pointless one.

## Verification

Expectation-checked matrix against the real hook:

- **Inside a worktree — 39/39.** 18 ordinary commands allowed (`pytest`, `npm ci`,
  `git merge`, `rm -f`, `git push origin fix/mainpage-bug`, `grep "sudo " docs/`),
  9 globally-scoped → `ask`, 12 escape attempts → `ask`.
- **From the main checkout — 9/9 fall through.** Strictly worktree-scoped.

Link sweep produced 24 symlinks and correctly skipped the one worktree carrying a
real (non-symlink) local settings file. `./scripts/quality-check.sh`: **0 errors**
(3 warnings are the script probing `PATH` for pytest/black/ruff instead of
`.venv/bin` — pre-existing; this diff contains no Python).

## Scope

`.venv` and `frontend/node_modules` have the identical doesn't-travel problem — this
worktree started with neither, which is what made `quality-check.sh` fail on first
run. Left to `scripts/worktree-setup.sh` (#556) rather than duplicated here.

Two review findings are knowingly **not** addressed, as judgement calls rather than
defects: the symlink is bidirectional (a `/permissions` edit from inside a worktree
writes through to the main checkout — that is the intended single source of truth),
and `WorktreeCreate` ordering is assumed rather than proven, since it can't be
exercised from inside an existing worktree session. The `SessionStart` registration
and fleet-wide sweep are what bound the cost of that assumption being wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W29UVDwQPwVRRqBn2sMgHa
