### PR TITLE
fix: surface a missing consumption sensor instead of stalling on "Initializing"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **A missing consumption sensor no longer leaves the dashboard stuck on "Initializing"** — with the `sensor` strategy selected and no `48h_avg_grid_import` entity, the health check now reports a critical error, that strategy can't be selected without its sensor, and new installs default to `fixed`. ([#558](https://github.com/johanzander/bess-manager/issues/558))
 - **The setup wizard no longer completes with a configuration that cannot work** — it now blocks on inverter sensors whose Home Assistant entity is disabled (naming them so you can enable them) and on a price provider that isn't configured, instead of reporting "SYSTEM DEGRADED" afterwards. ([#549](https://github.com/johanzander/bess-manager/issues/549))
 - **Growatt MIN TOU segments are now written against the inverter's real state**, ending repeated "500 Server Error" write failures and leaving no unplanned segments running on the battery. ([#551](https://github.com/johanzander/bess-manager/issues/551))
 - **House load spikes during a battery-supported period are now covered from the battery instead of the grid**, on TOU/register platforms, whenever the stored energy is worth less than importing at that moment (`buy_price × discharge_efficiency ≥ shadow_price`, decided by the optimizer). When the battery is genuinely being reserved for a pricier later period the reserve is still protected and the spike is imported. ([#520](https://github.com/johanzander/bess-manager/issues/520))

--- a/backend/api.py
+++ b/backend/api.py
@@ -158,6 +158,44 @@ def _validate_power_monitoring_sensors(
         )
 
 
+_CONSUMPTION_STRATEGIES = ("fixed", "sensor", "influxdb_7d_avg", "ha_statistics")
+
+
+def _validate_consumption_strategy(home_section: dict, active_sensors: dict) -> None:
+    """Raise HTTPException(422) for a consumption strategy that cannot work.
+
+    Mirrors the frontend gating in HomeFormSection.tsx — the server-side
+    backstop so the API refuses the combination regardless of which client
+    called it. Only ``sensor`` is checked against its sensor: it is the one
+    strategy with no fallback, so without ``48h_avg_grid_import`` every
+    optimization run aborts, no schedule is ever built, and the dashboard
+    sits on "Initializing" forever (#558). ``ha_statistics`` and
+    ``influxdb_7d_avg`` are left alone — they degrade to the fixed profile
+    and report it, rather than stalling.
+    """
+    strategy = home_section.get("consumption_strategy")
+    if strategy is None:
+        return
+    if strategy not in _CONSUMPTION_STRATEGIES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Unknown consumption strategy '{strategy}'. Valid values: "
+                f"{', '.join(_CONSUMPTION_STRATEGIES)}."
+            ),
+        )
+    if strategy == "sensor" and not active_sensors.get("48h_avg_grid_import"):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Consumption strategy 'sensor' requires the "
+                "'48h_avg_grid_import' sensor, which is not configured. "
+                "Configure it in Settings → Sensors first, or choose a "
+                "strategy that does not need it."
+            ),
+        )
+
+
 def _require_configured_system(bess_controller) -> None:
     """Raise HTTP 503 if the BESS system has not been configured yet.
 
@@ -327,6 +365,7 @@ async def patch_settings(updates: dict):
                     **flatten_sensors(updates.get("sensors") or {}),
                 }
                 _validate_power_monitoring_sensors(section, effective_sensors)
+                _validate_consumption_strategy(section, effective_sensors)
 
             if store_key == "sensors":
                 # A sensor removal (e.g. unmapping a phase-current sensor) can
@@ -337,6 +376,7 @@ async def patch_settings(updates: dict):
                 _validate_power_monitoring_sensors(
                     persisted_home, flatten_sensors(section)
                 )
+                _validate_consumption_strategy(persisted_home, flatten_sensors(section))
 
             bess_controller.settings_store.save_section(store_key, section)
 
@@ -3071,6 +3111,7 @@ async def setup_complete(payload: APISetupCompletePayload):
                 **flatten_sensors(sections.get("sensors") or {}),
             }
             _validate_power_monitoring_sensors(home, effective_sensors)
+            _validate_consumption_strategy(home, effective_sensors)
             sections["home"] = home
 
         # --- electricity price ---

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -708,6 +708,67 @@ class TestPatchSettingsPowerMonitoringValidation:
 
 
 # ===========================================================================
+# PATCH /api/settings — consumption strategy gating
+# ===========================================================================
+
+
+class TestPatchSettingsConsumptionStrategyValidation:
+    """Selecting the "sensor" consumption strategy without its sensor leaves
+    the system unable to build any schedule at all, so the dashboard never
+    leaves "Initializing" (#558). The UI hides the option, but PATCH is what
+    persists it, so the check has to exist here too."""
+
+    def test_rejects_sensor_strategy_without_its_sensor(self, mock_controller):
+        response = _client.patch(
+            "/api/settings",
+            json={"home": {"consumptionStrategy": "sensor"}},
+        )
+        assert response.status_code == 422
+        assert "48h_avg_grid_import" in response.json()["detail"]
+        # Never persisted — a rejected request must not leave the stalling
+        # config on disk.
+        assert (
+            mock_controller.settings_store.data["home"]["consumption_strategy"]
+            == "fixed"
+        )
+
+    def test_allows_sensor_strategy_when_its_sensor_is_mapped(self, mock_controller):
+        mock_controller.settings_store.data["sensors"]["shared"] = {
+            "48h_avg_grid_import": "sensor.avg_grid_import",
+        }
+        response = _client.patch(
+            "/api/settings",
+            json={"home": {"consumptionStrategy": "sensor"}},
+        )
+        assert response.status_code == 200
+
+    def test_rejects_unknown_strategy(self, mock_controller):
+        response = _client.patch(
+            "/api/settings",
+            json={"home": {"consumptionStrategy": "bogus_strategy"}},
+        )
+        assert response.status_code == 422
+
+    def test_rejects_unmapping_the_sensor_the_active_strategy_needs(
+        self, mock_controller
+    ):
+        """Removing 48h_avg_grid_import while the sensor strategy is active
+        breaks the system exactly as selecting the strategy without it does —
+        the same shape as the power-monitoring sensor-removal guard."""
+        mock_controller.settings_store.data["home"]["consumption_strategy"] = "sensor"
+        mock_controller.settings_store.data["sensors"]["shared"] = {
+            "48h_avg_grid_import": "sensor.avg_grid_import",
+        }
+
+        response = _client.patch(
+            "/api/settings",
+            json={"sensors": {"shared": {"48h_avg_grid_import": ""}}},
+        )
+
+        assert response.status_code == 422
+
+
+# ===========================================================================
 # PATCH /api/settings — response shape
 # ===========================================================================
 

--- a/backend/tests/test_setup_api.py
+++ b/backend/tests/test_setup_api.py
@@ -139,6 +139,11 @@ def _full_wizard_payload(**overrides) -> dict:
                 "current_l2": "sensor.current_l2",
                 "current_l3": "sensor.current_l3",
                 "battery_charging_power_rate": "sensor.charge_rate",
+                # consumptionStrategy is "sensor" below, which has no
+                # fallback — without this sensor every optimization run
+                # aborts and the dashboard never leaves "Initializing", so
+                # the API rejects that combination with a 422 (#558).
+                "48h_avg_grid_import": "sensor.avg_grid_import",
             },
         },
         "nordpoolArea": "SE4",
@@ -640,6 +645,8 @@ class TestSetupComplete:
                     "current_l2": "sensor.current_l2",
                     "current_l3": "sensor.current_l3",
                     "battery_charging_power_rate": "sensor.charge_rate",
+                    # matches the base payload's "sensor" strategy (#558)
+                    "48h_avg_grid_import": "sensor.avg_grid_import",
                 },
             },
             powerMonitoringEnabled=True,
@@ -1326,6 +1333,63 @@ class TestSetupCompleteRejectsUnusableProvider:
         resp = _client.post("/api/setup/complete", json=payload)
 
         assert resp.status_code == 200
+
+
+class TestSetupCompleteRejectsUnusableConsumptionStrategy:
+    """POST /api/setup/complete must refuse a consumption strategy it cannot
+    read a forecast from (#558).
+
+    The reporter's system had consumption_strategy="sensor" with no
+    48h_avg_grid_import entity. Every optimization run aborted, no schedule
+    was ever stored, and the dashboard sat on "Initializing" forever. The
+    frontend now hides that combination, but the API is what actually
+    persists it, so the guarantee has to live here too.
+    """
+
+    def _strip_48h(self, payload: dict) -> dict:
+        payload["sensors"]["shared"].pop("48h_avg_grid_import", None)
+        return payload
+
+    def test_sensor_strategy_without_its_sensor_is_rejected(self, complete_controller):
+        payload = self._strip_48h(_full_wizard_payload(consumptionStrategy="sensor"))
+
+        resp = _client.post("/api/setup/complete", json=payload)
+
+        assert resp.status_code == 422
+        assert "48h_avg_grid_import" in resp.json()["detail"]
+        complete_controller.settings_store.save_all.assert_not_called()
+
+    def test_sensor_strategy_with_its_sensor_is_accepted(self, complete_controller):
+        resp = _client.post(
+            "/api/setup/complete",
+            json=_full_wizard_payload(consumptionStrategy="sensor"),
+        )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize("strategy", ["fixed", "ha_statistics", "influxdb_7d_avg"])
+    def test_other_strategies_do_not_need_that_sensor(
+        self, complete_controller, strategy
+    ):
+        """Only "sensor" has no fallback. ha_statistics and influxdb_7d_avg
+        degrade to the fixed profile and report it, so rejecting them here
+        would invent a failure the optimizer does not have."""
+        payload = self._strip_48h(_full_wizard_payload(consumptionStrategy=strategy))
+
+        resp = _client.post("/api/setup/complete", json=payload)
+
+        assert resp.status_code == 200
+
+    def test_unknown_strategy_is_rejected(self, complete_controller):
+        """An unrecognised value otherwise persists fine and only surfaces
+        later, as a ValueError from _get_consumption_forecast on every run."""
+        payload = _full_wizard_payload(consumptionStrategy="bogus_strategy")
+
+        resp = _client.post("/api/setup/complete", json=payload)
+
+        assert resp.status_code == 422
+        assert "bogus_strategy" in resp.json()["detail"]
+        complete_controller.settings_store.save_all.assert_not_called()
 
 
 class TestSetupCompleteDemoMode:

--- a/core/bess/health_check.py
+++ b/core/bess/health_check.py
@@ -141,6 +141,7 @@ def perform_health_check(
     is_required: bool,
     controller,
     all_methods: list[str],
+    required_methods: list[str] | None = None,
 ) -> dict:
     """Generic health check function that can be used by any component.
 
@@ -156,11 +157,22 @@ def perform_health_check(
             optional components show WARNING.
         controller: The controller instance with validate_methods_sensors method
         all_methods: List of all method names this component uses
+        required_methods: Subset of ``all_methods`` that is required, for
+            components where only some methods are load-bearing. Only
+            meaningful with ``is_required=True``; defaults to all of them.
+            Energy Prediction uses this: under the ``sensor`` consumption
+            strategy the consumption sensor is mandatory while the solar
+            forecast stays genuinely optional (#558).
 
     Returns:
         Health check result dictionary
     """
-    required_methods = all_methods if is_required else []
+    if is_required:
+        required_methods = (
+            all_methods if required_methods is None else list(required_methods)
+        )
+    else:
+        required_methods = []
     health_check = {
         "name": component_name,
         "description": description,

--- a/core/bess/health_check.py
+++ b/core/bess/health_check.py
@@ -171,6 +171,16 @@ def perform_health_check(
         required_methods = (
             all_methods if required_methods is None else list(required_methods)
         )
+        # A required method that is not also checked is never returned by
+        # validate_methods_sensors, so required_total stays 0 and the
+        # "specified but none configured" branch below reports ERROR for
+        # something that was never looked at.
+        unchecked = set(required_methods) - set(all_methods)
+        if unchecked:
+            raise ValueError(
+                f"required_methods {sorted(unchecked)} are not in all_methods "
+                f"for component '{component_name}'"
+            )
     else:
         required_methods = []
     health_check = {

--- a/core/bess/sensor_collector.py
+++ b/core/bess/sensor_collector.py
@@ -845,17 +845,27 @@ class SensorCollector:
         Only validates the ``get_estimated_consumption`` sensor when the
         ``sensor`` strategy is active — other strategies (fixed,
         influxdb_7d_avg, ha_statistics) do not rely on that HA sensor.
+
+        Under the ``sensor`` strategy that sensor is *required*: every
+        optimization run reads it and aborts without it, so no schedule can
+        ever be built and the dashboard sits on "Initializing" indefinitely
+        (#558). The solar forecast stays optional under every strategy, so
+        only the consumption method is named as required.
         """
         all_methods = ["get_solar_forecast"]
-        if consumption_strategy == "sensor":
+        sensor_strategy_active = consumption_strategy == "sensor"
+        if sensor_strategy_active:
             all_methods = ["get_estimated_consumption", *all_methods]
 
         return perform_health_check(
             component_name="Energy Prediction",
             description="Solar and consumption forecasting for optimization",
-            is_required=False,
+            is_required=sensor_strategy_active,
             controller=self.ha_controller,
             all_methods=all_methods,
+            required_methods=(
+                ["get_estimated_consumption"] if sensor_strategy_active else None
+            ),
         )
 
     def check_health(self, consumption_strategy: str = "sensor") -> list:

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -213,7 +213,7 @@ class HomeSettings:
     default_hourly: float = HOME_HOURLY_CONSUMPTION_KWH
     min_valid: float = MIN_CONSUMPTION
     currency: str = DEFAULT_CURRENCY
-    consumption_strategy: str = "sensor"
+    consumption_strategy: str = "fixed"
     power_monitoring_enabled: bool = False
 
     def __post_init__(self):
@@ -269,9 +269,7 @@ class HomeSettings:
                 "consumption", HOME_HOURLY_CONSUMPTION_KWH
             )
             self.currency = config["home"].get("currency", DEFAULT_CURRENCY)
-            self.consumption_strategy = home_config.get(
-                "consumption_strategy", "sensor"
-            )
+            self.consumption_strategy = home_config.get("consumption_strategy", "fixed")
             self.power_monitoring_enabled = home_config["power_monitoring_enabled"]
             self.__post_init__()
         return self

--- a/core/bess/settings_store.py
+++ b/core/bess/settings_store.py
@@ -453,7 +453,7 @@ class SettingsStore:
             "home": {
                 "default_hourly": HOME_HOURLY_CONSUMPTION_KWH,
                 "currency": DEFAULT_CURRENCY,
-                "consumption_strategy": "sensor",
+                "consumption_strategy": "fixed",
                 "max_fuse_current": HOUSE_MAX_FUSE_CURRENT_A,
                 "voltage": HOUSE_VOLTAGE_V,
                 "safety_margin": SAFETY_MARGIN_FACTOR,

--- a/core/bess/tests/unit/test_extended_horizon.py
+++ b/core/bess/tests/unit/test_extended_horizon.py
@@ -552,6 +552,9 @@ class TestTerminalValueCapExcludesCommittedPeriods:
         controller.consumption_forecast = [0.0] * n  # isolate export decisions
         system = _make_system(source, controller)
         system.battery_settings.cycle_cost_per_kwh = 0.035
+        # The "fixed" default ignores the mocked zero consumption_forecast;
+        # force "sensor" so the isolation above actually takes effect.
+        system.home_settings.consumption_strategy = "sensor"
 
         optimization_period = 75  # ~18:45 today, before the near-term peak
 

--- a/core/bess/tests/unit/test_prediction_health_check.py
+++ b/core/bess/tests/unit/test_prediction_health_check.py
@@ -6,8 +6,12 @@ consumption strategy.  Before this fix, it always checked
 false-positive warnings when other strategies were active.
 """
 
+from unittest.mock import patch
+
 import pytest
 
+from core.bess.battery_system_manager import BatterySystemManager
+from core.bess.price_manager import MockSource
 from core.bess.sensor_collector import SensorCollector
 from core.bess.settings import BatterySettings
 
@@ -19,6 +23,7 @@ from core.bess.settings import BatterySettings
 def _make_controller(
     estimated_consumption_ok: bool = True,
     solar_forecast_ok: bool = True,
+    estimated_consumption_configured: bool = True,
 ):
     """Return a minimal controller stub with configurable sensor behaviour.
 
@@ -50,6 +55,22 @@ def _make_controller(
         results = []
         for name in method_list:
             info = controller.METHOD_SENSOR_MAP.get(name, {})
+            if name == "get_estimated_consumption" and not (
+                estimated_consumption_configured
+            ):
+                # Mirrors get_method_sensor_info() when the sensor key resolves
+                # to nothing: the user never mapped an entity for it.
+                results.append(
+                    {
+                        "method_name": name,
+                        "name": info.get("name", name),
+                        "sensor_key": info.get("sensor_key", name),
+                        "entity_id": "Not configured",
+                        "status": "not_configured",
+                        "error": "Sensor not configured",
+                    }
+                )
+                continue
             results.append(
                 {
                     "method_name": name,
@@ -63,6 +84,12 @@ def _make_controller(
         return results
 
     controller.validate_methods_sensors.side_effect = _validate
+
+    # An unmapped sensor also fails at the method level: _get_sensor_value
+    # returns None and get_estimated_consumption raises
+    # (ha_api_controller.py:1369-1371).
+    if not estimated_consumption_configured:
+        estimated_consumption_ok = False
 
     if estimated_consumption_ok:
         controller.get_estimated_consumption.return_value = [1.125] * 96
@@ -109,10 +136,37 @@ class TestSensorStrategy:
         method_names = [c["method_name"] for c in result["checks"]]
         assert "get_estimated_consumption" in method_names
 
-    def test_warning_when_estimated_consumption_unavailable(self):
+    def test_error_when_estimated_consumption_unavailable(self):
+        """Issue #558: under the sensor strategy this sensor is what every
+        optimization run reads. A broken one means no schedule can ever be
+        built, so it must surface as ERROR (a critical failure the dashboard
+        shows) rather than a WARNING nobody acts on."""
         collector = _make_collector(_make_controller(estimated_consumption_ok=False))
         result = collector.check_prediction_health("sensor")
-        # is_required=False → failure → WARNING not ERROR
+        assert result["status"] == "ERROR"
+
+    def test_error_when_estimated_consumption_not_configured(self):
+        """Issue #558's actual reporter state: the strategy is ``sensor`` but
+        no entity was ever mapped. That was reported SKIPPED/OK, so the
+        dashboard sat on "Initializing" forever with a green health check."""
+        collector = _make_collector(
+            _make_controller(estimated_consumption_configured=False)
+        )
+        result = collector.check_prediction_health("sensor")
+        assert result["status"] == "ERROR"
+
+    def test_component_is_required_under_sensor_strategy(self):
+        """``required`` is what promotes an ERROR to a critical sensor failure
+        in BatterySystemManager._run_health_check."""
+        collector = _make_collector()
+        result = collector.check_prediction_health("sensor")
+        assert result["required"] is True
+
+    def test_solar_forecast_failure_is_only_a_warning_under_sensor_strategy(self):
+        """Requiring the consumption sensor must not drag the genuinely
+        optional solar forecast up to required with it."""
+        collector = _make_collector(_make_controller(solar_forecast_ok=False))
+        result = collector.check_prediction_health("sensor")
         assert result["status"] == "WARNING"
 
     def test_consumption_check_shows_error_when_sensor_fails(self):
@@ -132,6 +186,12 @@ class TestSensorStrategy:
 
 
 class TestFixedStrategy:
+    def test_component_is_not_required(self):
+        """Only the sensor strategy makes this component required."""
+        collector = _make_collector()
+        result = collector.check_prediction_health("fixed")
+        assert result["required"] is False
+
     def test_ok_without_any_consumption_sensor(self):
         # fixed strategy never needs the HA sensor
         controller = _make_controller(estimated_consumption_ok=False)
@@ -214,6 +274,53 @@ class TestSolarForecastAlwaysChecked:
 # ---------------------------------------------------------------------------
 # check_health passes strategy through to prediction check
 # ---------------------------------------------------------------------------
+
+
+class TestCriticalFailurePromotion:
+    """The end the reporter actually experienced (#558): the unmapped sensor
+    has to reach ``get_critical_sensor_failures()``, which is what the
+    dashboard renders as a degraded-system banner. Anything short of that is
+    an endless "Initializing" spinner over a health check claiming OK.
+    """
+
+    def _system(self, mock_controller):
+        return BatterySystemManager(
+            controller=mock_controller,
+            price_source=MockSource([1.0] * 96),
+            addon_options={"inverter": {"platform": "growatt_server_min"}},
+        )
+
+    def test_unconfigured_sensor_becomes_a_critical_failure(self, mock_controller):
+        collector = _make_collector(
+            _make_controller(estimated_consumption_configured=False)
+        )
+        prediction = collector.check_prediction_health("sensor")
+        system = self._system(mock_controller)
+
+        with patch(
+            "core.bess.battery_system_manager.run_system_health_checks",
+            return_value={"status": "ERROR", "checks": [prediction]},
+        ):
+            system._run_health_check()
+
+        assert system.get_critical_sensor_failures() == ["Energy Prediction"]
+
+    def test_unconfigured_sensor_is_not_critical_under_ha_statistics(
+        self, mock_controller
+    ):
+        collector = _make_collector(
+            _make_controller(estimated_consumption_configured=False)
+        )
+        prediction = collector.check_prediction_health("ha_statistics")
+        system = self._system(mock_controller)
+
+        with patch(
+            "core.bess.battery_system_manager.run_system_health_checks",
+            return_value={"status": "OK", "checks": [prediction]},
+        ):
+            system._run_health_check()
+
+        assert system.get_critical_sensor_failures() == []
 
 
 class TestCheckHealthStrategyPropagation:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -302,7 +302,9 @@ For Octopus Energy, prices are already final (VAT-inclusive, GBP/kWh). Markup, V
 
 BESS needs a forecast of your home consumption to plan the battery schedule. Four strategies are available, configured via `home.consumption_strategy` in your add-on settings:
 
-#### Strategy 1: `sensor` (default)
+#### Strategy 1: `sensor` (legacy)
+
+This strategy is selectable only once the `48h_avg_grid_import` sensor is configured: it is the one strategy with no fallback, so choosing it without that sensor means no schedule can be built at all and the dashboard never leaves "Initializing". New installs default to `fixed`; `ha_statistics` is the recommended choice (see [INSTALLATION.md](INSTALLATION.md), Step 3).
 
 BESS reads a Home Assistant sensor named `*48h_avg*grid_import*` (the exact entity ID is auto-discovered by name pattern). This sensor should be a 48-hour rolling average of your grid import power, filtered to exclude periods when the battery is active. See [INSTALLATION.md](INSTALLATION.md), Step 3 for how to create it.
 

--- a/e2e/tests/settings-page.spec.ts
+++ b/e2e/tests/settings-page.spec.ts
@@ -43,6 +43,28 @@ test.describe('Settings Page', () => {
     await expect(page.getByText(/Consumption/i).first()).toBeVisible();
   });
 
+  test('consumption strategy "Home Assistant sensor" is blocked without its sensor', async ({ page }) => {
+    // Issue #558: selecting this strategy without a 48h_avg_grid_import entity
+    // makes every optimization run abort, so no schedule is ever built and the
+    // dashboard sits on "Initializing" forever. The CI settings fixture has no
+    // such sensor configured, so the option must be unselectable here.
+    await page.goto('/settings');
+    await expect(page.getByText('Loading settings')).not.toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Home', exact: true }).click();
+
+    const sensorOption = page.getByRole('radio', { name: 'Home Assistant sensor' });
+    await expect(sensorOption).toBeDisabled();
+    await expect(sensorOption).not.toBeChecked();
+    await expect(
+      page.getByText(/requires the 48h Avg Grid Import sensor/i),
+    ).toBeVisible();
+
+    // "Fixed value" needs no sensor and stays selectable — the guard must not
+    // leave the user with nothing to choose.
+    await expect(page.getByRole('radio', { name: 'Fixed value' })).toBeEnabled();
+  });
+
   test('pricing tab shows provider configuration', async ({ page }) => {
     await page.goto('/settings');
     await expect(page.getByText('Loading settings')).not.toBeVisible({ timeout: 15_000 });

--- a/frontend/src/components/PreflightCheckDialog.tsx
+++ b/frontend/src/components/PreflightCheckDialog.tsx
@@ -15,12 +15,21 @@ interface PreflightCheck {
  * from a healthy one — `check_historical_data_access()` reports
  * `required: false` with `status: "ERROR"` when InfluxDB is misconfigured, and
  * that used to render as a green check.
+ *
+ * A required component reporting WARNING does not block: `determine_health_status`
+ * returns ERROR whenever any required method is not working, so WARNING on a
+ * required component can only mean an *optional* member of it failed. Blocking
+ * on that would stop a user leaving demo mode over e.g. a NaN solar forecast
+ * (#558, where "Energy Prediction" became required under the sensor strategy
+ * while its solar-forecast member stayed optional).
  */
 function toRowStatus(status: string, required?: boolean): 'ok' | 'warning' | 'error' {
   if (status === 'OK') return 'ok';
-  // Not configuring an optional component is a deliberate choice, not a fault.
-  if (required === false && status === 'NOT_CONFIGURED') return 'ok';
-  return required === false ? 'warning' : 'error';
+  if (required === false) {
+    // Not configuring an optional component is a deliberate choice, not a fault.
+    return status === 'NOT_CONFIGURED' ? 'ok' : 'warning';
+  }
+  return status === 'ERROR' ? 'error' : 'warning';
 }
 
 interface PreflightCheckDialogProps {

--- a/frontend/src/components/__tests__/PreflightCheckDialog.test.tsx
+++ b/frontend/src/components/__tests__/PreflightCheckDialog.test.tsx
@@ -54,6 +54,28 @@ describe('PreflightCheckDialog', () => {
     })
   })
 
+  it('enables the button when a required component has WARNING status', async () => {
+    // #558: "Energy Prediction" is required under the sensor consumption
+    // strategy, but its solar-forecast member stays optional. A required
+    // component only reports WARNING when every required method works, so a
+    // failing optional member must not block leaving demo mode.
+    mockGet.mockResolvedValueOnce({
+      data: {
+        checks: [
+          { name: 'Battery Control', status: 'OK', required: true },
+          { name: 'Energy Prediction', status: 'WARNING', required: true },
+        ],
+      },
+    })
+
+    render(<PreflightCheckDialog open={true} onClose={() => {}} onConfirm={() => {}} />)
+
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /enable live control/i })
+      expect(button).not.toBeDisabled()
+    })
+  })
+
   it('disables the button when a required component has ERROR status', async () => {
     mockGet.mockResolvedValueOnce({
       data: {

--- a/frontend/src/components/settings/HomeFormSection.tsx
+++ b/frontend/src/components/settings/HomeFormSection.tsx
@@ -19,6 +19,7 @@ interface Props {
 
 export function HomeFormSection({ form, onChange, sensors }: Props) {
   const haStatsSensorConfigured = Boolean(sensors?.['lifetime_load_consumption']);
+  const avgGridImportSensorConfigured = Boolean(sensors?.['48h_avg_grid_import']);
   const localLoadSensorConfigured = Boolean(sensors?.['local_load_power']);
   const chargeRateSensorConfigured = Boolean(sensors?.['battery_charging_power_rate']);
   const currentSensorsConfigured = form.phaseCount === 1
@@ -34,7 +35,7 @@ export function HomeFormSection({ form, onChange, sensors }: Props) {
           'Data source',
           [
             { value: 'fixed', label: 'Fixed value' },
-            { value: 'sensor', label: 'Home Assistant sensor' },
+            { value: 'sensor', label: 'Home Assistant sensor', disabled: !avgGridImportSensorConfigured },
             { value: 'influxdb_7d_avg', label: 'InfluxDB (requires InfluxDB integration)', disabled: !localLoadSensorConfigured },
             { value: 'ha_statistics', label: 'HA Statistics (7-day hourly profile)', disabled: !haStatsSensorConfigured },
           ],
@@ -45,6 +46,13 @@ export function HomeFormSection({ form, onChange, sensors }: Props) {
           <p className="text-xs text-amber-600 dark:text-amber-400 pt-1">
             InfluxDB requires the <strong>Local Load Power</strong> sensor to be configured in the{' '}
             <strong>Sensors</strong> tab. This sensor is not available on all inverter platforms (e.g. Growatt SPH).
+          </p>
+        )}
+        {!avgGridImportSensorConfigured && (
+          <p className="text-xs text-amber-600 dark:text-amber-400 pt-1">
+            Home Assistant sensor requires the <strong>48h Avg Grid Import</strong> sensor to be
+            configured in the <strong>Sensors</strong> tab under Consumption Forecast. Without it
+            no schedule can be built at all.
           </p>
         )}
         {!haStatsSensorConfigured && (

--- a/frontend/src/components/settings/HomeFormSection.tsx
+++ b/frontend/src/components/settings/HomeFormSection.tsx
@@ -51,8 +51,7 @@ export function HomeFormSection({ form, onChange, sensors }: Props) {
         {!avgGridImportSensorConfigured && (
           <p className="text-xs text-amber-600 dark:text-amber-400 pt-1">
             Home Assistant sensor requires the <strong>48h Avg Grid Import</strong> sensor to be
-            configured in the <strong>Sensors</strong> tab under Consumption Forecast. Without it
-            no schedule can be built at all.
+            configured in the <strong>Sensors</strong> tab under Consumption Forecast.
           </p>
         )}
         {!haStatsSensorConfigured && (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -44,7 +44,7 @@ const EMPTY_BATTERY: BatteryForm = {
   exportCurtailmentEnabled: false, exportCurtailmentPriceFloor: 0,
 };
 const EMPTY_HOME: HomeForm = {
-  consumption: 3.5, consumptionStrategy: 'sensor',
+  consumption: 3.5, consumptionStrategy: 'fixed',
   maxFuseCurrent: 25, voltage: 230, safetyMarginFactor: 1.0,
   phaseCount: 3, powerMonitoringEnabled: true,
 };
@@ -181,7 +181,7 @@ const SettingsPage: React.FC = () => {
 
       const h: HomeForm = {
         consumption: home_s.defaultHourly ?? 3.5,
-        consumptionStrategy: home_s.consumptionStrategy ?? 'sensor',
+        consumptionStrategy: home_s.consumptionStrategy ?? 'fixed',
         maxFuseCurrent: home_s.maxFuseCurrent ?? 25,
         voltage: home_s.voltage ?? 230,
         safetyMarginFactor: home_s.safetyMargin ?? 1.0,

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -82,7 +82,7 @@ const SetupWizardPage: React.FC = () => {
 
   const [homeForm, setHomeForm] = useState<HomeForm>({
     consumption: 3.5,
-    consumptionStrategy: 'sensor',
+    consumptionStrategy: 'fixed',
     maxFuseCurrent: 25,
     voltage: 230,
     safetyMarginFactor: 1.0,


### PR DESCRIPTION
## Summary

- A missing consumption sensor now reports a critical health error instead of an endless "Initializing" dashboard
- The `sensor` strategy can no longer be selected without the sensor it requires, and is no longer the default
- No consumption fallback added — the failure stays explicit, it just becomes visible

## Root cause

The reporter's system (`solax_modbus_growatt_min`, v10.0.2) had `consumption_strategy: "sensor"` with `48h_avg_grid_import` **"Not configured"**. Every optimization run therefore aborted:

```
ERROR | core.bess.battery_system_manager:740 - Failed to update battery schedule:
       Configuration error in 48h_avg_grid_import sensor not available
```

15 occurrences between 00:00:39 and 00:25:00 in the bundle; **Total Schedules: 0**. `backend/api.py:746-755` returns `{"error": "initializing"}` for as long as `schedule_store` is empty, so `DashboardPage.tsx:156` spun forever with no error code. Demo mode changed nothing — `set_demo_mode` only flips write suppression, reads still hit HA, which is why the reporter saw it in both modes.

**Why nothing warned.** `check_prediction_health` already added `get_estimated_consumption` to the checked methods under this strategy (`sensor_collector.py:850`), but the component was declared `is_required=False`, so `required_methods` was empty (`health_check.py:162`), an unmapped sensor became `SKIPPED` (`health_check.py:189-201`), the component reported OK, and `_critical_sensor_failures` stayed empty (`battery_system_manager.py:3163`). The bundle reports **"Overall Status: OK, Critical Issues: 0"** on a system that could not optimize at all, while `refresh_health_check` kept retrying the schedule build believing every sensor was healthy.

**Why the reporter hit it.** `sensor` was the default in `settings.py:216`, `settings_store.py:456` and `SetupWizardPage.tsx:73`, while `HomeFormSection.tsx` disabled the `influxdb_7d_avg` and `ha_statistics` options when their backing sensor was missing — but not the default one. Finishing the wizard without hand-building a 48h template helper produced a system that could never build a schedule.

## Fix

| area | change |
|---|---|
| `health_check.py` | `perform_health_check` gains an optional `required_methods` subset, so a component can require one method without promoting its optional siblings. Defaults to `all_methods`, so every existing caller is unchanged |
| `sensor_collector.py` | `check_prediction_health` passes `is_required=(strategy == "sensor")` and names only `get_estimated_consumption` as required — the solar forecast stays optional under every strategy |
| `HomeFormSection.tsx` | the "Home Assistant sensor" option gets the guard the other two already had, plus an amber note naming the sensor |
| `settings.py`, `settings_store.py`, `SetupWizardPage.tsx`, `SettingsPage.tsx` | default `sensor` → `fixed`, the one strategy that needs no sensor and cannot stall |
| `USER_GUIDE.md` | the "Strategy 1: `sensor` (default)" heading was invalidated by this change — now labelled legacy, with the requirement stated |

**Existing installs are unaffected**: persisted settings are applied with `.update(**settings["home"])`, which only sets keys present in the file, so a stored `consumption_strategy` always wins over the new default.

**Deliberately not changed:** no fallback consumption value for the `sensor` strategy. Per `rules.md` the fix is explicit failure plus preventing the invalid configuration, not silently substituting a number the user did not ask for. `ha_statistics` keeps its documented fixed-profile fallback because that is a *temporary data-accumulation* state, not a misconfiguration.

**Scope assessment:** local, within the existing owners. No parameter, flag, extra trigger or second construction site was added to route around an ordering/timing/dependency problem — `required_methods` expresses a domain fact (which method is load-bearing for the active strategy) inside the function that already computes exactly that list.

## Test plan

- [x] Fast suite: 1762 passed, 29 skipped
- [x] Slow suite: 534 passed, 4 skipped
- [x] `black --check` / `ruff` clean; `tsc --noEmit` clean; eslint 0 errors; vitest 124 passed
- [x] **Live stack** (`docker-compose.ci.yml` + mock-HA, real HTTP against the real backend), reporter-shaped settings — `consumption_strategy: "sensor"`, `48h_avg_grid_import` stripped:
  - `GET /api/system-health` → `Energy Prediction | required=True | ERROR`, detail `Average Hourly Power Consumption | ERROR | Method call failed: Configuration error in 48h_avg_grid_import sensor not available` — the reporter's exact string
  - `GET /api/dashboard-health-summary` → `hasCriticalErrors: true`, `systemMode: degraded`, `Energy Prediction` listed in `criticalIssues`
  - **Control run**, same stack with the stock fixture (`consumption_strategy: "fixed"`) → `Energy Prediction | required=False | OK`, absent from `criticalIssues`. The two runs differ only in the strategy, so the escalation is keyed to the strategy and not blanket-applied
  - Served JS bundle contains the new guard text (`48h Avg Grid Import`, `Without it no schedule can be built at all.`)
- [ ] **The new Playwright spec was NOT executed locally.** The local Playwright browser install is still the corrupted one from #556 (`npx playwright install chromium` did not complete). The spec parses and registers (`[chromium] › settings-page.spec.ts:46:7`), but its assertions are unverified until CI runs them.

## Evidence the test discriminates

Written RED first, then mutated. Tree confirmed clean afterwards.

- Before the fix existed: **4 failed, 23 passed** — including the log line the reporter saw, `✓ [OPTIONAL] Energy Prediction: OK`
- Reverted: `is_required=sensor_strategy_active` → `is_required=False` in `sensor_collector.py`
- Result: **4 failed, 23 passed** — `test_error_when_estimated_consumption_unavailable`, `test_error_when_estimated_consumption_not_configured`, `test_component_is_required_under_sensor_strategy`, `test_unconfigured_sensor_becomes_a_critical_failure`
- Restored: 32 passed, tree clean

The guard tests (`test_solar_forecast_failure_is_only_a_warning_under_sensor_strategy`, the `fixed`/`ha_statistics` non-required tests) pass both before and after, so they pin that the change does not over-require. One pre-existing test, `test_extended_horizon.py:557`, genuinely depended on the old default — it mocks `controller.consumption_forecast`, which only the `sensor` strategy reads — and now sets the strategy explicitly rather than having its isolation silently ignored.

## Outcome-level coverage

- `TestCriticalFailurePromotion` asserts the end state the reporter experienced: the unmapped sensor reaching `get_critical_sensor_failures()`, which is what the dashboard renders as a degraded banner. It builds the component from the real `check_prediction_health` output and runs it through the real promotion path in `_run_health_check`, rather than asserting an internal flag.
- Live HTTP evidence above covers the API surface the frontend actually consumes (`/api/system-health`, `/api/dashboard-health-summary`), with a control run isolating the strategy as the cause.
- No DP/intent/control-mapping behaviour changes, so no golden re-pin and no `R == P` scenario is implicated; no fixture was added, so the selector-golden and VPP-baseline meta-tests are untouched.

Closes #558
