### PR TITLE
fix: include the battery terms when deriving lifetime load consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Reported lifetime house consumption is now correct on SolaX, Solis and Huawei**, which have no load register — it previously overstated load by the battery's lifetime net charge. ([#528](https://github.com/johanzander/bess-manager/issues/528))
 - **The setup wizard no longer completes with a configuration that cannot work** — it now blocks on inverter sensors whose Home Assistant entity is disabled (naming them so you can enable them) and on a price provider that isn't configured, instead of reporting "SYSTEM DEGRADED" afterwards. ([#549](https://github.com/johanzander/bess-manager/issues/549))
 - **Growatt MIN TOU segments are now written against the inverter's real state**, ending repeated "500 Server Error" write failures and leaving no unplanned segments running on the battery. ([#551](https://github.com/johanzander/bess-manager/issues/551))
 - **House load spikes during a battery-supported period are now covered from the battery instead of the grid**, on TOU/register platforms, whenever the stored energy is worth less than importing at that moment (`buy_price × discharge_efficiency ≥ shadow_price`, decided by the optimizer). When the battery is genuinely being reserved for a pricier later period the reserve is still protected and the spike is imported. ([#520](https://github.com/johanzander/bess-manager/issues/520))

--- a/TODO.md
+++ b/TODO.md
@@ -523,7 +523,7 @@ immediately and the context's shape is dictated by a real requirement.
 
 - `lifetime_system_production` (mapped from `total_yield`) — derived as `solar_production` when missing
 - `lifetime_self_consumption` — derived as `load - import` when missing
-- `lifetime_load_consumption` — derived as `solar + import - export` when missing
+- `lifetime_load_consumption` — derived as `solar + import + discharged - charged - export` when missing (issue #528)
 
 These sensors remain in the per-platform suffix maps (`GROWATT_MIN_SUFFIX_MAP`, `GROWATT_SPH_SUFFIX_MAP`, etc.), get discovered, appear in the wizard sensor list, and are saved to config, but nothing reads them at runtime. Remove them from the suffix maps and `sensorDefinitions.ts` to reduce wizard clutter and avoid confusion about which sensors actually matter.
 

--- a/core/bess/energy_balance.py
+++ b/core/bess/energy_balance.py
@@ -1,0 +1,58 @@
+"""Energy-balance identities shared by the sensor and flow layers.
+
+House load is not measured on every platform (SolaX native, Solis and Huawei
+have no load register), so it has to be derived from the counters that every
+platform does provide. That derivation was duplicated — once over lifetime
+totals in ``ha_api_controller`` and once over period deltas in
+``energy_flow_calculator`` — and the two copies drifted: the lifetime copy
+omitted the battery terms entirely and reported load plus net battery charge
+(issue #528). One definition, two callers, so they cannot drift again.
+"""
+
+
+def derive_load_consumption(
+    *,
+    solar_production: float,
+    import_from_grid: float,
+    export_to_grid: float,
+    battery_charged: float,
+    battery_discharged: float,
+) -> float:
+    """Derive house load consumption from the five core energy counters.
+
+    Decomposing into the seven physical flows::
+
+        solar       = solar_to_home + solar_to_battery + solar_to_grid
+        import      = grid_to_home  + grid_to_battery
+        export      = solar_to_grid + battery_to_grid
+        charged     = solar_to_battery + grid_to_battery
+        discharged  = battery_to_home + battery_to_grid
+
+    gives ``load = solar_to_home + battery_to_home + grid_to_home``, which
+    reduces to the balance below. Dropping the battery terms yields
+    ``load + (charged - discharged)`` — the issue #528 defect.
+
+    The result is returned unclamped: over a consistent set of counters it is
+    physically non-negative, so a negative value means the inputs disagree and
+    must stay visible rather than being laundered into a plausible zero (per
+    ``docs/agents/rules.md`` — no silent fallbacks). Callers working with
+    per-period deltas, where sensor noise can legitimately produce a small
+    negative, clamp it themselves.
+
+    Args:
+        solar_production: Solar energy produced, kWh.
+        import_from_grid: Energy imported from the grid, kWh.
+        export_to_grid: Energy exported to the grid, kWh.
+        battery_charged: Energy charged into the battery, kWh.
+        battery_discharged: Energy discharged from the battery, kWh.
+
+    Returns:
+        House load consumption in kWh.
+    """
+    return (
+        solar_production
+        + import_from_grid
+        + battery_discharged
+        - battery_charged
+        - export_to_grid
+    )

--- a/core/bess/energy_flow_calculator.py
+++ b/core/bess/energy_flow_calculator.py
@@ -7,6 +7,7 @@ while separating it from sensor collection and predictions.
 
 import logging
 
+from .energy_balance import derive_load_consumption
 from .settings import BatterySettings
 
 logger = logging.getLogger(__name__)
@@ -146,18 +147,22 @@ class EnergyFlowCalculator:
         import_from_grid = flows.get("import_from_grid", 0)
 
         # Derive load_consumption when no direct sensor is available.
-        # GEN4 Growatt Modbus and SolaX Native lack a native register.
-        # Energy balance: load = solar + import + battery_out - battery_in - export
+        # SolaX Native, Solis and Huawei lack a native register.
+        # These are per-period deltas, so cross-sensor noise can push the
+        # balance slightly negative; clamp here rather than in the shared
+        # identity, which stays unclamped for lifetime totals (issue #528).
         if load_consumption == 0 and (
             solar_production > 0 or import_from_grid > 0 or battery_discharged > 0
         ):
             load_consumption = max(
                 0,
-                solar_production
-                + import_from_grid
-                + battery_discharged
-                - battery_charged
-                - export_to_grid,
+                derive_load_consumption(
+                    solar_production=solar_production,
+                    import_from_grid=import_from_grid,
+                    export_to_grid=export_to_grid,
+                    battery_charged=battery_charged,
+                    battery_discharged=battery_discharged,
+                ),
             )
             flows["load_consumption"] = load_consumption
 

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -2528,35 +2528,56 @@ class HomeAssistantAPIController:
     def get_load_consumption_lifetime(self):
         """Get lifetime total load consumption energy in kWh.
 
-        If no direct sensor is configured, derives the value from the energy
-        balance (see :func:`core.bess.energy_balance.derive_load_consumption`).
-        SolaX native, Solis and Huawei lack a native load register and take
-        this path; all three map both battery counters.
+        Falls through to the derived path whenever the direct reading is
+        missing — the gate is the runtime value, not the platform, so an
+        unmapped *or* momentarily unavailable entity reaches it. SolaX native,
+        Solis and Huawei are the platforms with no native load register at
+        all, so they take it on every call; any other platform lands here only
+        while its own load sensor is unreadable.
 
-        Returns ``None`` when any input is unmapped — the battery terms are
-        not optional, and dropping them reports load plus net battery charge
-        (issue #528) — and also when the balance comes out negative, which on
-        monotonic lifetime totals means a counter is stalled or
-        under-reporting rather than rounding noise.
+        The derived value comes from the energy balance (see
+        :func:`core.bess.energy_balance.derive_load_consumption`), which needs
+        all five counters. Returns ``None`` when any is unreadable — the
+        battery terms are not optional, and dropping them reports load plus
+        net battery charge (issue #528) — and also when the balance comes out
+        negative, which on monotonic lifetime totals means a counter is
+        stalled or under-reporting rather than rounding noise.
         """
         direct = self._get_sensor_value("lifetime_load_consumption")
         if direct is not None:
             return direct
 
         # Derive from other lifetime sensors when direct sensor unavailable
-        solar = self._get_sensor_value("lifetime_solar_energy")
-        grid_import = self._get_sensor_value("lifetime_import_from_grid")
-        grid_export = self._get_sensor_value("lifetime_export_to_grid")
-        battery_charged = self._get_sensor_value("lifetime_battery_charged")
-        battery_discharged = self._get_sensor_value("lifetime_battery_discharged")
-        if None in (
-            solar,
-            grid_import,
-            grid_export,
-            battery_charged,
-            battery_discharged,
-        ):
+        inputs = {
+            "lifetime_solar_energy": self._get_sensor_value("lifetime_solar_energy"),
+            "lifetime_import_from_grid": self._get_sensor_value(
+                "lifetime_import_from_grid"
+            ),
+            "lifetime_export_to_grid": self._get_sensor_value(
+                "lifetime_export_to_grid"
+            ),
+            "lifetime_battery_charged": self._get_sensor_value(
+                "lifetime_battery_charged"
+            ),
+            "lifetime_battery_discharged": self._get_sensor_value(
+                "lifetime_battery_discharged"
+            ),
+        }
+        missing = [key for key, value in inputs.items() if value is None]
+        if missing:
+            # Name the counters, so "N/A" in the health check is traceable to
+            # a specific unmapped or unavailable sensor rather than silent.
+            logger.warning(
+                "Cannot derive lifetime load consumption: %s unreadable "
+                "(unmapped or unavailable). All five counters are required.",
+                ", ".join(missing),
+            )
             return None
+        solar = inputs["lifetime_solar_energy"]
+        grid_import = inputs["lifetime_import_from_grid"]
+        grid_export = inputs["lifetime_export_to_grid"]
+        battery_charged = inputs["lifetime_battery_charged"]
+        battery_discharged = inputs["lifetime_battery_discharged"]
         derived = derive_load_consumption(
             solar_production=solar,
             import_from_grid=grid_import,

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -15,6 +15,7 @@ from typing import ClassVar
 import requests
 import websocket
 
+from .energy_balance import derive_load_consumption
 from .exceptions import SystemConfigurationError
 from .runtime_failure_tracker import RuntimeFailureTracker
 from .settings_store import SettingsStore
@@ -2527,9 +2528,16 @@ class HomeAssistantAPIController:
     def get_load_consumption_lifetime(self):
         """Get lifetime total load consumption energy in kWh.
 
-        If no direct sensor is configured (e.g. GEN4 Growatt inverters lack a
-        native load consumption register), derives the value from:
-            load = solar + grid_import - grid_export
+        If no direct sensor is configured, derives the value from the energy
+        balance (see :func:`core.bess.energy_balance.derive_load_consumption`).
+        SolaX native, Solis and Huawei lack a native load register and take
+        this path; all three map both battery counters.
+
+        Returns ``None`` when any input is unmapped — the battery terms are
+        not optional, and dropping them reports load plus net battery charge
+        (issue #528) — and also when the balance comes out negative, which on
+        monotonic lifetime totals means a counter is stalled or
+        under-reporting rather than rounding noise.
         """
         direct = self._get_sensor_value("lifetime_load_consumption")
         if direct is not None:
@@ -2539,10 +2547,39 @@ class HomeAssistantAPIController:
         solar = self._get_sensor_value("lifetime_solar_energy")
         grid_import = self._get_sensor_value("lifetime_import_from_grid")
         grid_export = self._get_sensor_value("lifetime_export_to_grid")
-        if solar is not None and grid_import is not None and grid_export is not None:
-            derived = solar + grid_import - grid_export
-            return max(derived, 0.0)  # Guard against small negative rounding
-        return None
+        battery_charged = self._get_sensor_value("lifetime_battery_charged")
+        battery_discharged = self._get_sensor_value("lifetime_battery_discharged")
+        if None in (
+            solar,
+            grid_import,
+            grid_export,
+            battery_charged,
+            battery_discharged,
+        ):
+            return None
+        derived = derive_load_consumption(
+            solar_production=solar,
+            import_from_grid=grid_import,
+            export_to_grid=grid_export,
+            battery_charged=battery_charged,
+            battery_discharged=battery_discharged,
+        )
+        if derived < 0:
+            # Report the inputs rather than a laundered number: a health check
+            # showing a plausible value would hide the broken counter.
+            logger.warning(
+                "Derived lifetime load consumption is negative (%.1f kWh) - "
+                "lifetime counters disagree, so no value can be reported. "
+                "solar=%.1f import=%.1f export=%.1f charged=%.1f discharged=%.1f",
+                derived,
+                solar,
+                grid_import,
+                grid_export,
+                battery_charged,
+                battery_discharged,
+            )
+            return None
+        return derived
 
     def get_system_production_lifetime(self):
         """Get lifetime total system production energy in kWh.

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -1685,7 +1685,7 @@ class TestDerivedLifetimeSensors:
             assert self.ctrl.get_load_consumption_lifetime() is None
 
     def test_load_consumption_names_the_missing_counter_in_the_log(self, caplog):
-        """"N/A" in the health check must be traceable to a specific sensor.
+        """An N/A in the health check must be traceable to a specific sensor.
 
         Returning ``None`` silently would leave a user with a degraded
         Energy Monitoring component and nothing naming the cause.

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -8,6 +8,7 @@ Tests cover:
   GEN3 lacks a system-production one)
 """
 
+import logging
 from typing import ClassVar
 from unittest.mock import patch
 
@@ -1683,6 +1684,27 @@ class TestDerivedLifetimeSensors:
         ):
             assert self.ctrl.get_load_consumption_lifetime() is None
 
+    def test_load_consumption_names_the_missing_counter_in_the_log(self, caplog):
+        """"N/A" in the health check must be traceable to a specific sensor.
+
+        Returning ``None`` silently would leave a user with a degraded
+        Energy Monitoring component and nothing naming the cause.
+        """
+        with self._mock_sensor(
+            {
+                "lifetime_solar_energy": 5000.0,
+                "lifetime_import_from_grid": 3000.0,
+                "lifetime_export_to_grid": 1500.0,
+                "lifetime_battery_charged": 2000.0,
+                # lifetime_battery_discharged deliberately absent
+            }
+        ):
+            with caplog.at_level(logging.WARNING):
+                assert self.ctrl.get_load_consumption_lifetime() is None
+
+        assert "lifetime_battery_discharged" in caplog.text
+        assert "lifetime_solar_energy" not in caplog.text
+
     def test_load_consumption_none_when_balance_is_negative(self):
         """A negative balance means the counters disagree, so report nothing.
 
@@ -2150,9 +2172,10 @@ class TestEnergyFlowSensorsRequiredOnEveryPlatform:
     happily completed without them and the runtime then reported
     "Energy Monitoring [ERROR] — SYSTEM DEGRADED".  Meanwhile
     ``lifetime_load_consumption`` — which ``get_load_consumption_lifetime``
-    derives as ``solar + grid_import - grid_export`` when unmapped
-    (ha_api_controller.py) — was ``required: true`` on both cloud
-    platforms, demanding a sensor BESS can compute for itself.
+    derives from the five flow sensors when unmapped (issue #528:
+    ``solar + import + discharged - charged - export``) — was
+    ``required: true`` on both cloud platforms, demanding a sensor BESS
+    can compute for itself.
     """
 
     #: Read directly by energy-flow calculation; no derivation exists.
@@ -2255,9 +2278,9 @@ class TestEnergyFlowSensorsRequiredOnEveryPlatform:
         }
 
         assert not required_anywhere, (
-            "lifetime_load_consumption is derived from solar + grid_import - "
-            "grid_export when unmapped, so requiring it blocks the wizard on "
-            f"a sensor BESS can compute itself: {sorted(required_anywhere)}"
+            "lifetime_load_consumption is derived from the five flow sensors "
+            "when unmapped, so requiring it blocks the wizard on a sensor "
+            f"BESS can compute itself: {sorted(required_anywhere)}"
         )
 
 

--- a/core/bess/tests/unit/test_registry_discovery.py
+++ b/core/bess/tests/unit/test_registry_discovery.py
@@ -4,11 +4,14 @@ Tests cover:
 - _map_registry_entities: unique_id-based suffix matching
 - discover_sensors_from_registry: single suffix map per platform
 - Robustness against user entity renaming (unique_id is immutable)
-- Derived lifetime sensor fallbacks (GEN3/GEN4)
+- Derived lifetime sensors (SolaX native/Solis/Huawei lack a load register;
+  GEN3 lacks a system-production one)
 """
 
 from typing import ClassVar
 from unittest.mock import patch
+
+import pytest
 
 from core.bess.ha_api_controller import HomeAssistantAPIController
 from core.bess.settings_store import SettingsStore
@@ -1608,8 +1611,69 @@ class TestDerivedLifetimeSensors:
         with self._mock_sensor({"lifetime_load_consumption": 1234.5}):
             assert self.ctrl.get_load_consumption_lifetime() == 1234.5
 
-    def test_load_consumption_derived_for_gen4(self):
-        """When no direct sensor, derive from solar + import - export."""
+    @pytest.mark.parametrize(
+        (
+            "solar_to_home,solar_to_battery,solar_to_grid,"
+            "grid_to_home,grid_to_battery,battery_to_home,battery_to_grid"
+        ),
+        [
+            # Overnight discharge: battery serves the house.
+            (0.0, 0.0, 0.0, 0.40, 0.0, 1.60, 0.0),
+            # Midday charging from solar.
+            (1.00, 2.00, 0.0, 0.0, 0.0, 0.0, 0.0),
+            # Battery idle, house on grid only.
+            (0.0, 0.0, 0.0, 2.00, 0.0, 0.0, 0.0),
+            # Battery exporting to grid: the case the old clamp hid.
+            (0.30, 0.0, 0.0, 0.50, 0.0, 0.0, 1.70),
+            # Mixed: solar splits three ways while the grid also charges.
+            (1.20, 0.80, 0.60, 0.40, 0.90, 0.0, 0.0),
+        ],
+        ids=["discharge", "charge", "idle", "export", "mixed"],
+    )
+    def test_derived_load_equals_actual_load_whatever_the_battery_does(
+        self,
+        solar_to_home,
+        solar_to_battery,
+        solar_to_grid,
+        grid_to_home,
+        grid_to_battery,
+        battery_to_home,
+        battery_to_grid,
+    ):
+        """Derived lifetime load must equal real house consumption (issue #528).
+
+        The counters are built up from the seven physical flows rather than
+        from the derivation formula, so this asserts the energy balance
+        itself, not an arithmetic restatement of the implementation. The old
+        ``solar + import - export`` formula returns ``actual + net battery
+        charge`` and fails every case here except ``idle``.
+        """
+        counters = {
+            "lifetime_solar_energy": solar_to_home + solar_to_battery + solar_to_grid,
+            "lifetime_import_from_grid": grid_to_home + grid_to_battery,
+            "lifetime_export_to_grid": solar_to_grid + battery_to_grid,
+            "lifetime_battery_charged": solar_to_battery + grid_to_battery,
+            "lifetime_battery_discharged": battery_to_home + battery_to_grid,
+        }
+        actual_load = solar_to_home + battery_to_home + grid_to_home
+
+        with self._mock_sensor(counters):
+            assert self.ctrl.get_load_consumption_lifetime() == pytest.approx(
+                actual_load
+            )
+
+    def test_load_consumption_none_when_missing_sources(self):
+        """Returns None when derivation sources are incomplete."""
+        with self._mock_sensor({"lifetime_solar_energy": 5000.0}):
+            assert self.ctrl.get_load_consumption_lifetime() is None
+
+    def test_load_consumption_none_when_battery_counters_missing(self):
+        """No battery counters means no honest answer, so return None.
+
+        Per ``docs/agents/rules.md`` (no silent fallbacks): deriving without
+        the battery terms would return a wrong-but-plausible number, which is
+        exactly the defect in issue #528.
+        """
         with self._mock_sensor(
             {
                 "lifetime_solar_energy": 5000.0,
@@ -1617,23 +1681,28 @@ class TestDerivedLifetimeSensors:
                 "lifetime_export_to_grid": 1500.0,
             }
         ):
-            assert self.ctrl.get_load_consumption_lifetime() == 6500.0
-
-    def test_load_consumption_none_when_missing_sources(self):
-        """Returns None when derivation sources are incomplete."""
-        with self._mock_sensor({"lifetime_solar_energy": 5000.0}):
             assert self.ctrl.get_load_consumption_lifetime() is None
 
-    def test_load_consumption_clamps_negative(self):
-        """Derived value is clamped to 0 to guard against rounding."""
+    def test_load_consumption_none_when_balance_is_negative(self):
+        """A negative balance means the counters disagree, so report nothing.
+
+        Lifetime totals are large and monotonic, so the balance cannot go
+        negative through rounding — only through a stalled or under-reporting
+        counter. Returning the negative would surface as a healthy "OK"
+        reading (``health_check.py`` treats any float as OK), which is the
+        silent degradation ``docs/agents/rules.md`` forbids. ``None`` drives
+        the Energy Monitoring check to WARNING instead.
+        """
         with self._mock_sensor(
             {
                 "lifetime_solar_energy": 100.0,
                 "lifetime_import_from_grid": 50.0,
                 "lifetime_export_to_grid": 200.0,
+                "lifetime_battery_charged": 40.0,
+                "lifetime_battery_discharged": 30.0,
             }
         ):
-            assert self.ctrl.get_load_consumption_lifetime() == 0.0
+            assert self.ctrl.get_load_consumption_lifetime() is None
 
     def test_system_production_direct_sensor(self):
         """Direct sensor is returned when available."""

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -170,10 +170,11 @@ that mode. Writes only occur on mode transitions, not every period.
 - Grid charge: `switch.turn_on` / `switch.turn_off` on charger_switch entity
 - Charge/discharge rate: `number.set_value` on EMS rate entities
 
-**Lifetime energy notes (GEN4):** GEN4 has no native load consumption
-register (`total_load` is GEN3, `home_consumption_energy` is SPF). BESS
-derives `lifetime_load_consumption` as `solar + grid_import − grid_export`.
-`total_yield` maps to `lifetime_system_production`.
+**Lifetime energy notes (GEN4):** GEN4 *does* have a native load consumption
+register — `total_yield` (register 3077, "Total Load Energy") maps to
+`lifetime_load_consumption`, and `total_power_generation` (register 3051) maps
+to `lifetime_system_production`. GEN4 therefore never takes the derived-load
+path. (`total_load` is GEN3, `home_consumption_energy` is SPF.)
 
 ### Export-limit curtailment (GEN2/GEN3/GEN4) — *(optional, opt-in)*
 
@@ -526,6 +527,25 @@ for design rationale and open items.
 
 ## Required Entities by Platform
 
+### Derived load consumption
+
+**SolaX native, Solis and Huawei LUNA2000** expose no lifetime load-consumption
+register. For those three, BESS derives it from the energy balance:
+
+```
+load = solar + grid_import + battery_discharged − battery_charged − grid_export
+```
+
+All three map both battery counters, so the derivation is always computable
+where it is used. If any of the five inputs is unmapped, BESS returns *no
+value* rather than a partial one — dropping the battery terms would report
+load plus net battery charge, a kWh-scale error on every period the battery is
+active (issue #528). The identity lives in one place,
+`core/bess/energy_balance.py`, and is shared by the lifetime-sensor path
+(`ha_api_controller`) and the per-period flow path (`energy_flow_calculator`).
+
+Every Growatt variant maps a native load register and never takes this path.
+
 ### Growatt MIN (Cloud) — `growatt_server` integration
 
 | BESS Sensor Key | Entity Type | Growatt Server Suffix | Purpose |
@@ -635,8 +655,8 @@ actively uses slot 1. A `time_N_clear` button also exists in the plugin
 | `lifetime_solar_energy` | `total_solar_energy` | |
 | `lifetime_import_from_grid` | `total_grid_import` | |
 | `lifetime_export_to_grid` | `total_grid_export` | |
-| `lifetime_system_production` | `total_yield` | GEN4 register 3077 |
-| `lifetime_load_consumption` | — | **No native register.** BESS derives: solar + grid_import − grid_export |
+| `lifetime_system_production` | `total_power_generation` | GEN4 register 3051 |
+| `lifetime_load_consumption` | `total_yield` | GEN4 register 3077, "Total Load Energy" |
 
 **Export-limit curtailment (GEN4, optional):**
 
@@ -704,7 +724,7 @@ GEN4 above (`limit_grid_export` / `grid_export_limit`, registers 122/123) —
 | `lifetime_import_from_grid` | `grid_import_total` | |
 | `lifetime_export_to_grid` | `grid_export_total` | |
 | `lifetime_system_production` | `total_yield` | Register 0x52, "Total Yield" (production) |
-| `lifetime_load_consumption` | — | **No native register.** Derived from other sensors |
+| `lifetime_load_consumption` | — | **No native register.** BESS derives it — see [Derived load consumption](#derived-load-consumption) |
 
 **VPP control (required for SolaX):**
 


### PR DESCRIPTION
## Summary

- Derived lifetime load consumption now includes the battery terms, so it reports actual house load instead of load plus lifetime net battery charge.
- The energy-balance identity lives in one place (`core/bess/energy_balance.py`) instead of two copies that had drifted.
- A negative balance now returns no value (surfacing as a health-check WARNING) rather than being clamped to a plausible `0.0`.
- Corrects the platform facts in `docs/INVERTER_PLATFORMS.md`, which had two GEN4 registers swapped.

## Root cause

`get_load_consumption_lifetime` derived load as `solar + grid_import - grid_export`. Decomposing a period into its seven physical flows:

```
solar       = solar_to_home + solar_to_battery + solar_to_grid
grid_import = grid_to_home  + grid_to_battery
grid_export = solar_to_grid + battery_to_grid

derived     = solar_to_home + solar_to_battery + grid_to_home + grid_to_battery - battery_to_grid
actual load = solar_to_home + battery_to_home  + grid_to_home

derived - actual = (solar_to_battery + grid_to_battery) - (battery_to_home + battery_to_grid)
                 = battery_charged - battery_discharged
```

So the reported figure was `actual_load + net_battery_charge` — inflated while charging, understated while discharging, correct only at exactly zero battery throughput. On lifetime totals that accumulates to stored energy plus all lifetime round-trip losses.

The `max(derived, 0.0)` guard was commented as protecting against "small negative rounding". With the battery terms present the balance is physically non-negative, so it could *only* go negative because they were missing — meaning the guard was converting the loudest case of the bug (a battery exporting to grid) into a silently plausible `0.0`.

## Fix

The correct balance already existed in `energy_flow_calculator._calculate_derived_flows`, applied to per-period deltas. This was one identity duplicated in two places, which had drifted — so rather than patch the wrong copy in place, the identity now lives once in `core/bess/energy_balance.py` and both call sites use it:

```
load = solar + grid_import + battery_discharged - battery_charged - grid_export
```

- `ha_api_controller.get_load_consumption_lifetime` reads all five counters, returns `None` if any is unmapped, and applies no clamp.
- `energy_flow_calculator` keeps its own `max(0, ...)`, which is legitimate there and *not* the same guard: it operates on per-period deltas, where cross-sensor noise genuinely can produce a small negative. Its behaviour is unchanged.
- A negative balance returns `None` and logs the five inputs. Lifetime counters are large and monotonic, so a negative means a counter is stalled or under-reporting — and `health_check.py` reports any float as OK, so returning the negative would have swapped one laundered value for another rather than surfacing the fault.

**Scope assessment (`rules.md` step 8): local.** The change stays inside the method's existing contract and signature, and adds no parameter, flag, default-fallback, second construction site, extra trigger, or branch that routes around an ordering/timing/dependency problem. It is net-subtractive on fallback behaviour: it removes a clamp and replaces a wrong-but-plausible return with an explicit absence.

**Blast radius: display and diagnostics only.** The sole runtime consumer is the Energy Monitoring health check (`sensor_collector.py` → `health_check.py`), shown on the System Health page and in debug bundles. No optimizer input, savings figure, or schedule decision reads this getter — the period-flow path already used the correct formula. `_fetch_ha_statistics_raw` resolves the entity directly and never calls it, so the `ha_statistics` consumption forecast is unaffected.

### Correction to the issue's premise

The issue, and the method's own docstring, named GEN4 Growatt as the affected platform. That is stale: GEN4 maps `total_yield` (register 3077, "Total Load Energy") to `lifetime_load_consumption`. The platforms that actually reach the derived path are **SolaX native, Solis and Huawei** — all three map both battery counters, so the corrected formula is always computable where it runs.

`docs/INVERTER_PLATFORMS.md` had GEN4's two registers swapped (`total_yield` → production, and load "derived"); the code has mapped `total_power_generation` → `lifetime_system_production` all along. Both are corrected here.

## Test plan

- [x] `./scripts/quality-check.sh` passes locally — Errors: 0, Warnings: 0
- [x] Fast suite: 1338 passed, 29 skipped. Slow suite: 534 passed, 4 skipped
- [x] **Ran the real stack** (`docker-compose.ci.yml` + mock-HA) with the five lifetime counters mapped and `lifetime_load_consumption` deliberately unmapped, reproducing the SolaX/Solis/Huawei condition. Counters: solar 5000, import 3000, export 1500, charged 2000, discharged 1800.
  - `GET /api/system-health` → **`Lifetime Total Load Consumption: 6,300.0 kWh`**. The old formula yields 6,500.0; the 200 kWh gap is exactly net charge (2000 − 1800).
  - Raised export to 12000 (balance −4200) → check flips to **`WARNING | value='N/A' | Method returned None`**, driving Energy Monitoring to ERROR, with the log line `Derived lifetime load consumption is negative (-4200.0 kWh) ... solar=5000.0 import=3000.0 export=12000.0 charged=2000.0 discharged=1800.0`. Pre-fix this displayed a healthy `0.0`.

## Evidence the test discriminates

Two mutations, each run against the full fast suite:

**Mutation 1 — dropped the battery terms** (`derive_load_consumption` → `solar + import - export`):
- Result: `test_derived_load_equals_actual_load_whatever_the_battery_does` FAILED on `[discharge]`, `[charge]`, `[export]`, `[mixed]` — **4 failed, 1334 passed**
- `[idle]` still passed, which is the point: the old formula is correct only at zero battery throughput, so the test's pass/fail split matches the physics rather than the implementation.

**Mutation 2 — disabled the negative guard** (`if derived < 0:` → `if False:`):
- Result: `test_load_consumption_none_when_balance_is_negative` FAILED — **1 failed, 1337 passed**

**Restored:** 1338 passed, 29 skipped; `git diff` clean against the committed tree.

The primary test builds the five counters up from the seven physical flows and asserts against independently-computed actual load, so it encodes the energy balance rather than restating the implementation's arithmetic.

## Outcome-level coverage

Asserted outcome is the returned kWh value and the resulting health-check status — the only observable outcomes this getter has, since it feeds no execution model. No plan-faithfulness (`R == P`) scenario applies: the diff touches neither the DP, intent classification, nor control/rate mapping, and `energy_flow_calculator`'s behaviour is unchanged (pure refactor to the shared helper, clamp retained).

Also verified: no test anywhere still pins the old formula or the removed clamp, and the `None` return breaks no consumer — `health_check.py` already has an explicit `value is None` branch.

## Documentation check

- `docs/INVERTER_PLATFORMS.md` — updated (new "Derived load consumption" section; GEN4 register table corrected).
- `docs/SOFTWARE_DESIGN.md:653` — references this fallback only generically ("derives a value from other sensors"), which remains true. No edit needed.
- `docs/agents/bess-knowledge.md` — grepped; contains no claim about this getter or the derived-load formula.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbwykkq5SCabDtnVuiZm8H
