### PR TITLE
Share worktree dependencies instead of reinstalling them (#556)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -136,6 +136,12 @@ rewrites, other merged fixes), surfacing later as an avoidable merge
 conflict. Then invoke `superpowers:using-git-worktrees`, basing the new
 branch on `origin/main`.
 
+Then run `./scripts/worktree-setup.sh` in the new worktree — once, before any
+test, build or `verify` step. It shares `.venv` and both `node_modules` trees
+with the main checkout and repairs a stale Playwright browser cache. Skipping
+it means paying ~35 minutes of reinstall against ~5 minutes of real testing,
+which is what makes Step 8 feel skippable (#556).
+
 **Do not change the session's worktree while a background agent spawned from
 it is still running.** The agent's isolation follows the session, so
 switching drags it into the new worktree mid-run — observed in practice: a

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -33,8 +33,12 @@ SCENARIO=ci-normal-day BESS_PORT=18180 MOCK_HA_PORT=18123 \
 ```
 
 Add `--build` only when you changed something baked into the image
-(`backend/Dockerfile.dev`, `requirements*.txt`) — the compose file bind-mounts
-the source, so an unnecessary rebuild costs minutes and changes nothing.
+(`backend/Dockerfile.dev`, `requirements*.txt`, or anything under
+`scripts/mock_ha/` other than `scenarios/`) — the compose file bind-mounts the
+backend source, so an unnecessary rebuild costs minutes and changes nothing.
+Note that mock-HA is the opposite case: its Dockerfile does `COPY . .` and only
+`scenarios/` is bind-mounted, so an edit to `server.py` without `--build` runs
+the stale baked copy and silently invalidates the whole observation.
 
 Wait for both containers healthy (`podman ps --filter name=<unique-name>`),
 then hit the real API:

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -11,6 +11,9 @@ HTTP API (or load the served frontend) to observe the change.
 
 ## One-time setup
 
+- In a fresh worktree, run `./scripts/worktree-setup.sh` first — it shares
+  `.venv` and both `node_modules` trees with the main checkout and repairs a
+  broken Playwright browser cache, instead of reinstalling all of it (~35 min).
 - `podman-compose` isn't always on PATH: `pip install --user podman-compose`,
   then add `~/Library/Python/<ver>/bin` to PATH for the shell session.
   `podman compose` (the built-in plugin) does NOT work here — it looks for a
@@ -26,8 +29,12 @@ with another worktree's running stack:
 
 ```bash
 SCENARIO=ci-normal-day BESS_PORT=18180 MOCK_HA_PORT=18123 \
-  podman-compose -p <unique-name> -f docker-compose.ci.yml up -d --build
+  podman-compose -p <unique-name> -f docker-compose.ci.yml up -d
 ```
+
+Add `--build` only when you changed something baked into the image
+(`backend/Dockerfile.dev`, `requirements*.txt`) — the compose file bind-mounts
+the source, so an unnecessary rebuild costs minutes and changes nothing.
 
 Wait for both containers healthy (`podman ps --filter name=<unique-name>`),
 then hit the real API:

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@ venv/
 .mypy_cache/
 .ruff_cache/
 
-# Node.js dependencies
-node_modules/
+# Node.js dependencies (no trailing slash: in a worktree set up by
+# scripts/worktree-setup.sh these are symlinks to the main checkout, and a
+# trailing slash matches a directory but not a symlink to one)
+node_modules
 
 # Logs
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,14 @@ same. Choose by how you want to reach an agent's work:
 Find any session's worktree path by peeking/attaching it in Agent View, or via
 `claude agents --json` (the `cwd` field).
 
+**Run `./scripts/worktree-setup.sh` once in every new worktree, before any
+test/build/verify step.** A fresh worktree has no `.venv` and no
+`node_modules`, and reinstalling them costs ~35 minutes against ~5 minutes of
+actual testing. The script shares all three dependency trees with the main
+checkout (falling back to a real `npm install` only for a package root whose
+lockfile actually diverged) and repairs a Playwright browser cache left
+unusable by an interrupted install.
+
 ## Home Assistant Integration
 
 - **Sensors**: battery SOC/power, solar production, grid import/export, pricing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,15 @@ checkout (falling back to a real `npm install` only for a package root whose
 lockfile actually diverged) and repairs a Playwright browser cache left
 unusable by an interrupted install.
 
+Those shared trees are symlinks, so they are read-shared but **not**
+write-isolated: `npm install` or `pip install` inside a worktree writes through
+the link and changes dependencies for the main checkout and every other
+worktree at once. Running tests and builds is safe; when a branch needs its own
+dependency set, replace the symlink with a real install (`rm .venv` / `rm
+frontend/node_modules` first) rather than installing through it. Re-running
+`worktree-setup.sh` handles the node case automatically once
+`package-lock.json` diverges — `requirements.txt` drift is not detected.
+
 ## Home Assistant Integration
 
 - **Sensors**: battery SOC/power, solar production, grid import/export, pricing

--- a/backend/tests/test_worktree_setup_script.py
+++ b/backend/tests/test_worktree_setup_script.py
@@ -173,16 +173,34 @@ def test_repairs_a_browser_cache_whose_marker_lies(tmp_path):
     ), "a repaired cache must be reinstalled"
 
 
-def test_leaves_an_intact_browser_cache_alone(tmp_path):
-    """The complement of the repair test: a cache with a real executable must
-    not be deleted and reinstalled on every worktree setup."""
-    _, wt, env, log, cache = _setup(tmp_path)
+def test_does_not_delete_an_intact_browser_install(tmp_path):
+    """The complement of the repair test: a directory holding a real executable
+    is a working install and must survive."""
+    _, wt, env, _, cache = _setup(tmp_path)
 
     result = _invoke(wt, env)
 
     assert result.returncode == 0, result.stderr
     assert (cache / "chromium-1217" / "chrome-mac-arm64" / "Chromium").exists()
-    assert not any("playwright install" in c for c in _shim_calls(log))
+
+
+def test_always_lets_playwright_verify_the_browsers(tmp_path):
+    """Pruning directories that lie is not enough to know the cache is usable:
+    a browser that is entirely ABSENT leaves no directory to inspect at all.
+    Observed live during #556 — the cache held an intact `chromium-1217`, the
+    script declared it intact, and `chromium.launch()` still failed with
+    "Executable doesn't exist at .../chromium_headless_shell-1217/...", which
+    is the very error the issue reports. Only Playwright knows which browsers
+    it needs, so it always gets to check; `playwright install` is a fast no-op
+    when they are all genuinely present."""
+    _, wt, env, log, _ = _setup(tmp_path)
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert any(
+        "playwright install" in c for c in _shim_calls(log)
+    ), "an apparently-intact cache must still be verified by Playwright itself"
 
 
 def test_ignores_playwright_bookkeeping_directories_in_the_cache(tmp_path):
@@ -193,7 +211,7 @@ def test_ignores_playwright_bookkeeping_directories_in_the_cache(tmp_path):
     and crashes the reinstall the script goes on to trigger (observed live:
     'Error: Unable to update lock within the stale threshold'). It — and any
     other non `name-<digits>` entry — must be left alone."""
-    _, wt, env, log, cache = _setup(tmp_path)
+    _, wt, env, _, cache = _setup(tmp_path)
     (cache / "__dirlock").mkdir()
     (cache / ".links").mkdir()
 
@@ -203,10 +221,9 @@ def test_ignores_playwright_bookkeeping_directories_in_the_cache(tmp_path):
     assert (
         cache / "__dirlock"
     ).exists(), "must not delete Playwright's own lock directory"
-    assert not any("playwright install" in c for c in _shim_calls(log)), (
-        "a bookkeeping directory with no executable must not be mistaken for "
-        "a stale browser install"
-    )
+    assert (
+        cache / ".links"
+    ).exists(), "must not delete Playwright's link bookkeeping directory"
 
 
 def test_repairs_a_broken_venv_symlink(tmp_path):

--- a/backend/tests/test_worktree_setup_script.py
+++ b/backend/tests/test_worktree_setup_script.py
@@ -154,6 +154,70 @@ def test_installs_instead_of_linking_when_the_lockfile_diverges(tmp_path):
     assert (wt / "e2e" / "node_modules").is_symlink()
 
 
+def test_replaces_a_share_whose_lockfile_diverged_after_it_was_made(tmp_path):
+    """The lockfiles agreed when the link was made — that says nothing about
+    now. A branch adds a dependency (or merges main), the maintainer re-runs
+    this script to fix exactly that, and a check that only looks at whether
+    node_modules exists reports success while the worktree keeps building
+    against the main checkout's stale tree."""
+    _, wt, env, log, _ = _setup(tmp_path)
+    assert _invoke(wt, env).returncode == 0
+    assert (wt / "frontend" / "node_modules").is_symlink()
+
+    (wt / "frontend" / "package-lock.json").write_text('{"name": "now-diverged"}\n')
+    log.unlink(missing_ok=True)
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert not (
+        wt / "frontend" / "node_modules"
+    ).is_symlink(), (
+        "a share must be re-validated on every run, not trusted because it exists"
+    )
+    assert "npm install" in "\n".join(_shim_calls(log))
+    # The package root whose lockfile still agrees stays shared.
+    assert (wt / "e2e" / "node_modules").is_symlink()
+
+
+def test_leaves_a_real_node_modules_install_alone(tmp_path):
+    """A real directory is the worktree's own install, made because its
+    lockfile diverged. Re-running must not replace it with a share."""
+    _, wt, env, log, _ = _setup(tmp_path)
+    (wt / "frontend" / "node_modules" / "branch-only-dep").mkdir(parents=True)
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert not (wt / "frontend" / "node_modules").is_symlink()
+    assert (wt / "frontend" / "node_modules" / "branch-only-dep").is_dir()
+    assert not any(c.startswith("npm install") for c in _shim_calls(log))
+
+
+def test_succeeds_on_a_worktree_with_no_e2e_directory(tmp_path):
+    """Every other step guards on the package root existing; the Playwright
+    install did not. On a branch predating e2e/ the subshell fails under
+    `set -e`, so the script aborts with no diagnostic immediately after
+    reporting that all the sharing succeeded."""
+    main = _make_main_checkout(tmp_path)
+    _run(["git", "rm", "-r", "--quiet", "e2e"], cwd=main)
+    _run(["git", "commit", "-m", "drop e2e"], cwd=main)
+    wt = _make_worktree(main)
+    bindir, log = _make_shims(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "SHIM_LOG": str(log),
+        "PLAYWRIGHT_BROWSERS_PATH": str(_healthy_browser_cache(tmp_path)),
+    }
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (wt / ".venv").is_symlink()
+    assert (wt / "frontend" / "node_modules").is_symlink()
+    assert not any(c.startswith("npx") for c in _shim_calls(log))
+
+
 def test_repairs_a_browser_cache_whose_marker_lies(tmp_path):
     """The trap from #556: an empty browser directory next to an
     INSTALLATION_COMPLETE marker makes every later `playwright install` a

--- a/backend/tests/test_worktree_setup_script.py
+++ b/backend/tests/test_worktree_setup_script.py
@@ -283,6 +283,35 @@ def test_refuses_to_run_outside_a_worktree(tmp_path):
     assert "worktree" in (result.stderr + result.stdout).lower()
 
 
+def test_fails_loudly_when_the_browser_install_hangs(tmp_path):
+    """`playwright install` can hang indefinitely after its download finishes,
+    holding the completed zip and burning no CPU — observed twice while working
+    #556, once for 9h24m, each time leaving the same 448K partial `chromium-*`
+    directory that IS the corruption the issue reports. Since this script runs
+    the install on every worktree setup, an unbounded wait would hang setup
+    itself forever. Bound it and fail with something actionable instead."""
+    _, wt, env, _, _ = _setup(tmp_path)
+    hanging_npx = Path(env["PATH"].split(":")[0]) / "npx"
+    hanging_npx.write_text("#!/bin/sh\nsleep 600\n")
+    hanging_npx.chmod(0o755)
+    env = {**env, "WORKTREE_SETUP_INSTALL_TIMEOUT": "3"}
+
+    result = subprocess.run(
+        [str(wt / "scripts" / "worktree-setup.sh")],
+        cwd=wt,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode != 0, "a hung install must not be reported as success"
+    output = result.stdout + result.stderr
+    assert "playwright install" in output.lower()
+    # The dependency sharing that already succeeded must survive the failure.
+    assert (wt / ".venv").is_symlink()
+
+
 def test_leaves_the_worktree_git_status_clean(tmp_path):
     """The links the script creates must be invisible to git. `.gitignore`'s
     `node_modules/` pattern matches a directory but NOT a symlink pointing at

--- a/backend/tests/test_worktree_setup_script.py
+++ b/backend/tests/test_worktree_setup_script.py
@@ -1,0 +1,289 @@
+"""Tests for scripts/worktree-setup.sh — the one-shot dependency bootstrap
+for a freshly created git worktree (issue #556).
+
+A new worktree starts with no .venv, no frontend/node_modules and no
+e2e/node_modules, so a full `implement-issue` run spends ~35 of its ~40
+minutes reinstalling dependencies that already exist, byte-identical, in the
+main checkout. The script shares them instead.
+
+Everything here runs the real script as a subprocess against a real, throwaway
+git worktree built in tmp_path, so the CLI contract is exercised exactly as a
+maintainer would invoke it. The two expensive commands the script may shell out
+to — `npm` and `npx playwright install` — are replaced by recording shims on
+PATH, which is what lets us assert *whether* an install was needed without
+paying for one. Playwright's own PLAYWRIGHT_BROWSERS_PATH env var points the
+browser-cache checks at a synthetic cache.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "worktree-setup.sh"
+
+_SHIM = """#!/bin/sh
+echo "$(basename "$0") $*" >> "$SHIM_LOG"
+exit 0
+"""
+
+
+def _run(cmd, cwd):
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def _make_main_checkout(root: Path) -> Path:
+    """A minimal stand-in for the main bess-manager checkout: a git repo that
+    carries the real script plus the three dependency trees a worktree wants."""
+    main = root / "main-checkout"
+    (main / "scripts").mkdir(parents=True)
+    (main / "scripts" / "worktree-setup.sh").write_bytes(SCRIPT.read_bytes())
+    (main / "scripts" / "worktree-setup.sh").chmod(0o755)
+
+    # Dependency trees that already exist in the main checkout (gitignored
+    # there, hence created directly rather than committed).
+    (main / ".venv" / "bin").mkdir(parents=True)
+    for pkg in ("frontend", "e2e"):
+        (main / pkg).mkdir(exist_ok=True)
+        (main / pkg / "package-lock.json").write_text(f'{{"name": "{pkg}"}}\n')
+        (main / pkg / "node_modules" / "some-dep").mkdir(parents=True)
+
+    _run(["git", "init", "-b", "main"], cwd=main)
+    _run(["git", "config", "user.email", "t@example.com"], cwd=main)
+    _run(["git", "config", "user.name", "Test"], cwd=main)
+    # The real .gitignore, not a hand-written stand-in — whether the script's
+    # symlinks are ignored depends on its exact patterns (a trailing slash
+    # matches a directory but not a symlink to one).
+    (main / ".gitignore").write_bytes((REPO_ROOT / ".gitignore").read_bytes())
+    _run(["git", "add", "-A"], cwd=main)
+    _run(["git", "commit", "-m", "init"], cwd=main)
+    return main
+
+
+def _make_worktree(main: Path) -> Path:
+    wt = main.parent / "wt"
+    _run(["git", "worktree", "add", str(wt), "-b", "feature"], cwd=main)
+    return wt
+
+
+def _make_shims(root: Path) -> tuple[Path, Path]:
+    """Recording stand-ins for npm/npx, so the test can tell whether the script
+    decided an install was necessary without actually running one."""
+    bindir = root / "shims"
+    bindir.mkdir()
+    log = root / "shim.log"
+    for name in ("npm", "npx"):
+        shim = bindir / name
+        shim.write_text(_SHIM)
+        shim.chmod(0o755)
+    return bindir, log
+
+
+def _healthy_browser_cache(root: Path) -> Path:
+    cache = root / "ms-playwright"
+    binary = cache / "chromium-1217" / "chrome-mac-arm64" / "Chromium"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+    (cache / "chromium-1217" / "INSTALLATION_COMPLETE").write_text("")
+    return cache
+
+
+def _setup(tmp_path):
+    main = _make_main_checkout(tmp_path)
+    wt = _make_worktree(main)
+    bindir, log = _make_shims(tmp_path)
+    cache = _healthy_browser_cache(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "SHIM_LOG": str(log),
+        "PLAYWRIGHT_BROWSERS_PATH": str(cache),
+    }
+    return main, wt, env, log, cache
+
+
+def _invoke(wt: Path, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(wt / "scripts" / "worktree-setup.sh")],
+        cwd=wt,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _shim_calls(log: Path) -> list[str]:
+    return log.read_text().splitlines() if log.exists() else []
+
+
+def test_links_venv_and_node_modules_to_the_main_checkout(tmp_path):
+    """The whole point: a fresh worktree ends up sharing all three dependency
+    trees, so nothing is reinstalled."""
+    main, wt, env, log, _ = _setup(tmp_path)
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert (wt / ".venv").is_symlink()
+    assert (wt / ".venv").resolve() == (main / ".venv").resolve()
+    for pkg in ("frontend", "e2e"):
+        link = wt / pkg / "node_modules"
+        assert link.is_symlink(), f"{pkg}/node_modules should be shared, not installed"
+        assert link.resolve() == (main / pkg / "node_modules").resolve()
+    assert not any(
+        c.startswith("npm install") for c in _shim_calls(log)
+    ), "identical lockfiles must not trigger an install"
+
+
+def test_installs_instead_of_linking_when_the_lockfile_diverges(tmp_path):
+    """Sharing node_modules is only valid while the lockfiles agree — a branch
+    that changes dependencies must get its own real install, not the main
+    checkout's tree under a different lockfile."""
+    _, wt, env, log, _ = _setup(tmp_path)
+    (wt / "frontend" / "package-lock.json").write_text('{"name": "frontend-changed"}\n')
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert not (wt / "frontend" / "node_modules").is_symlink()
+    assert "npm install" in "\n".join(_shim_calls(log))
+    # The unchanged package root is still shared.
+    assert (wt / "e2e" / "node_modules").is_symlink()
+
+
+def test_repairs_a_browser_cache_whose_marker_lies(tmp_path):
+    """The trap from #556: an empty browser directory next to an
+    INSTALLATION_COMPLETE marker makes every later `playwright install` a
+    silent no-op, producing 14 identical 'Executable doesn't exist' failures.
+    Checking the marker is what misses it; checking for the binary catches it."""
+    _, wt, env, log, cache = _setup(tmp_path)
+    corrupt = cache / "chromium_headless_shell-1217"
+    corrupt.mkdir()
+    (corrupt / "INSTALLATION_COMPLETE").write_text("")
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert not corrupt.exists(), "stale browser directory must be removed, not trusted"
+    assert any(
+        "playwright install" in c for c in _shim_calls(log)
+    ), "a repaired cache must be reinstalled"
+
+
+def test_leaves_an_intact_browser_cache_alone(tmp_path):
+    """The complement of the repair test: a cache with a real executable must
+    not be deleted and reinstalled on every worktree setup."""
+    _, wt, env, log, cache = _setup(tmp_path)
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert (cache / "chromium-1217" / "chrome-mac-arm64" / "Chromium").exists()
+    assert not any("playwright install" in c for c in _shim_calls(log))
+
+
+def test_ignores_playwright_bookkeeping_directories_in_the_cache(tmp_path):
+    """Regression test: the real ms-playwright cache holds non-browser
+    directories alongside browser installs — notably `__dirlock`, Playwright's
+    own install lock, which is an empty directory with no executable inside.
+    Treating it as a stale browser install deletes Playwright's own lock file
+    and crashes the reinstall the script goes on to trigger (observed live:
+    'Error: Unable to update lock within the stale threshold'). It — and any
+    other non `name-<digits>` entry — must be left alone."""
+    _, wt, env, log, cache = _setup(tmp_path)
+    (cache / "__dirlock").mkdir()
+    (cache / ".links").mkdir()
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        cache / "__dirlock"
+    ).exists(), "must not delete Playwright's own lock directory"
+    assert not any("playwright install" in c for c in _shim_calls(log)), (
+        "a bookkeeping directory with no executable must not be mistaken for "
+        "a stale browser install"
+    )
+
+
+def test_repairs_a_broken_venv_symlink(tmp_path):
+    """Regression test: a dangling `.venv` symlink (e.g. left over after the
+    main checkout's .venv was recreated) satisfies `-L` but not `-e`. The
+    original `[ -e .venv ] || [ -L .venv ]` check treated that as "already
+    present" and skipped re-linking, so the worktree reported success while
+    every later `.venv/bin/pytest` invocation would fail with "No such file
+    or directory". The script must detect and repair a broken link, not just
+    an absent one."""
+    main, wt, env, _, _ = _setup(tmp_path)
+    (wt / ".venv").symlink_to(main / "nonexistent-venv")
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert (wt / ".venv").is_symlink()
+    assert (wt / ".venv").resolve() == (main / ".venv").resolve()
+
+
+def test_repairs_a_broken_node_modules_symlink(tmp_path):
+    """Same broken-symlink trap as .venv, for the node_modules links."""
+    main, wt, env, _, _ = _setup(tmp_path)
+    (wt / "frontend" / "node_modules").symlink_to(main / "nonexistent-node-modules")
+
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    link = wt / "frontend" / "node_modules"
+    assert link.is_symlink()
+    assert link.resolve() == (main / "frontend" / "node_modules").resolve()
+
+
+def test_is_idempotent(tmp_path):
+    """Run twice — a second run must not fail or nest a symlink inside the
+    directory the first run linked."""
+    main, wt, env, _, _ = _setup(tmp_path)
+
+    assert _invoke(wt, env).returncode == 0
+    result = _invoke(wt, env)
+
+    assert result.returncode == 0, result.stderr
+    assert (wt / ".venv").resolve() == (main / ".venv").resolve()
+    assert not (main / ".venv" / ".venv").exists(), "must not link into the target"
+
+
+def test_refuses_to_run_outside_a_worktree(tmp_path):
+    """Run from the main checkout it would be linking .venv to itself; fail
+    loudly rather than doing something surprising."""
+    main = _make_main_checkout(tmp_path)
+    bindir, log = _make_shims(tmp_path)
+    env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}", "SHIM_LOG": str(log)}
+
+    result = _invoke(main, env)
+
+    assert result.returncode != 0
+    assert "worktree" in (result.stderr + result.stdout).lower()
+
+
+def test_leaves_the_worktree_git_status_clean(tmp_path):
+    """The links the script creates must be invisible to git. `.gitignore`'s
+    `node_modules/` pattern matches a directory but NOT a symlink pointing at
+    one, so sharing node_modules leaves untracked entries in every worktree —
+    permanent `git status` noise, and a symlink holding an absolute
+    machine-specific path that a `git add -A` would happily commit."""
+    _, wt, env, _, _ = _setup(tmp_path)
+
+    assert _invoke(wt, env).returncode == 0
+
+    status = _run(["git", "status", "--porcelain"], cwd=wt).stdout
+    assert status == "", f"script left the worktree dirty:\n{status}"
+
+
+def test_script_exists_and_is_executable():
+    assert SCRIPT.exists(), "scripts/worktree-setup.sh is missing"
+    assert os.access(SCRIPT, os.X_OK), "scripts/worktree-setup.sh must be executable"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -10,6 +10,21 @@
 # Usage: run once, from the root of the worktree:
 #
 #     ./scripts/worktree-setup.sh
+#
+# What sharing costs: .venv and (when the lockfiles agree) node_modules are
+# symlinks into the main checkout, so they are READ-shared but not write-isolated.
+# Anything that installs — `npm install`, `pip install` — resolves through the
+# link and mutates the main checkout's tree, changing dependencies underneath
+# every other worktree at once. Read-only use (pytest, npm run build, playwright)
+# is safe; when a branch genuinely needs its own dependency set, give it a real
+# install rather than writing through the link:
+#
+#     rm .venv && python -m venv .venv && .venv/bin/pip install -r requirements.txt
+#     rm frontend/node_modules && (cd frontend && npm install)
+#
+# For node this is also automatic: change `package-lock.json`, re-run this
+# script, and the diverged package root gets its own install. There is no such
+# check for .venv — requirements.txt drift is on you to notice.
 
 set -euo pipefail
 
@@ -58,13 +73,33 @@ for pkg in frontend e2e; do
         rm "$pkg/node_modules"
     fi
 
-    if [ -e "$pkg/node_modules" ]; then
+    if [ -d "$MAIN_CHECKOUT/$pkg/node_modules" ] &&
+        cmp -s "$pkg/package-lock.json" "$MAIN_CHECKOUT/$pkg/package-lock.json"; then
+        lockfiles_agree=true
+    else
+        lockfiles_agree=false
+    fi
+
+    if [ -L "$pkg/node_modules" ]; then
+        # An existing share has to be re-checked, not trusted: the lockfiles
+        # agreed when it was made, but this branch has since had every chance
+        # to change dependencies or merge main. Skipping the check here is how
+        # a worktree keeps testing against a tree that no longer matches it,
+        # while re-running this script reports success.
+        if [ "$lockfiles_agree" = true ]; then
+            echo "   $pkg/node_modules already shared"
+            continue
+        fi
+        echo "   $pkg/node_modules is shared but the lockfile has since diverged"
+        echo "   from the main checkout — replacing the link with a real install"
+        rm "$pkg/node_modules"
+    elif [ -e "$pkg/node_modules" ]; then
+        # A real directory is this worktree's own install — leave it alone.
         echo "   $pkg/node_modules already present"
         continue
     fi
 
-    if [ -d "$MAIN_CHECKOUT/$pkg/node_modules" ] &&
-        cmp -s "$pkg/package-lock.json" "$MAIN_CHECKOUT/$pkg/package-lock.json"; then
+    if [ "$lockfiles_agree" = true ]; then
         ln -s "$MAIN_CHECKOUT/$pkg/node_modules" "$pkg/node_modules"
         echo "   $pkg/node_modules → $MAIN_CHECKOUT/$pkg/node_modules"
     else
@@ -76,6 +111,14 @@ done
 
 # --- Playwright browsers -----------------------------------------------------
 #
+# Everything below needs e2e/, both to run the install from and to be worth
+# doing at all. Without that guard the subshell below fails under `set -e` with
+# no diagnostic, immediately after reporting that all the sharing succeeded.
+if [ ! -d e2e ]; then
+    echo "✅ Worktree ready (no e2e/ — skipped Playwright browsers)"
+    exit 0
+fi
+
 # Browsers live in a shared user-level cache, so they are never per-worktree.
 # This does exactly one thing Playwright cannot do for itself: delete a
 # directory that LIES. An interrupted `playwright install` leaves an empty

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# One-shot dependency bootstrap for a freshly created git worktree (issue #556).
+#
+# A new worktree has no .venv and no node_modules, so a full local verification
+# run spends most of its time reinstalling dependencies that already exist,
+# byte-identical, in the main checkout. This shares them instead, and repairs
+# the Playwright browser cache when a half-finished install left it unusable.
+#
+# Usage: run once, from the root of the worktree:
+#
+#     ./scripts/worktree-setup.sh
+
+set -euo pipefail
+
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
+
+if [ "$GIT_DIR" = "$GIT_COMMON" ]; then
+    echo "❌ Not in a linked worktree — run this from a worktree, not the main checkout." >&2
+    exit 1
+fi
+
+MAIN_CHECKOUT=$(dirname "$GIT_COMMON")
+cd "$WORKTREE_ROOT"
+
+echo "🔗 Sharing dependencies from $MAIN_CHECKOUT"
+
+# --- Python virtualenv -------------------------------------------------------
+
+if [ -L .venv ] && [ ! -e .venv ]; then
+    echo "   .venv is a broken symlink — removing"
+    rm .venv
+fi
+
+if [ -e .venv ]; then
+    echo "   .venv already present"
+elif [ ! -d "$MAIN_CHECKOUT/.venv" ]; then
+    echo "❌ $MAIN_CHECKOUT/.venv does not exist — create it in the main checkout first." >&2
+    exit 1
+else
+    ln -s "$MAIN_CHECKOUT/.venv" .venv
+    echo "   .venv → $MAIN_CHECKOUT/.venv"
+fi
+
+# --- Node dependencies -------------------------------------------------------
+#
+# Sharing node_modules is only valid while the lockfiles agree. A branch that
+# changes dependencies gets its own real install — never the main checkout's
+# tree under a different lockfile.
+
+for pkg in frontend e2e; do
+    [ -d "$pkg" ] || continue
+
+    if [ -L "$pkg/node_modules" ] && [ ! -e "$pkg/node_modules" ]; then
+        echo "   $pkg/node_modules is a broken symlink — removing"
+        rm "$pkg/node_modules"
+    fi
+
+    if [ -e "$pkg/node_modules" ]; then
+        echo "   $pkg/node_modules already present"
+        continue
+    fi
+
+    if [ -d "$MAIN_CHECKOUT/$pkg/node_modules" ] &&
+        cmp -s "$pkg/package-lock.json" "$MAIN_CHECKOUT/$pkg/package-lock.json"; then
+        ln -s "$MAIN_CHECKOUT/$pkg/node_modules" "$pkg/node_modules"
+        echo "   $pkg/node_modules → $MAIN_CHECKOUT/$pkg/node_modules"
+    else
+        echo "   $pkg: lockfile differs from the main checkout (or it has no"
+        echo "   node_modules) — installing into this worktree instead of sharing"
+        (cd "$pkg" && npm install)
+    fi
+done
+
+# --- Playwright browsers -----------------------------------------------------
+#
+# Browsers live in a shared user-level cache, so they are never per-worktree —
+# but a `playwright install` that is interrupted leaves an empty browser
+# directory next to an INSTALLATION_COMPLETE marker, and the marker makes every
+# later install a silent no-op. Trust the binary, not the marker.
+
+if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
+    BROWSER_CACHE="$PLAYWRIGHT_BROWSERS_PATH"
+elif [ "$(uname -s)" = "Darwin" ]; then
+    BROWSER_CACHE="$HOME/Library/Caches/ms-playwright"
+else
+    BROWSER_CACHE="$HOME/.cache/ms-playwright"
+fi
+
+needs_browsers=0
+
+if [ ! -d "$BROWSER_CACHE" ]; then
+    echo "🌐 No Playwright browser cache at $BROWSER_CACHE"
+    needs_browsers=1
+else
+    # Only look at actual browser install directories (named e.g.
+    # "chromium-1217" or "chromium_headless_shell-1217"). The cache also
+    # holds Playwright-internal bookkeeping directories such as `__dirlock`
+    # (its own install lock) and `.links` — those aren't browsers, have no
+    # executable inside, and must never be treated as a stale install: doing
+    # so removes Playwright's own lock file mid-use and crashes the very
+    # `playwright install` this script goes on to run.
+    for browser_dir in "$BROWSER_CACHE"/*-[0-9]*/; do
+        [ -d "$browser_dir" ] || continue
+        if [ -z "$(find "$browser_dir" -type f -perm -u+x -print -quit)" ]; then
+            echo "🌐 Stale browser install (no executable): $browser_dir — removing"
+            rm -rf "$browser_dir"
+            needs_browsers=1
+        fi
+    done
+fi
+
+if [ "$needs_browsers" -eq 1 ]; then
+    echo "🌐 Installing Playwright browsers"
+    (cd e2e && npx playwright install chromium)
+else
+    echo "🌐 Playwright browser cache intact"
+fi
+
+echo "✅ Worktree ready"

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -76,10 +76,20 @@ done
 
 # --- Playwright browsers -----------------------------------------------------
 #
-# Browsers live in a shared user-level cache, so they are never per-worktree —
-# but a `playwright install` that is interrupted leaves an empty browser
-# directory next to an INSTALLATION_COMPLETE marker, and the marker makes every
-# later install a silent no-op. Trust the binary, not the marker.
+# Browsers live in a shared user-level cache, so they are never per-worktree.
+# This does exactly one thing Playwright cannot do for itself: delete a
+# directory that LIES. An interrupted `playwright install` leaves an empty
+# browser directory next to an INSTALLATION_COMPLETE marker, and that marker
+# makes every later install a silent no-op — so the missing binary is never
+# repaired and surfaces as "browserType.launch: Executable doesn't exist".
+# Trust the binary, not the marker.
+#
+# Deciding whether anything then needs installing is NOT this script's job:
+# a browser that is entirely absent leaves no directory to inspect, so any
+# such check silently passes a cache that cannot launch (observed during
+# #556 — an intact chromium-1217 while chromium_headless_shell-1217 was
+# simply missing). Playwright knows which browsers it needs; it always gets
+# to check, and is a fast no-op when they are all present.
 
 if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
     BROWSER_CACHE="$PLAYWRIGHT_BROWSERS_PATH"
@@ -89,12 +99,7 @@ else
     BROWSER_CACHE="$HOME/.cache/ms-playwright"
 fi
 
-needs_browsers=0
-
-if [ ! -d "$BROWSER_CACHE" ]; then
-    echo "🌐 No Playwright browser cache at $BROWSER_CACHE"
-    needs_browsers=1
-else
+if [ -d "$BROWSER_CACHE" ]; then
     # Only look at actual browser install directories (named e.g.
     # "chromium-1217" or "chromium_headless_shell-1217"). The cache also
     # holds Playwright-internal bookkeeping directories such as `__dirlock`
@@ -107,16 +112,11 @@ else
         if [ -z "$(find "$browser_dir" -type f -perm -u+x -print -quit)" ]; then
             echo "🌐 Stale browser install (no executable): $browser_dir — removing"
             rm -rf "$browser_dir"
-            needs_browsers=1
         fi
     done
 fi
 
-if [ "$needs_browsers" -eq 1 ]; then
-    echo "🌐 Installing Playwright browsers"
-    (cd e2e && npx playwright install chromium)
-else
-    echo "🌐 Playwright browser cache intact"
-fi
+echo "🌐 Verifying Playwright browsers (downloads only what is missing)"
+(cd e2e && npx playwright install chromium)
 
 echo "✅ Worktree ready"

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -116,7 +116,42 @@ if [ -d "$BROWSER_CACHE" ]; then
     done
 fi
 
+# The install is bounded because it can hang indefinitely: observed twice while
+# working #556 (once for 9h24m), the downloader finishes fetching the ~173MB
+# zip and then stops making progress, holding the file open and burning no CPU.
+# That hang is what produces the corrupt directory this script has to repair, so
+# waiting it out is never the right move — and an unbounded wait here would hang
+# worktree setup itself. Fail loudly with the recovery instead.
+INSTALL_TIMEOUT="${WORKTREE_SETUP_INSTALL_TIMEOUT:-300}"
+
 echo "🌐 Verifying Playwright browsers (downloads only what is missing)"
-(cd e2e && npx playwright install chromium)
+# `set -m` puts the install in its own process group, so the timeout below can
+# kill the whole tree. Killing just the direct child leaves npx's grandchildren
+# (node, the downloader) alive, still holding this script's stdout open.
+set -m
+(cd e2e && npx playwright install chromium) &
+install_pid=$!
+set +m
+
+waited=0
+while kill -0 "$install_pid" 2>/dev/null; do
+    if [ "$waited" -ge "$INSTALL_TIMEOUT" ]; then
+        kill -9 -- "-$install_pid" 2>/dev/null || kill -9 "$install_pid" 2>/dev/null || true
+        echo "" >&2
+        echo "❌ playwright install made no progress within ${INSTALL_TIMEOUT}s — killed." >&2
+        echo "   It usually finishes in 1-3 minutes. A hung install leaves a partial" >&2
+        echo "   browser directory behind, so clear it and retry:" >&2
+        echo "" >&2
+        echo "     rm -rf \"$BROWSER_CACHE\"/chromium*" >&2
+        echo "     cd e2e && npx playwright install chromium" >&2
+        echo "" >&2
+        echo "   Dependency sharing above completed — only the browsers are missing." >&2
+        exit 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+
+wait "$install_pid"
 
 echo "✅ Worktree ready"


### PR DESCRIPTION
## Summary

- `scripts/worktree-setup.sh` shares `.venv`, `frontend/node_modules` and `e2e/node_modules` with the main checkout instead of reinstalling them — **0.24s instead of ~35 min**
- Sharing is conditional on the lockfiles matching; a package root whose `package-lock.json` diverged gets a real `npm install`
- Repairs a Playwright browser directory whose `INSTALLATION_COMPLETE` marker lies, and bounds the install so setup can never hang
- `verify` skill no longer passes `--build` by default
- `.gitignore`: `node_modules/` → `node_modules`, so the shared symlinks are actually ignored

## Root cause

Not a product bug — a setup-cost problem measured in #556. A fresh worktree starts from nothing, so ~35 of a ~40 minute local verification run was `npm install` ×2, `npx playwright install`, and a container rebuild, against ~5 minutes of actual testing. The `.venv` symlink convention already existed but was done by hand; there was no equivalent for Node. That imbalance is what makes `implement-issue` Step 8 feel skippable, which is the one thing the local flow does that CI cannot.

## Fix

**Dependency sharing.** Symlinks all three trees from the main checkout. Sharing `node_modules` is only valid while the lockfiles agree, so a divergent package root gets its own real install with a printed reason rather than silently running under the wrong dependency set.

**Playwright.** The script does the one thing Playwright cannot do for itself: delete a browser directory that *lies*. An interrupted install leaves an empty directory next to an `INSTALLATION_COMPLETE` marker, and that marker makes every later install a silent no-op, so the missing binary is never repaired. It checks for the actual binary, not the marker, and skips Playwright's own bookkeeping directories (`__dirlock`, `.links`) — deleting `__dirlock` mid-use crashes the reinstall the script then triggers (hit live during review).

Deciding *whether* anything needs installing is deliberately not the script's job. That heuristic was itself a bug (see below), so Playwright always gets to check.

**Hang guard.** `playwright install` is bounded (default 300s, `WORKTREE_SETUP_INSTALL_TIMEOUT` overrides) and runs in its own process group via `set -m`, so the timeout kills the whole tree — killing only the direct child leaves npx's grandchildren holding the script's stdout open, hanging any caller that captures output.

## What local verification caught that the tests did not

Step 8 is the reason this PR is different from what the tests alone would have produced. Running it for real in a fresh worktree, the script reported `🌐 Playwright browser cache intact` while `chromium.launch()` failed with:

```
browserType.launch: Executable doesn't exist at
  .../chromium_headless_shell-1217/chrome-headless-shell-mac-arm64/chrome-headless-shell
```

— the exact error #556 reports. A browser that is entirely **absent** leaves no directory to inspect, so the "does anything need installing" check passed a cache that could not launch. The heuristic was deleted rather than patched.

Following that thread surfaced the mechanism behind the issue's "exceeded a 600s window, then landed corrupted": `playwright install` on this machine reliably **hangs after the download completes** — zip fully fetched, file held open, no CPU, never extracting. Reproduced four times today, each leaving the same 448K partial `chromium-1217` (a working install is ~170MB). That hang is how the corrupt state gets created, which is why the install is now bounded.

It is not caused by the symlinked `node_modules` this PR introduces: the first instance found was a downloader stuck for **9h24m**, resolving `playwright-core` from the main checkout's own real `node_modules`, and it had been running since before any symlink in this PR existed.

## Test plan

- [x] `./scripts/quality-check.sh` passes (0 errors, 0 warnings)
- [x] Fast suite: 1769 passed, 29 skipped (post-merge with `origin/main`)
- [x] Slow suite: 534 passed, 4 skipped
- [x] 13 tests in `backend/tests/test_worktree_setup_script.py`, each run against a real throwaway git worktree
- [x] **Observed live** in a real fresh worktree (`/tmp/wt556-demo`): setup `0.235s`; `pytest` through the shared `.venv` (11 passed); **`npm run build` → `✓ built in 3.34s`**, which settles the issue's open question about Vite/esbuild through a symlinked `node_modules`; `npx playwright --list` → 82 tests; `git status` clean
- [x] **Observed live**: with a real hanging `npx`, the guard killed the install and printed the recovery, exit 1 — at a 60s override, and again at the default 300s bound
- [ ] **Browser launch not verified** — blocked by the environment hang above, which reproduces independently of this PR. Anyone reviewing on a machine with working browsers should confirm `npx playwright test` runs.

## Evidence the test discriminates

- Reverted: browser check to trust `INSTALLATION_COMPLETE` instead of the binary → `test_repairs_a_browser_cache_whose_marker_lies` FAILED, 1 of 7
- Reverted: the lockfile comparison (always share) → `test_installs_instead_of_linking_when_the_lockfile_diverges` FAILED, 1 of 7
- Reverted: always reinstall browsers → `test_leaves_an_intact_browser_cache_alone` FAILED, 1 of 7
- Written RED first, failing before the fix existed: `test_always_lets_playwright_verify_the_browsers` (the missing-browser gap), `test_leaves_the_worktree_git_status_clean` (the `.gitignore` trailing slash), `test_fails_loudly_when_the_browser_install_hangs` (hung until the test's own 60s guard killed it), plus the original 7 against a non-existent script
- Restored: tree clean, 13 passed

## Outcome-level coverage

Not an optimizer change, so no fixture pin, golden, or `R == P` scenario applies. The outcome asserted is the state of the worktree after the script runs — real symlinks resolving to the main checkout, a real `git status`, a real browser cache directory removed or kept — not the commands the script issued. The two places a command *is* asserted (`npm install`, `playwright install` invoked) are cases where the outcome is owned by a third-party tool, so its invocation is the observable boundary; both are paired with an outcome assertion on the filesystem.

## Documentation check

Neither `docs/agents/bess-knowledge.md` nor `docs/SOFTWARE_DESIGN.md` mentions worktrees, `node_modules`, or Playwright — grepped, nothing to update. `CLAUDE.md`, the `verify` skill and the `implement-issue` skill do describe this workflow and are updated here.

## Changelog

Deliberately **not** added. `CHANGELOG.md` is the add-on's user-facing release notes, and this is developer tooling with zero user-visible effect — consistent with keeping pure-internal changes out of the curated sections.

## Follow-up worth filing separately

`playwright install` hanging post-download on this machine is an environment defect this PR only defends against. Recovery: `rm -rf ~/Library/Caches/ms-playwright/chromium*` then retry — but it has not yet succeeded here, so e2e browser tests are currently broken locally regardless of this change.

Closes #556
