### PR TITLE
feat: read Huawei TOU periods back instead of rewriting them blind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **Huawei LUNA2000 no longer rewrites TOU periods the battery already holds** — BESS reads the programmed periods back and skips the write when they match, sparing needless flash wear. ([#431](https://github.com/johanzander/bess-manager/issues/431))
 - **Finer battery optimization grid** — the DP's state/action resolution is halved (0.1 kW / 0.025 kWh), recovering 2.43 SEK/day of savings across the benchmark corpus while reducing solve time. ([#512](https://github.com/johanzander/bess-manager/issues/512))
 
 ### Fixed

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -891,6 +891,17 @@ class HomeAssistantAPIController:
         "grid_accumulated_energy": "lifetime_import_from_grid",
         "input_power": "pv_power",
         "power_meter_active_power": "import_power",
+        # TOU period readback (#431). The integration publishes the configured
+        # periods as extra state attributes of this sensor, in the same text
+        # format set_tou_periods accepts (sensor.py:2487-2513) — so BESS can
+        # start from what the battery actually holds instead of assuming
+        # nothing. EMMA's equivalent register (emma_tou_periods) is
+        # deliberately absent: its entity is disabled by default upstream
+        # (sensor.py:1789), and mapping a disabled entity would hand those
+        # installs a startup read of an entity with no state.
+        "storage_huawei_luna2000_time_of_use_charging_and_discharging_periods": (
+            "huawei_tou_periods"
+        ),
     }
 
     def resolve_sensor_for_influxdb(self, sensor_key: str) -> str | None:
@@ -1588,6 +1599,47 @@ class HomeAssistantAPIController:
             device_id=self.huawei_device_id,
             periods=periods_text,
         )
+
+    def read_huawei_tou_periods(self) -> list[str]:
+        """Read the TOU period list currently programmed on the battery.
+
+        The huawei_solar integration has no read_tou_periods service, but
+        HuaweiSolarTOUSensorEntity publishes the periods as "Period N" extra
+        state attributes in the same text format set_tou_periods accepts
+        (wlcrs/huawei_solar sensor.py:2487-2513), so this is a public entity
+        read, not coordinator internals.
+
+        Returns:
+            Period lines "HH:MM-HH:MM/<days>/<+|->", ordered by period number.
+            Empty when the battery holds no periods.
+
+        Raises:
+            ValueError: If the TOU period sensor isn't configured.
+            SystemConfigurationError: If the entity can't be read. An
+                unreadable entity must not be reported as "no periods
+                programmed" — that would let BESS skip a needed write (the
+                distinction #552 drew for Growatt MIN).
+        """
+        entity_id = self._get_entity_for_service("huawei_tou_periods")
+        response = self._api_request(
+            "get",
+            f"/api/states/{entity_id}",
+            operation="Read Huawei TOU periods",
+            category="sensor_read",
+        )
+        if not response or response.get("state") in ("unavailable", "unknown", None):
+            raise SystemConfigurationError(
+                f"Huawei TOU period sensor '{entity_id}' is unreadable "
+                f"(state={response.get('state') if response else None})"
+            )
+
+        attributes = response.get("attributes", {})
+        numbered = [
+            (int(key.removeprefix("Period ")), str(value))
+            for key, value in attributes.items()
+            if key.startswith("Period ") and key.removeprefix("Period ").isdigit()
+        ]
+        return [text for _, text in sorted(numbered)]
 
     def set_inverter_time_segment(
         self,

--- a/core/bess/huawei_controller.py
+++ b/core/bess/huawei_controller.py
@@ -273,7 +273,8 @@ class HuaweiController(InverterController):
         also spares the battery a flash write per cycle, since set_tou_periods
         rewrites the whole list atomically and cannot update just what moved.
         The comparison is skipped, and the write always made, when no TOU
-        period sensor is mapped (#431).
+        period sensor is mapped (#431). The read happens before any hardware
+        write, so a failed read leaves the battery exactly as it was.
 
         First confirms the connected battery is LUNA2000 (via the
         integration-exposed working-mode option list — see
@@ -295,6 +296,19 @@ class HuaweiController(InverterController):
                 (i.e. it's an LG RESU battery, not supported).
         """
         writes = 0
+
+        # Read before writing anything. The read raises rather than reporting
+        # an empty list, so ordering decides what a failed read leaves behind:
+        # done here it aborts the cycle untouched, and BSM sets
+        # _hardware_write_pending and retries the whole sync next cycle. Done
+        # after set_grid_charge, it would leave the battery holding a new
+        # grid-charge state against the old period list for an hour.
+        hardware_periods = (
+            self._read_periods_from_hardware(controller)
+            if controller.is_sensor_configured("huawei_tou_periods")
+            else None
+        )
+
         has_working_mode = controller.is_sensor_configured("huawei_working_mode")
 
         if not has_working_mode:
@@ -333,14 +347,13 @@ class HuaweiController(InverterController):
         except Exception as e:
             logger.error("FAILED: set_grid_charge: %s", e)
 
-        if controller.is_sensor_configured("huawei_tou_periods"):
-            if self._read_periods_from_hardware(controller) == self._periods:
-                logger.info(
-                    "HUAWEI HARDWARE: battery already holds these %d TOU period(s) "
-                    "— no write",
-                    len(self._periods),
-                )
-                return writes, 0
+        if hardware_periods is not None and hardware_periods == self._periods:
+            logger.info(
+                "HUAWEI HARDWARE: battery already holds these %d TOU period(s) "
+                "— no write",
+                len(self._periods),
+            )
+            return writes, 0
 
         periods_text = self._periods_to_text()
         logger.info("HUAWEI HARDWARE: Writing %d TOU period(s)", len(self._periods))

--- a/core/bess/huawei_controller.py
+++ b/core/bess/huawei_controller.py
@@ -156,6 +156,7 @@ class HuaweiController(InverterController):
                 {
                     "start_time": f"{sh:02d}:{sm:02d}",
                     "end_time": f"{eh:02d}:{em:02d}",
+                    "days": ALL_DAYS,
                     "flag": block["flag"],
                 }
             )
@@ -177,28 +178,34 @@ class HuaweiController(InverterController):
 
         return periods
 
+    def _periods_to_tou_intervals(
+        self, periods: list[dict], intent: str | None = None
+    ) -> list[dict]:
+        """Render periods for display. ``intent`` overrides the flag-derived
+        label for periods BESS read back rather than planned."""
+        return [
+            {
+                "start_time": p["start_time"],
+                "end_time": p["end_time"],
+                "enabled": True,
+                "is_default": False,
+                "strategic_intent": intent
+                or (
+                    "GRID_CHARGING"
+                    if p["flag"] == "+"
+                    else "LOAD_SUPPORT/BATTERY_EXPORT"
+                ),
+                "segment_id": idx + 1,
+            }
+            for idx, p in enumerate(periods)
+        ]
+
     def _build_huawei_periods(self) -> None:
         """Unchanged public behavior: mutates self._periods/self.tou_intervals
         from self.strategic_intents. Delegates to _build_candidate, shared
         with apply_intents/evaluate_intents."""
         self._periods = self._build_candidate(self.strategic_intents)
-
-        self.tou_intervals = []
-        for idx, p in enumerate(self._periods):
-            self.tou_intervals.append(
-                {
-                    "start_time": p["start_time"],
-                    "end_time": p["end_time"],
-                    "enabled": True,
-                    "is_default": False,
-                    "strategic_intent": (
-                        "GRID_CHARGING"
-                        if p["flag"] == "+"
-                        else "LOAD_SUPPORT/BATTERY_EXPORT"
-                    ),
-                    "segment_id": idx + 1,
-                }
-            )
+        self.tou_intervals = self._periods_to_tou_intervals(self._periods)
 
     def apply_intents(self, schedule: DPSchedule, current_period: int = 0) -> None:
         """Adopt this cycle's DP intent list, rebuilding Huawei TOU periods."""
@@ -214,17 +221,59 @@ class HuaweiController(InverterController):
     def _periods_to_text(self) -> str:
         """Join periods into huawei_solar.set_tou_periods text format."""
         lines = [
-            f"{p['start_time']}-{p['end_time']}/{ALL_DAYS}/{p['flag']}"
+            f"{p['start_time']}-{p['end_time']}/{p['days']}/{p['flag']}"
             for p in self._periods
         ]
         return "\n".join(lines)
+
+    @staticmethod
+    def _period_from_text(line: str) -> dict:
+        """Inverse of one _periods_to_text line: "HH:MM-HH:MM/<days>/<+|->".
+
+        Raises:
+            ValueError: If the line isn't a period. A period BESS cannot read
+                is not one it may drop — a dropped period would make the
+                hardware look like it already holds BESS's plan.
+        """
+        times, days, flag = line.strip().split("/")
+        start_time, end_time = times.split("-")
+        if flag not in ("+", "-"):
+            raise ValueError(f"Unknown Huawei charge flag {flag!r} in {line!r}")
+        return {
+            "start_time": start_time,
+            "end_time": end_time,
+            "days": days,
+            "flag": flag,
+        }
+
+    def _read_periods_from_hardware(self, controller) -> list[dict]:
+        """The period list the battery currently holds, parsed.
+
+        Raises:
+            ValueError: If a reported period can't be parsed.
+            SystemConfigurationError: If the sensor can't be read — an
+                unreadable entity must not read as "no periods programmed".
+        """
+        return [
+            self._period_from_text(line)
+            for line in controller.read_huawei_tou_periods()
+        ]
 
     def sync_to_hardware(
         self,
         controller,
         effective_period: int,
     ) -> tuple[int, int]:
-        """Write Huawei TOU periods to hardware.
+        """Write Huawei TOU periods to hardware, unless it already holds them.
+
+        The period list is compared against one read fresh from the battery,
+        never against this controller's own model of it — the same
+        read-compare-write Growatt MIN adopted in #551/#552, for the same
+        reason: a model can only ever claim what BESS meant to write. Here it
+        also spares the battery a flash write per cycle, since set_tou_periods
+        rewrites the whole list atomically and cannot update just what moved.
+        The comparison is skipped, and the write always made, when no TOU
+        period sensor is mapped (#431).
 
         First confirms the connected battery is LUNA2000 (via the
         integration-exposed working-mode option list — see
@@ -284,6 +333,15 @@ class HuaweiController(InverterController):
         except Exception as e:
             logger.error("FAILED: set_grid_charge: %s", e)
 
+        if controller.is_sensor_configured("huawei_tou_periods"):
+            if self._read_periods_from_hardware(controller) == self._periods:
+                logger.info(
+                    "HUAWEI HARDWARE: battery already holds these %d TOU period(s) "
+                    "— no write",
+                    len(self._periods),
+                )
+                return writes, 0
+
         periods_text = self._periods_to_text()
         logger.info("HUAWEI HARDWARE: Writing %d TOU period(s)", len(self._periods))
         try:
@@ -329,15 +387,36 @@ class HuaweiController(InverterController):
         self.sync_soc_limits(controller)
 
     def read_and_initialize_from_hardware(self, controller, current_hour: int) -> None:
-        """Huawei has no readback API for TOU periods in this Phase 1 pass.
+        """Initialize the period list from what the battery currently holds.
 
-        huawei_solar exposes no read_tou_periods service — the periods are
-        only visible via the (undocumented) coordinator state, not a public
-        service call. Leaves strategic_intents empty; the next
-        apply_intents() call populates it, matching the pattern used
-        when hardware state genuinely can't be read back.
+        Readback is available when the integration's TOU period sensor is
+        mapped — declared configuration, not a probe (#431). Installs whose
+        integration exposes no such entity keep the original behaviour: an
+        empty schedule that the next apply_intents() converges, at the cost
+        of one redundant rewrite per restart.
+
+        strategic_intents stays empty either way: the battery reports charge
+        and discharge periods, never which intent produced them.
         """
-        logger.info("Huawei: no TOU readback available — starting with empty schedule")
+        if not controller.is_sensor_configured("huawei_tou_periods"):
+            logger.info(
+                "Huawei: no TOU period sensor mapped — starting with empty schedule"
+            )
+            return
+
+        logger.info("Reading Huawei TOU periods from the battery")
+        self._periods = self._read_periods_from_hardware(controller)
+        self.tou_intervals = self._periods_to_tou_intervals(
+            self._periods, intent="existing_schedule"
+        )
+
+        logger.info(
+            "Huawei initialized from hardware: %d period(s)", len(self._periods)
+        )
+        for p in self._periods:
+            logger.info(
+                "  %s: %s-%s/%s", p["flag"], p["start_time"], p["end_time"], p["days"]
+            )
 
     # ── Schedule comparison ───────────────────────────────────────────────
 
@@ -359,10 +438,14 @@ class HuaweiController(InverterController):
             return True, "Huawei period count differs"
 
         for pa, pb in zip(current, new, strict=False):
+            # days is part of the identity of a period, not decoration: BESS
+            # always writes all-days, so a period read back covering only
+            # some weekdays leaves BESS's own period genuinely missing (#431).
             if (
-                pa.get("start_time") != pb.get("start_time")
-                or pa.get("end_time") != pb.get("end_time")
-                or pa.get("flag") != pb.get("flag")
+                pa["start_time"] != pb["start_time"]
+                or pa["end_time"] != pb["end_time"]
+                or pa["days"] != pb["days"]
+                or pa["flag"] != pb["flag"]
             ):
                 logger.info(
                     "DECISION: Huawei periods differ — current=%s new=%s",

--- a/core/bess/tests/unit/test_huawei_controller.py
+++ b/core/bess/tests/unit/test_huawei_controller.py
@@ -528,6 +528,38 @@ class TestTouReadback:
 
         assert inverter.write_count == 2
 
+    def test_failed_read_leaves_the_battery_untouched(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """An unreadable sensor aborts the cycle before anything is written.
+
+        The read raises rather than reporting "no periods programmed", so the
+        only question is what it leaves behind. Reading after set_grid_charge
+        would arm grid charging against the period list from the previous
+        plan and leave it that way until the next cycle's retry.
+        """
+
+        class UnreadableInverter(FakeHuaweiInverter):
+            def __init__(self) -> None:
+                super().__init__()
+                self.grid_charge_calls: list[bool] = []
+
+            def read_huawei_tou_periods(self) -> list[str]:
+                raise SystemConfigurationError("TOU period entity unavailable")
+
+            def set_grid_charge(self, enabled: bool) -> None:
+                self.grid_charge_calls.append(enabled)
+
+        inverter = UnreadableInverter()
+        controller = HuaweiController(battery_settings=battery_settings)
+        controller.apply_intents(make_schedule_mock(make_intents({2: "GRID_CHARGING"})))
+
+        with pytest.raises(SystemConfigurationError):
+            controller.sync_to_hardware(inverter, 0)
+
+        assert inverter.grid_charge_calls == []
+        assert inverter.write_count == 0
+
     def test_read_periods_are_shown_as_the_existing_schedule(
         self, battery_settings: BatterySettings
     ) -> None:

--- a/core/bess/tests/unit/test_huawei_controller.py
+++ b/core/bess/tests/unit/test_huawei_controller.py
@@ -115,14 +115,20 @@ class TestWriteSchedule:
         assert "02:00-02:59/1234567/+" in text
         assert "18:00-18:59/1234567/-" in text
 
-    def test_write_schedule_no_periods_writes_empty_string(
+    def test_write_schedule_no_periods_clears_the_battery(
         self, controller: HuaweiController
     ) -> None:
+        """An idle plan must clear periods the battery still holds.
+
+        Skipping the write when the plan is empty would leave the old periods
+        running — the empty string is how BESS says "no periods".
+        """
         intents = make_intents({})
         controller.apply_intents(make_schedule_mock(intents))
         ha = MagicMock()
         ha.get_huawei_working_mode_options.return_value = []
         ha.get_huawei_working_mode.return_value = "time_of_use_luna2000"
+        ha.read_huawei_tou_periods.return_value = ["02:00-02:59/1234567/+"]
         controller.sync_to_hardware(ha, 0)
         ha.write_huawei_tou_periods.assert_called_once_with("")
 
@@ -297,6 +303,241 @@ class TestEvaluateIntentsHuawei:
             make_schedule_mock(make_intents({18: "BATTERY_EXPORT"}))
         )
         assert differ is True
+
+
+class FakeHuaweiInverter:
+    """Execution model of a LUNA2000's TOU period list.
+
+    Holds whatever BESS last wrote and reports it back in the huawei_solar
+    sensor's attribute text format, so a restart can be replayed end to end:
+    write → read back → decide whether to write again. Without this the tests
+    could only pin the text BESS emits, which says nothing about whether a
+    restart leaves the hardware alone.
+    """
+
+    def __init__(self, periods_text: str = "", tou_sensor_mapped: bool = True) -> None:
+        self.periods_text = periods_text
+        self.tou_sensor_mapped = tou_sensor_mapped
+        self.write_count = 0
+
+    def is_sensor_configured(self, sensor_key: str) -> bool:
+        if sensor_key == "huawei_tou_periods":
+            return self.tou_sensor_mapped
+        return True
+
+    def read_huawei_tou_periods(self) -> list[str]:
+        if not self.tou_sensor_mapped:
+            raise AssertionError("read attempted while the sensor is unmapped")
+        return self.periods_text.splitlines() if self.periods_text else []
+
+    def write_huawei_tou_periods(self, periods_text: str) -> None:
+        self.periods_text = periods_text
+        self.write_count += 1
+
+    def get_huawei_working_mode(self) -> str:
+        return "time_of_use_luna2000"
+
+    def get_huawei_working_mode_options(self) -> list[str]:
+        return ["maximise_self_consumption", "time_of_use_luna2000"]
+
+    def set_huawei_working_mode(self, option: str) -> None:
+        pass
+
+    def set_grid_charge(self, enabled: bool) -> None:
+        pass
+
+
+def restart_against(
+    inverter: FakeHuaweiInverter, battery_settings: BatterySettings
+) -> HuaweiController:
+    """A freshly constructed controller initialized from that inverter."""
+    restarted = HuaweiController(battery_settings=battery_settings)
+    restarted.read_and_initialize_from_hardware(inverter, current_hour=10)
+    return restarted
+
+
+def run_cycle(
+    controller: HuaweiController, inverter: FakeHuaweiInverter, schedule: MagicMock
+) -> bool:
+    """One BESS decision cycle, as battery_system_manager drives it.
+
+    evaluate_intents gates the write (_evaluate_schedule_application →
+    _apply_schedule, battery_system_manager.py:2537/2585): no difference
+    means the inverter is never touched. Returns whether it was written.
+    """
+    differs, _ = controller.evaluate_intents(schedule)
+    if differs:
+        controller.apply_intents(schedule)
+        controller.sync_to_hardware(inverter, 0)
+    return differs
+
+
+class TestTouReadback:
+    """Startup readback of the periods already programmed on the battery."""
+
+    def test_restart_leaves_matching_hardware_untouched(
+        self, controller: HuaweiController, battery_settings: BatterySettings
+    ) -> None:
+        """The point of the readback: no redundant rewrite after a restart.
+
+        Every write is a flash-wear event on the battery, and until now BESS
+        started blind and always rewrote the schedule it had just written.
+        """
+        intents = make_intents({2: "GRID_CHARGING", 18: "LOAD_SUPPORT"})
+        inverter = FakeHuaweiInverter()
+        controller.apply_intents(make_schedule_mock(intents))
+        controller.sync_to_hardware(inverter, 0)
+        assert inverter.write_count == 1
+
+        restarted = restart_against(inverter, battery_settings)
+        wrote = run_cycle(restarted, inverter, make_schedule_mock(intents))
+
+        assert wrote is False
+        assert inverter.write_count == 1
+
+    def test_restart_rewrites_when_the_plan_has_moved_on(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        inverter = FakeHuaweiInverter("02:00-02:59/1234567/+")
+        restarted = restart_against(inverter, battery_settings)
+
+        new_plan = make_intents({18: "BATTERY_EXPORT"})
+        wrote = run_cycle(restarted, inverter, make_schedule_mock(new_plan))
+
+        assert wrote is True
+        assert inverter.periods_text == "18:00-18:59/1234567/-"
+
+    def test_period_limited_to_some_weekdays_is_not_a_match(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """BESS only ever writes all-days periods.
+
+        A period programmed elsewhere for Mon-Fri covers the same clock times
+        but not the same days, so BESS's own all-days period is still missing
+        from the battery — treating it as a match would suppress a write that
+        is genuinely needed.
+        """
+        inverter = FakeHuaweiInverter("02:00-02:59/12345/+")
+        restarted = restart_against(inverter, battery_settings)
+
+        wrote = run_cycle(
+            restarted, inverter, make_schedule_mock(make_intents({2: "GRID_CHARGING"}))
+        )
+
+        assert wrote is True
+        assert inverter.periods_text == "02:00-02:59/1234567/+"
+
+    def test_unmapped_sensor_keeps_the_previous_blind_start(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """Readback is opt-in by configuration, never probed for.
+
+        Installs whose integration exposes no TOU period entity (EMMA behind
+        its own bridge) keep the documented pre-#431 behaviour: start with an
+        empty schedule and let the first cycle converge.
+        """
+        inverter = FakeHuaweiInverter("02:00-02:59/1234567/+", tou_sensor_mapped=False)
+        restarted = restart_against(inverter, battery_settings)
+
+        assert restarted._periods == []
+        wrote = run_cycle(
+            restarted, inverter, make_schedule_mock(make_intents({2: "GRID_CHARGING"}))
+        )
+        assert wrote is True
+
+    def test_readback_survives_a_second_restart(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """Periods parsed from hardware must round-trip back out unchanged.
+
+        A parse that dropped or reshaped a field would only show up when the
+        read-back state is written out again.
+        """
+        inverter = FakeHuaweiInverter()
+        first = HuaweiController(battery_settings=battery_settings)
+        intents = make_intents({2: "GRID_CHARGING", 18: "LOAD_SUPPORT"})
+        first.apply_intents(make_schedule_mock(intents))
+        first.sync_to_hardware(inverter, 0)
+        text_after_first = inverter.periods_text
+
+        second = restart_against(inverter, battery_settings)
+        second.sync_to_hardware(inverter, 0)
+
+        assert inverter.periods_text == text_after_first
+
+    def test_unparseable_period_text_raises(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """No silent skip: a period BESS can't read is not a period it may
+        pretend isn't there — that would suppress a needed write."""
+        inverter = FakeHuaweiInverter("02:00-02:59/1234567")
+        with pytest.raises(ValueError):
+            restart_against(inverter, battery_settings)
+
+    def test_write_is_skipped_when_the_battery_already_holds_the_plan(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """The read-compare-write guard, same shape as Growatt MIN (#551/#552).
+
+        Not every write goes through the evaluate_intents gate — a retry of a
+        failed write, the corruption flag and the 23:55 next-day preparation
+        all call sync_to_hardware directly. Each one is a flash-wear event on
+        a battery that may already hold exactly these periods.
+        """
+        inverter = FakeHuaweiInverter()
+        controller = HuaweiController(battery_settings=battery_settings)
+        schedule = make_schedule_mock(make_intents({2: "GRID_CHARGING"}))
+
+        controller.apply_intents(schedule)
+        controller.sync_to_hardware(inverter, 0)
+        assert inverter.write_count == 1
+
+        controller.apply_intents(schedule)
+        controller.sync_to_hardware(inverter, 0)
+
+        assert inverter.write_count == 1
+
+    def test_periods_changed_behind_bess_are_rewritten(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """Skipping is decided against hardware, never against the model."""
+        inverter = FakeHuaweiInverter()
+        controller = HuaweiController(battery_settings=battery_settings)
+        schedule = make_schedule_mock(make_intents({2: "GRID_CHARGING"}))
+
+        controller.apply_intents(schedule)
+        controller.sync_to_hardware(inverter, 0)
+        inverter.periods_text = "07:00-07:59/1234567/-"
+
+        controller.sync_to_hardware(inverter, 0)
+
+        assert inverter.write_count == 2
+        assert inverter.periods_text == "02:00-02:59/1234567/+"
+
+    def test_unmapped_sensor_still_writes_every_cycle(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """No readback, no comparison — the blind rewrite is all BESS has."""
+        inverter = FakeHuaweiInverter(tou_sensor_mapped=False)
+        controller = HuaweiController(battery_settings=battery_settings)
+        schedule = make_schedule_mock(make_intents({2: "GRID_CHARGING"}))
+
+        controller.apply_intents(schedule)
+        controller.sync_to_hardware(inverter, 0)
+        controller.sync_to_hardware(inverter, 0)
+
+        assert inverter.write_count == 2
+
+    def test_read_periods_are_shown_as_the_existing_schedule(
+        self, battery_settings: BatterySettings
+    ) -> None:
+        """Read-back periods carry no intent — BESS didn't plan them."""
+        inverter = FakeHuaweiInverter("02:00-02:59/1234567/+")
+        restarted = restart_against(inverter, battery_settings)
+        intervals = restarted.get_daily_TOU_settings()
+        assert len(intervals) == 1
+        assert intervals[0]["start_time"] == "02:00"
+        assert intervals[0]["strategic_intent"] == "existing_schedule"
 
 
 class TestWorkingModeAbsenceSeverity:

--- a/core/bess/tests/unit/test_huawei_ha_controller.py
+++ b/core/bess/tests/unit/test_huawei_ha_controller.py
@@ -85,3 +85,97 @@ class TestHuaweiServiceCalls:
         with patch.object(controller, "_api_request") as mock_request:
             mock_request.return_value = None
             assert controller.get_huawei_working_mode_options() == []
+
+
+class TestReadHuaweiTouPeriods:
+    """The TOU period readback reads the huawei_solar sensor's attributes.
+
+    HuaweiSolarTOUSensorEntity (wlcrs/huawei_solar sensor.py:2510) publishes
+    the configured periods as {"Period 1": "<text>", ...} extra state
+    attributes, in the same text format huawei_solar.set_tou_periods accepts.
+    """
+
+    @pytest.fixture
+    def controller(self) -> HomeAssistantAPIController:
+        ctrl = HomeAssistantAPIController(
+            ha_url="http://ha.local",
+            token="tok",
+            settings_store=_settings_store(
+                {
+                    "huawei_tou_periods": (
+                        "sensor.batteries_tou_charging_and_discharging_periods"
+                    )
+                }
+            ),
+            huawei_device_id="dev-123",
+            service_domain="huawei_solar",
+        )
+        ctrl.test_mode = False
+        return ctrl
+
+    def test_returns_period_lines_in_period_number_order(
+        self, controller: HomeAssistantAPIController
+    ) -> None:
+        with patch.object(controller, "_api_request") as mock_request:
+            mock_request.return_value = {
+                "state": "11",
+                "attributes": {
+                    "Period 10": "20:00-20:59/1234567/-",
+                    "Period 2": "18:00-18:59/1234567/-",
+                    "Period 1": "02:00-05:59/1234567/+",
+                    "Period 11": "21:00-21:59/1234567/-",
+                    "friendly_name": "Batteries TOU periods",
+                    "icon": "mdi:calendar-text",
+                },
+            }
+            assert controller.read_huawei_tou_periods() == [
+                "02:00-05:59/1234567/+",
+                "18:00-18:59/1234567/-",
+                "20:00-20:59/1234567/-",
+                "21:00-21:59/1234567/-",
+            ]
+
+    def test_no_periods_configured_reads_as_empty(
+        self, controller: HomeAssistantAPIController
+    ) -> None:
+        with patch.object(controller, "_api_request") as mock_request:
+            mock_request.return_value = {
+                "state": "0",
+                "attributes": {"friendly_name": "Batteries TOU periods"},
+            }
+            assert controller.read_huawei_tou_periods() == []
+
+    def test_unreadable_entity_raises_rather_than_reporting_empty(
+        self, controller: HomeAssistantAPIController
+    ) -> None:
+        """An empty inverter and an unreadable entity must not look alike.
+
+        Same distinction #551/#552 drew for Growatt MIN: [] means "no periods
+        programmed", and a failed read arrives as an exception. Reporting []
+        for a failed read would let BESS conclude its schedule matches nothing
+        and silently skip a needed write.
+        """
+        with patch.object(controller, "_api_request") as mock_request:
+            mock_request.return_value = None
+            with pytest.raises(SystemConfigurationError):
+                controller.read_huawei_tou_periods()
+
+    def test_unavailable_state_raises(
+        self, controller: HomeAssistantAPIController
+    ) -> None:
+        with patch.object(controller, "_api_request") as mock_request:
+            mock_request.return_value = {"state": "unavailable", "attributes": {}}
+            with pytest.raises(SystemConfigurationError):
+                controller.read_huawei_tou_periods()
+
+
+class TestHuaweiSuffixMap:
+    def test_tou_period_sensor_is_discoverable(self) -> None:
+        """The LUNA2000 TOU register key, verified against
+        huawei-solar-lib register_names.py:402."""
+        assert (
+            HomeAssistantAPIController.HUAWEI_SUFFIX_MAP[
+                "storage_huawei_luna2000_time_of_use_charging_and_discharging_periods"
+            ]
+            == "huawei_tou_periods"
+        )

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -533,7 +533,11 @@ read and catching failure. Installs whose integration exposes no such entity
 keep the original behaviour: start with an empty period list, converge on the
 first cycle. If the entity is mapped but unreadable, that raises rather than
 reading as "no periods programmed" — the two must not look alike, or BESS
-would skip a write it genuinely needs.
+would skip a write it genuinely needs. That read is the *first* thing
+`sync_to_hardware` does, ahead of the working-mode and grid-charge writes, so
+a failed read aborts the cycle with the battery untouched instead of arming
+grid charging against the period list the old plan left behind; BSM's
+`_hardware_write_pending` then retries the whole sync next cycle.
 
 `days` is part of a period's identity in that comparison. BESS always writes
 all-days (`1234567`) periods, so a period programmed elsewhere for a subset

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -506,6 +506,44 @@ targets whichever domain `inverter.service_domain` resolves to (default
 `huawei_solar`) — see "Bring-your-own integration" above for when and how to
 change it.
 
+**Schedule readback (optional, #431).** `huawei_solar` has no
+`read_tou_periods` service, but its TOU period sensor publishes the
+programmed periods as `Period N` extra state attributes, in the very text
+format `set_tou_periods` accepts (`HuaweiSolarTOUSensorEntity`, sensor.py).
+When the `huawei_tou_periods` sensor is mapped, BESS reads those in two
+places, the same read-compare-write shape Growatt MIN adopted in #551/#552:
+
+- at startup, to initialise the period list from what the battery actually
+  holds, so a restart doesn't rewrite a schedule already running. The periods
+  carry no strategic intent (the battery reports only charge/discharge
+  flags), so they display as `existing_schedule` until the first optimization.
+- before every write, comparing the plan against a fresh read rather than
+  against BESS's own model of the battery — a model can only ever claim what
+  BESS *meant* to write. `set_tou_periods` rewrites the whole list atomically
+  and cannot update just what moved, so every skipped write is a flash-wear
+  event spared. Paths that write without consulting `evaluate_intents` (a
+  retried write, the corruption flag, the 23:55 next-day preparation) go
+  through this check too.
+
+An empty plan still writes: the empty string is how BESS clears periods the
+battery is otherwise left running.
+
+Readback is enabled by the sensor being *mapped*, never by attempting the
+read and catching failure. Installs whose integration exposes no such entity
+keep the original behaviour: start with an empty period list, converge on the
+first cycle. If the entity is mapped but unreadable, that raises rather than
+reading as "no periods programmed" — the two must not look alike, or BESS
+would skip a write it genuinely needs.
+
+`days` is part of a period's identity in that comparison. BESS always writes
+all-days (`1234567`) periods, so a period programmed elsewhere for a subset
+of weekdays is not a match for BESS's own period even at identical times.
+
+EMMA's equivalent register (`emma_tou_periods`) uses the same period format
+but its entity is disabled by default upstream, so it is deliberately left
+out of `HUAWEI_SUFFIX_MAP` — auto-discovery would otherwise map a disabled,
+stateless entity. EMMA users who enable it can map it by hand in Settings.
+
 **Scheduling model:** Charge periods are flagged `GRID_CHARGING` intents;
 discharge periods are flagged `LOAD_SUPPORT` or `BATTERY_EXPORT` intents.
 Periods without an explicit flag (SOLAR_STORAGE, SOLAR_EXPORT, IDLE) use the
@@ -768,6 +806,7 @@ Only slot 1 of each direction is strictly required; slots 2-6 are optional
 | `battery_discharge_stop_soc` | number | `storage_grid_charge_cutoff_state_of_charge` | Discharge stop SOC (%) |
 | `grid_charge` | switch | `storage_charge_from_grid_function` | Grid charge enable |
 | `huawei_working_mode` | select | `storage_working_mode_settings` | Battery working mode (gating TOU writes) |
+| `huawei_tou_periods` | sensor | `storage_huawei_luna2000_time_of_use_charging_and_discharging_periods` | Optional: programmed TOU periods, read back at startup (#431) |
 | `local_load_power` | sensor | `active_power` | Home consumption (W) |
 | `pv_power` | sensor | `input_power` | Real-time solar PV power (W) |
 | `import_power` / `export_power` | sensor | `power_meter_active_power` (separate power-meter device, signed) | Net grid power (W); both keys map to this entity, split by sign at read time (`grid_power_polarity`, `"export_positive"` — issue #438) |

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -126,6 +126,23 @@ mask a wrong value there.
 | `ci-wizard-growatt-modbus` | Nordpool Official | MIN (Cloud) — auto-selects Growatt Cloud even though SolaX Modbus is also detected | - | - | - | - | - |
 | `ci-wizard-solis` | Nordpool Official | Solis | - | - | - | - | - |
 | `ci-wizard-growatt-vpp` | Nordpool Official | SPH (SolaX Modbus, GEN3, VPP) — experimental, see [platform maturity](memory/project_platform_maturity.md) | 3 | - | - | - | - |
+| `ci-wizard-huawei-luna2000` | Nordpool Official | Huawei LUNA2000 — experimental, see [platform maturity](memory/project_platform_maturity.md) | - | - | - | - | YES |
+
+`ci-wizard-huawei-luna2000` is the only fixture that drives a full backend
+schedule cycle on Huawei. It carries two TOU periods on the battery so the
+#431 readback has something to read, 96 quarterly prices and a solar forecast
+so the DP actually solves. Run it end to end with:
+
+```bash
+SCENARIO=ci-wizard-huawei-luna2000 BESS_SETTINGS=./e2e/ci-bess-settings-huawei.json \
+  BESS_FAKETIME_PRELOAD=/usr/local/lib/libfaketime.so.1 \
+  BESS_FAKETIME="2026-05-21 17:17:48" \
+  podman-compose -f docker-compose.ci.yml up -d
+```
+
+The faketime pin is required: the fixture's prices are keyed to its
+`mock_time` date, so without it the scheduler aborts with "No price data
+available" (see the `verify` skill's gotchas).
 
 **Not in this table — backend-discovery-only, not Playwright-runnable:**
 `ci-wizard-growatt-modbus-gen3.json` was meant to test a GEN3-via-SolaX-Modbus

--- a/e2e/ci-bess-settings-huawei.json
+++ b/e2e/ci-bess-settings-huawei.json
@@ -1,0 +1,82 @@
+{
+  "home": {
+    "default_hourly": 1.5,
+    "currency": "SEK",
+    "max_fuse_current": 25,
+    "voltage": 230,
+    "safety_margin": 1.0,
+    "phase_count": 3,
+    "consumption_strategy": "fixed",
+    "power_monitoring_enabled": false
+  },
+  "battery": {
+    "total_capacity": 10,
+    "min_soc": 10,
+    "max_soc": 100,
+    "max_charge_power_kw": 5,
+    "max_discharge_power_kw": 5,
+    "cycle_cost_per_kwh": 0.4,
+    "charging_power_rate": 40,
+    "efficiency_charge": 0.97,
+    "efficiency_discharge": 0.95,
+    "temperature_derating": {
+      "enabled": false,
+      "weather_entity": ""
+    },
+    "inverter_max_ac_power_kw": 0.0,
+    "inverter_ac_power_margin": 0.05
+  },
+  "electricity_price": {
+    "area": "SE3",
+    "markup_rate": 0.08,
+    "vat_multiplier": 1.25,
+    "additional_costs": 1.03,
+    "tax_reduction": 0.0,
+    "spot_multiplier": 1.0,
+    "export_spot_multiplier": 1.0,
+    "use_actual_price": false
+  },
+  "energy_provider": {
+    "provider": "nordpool_official",
+    "nordpool_official": {
+      "config_entry_id": "mock_config_entry"
+    }
+  },
+  "inverter": {
+    "platform": "huawei_solar_luna2000",
+    "control_mode": "tou",
+    "device_id": "dev-huawei-battery-001"
+  },
+  "growatt": {
+    "inverter_type": "",
+    "device_id": ""
+  },
+  "sensors": {
+    "platform": "huawei_solar_luna2000",
+    "huawei_solar_luna2000": {
+      "battery_soc": "sensor.batteries_state_of_capacity",
+      "battery_charge_power": "sensor.batteries_charge_discharge_power",
+      "huawei_working_mode": "select.batteries_working_mode",
+      "huawei_tou_periods": "sensor.batteries_tou_charging_and_discharging_periods",
+      "grid_charge": "switch.batteries_charge_from_grid",
+      "battery_charging_power_rate": "number.batteries_maximum_charging_power",
+      "battery_discharging_power_rate": "number.batteries_maximum_discharging_power",
+      "battery_charge_stop_soc": "number.batteries_charging_cutoff_capacity",
+      "battery_discharge_stop_soc": "number.batteries_grid_charge_cutoff_soc",
+      "local_load_power": "sensor.inverter_active_power",
+      "pv_power": "sensor.inverter_input_power",
+      "import_power": "sensor.power_meter_active_power",
+      "export_power": "sensor.power_meter_active_power",
+      "lifetime_solar_energy": "sensor.inverter_total_yield",
+      "lifetime_battery_charged": "sensor.batteries_total_charge",
+      "lifetime_battery_discharged": "sensor.batteries_total_discharge",
+      "lifetime_export_to_grid": "sensor.power_meter_exported",
+      "lifetime_import_from_grid": "sensor.power_meter_consumption",
+      "solar_forecast_today": "sensor.solcast_pv_forecast_forecast_today",
+      "solar_forecast_tomorrow": "sensor.solcast_pv_forecast_forecast_tomorrow"
+    }
+  },
+  "demo_mode": {
+    "enabled": false
+  }
+}

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -473,6 +473,7 @@ export const INTEGRATIONS: IntegrationDef[] = [
         name: 'Battery Control',
         sensors: [
           { key: 'huawei_working_mode', label: 'Working Mode (select)', required: true },
+          { key: 'huawei_tou_periods', label: 'TOU Charging/Discharging Periods (readback)', required: false },
           { key: 'battery_charging_power_rate', label: 'Maximum Charging Power', required: false },
           { key: 'battery_discharging_power_rate', label: 'Maximum Discharging Power', required: false },
           { key: 'battery_charge_stop_soc', label: 'Charging Cutoff Capacity', required: true },

--- a/scripts/mock_ha/scenarios/ci-wizard-huawei-luna2000.json
+++ b/scripts/mock_ha/scenarios/ci-wizard-huawei-luna2000.json
@@ -1,0 +1,810 @@
+{
+  "name": "ci-wizard-huawei-luna2000",
+  "description": "Fresh install with a Huawei LUNA2000 battery via huawei_solar (local Modbus) + official Nordpool SE3. Source-derived fixture: unique_ids are f\"{serial_number}_{register_key}\" (wlcrs/huawei_solar select.py:204, number.py:358, switch.py:200), register keys per wlcrs/huawei-solar-lib register_names.py \u2014 see core/bess/ha_api_controller.py HUAWEI_SUFFIX_MAP for the per-key citations. The battery holds two TOU periods, published as 'Period N' attributes by HuaweiSolarTOUSensorEntity (sensor.py:2510), which is what #431 reads back so BESS stops rewriting a schedule the battery already runs. huawei_solar splits one config entry across several devices (inverter, battery, power meter); the battery device is the one carrying storage_working_mode_settings.",
+  "mock_time": "@2026-05-21 17:17:48",
+  "timezone": "Europe/Stockholm",
+  "bess_config": {
+    "battery": {
+      "total_capacity": 15.0,
+      "min_soc": 10,
+      "max_soc": 100,
+      "max_charge_power_kw": 5.0,
+      "max_discharge_power_kw": 5.0,
+      "cycle_cost_per_kwh": 0.4,
+      "efficiency_charge": 0.97,
+      "efficiency_discharge": 0.95
+    },
+    "home": {
+      "default_hourly": 4.6,
+      "currency": "SEK",
+      "consumption_strategy": "fixed",
+      "max_fuse_current": 25,
+      "voltage": 230,
+      "safety_margin": 1.0,
+      "phase_count": 1,
+      "power_monitoring_enabled": false
+    },
+    "electricity_price": {
+      "markup_rate": 0.08,
+      "vat_multiplier": 1.25,
+      "additional_costs": 0.773,
+      "tax_reduction": 0.1988,
+      "area": "SE3"
+    },
+    "energy_provider": {
+      "provider": "nordpool_official",
+      "nordpool_official": {
+        "config_entry_id": ""
+      },
+      "nordpool": {
+        "entity": ""
+      },
+      "octopus": {}
+    },
+    "growatt": {
+      "inverter_type": "",
+      "device_id": ""
+    },
+    "inverter": {
+      "platform": "",
+      "device_id": ""
+    },
+    "sensors": {}
+  },
+  "sensors": {
+    "sensor.batteries_state_of_capacity": {
+      "state": "62",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "sensor.batteries_charge_discharge_power": {
+      "state": "-900",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.batteries_tou_charging_and_discharging_periods": {
+      "state": "2",
+      "attributes": {
+        "Period 1": "02:00-05:59/1234567/+",
+        "Period 2": "18:00-19:59/1234567/-",
+        "friendly_name": "Batteries TOU charging and discharging periods",
+        "icon": "mdi:calendar-text"
+      }
+    },
+    "select.batteries_working_mode": {
+      "state": "time_of_use_luna2000",
+      "attributes": {
+        "options": [
+          "adaptive",
+          "fixed_charge_discharge",
+          "maximise_self_consumption",
+          "time_of_use_luna2000",
+          "fully_fed_to_grid"
+        ]
+      }
+    },
+    "switch.batteries_charge_from_grid": {
+      "state": "on",
+      "attributes": {}
+    },
+    "number.batteries_maximum_charging_power": {
+      "state": "5000",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "number.batteries_maximum_discharging_power": {
+      "state": "5000",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "number.batteries_charging_cutoff_capacity": {
+      "state": "100",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "number.batteries_grid_charge_cutoff_soc": {
+      "state": "10",
+      "attributes": {
+        "unit_of_measurement": "%"
+      }
+    },
+    "sensor.inverter_active_power": {
+      "state": "3100",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.inverter_input_power": {
+      "state": "2200",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.power_meter_active_power": {
+      "state": "-1500",
+      "attributes": {
+        "unit_of_measurement": "W"
+      }
+    },
+    "sensor.inverter_total_yield": {
+      "state": "8600",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.batteries_total_charge": {
+      "state": "4200",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.batteries_total_discharge": {
+      "state": "3900",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.power_meter_exported": {
+      "state": "2100",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.power_meter_consumption": {
+      "state": "7400",
+      "attributes": {
+        "unit_of_measurement": "kWh"
+      }
+    },
+    "sensor.solcast_pv_forecast_forecast_today": {
+      "state": "37.4",
+      "attributes": {
+        "unit_of_measurement": "kWh",
+        "detailedHourly": [
+          {
+            "period_start": "2026-05-21T00:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-21T01:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-21T02:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-21T03:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-21T04:00:00+02:00",
+            "pv_estimate": 0.1
+          },
+          {
+            "period_start": "2026-05-21T05:00:00+02:00",
+            "pv_estimate": 0.4
+          },
+          {
+            "period_start": "2026-05-21T06:00:00+02:00",
+            "pv_estimate": 1.0
+          },
+          {
+            "period_start": "2026-05-21T07:00:00+02:00",
+            "pv_estimate": 1.8
+          },
+          {
+            "period_start": "2026-05-21T08:00:00+02:00",
+            "pv_estimate": 2.6
+          },
+          {
+            "period_start": "2026-05-21T09:00:00+02:00",
+            "pv_estimate": 3.4
+          },
+          {
+            "period_start": "2026-05-21T10:00:00+02:00",
+            "pv_estimate": 4.0
+          },
+          {
+            "period_start": "2026-05-21T11:00:00+02:00",
+            "pv_estimate": 4.3
+          },
+          {
+            "period_start": "2026-05-21T12:00:00+02:00",
+            "pv_estimate": 4.4
+          },
+          {
+            "period_start": "2026-05-21T13:00:00+02:00",
+            "pv_estimate": 4.2
+          },
+          {
+            "period_start": "2026-05-21T14:00:00+02:00",
+            "pv_estimate": 3.7
+          },
+          {
+            "period_start": "2026-05-21T15:00:00+02:00",
+            "pv_estimate": 3.0
+          },
+          {
+            "period_start": "2026-05-21T16:00:00+02:00",
+            "pv_estimate": 2.2
+          },
+          {
+            "period_start": "2026-05-21T17:00:00+02:00",
+            "pv_estimate": 1.4
+          },
+          {
+            "period_start": "2026-05-21T18:00:00+02:00",
+            "pv_estimate": 0.7
+          },
+          {
+            "period_start": "2026-05-21T19:00:00+02:00",
+            "pv_estimate": 0.2
+          },
+          {
+            "period_start": "2026-05-21T20:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-21T21:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-21T22:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-21T23:00:00+02:00",
+            "pv_estimate": 0.0
+          }
+        ]
+      }
+    },
+    "sensor.solcast_pv_forecast_forecast_tomorrow": {
+      "state": "37.4",
+      "attributes": {
+        "unit_of_measurement": "kWh",
+        "detailedHourly": [
+          {
+            "period_start": "2026-05-22T00:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-22T01:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-22T02:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-22T03:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-22T04:00:00+02:00",
+            "pv_estimate": 0.1
+          },
+          {
+            "period_start": "2026-05-22T05:00:00+02:00",
+            "pv_estimate": 0.4
+          },
+          {
+            "period_start": "2026-05-22T06:00:00+02:00",
+            "pv_estimate": 1.0
+          },
+          {
+            "period_start": "2026-05-22T07:00:00+02:00",
+            "pv_estimate": 1.8
+          },
+          {
+            "period_start": "2026-05-22T08:00:00+02:00",
+            "pv_estimate": 2.6
+          },
+          {
+            "period_start": "2026-05-22T09:00:00+02:00",
+            "pv_estimate": 3.4
+          },
+          {
+            "period_start": "2026-05-22T10:00:00+02:00",
+            "pv_estimate": 4.0
+          },
+          {
+            "period_start": "2026-05-22T11:00:00+02:00",
+            "pv_estimate": 4.3
+          },
+          {
+            "period_start": "2026-05-22T12:00:00+02:00",
+            "pv_estimate": 4.4
+          },
+          {
+            "period_start": "2026-05-22T13:00:00+02:00",
+            "pv_estimate": 4.2
+          },
+          {
+            "period_start": "2026-05-22T14:00:00+02:00",
+            "pv_estimate": 3.7
+          },
+          {
+            "period_start": "2026-05-22T15:00:00+02:00",
+            "pv_estimate": 3.0
+          },
+          {
+            "period_start": "2026-05-22T16:00:00+02:00",
+            "pv_estimate": 2.2
+          },
+          {
+            "period_start": "2026-05-22T17:00:00+02:00",
+            "pv_estimate": 1.4
+          },
+          {
+            "period_start": "2026-05-22T18:00:00+02:00",
+            "pv_estimate": 0.7
+          },
+          {
+            "period_start": "2026-05-22T19:00:00+02:00",
+            "pv_estimate": 0.2
+          },
+          {
+            "period_start": "2026-05-22T20:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-22T21:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-22T22:00:00+02:00",
+            "pv_estimate": 0.0
+          },
+          {
+            "period_start": "2026-05-22T23:00:00+02:00",
+            "pv_estimate": 0.0
+          }
+        ]
+      }
+    }
+  },
+  "entity_registry": [
+    {
+      "entity_id": "sensor.batteries_state_of_capacity",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_state_of_capacity",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "sensor.batteries_charge_discharge_power",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_charge_discharge_power",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "sensor.batteries_tou_charging_and_discharging_periods",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_huawei_luna2000_time_of_use_charging_and_discharging_periods",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "select.batteries_working_mode",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_working_mode_settings",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "switch.batteries_charge_from_grid",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_charge_from_grid_function",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "number.batteries_maximum_charging_power",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_maximum_charging_power",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "number.batteries_maximum_discharging_power",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_maximum_discharging_power",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "number.batteries_charging_cutoff_capacity",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_charging_cutoff_capacity",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "number.batteries_grid_charge_cutoff_soc",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_grid_charge_cutoff_state_of_charge",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "sensor.inverter_active_power",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_active_power",
+      "device_id": "dev-huawei-inverter-001"
+    },
+    {
+      "entity_id": "sensor.inverter_input_power",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_input_power",
+      "device_id": "dev-huawei-inverter-001"
+    },
+    {
+      "entity_id": "sensor.inverter_total_yield",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_accumulated_yield_energy",
+      "device_id": "dev-huawei-inverter-001"
+    },
+    {
+      "entity_id": "sensor.batteries_total_charge",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_total_charge",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "sensor.batteries_total_discharge",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_storage_total_discharge",
+      "device_id": "dev-huawei-battery-001"
+    },
+    {
+      "entity_id": "sensor.power_meter_active_power",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_power_meter_active_power",
+      "device_id": "dev-huawei-meter-001"
+    },
+    {
+      "entity_id": "sensor.power_meter_exported",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_grid_exported_energy",
+      "device_id": "dev-huawei-meter-001"
+    },
+    {
+      "entity_id": "sensor.power_meter_consumption",
+      "platform": "huawei_solar",
+      "unique_id": "SN2024HUAWEI01_grid_accumulated_energy",
+      "device_id": "dev-huawei-meter-001"
+    },
+    {
+      "entity_id": "sensor.nord_pool_se3_current_price",
+      "platform": "nordpool",
+      "unique_id": "SE3-current_price",
+      "device_id": "dev-nordpool-001",
+      "config_entry_id": "entry-nordpool-001"
+    }
+  ],
+  "config_entries": [
+    {
+      "entry_id": "entry-nordpool-001",
+      "domain": "nordpool",
+      "title": "Nord Pool",
+      "state": "loaded"
+    },
+    {
+      "entry_id": "entry-huawei-001",
+      "domain": "huawei_solar",
+      "title": "Huawei Solar",
+      "state": "loaded"
+    }
+  ],
+  "devices": [
+    {
+      "id": "dev-huawei-inverter-001",
+      "name": "SUN2000",
+      "manufacturer": "Huawei",
+      "model": "SUN2000-10KTL-M1",
+      "identifiers": [
+        [
+          "huawei_solar",
+          "SN2024HUAWEI01"
+        ]
+      ],
+      "config_entries": [
+        "entry-huawei-001"
+      ]
+    },
+    {
+      "id": "dev-huawei-battery-001",
+      "name": "Batteries",
+      "manufacturer": "Huawei",
+      "model": "LUNA2000",
+      "identifiers": [
+        [
+          "huawei_solar",
+          "SN2024HUAWEI01_batteries"
+        ]
+      ],
+      "config_entries": [
+        "entry-huawei-001"
+      ]
+    },
+    {
+      "id": "dev-huawei-meter-001",
+      "name": "Power meter",
+      "manufacturer": "Huawei",
+      "model": "DDSU666-H",
+      "identifiers": [
+        [
+          "huawei_solar",
+          "SN2024HUAWEI01_meter"
+        ]
+      ],
+      "config_entries": [
+        "entry-huawei-001"
+      ]
+    },
+    {
+      "id": "dev-nordpool-001",
+      "name": "Nord Pool SE3",
+      "manufacturer": "Nord Pool",
+      "model": null,
+      "identifiers": [
+        [
+          "nordpool",
+          "SE3"
+        ]
+      ],
+      "config_entries": [
+        "entry-nordpool-001"
+      ]
+    }
+  ],
+  "services": {
+    "select": {
+      "select_option": {}
+    },
+    "switch": {
+      "turn_on": {},
+      "turn_off": {}
+    },
+    "number": {
+      "set_value": {}
+    },
+    "huawei_solar": {
+      "set_tou_periods": {}
+    }
+  },
+  "price_data": {
+    "today": [
+      0.45,
+      0.45,
+      0.45,
+      0.45,
+      0.38,
+      0.38,
+      0.38,
+      0.38,
+      0.32,
+      0.32,
+      0.32,
+      0.32,
+      0.28,
+      0.28,
+      0.28,
+      0.28,
+      0.25,
+      0.25,
+      0.25,
+      0.25,
+      0.3,
+      0.3,
+      0.3,
+      0.3,
+      0.55,
+      0.55,
+      0.55,
+      0.55,
+      0.82,
+      0.82,
+      0.82,
+      0.82,
+      1.05,
+      1.05,
+      1.05,
+      1.05,
+      1.15,
+      1.15,
+      1.15,
+      1.15,
+      1.08,
+      1.08,
+      1.08,
+      1.08,
+      0.95,
+      0.95,
+      0.95,
+      0.95,
+      0.85,
+      0.85,
+      0.85,
+      0.85,
+      0.78,
+      0.78,
+      0.78,
+      0.78,
+      0.72,
+      0.72,
+      0.72,
+      0.72,
+      0.8,
+      0.8,
+      0.8,
+      0.8,
+      0.92,
+      0.92,
+      0.92,
+      0.92,
+      1.25,
+      1.25,
+      1.25,
+      1.25,
+      1.55,
+      1.55,
+      1.55,
+      1.55,
+      1.42,
+      1.42,
+      1.42,
+      1.42,
+      1.1,
+      1.1,
+      1.1,
+      1.1,
+      0.75,
+      0.75,
+      0.75,
+      0.75,
+      0.58,
+      0.58,
+      0.58,
+      0.58,
+      0.48,
+      0.48,
+      0.48,
+      0.48
+    ],
+    "tomorrow": [
+      0.42,
+      0.42,
+      0.42,
+      0.42,
+      0.35,
+      0.35,
+      0.35,
+      0.35,
+      0.3,
+      0.3,
+      0.3,
+      0.3,
+      0.26,
+      0.26,
+      0.26,
+      0.26,
+      0.23,
+      0.23,
+      0.23,
+      0.23,
+      0.28,
+      0.28,
+      0.28,
+      0.28,
+      0.5,
+      0.5,
+      0.5,
+      0.5,
+      0.78,
+      0.78,
+      0.78,
+      0.78,
+      1.0,
+      1.0,
+      1.0,
+      1.0,
+      1.1,
+      1.1,
+      1.1,
+      1.1,
+      1.02,
+      1.02,
+      1.02,
+      1.02,
+      0.9,
+      0.9,
+      0.9,
+      0.9,
+      0.8,
+      0.8,
+      0.8,
+      0.8,
+      0.74,
+      0.74,
+      0.74,
+      0.74,
+      0.68,
+      0.68,
+      0.68,
+      0.68,
+      0.76,
+      0.76,
+      0.76,
+      0.76,
+      0.88,
+      0.88,
+      0.88,
+      0.88,
+      1.2,
+      1.2,
+      1.2,
+      1.2,
+      1.48,
+      1.48,
+      1.48,
+      1.48,
+      1.35,
+      1.35,
+      1.35,
+      1.35,
+      1.05,
+      1.05,
+      1.05,
+      1.05,
+      0.7,
+      0.7,
+      0.7,
+      0.7,
+      0.55,
+      0.55,
+      0.55,
+      0.55,
+      0.45,
+      0.45,
+      0.45,
+      0.45
+    ]
+  },
+  "time_segments": [],
+  "expected_discovery": {
+    "growatt_found": false,
+    "solax_found": false,
+    "solis_found": false,
+    "huawei_found": true,
+    "huawei_device_id": "dev-huawei-battery-001",
+    "nordpool_found": true,
+    "nordpool_area": "SE3",
+    "nordpool_custom_area": null,
+    "nordpool_config_entry_id": "entry-nordpool-001",
+    "octopus_found": false,
+    "currency": "SEK",
+    "vat_multiplier": 1.25,
+    "detected_platform": "huawei_solar_luna2000",
+    "required_sensors": [
+      "battery_soc",
+      "battery_charge_power",
+      "huawei_working_mode",
+      "huawei_tou_periods",
+      "battery_charge_stop_soc",
+      "battery_discharge_stop_soc",
+      "import_power",
+      "export_power",
+      "pv_power",
+      "local_load_power",
+      "lifetime_battery_charged",
+      "lifetime_battery_discharged",
+      "lifetime_solar_energy",
+      "lifetime_import_from_grid",
+      "lifetime_export_to_grid"
+    ],
+    "detected_inverter_platforms": [
+      "huawei_solar_luna2000"
+    ]
+  },
+  "inverter_platform": "huawei_solar_luna2000"
+}


### PR DESCRIPTION
## Summary

- `HuaweiController.read_and_initialize_from_hardware()` stops being a no-op: BESS now initialises from the periods the battery actually holds.
- `sync_to_hardware` compares the plan against a fresh read and skips the write when the battery already holds it — the read-compare-write shape Growatt MIN adopted in #551/#552.
- Adds `ci-wizard-huawei-luna2000`, the first mock-HA fixture for this platform.

## Root cause

The no-op's docstring claimed the readback did not exist:

> huawei_solar exposes no read_tou_periods service — the periods are only visible via the (undocumented) coordinator state, not a public service call.

That premise is wrong, as @johanzander pointed out in #120. `HuaweiSolarTOUSensorEntity` publishes the programmed periods as `Period N` extra state attributes (wlcrs/huawei_solar `sensor.py:2510`), built by `_huawei_luna2000_period_to_text` (`sensor.py:2487`) in the *same* text format `set_tou_periods` accepts — byte-identical to what BESS's own `_periods_to_text()` emits. It is a public entity read, not coordinator internals. `unique_id` is `f"{serial_number}_{register_key}"` (`sensor.py:2485`) with register key `storage_huawei_luna2000_time_of_use_charging_and_discharging_periods` (huawei-solar-lib `register_names.py:402`), so it drops straight into the existing `HUAWEI_SUFFIX_MAP` discovery.

Consequence: BESS started every run assuming the battery held nothing and rewrote the schedule to converge. `set_tou_periods` rewrites the whole list atomically, so each of those was a flash-wear event buying nothing.

## Fix

- **`ha_api_controller.py`** — `read_huawei_tou_periods()` returns the `Period N` attribute values ordered by period number; one new `HUAWEI_SUFFIX_MAP` entry.
- **`huawei_controller.py`** — real `read_and_initialize_from_hardware()`; `_period_from_text()` as the exact inverse of `_periods_to_text()`; `_read_periods_from_hardware()` used at startup *and* before every write; `_periods_to_tou_intervals()` shared by both paths (readback labels intent `existing_schedule`, as Solis does).
- **`days` is now carried on period dicts** rather than `_periods_to_text` hardcoding `ALL_DAYS`, and is part of the comparison. BESS only ever writes all-days periods, but it can now read back one programmed elsewhere for a subset of weekdays; matching on times alone would call that identical and silently leave the battery idle on the days BESS's own period covers.

Three design points, all answering the questions in the issue:

1. **Readback is declared, not probed.** Enabled by the sensor being mapped (`is_sensor_configured`), the same predicate the working-mode gate already uses. Installs whose integration exposes no such entity keep the previous behaviour exactly.
2. **A mapped-but-unreadable entity raises** rather than reading as "no periods programmed" — the distinction #552 drew for Growatt MIN. Reporting `[]` for a failed read would let BESS conclude its plan matches and skip a write it genuinely needs.
3. **An empty plan still writes.** The empty string is how BESS clears periods the battery would otherwise keep running.

**Out of scope, deliberately:** EMMA's `emma_tou_periods` register uses the identical period format, but its entity is `entity_registry_enabled_default=False` upstream (`sensor.py:1789`). Auto-discovery maps disabled entities (with a warning), so wiring it would hand EMMA installs a mapped, stateless entity and a startup error. EMMA users who enable it can map it by hand.

## Scope assessment

**Local.** Every change lands inside the existing stated contract of the method holding it — `read_and_initialize_from_hardware` is defined platform-wide as "read the current schedule and initialise this controller" (`solis_modbus_controller.py:241`), and `sync_to_hardware` was renamed to exactly this read-compare-write meaning in #552. No new class.

**Workaround check: passes.** No parameter, flag, default-fallback, second construction site, extra trigger or branch exists to route around an ordering/timing/dependency problem. The one conditional is the declared-config predicate above, not a probe-and-swallow. `days` is a comparison-correctness fix for a case readback newly makes reachable, not defensive padding.

## Test plan

- [x] `./scripts/quality-check.sh` — fast suite 1775 passed, black/ruff clean
- [x] `.venv/bin/pytest -m slow` — 534 passed
- [x] frontend `npm run lint` + `npx tsc --noEmit` clean (one added sensor row)
- [x] **Observed live** on the real backend + mock-HA stack (`ci-wizard-huawei-luna2000`, faketime-pinned):

```
huawei_controller:407 - Reading Huawei TOU periods from the battery
huawei_controller:413 - Huawei initialized from hardware: 2 period(s)
huawei_controller:417 -   +: 02:00-05:59/1234567
huawei_controller:417 -   -: 18:00-19:59/1234567
huawei_controller:433 - DECISION: Huawei period count differs — current=2 new=1
huawei_controller:346 - HUAWEI HARDWARE: Writing 1 TOU period(s)
```

then, with the battery holding what BESS had just written, restarted:

```
huawei_controller:413 - Huawei initialized from hardware: 1 period(s)
huawei_controller:457 - DECISION: Huawei schedules match
battery_system_manager:2544 - DECISION: Keep current schedule
```

No write on the second run — the redundant flash write is gone. `/api/inverter/schedule` also served the read-back period as `strategicIntent: "existing_schedule"`.

The write-level guard (`sync_to_hardware` skipping when hardware already matches) could not be reached live: no API endpoint forces a schedule application, and the gate suppresses the call whenever hardware matches. It is covered by unit test + mutation below.

## Evidence the test discriminates

Three mutations, each run against the suite:

- Reverted: forced `read_and_initialize_from_hardware` back to the blind start (`if True:` on the unmapped branch).
  Result: **4 tests FAILED** — `test_restart_leaves_matching_hardware_untouched`, `test_readback_survives_a_second_restart`, `test_unparseable_period_text_raises`, `test_read_periods_are_shown_as_the_existing_schedule`.
- Reverted: dropped `pa["days"] != pb["days"]` from the `evaluate_intents` diff.
  Result: **1 test FAILED** — `test_period_limited_to_some_weekdays_is_not_a_match`.
- Reverted: disabled the pre-write comparison (`if False:` on the readback branch in `sync_to_hardware`).
  Result: **1 test FAILED** — `test_write_is_skipped_when_the_battery_already_holds_the_plan`.
- Also mutated the *fixture*: renamed the TOU sensor's `unique_id` suffix in `ci-wizard-huawei-luna2000.json`.
  Result: **1 test FAILED** — `test_required_sensors_discovered[ci-wizard-huawei-luna2000]`, confirming the discovery assertion is real and not vacuous.
- Restored: tree clean, 1775 passed.

## Outcome-level coverage

The tests assert whether BESS *writes to the battery*, not what text it emits. `FakeHuaweiInverter` is an execution model of the LUNA2000 period list — it stores what BESS writes and reports it back in the sensor's attribute format — so a restart replays end to end (write → read back → decide) and the assertions are on `write_count` and the resulting `periods_text`. `run_cycle` mirrors how `battery_system_manager.py:2537/2585` gates the write.

One existing test changed meaning rather than being deleted: `test_write_schedule_no_periods_writes_empty_string` pinned the old always-write behaviour for an empty plan against an empty battery, which must no longer write. It is now `test_write_schedule_no_periods_clears_the_battery`, pinning the case that still must write — clearing a battery that holds periods.

No DP, intent-classification or control/rate-mapping code is touched, so no `R == P` plan-faithfulness scenario is required here.

## Documentation

- `docs/INVERTER_PLATFORMS.md` — sensor-table row and a "Schedule readback" section covering both read sites, the days rule, and the EMMA exclusion.
- `docs/agents/testing.md` — the new fixture and the exact command to run it (including why the faketime pin is required).
- Checked and unaffected: `docs/agents/bess-knowledge.md` says nothing about Huawei readback; `docs/SOFTWARE_DESIGN.md` describes the Huawei write path and service domain but makes no readback claim. The stale "no readback API" wording also survives in `docs/superpowers/plans/2026-07-23-huawei-inverter-platform.md`, a historical plan doc from #120, left untouched.

## Notes for review

- `HuaweiController.sync_to_hardware` still swallows every hardware exception (`try/except logger.error`), so a failed write never sets `_hardware_write_pending` and never retries. The per-cycle read makes that self-heal — the next cycle sees the mismatch and rewrites — but the swallowing itself is untouched here and may deserve its own issue.
- `set_grid_charge` is still written unconditionally every cycle, unlike the working-mode write. Gating it on a read would be symmetric with this change but is outside #431 as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCWtr8sZqfckYCk5objtm4