### PR TITLE
refactor: stop inferring paths from command strings; classify by shape only

### DIFF
--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -1,60 +1,45 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash.
 #
-# The worktree IS the safety boundary. A linked git worktree
-# (.claude/worktrees/* or a sibling per CLAUDE.md's Worktree Conventions)
-# is disposable by construction: it can be blown away and recreated, and
-# nothing in it is shared with the main checkout or with another agent.
-# Inside one, a permission prompt protects nothing -- it just stalls
-# otherwise autonomous work (implement-issue rebuilding a venv, pruning a
-# scenario fixture, merging origin/main before a PR).
+# Inside a linked git worktree, do anything to the repository -- except
+# destroy the repository or its history.
 #
-# So this hook AUTO-ALLOWS Bash commands when the session's cwd resolves to
-# a linked worktree, and falls through (no decision) everywhere else, so
-# the normal ask/deny rules in settings.json still guard the shared main
-# checkout.
+# A linked worktree (.claude/worktrees/* or a sibling per CLAUDE.md's
+# Worktree Conventions) is disposable by construction: blow it away, make
+# another. Prompting there protects nothing and stalls otherwise autonomous
+# work, so this hook auto-allows Bash commands whose cwd is a linked
+# worktree. In the main checkout it stays silent and every ask/deny rule in
+# settings.json applies unchanged.
 #
-# It deliberately does NOT enumerate destructive command shapes. The
-# previous version did -- an allowlist of `rm -rf`, `git reset --hard`,
-# `git rebase`, `git merge`, `git push --force` -- and the enumeration was
-# the bug: a plain `rm -f <file>` fell through to `ask: Bash(rm *)` and
-# prompted, and every new command shape needed another entry. Inverting it
-# removes that whole class of stall.
+# What it still refuses is a short, closed list of effects no worktree can
+# contain, and which no amount of `git checkout` gets back:
 #
-# Most checks below fail CLOSED: where a pattern list is unavoidable it
-# enumerates what is SAFE, so a shape nobody thought of costs one prompt
-# rather than a silent auto-allow. That holds for the `gh` list, the
-# read-only list and the containment check.
+#   1. The shared podman VM every worktree's E2E stack runs on (a `deny`
+#      in settings.json, re-emitted here rather than downgraded).
+#   2. Elevated privileges, anything reaching GitHub, and pushes that move
+#      a shared ref (main, beta, beta-release-*, tags).
+#   3. Writes to state shared across worktrees: ONE object database, ONE
+#      ref namespace, ONE stash, ONE .git/config.
 #
-# `mutates_shared_state` is the exception and cannot be inverted: git's
-# subcommand surface is open-ended, so a safe-list would prompt on most
-# ordinary git use. It is a BLOCKLIST, which means a ref-mutating shape not
-# named there is allowed -- that is how `git branch -f main HEAD`,
-# `update-ref` and `symbolic-ref` were missed once already. Treat it as the
-# weakest link here and add to it whenever a new shared-state write shows
-# up, rather than assuming its absence implies safety.
+# WHAT THIS DELIBERATELY NO LONGER DOES
 #
-# Three exceptions never get auto-allowed:
+# An earlier version also tried to decide, from the command string, whether
+# a command would write OUTSIDE the worktree -- absolute paths, `..`, `~`,
+# variables, substitutions. That is shell parsing by regex, and it does not
+# work: quoting, globs, heredocs and `cd` all defeat it. It produced six
+# distinct false positives in one day, EVERY ONE introduced by the fix to
+# the previous one -- including blocking a live beta release, and judging a
+# worktree foreign to itself because `;` was not treated as a separator.
 #
-#   1. Globally-scoped actions (sudo, the shared podman VM, anything
-#      touching GitHub, a push that can move a shared ref) -- matched at
-#      command-word position, not as a bare substring, so that
-#      `grep "sudo " docs/` is not mistaken for running sudo.
-#   2. Mutations of state SHARED with the main checkout. A linked worktree
-#      has its own working tree but ONE object database and ONE ref
-#      namespace with every other checkout (see mutates_shared_state).
-#   3. Commands that can reach OUTSIDE the worktree. Those are put through
-#      a stricter check (see needs_scrutiny / escapes_worktree below).
+# It is gone. The accepted cost: a stale absolute path in a Bash command can
+# now reach the main checkout without a prompt. Tracked content there is
+# recoverable from git; uncommitted work is not. That trade was made
+# deliberately, because a guard with a false-positive rate this high gets
+# click-throughed and protects nothing anyway.
 #
-# THREAT MODEL: accidents, not an adversary. The damage this prevents is a
-# stale absolute path left over from before a worktree switch, or a `../..`
-# counted from the wrong cwd -- the Bash-side counterpart of what
-# check-worktree-path.sh blocks for Edit/Write. A command that deliberately
-# hides its target behind an unexpanded variable, an alias, or a here-doc
-# can still get through: a hook sees the command STRING, not the syscalls
-# it will make. Do not treat this as a sandbox. The real containment is
-# that a worktree is disposable; this guard only keeps ordinary mistakes
-# from reaching the shared checkout.
+# The equivalent guard for Edit/Write still exists and is reliable, because
+# it parses nothing: check-worktree-path.sh compares two `git rev-parse`
+# results as strings. Prefer that shape for anything added here.
 set -euo pipefail
 
 input=$(cat)
@@ -66,102 +51,85 @@ if [ -z "$command" ]; then
 fi
 
 # Anchored at command-word position: start of string, or after a shell
-# separator (; & | && || newline). A bare substring match would treat
-# `grep "sudo " docs/` as running sudo and reintroduce the prompt.
-#
-# The anchor must also step over anything that sits BEFORE the command word
-# without being it. Without this, one env assignment defeated every guard in
-# this file at once -- `PODMAN=1 podman machine rm` was auto-allowed,
-# silently upgrading a settings.json `deny` to an unprompted allow. Env
-# prefixes are ordinary generated-command shape (`PYTHONPATH=. ...`,
-# `TZ=UTC ...`), so that was an accident-class miss, not just an
-# adversarial one.
+# separator, stepping over anything that precedes the command word without
+# being it. A bare substring match would read `grep "sudo " docs/` as
+# running sudo; without the prefix step, one env assignment
+# (`PODMAN=1 podman machine rm`) shifted the command word out of every
+# guard at once and turned a deny into a silent allow.
 CMD_PREFIX='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(nohup|time|command|exec|env)[[:space:]]+)*'
 CMD_START="(^|[;&|(]|&&|\\|\\||\\n)[[:space:]]*${CMD_PREFIX}"
 
-# `git` accepts global options between the program name and the subcommand,
-# so a literal `git`+space+`push` match is trivially sidestepped by
-# `git -C sub push origin main` or `git --git-dir=... push origin main`.
-# Strip those options once, up front, and match against the normalised
-# string. Spaces are squeezed too so `git   push` matches the same way.
-# This is for MATCHING only -- the command that runs is untouched.
+# git accepts global options between the program name and the subcommand,
+# so a literal `git`+space+`push` match is sidestepped by `git -C sub push`.
+# Strip them once, for MATCHING only; the command that runs is untouched.
 normalise_git() {
   printf '%s' "$1" | sed -E \
     -e 's/(^|[[:space:]])git([[:space:]]+(-c[[:space:]]+[^[:space:]]+|-C[[:space:]]+[^[:space:]]+|--git-dir=[^[:space:]]+|--work-tree=[^[:space:]]+|--exec-path=[^[:space:]]*|--no-pager|--paginate|--bare|--literal-pathspecs))+/\1git/g' \
     | tr -s ' '
 }
 
-# --- Hard denials -------------------------------------------------------
-#
-# `podman machine rm` / `podman system reset` are `deny` entries in
-# settings.json -- a hard block on destroying the shared podman VM every
-# worktree's E2E stack runs on. A hook decision SUPERSEDES a settings rule,
-# so answering "ask" here would quietly downgrade that block to a single
-# keystroke. Re-emit the deny instead of weakening it.
+# settings.json DENIES these outright. A hook decision supersedes a settings
+# rule, so answering "ask" here would quietly downgrade that hard block to a
+# single keystroke. Re-emit the deny.
 is_hard_denied() {
   printf '%s' "$1" | grep -qE "${CMD_START}podman[[:space:]]+(machine[[:space:]]+(rm|reset)|system[[:space:]]+reset)"
 }
 
-# --- Globally-scoped actions -------------------------------------------
-#
-# Effects that no worktree can contain: elevated privileges, anything that
-# reaches GitHub, or a push that can move a shared ref.
-#
-# These get an explicit "ask" rather than a fall-through, because
-# settings.json ALLOWS `Bash(git push *)` outright -- falling through would
-# let a shared-ref push run unprompted rather than prompt. (There is no
-# blanket `Bash(gh *)` entry, only eight narrow `gh issue`/`gh pr`
-# patterns; the safe list below must stay a superset of those, or a hook
-# decision silently revokes a permission the user granted.)
+# Does one push's argument list name a ref shared with other checkouts?
+# Compared as TOKENS, not by substring: a substring test cannot tell `main`
+# from `feat/main-ish`, and widening it to catch `beta-release-*` would
+# swallow the latter.
+push_touches_shared_ref() {
+  local args="$1" tok dst
+
+  # --force-with-lease is the one force form that refuses to clobber an
+  # update it has not seen -- the accident a prompt here would guard -- and
+  # it is routine after a merge. Bare --force/-f overwrites unconditionally.
+  if ! printf '%s' "$args" | grep -qE '\-\-force-with-lease'; then
+    printf '%s' "$args" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
+  fi
+  printf '%s' "$args" | grep -qE "(--all|--mirror|--tags)" && return 0
+
+  set -f
+  for tok in $args; do
+    case "$tok" in -*) continue ;; esac
+    # `src:dst` pushes to dst; a bare token is its own destination. Strip the
+    # force marker and any fully-qualified prefix so every spelling of one
+    # ref -- main, HEAD:main, br:refs/heads/main, +main -- reduces alike.
+    dst=${tok##*:}
+    dst=${dst#+}
+    dst=${dst#refs/heads/}
+    dst=${dst#refs/tags/}
+    case "$dst" in
+      main | beta | beta-release* | release-* | v[0-9]*)
+        set +f
+        return 0
+        ;;
+    esac
+  done
+  set +f
+  return 1
+}
+
 is_globally_scoped() {
   printf '%s' "$1" | grep -qE "${CMD_START}sudo[[:space:]]" && return 0
 
   # `gh` reaches GitHub, which no worktree contains. Enumerating destructive
-  # subcommands fails the wrong way: `gh api -X DELETE repos/...` is the
-  # general form of every entry such a list could hold, and `gh workflow
-  # run` / `gh secret set` / `gh repo edit` are not obviously "destructive"
-  # names. So invert -- every `gh` asks unless it is on the safe list.
-  # Counting both forms catches a compound `gh pr view && gh pr merge`,
-  # where matching only the first invocation would clear the whole command.
-  #
-  # The safe list covers reads AND authoring, not reads alone. A read-only
-  # list looks tighter but defeats the point of the hook: `gh pr create` is
-  # the closing step of implement-issue, so a run that no longer stalls on
-  # `rm -f` would instead stall at the finish line, and `gh issue comment`
-  # would stall it in the middle. Authoring a PR/issue on this repo IS the
-  # work product. What stays behind a prompt is everything that publishes,
-  # merges, or reconfigures: pr merge, release, repo edit/delete, secret,
-  # workflow run, and any non-GET `gh api`.
+  # subcommands fails the wrong way -- `gh api -X DELETE` is the general form
+  # of every entry such a list could hold -- so invert: every `gh` asks
+  # unless it is on the safe list. That list covers reads AND authoring,
+  # because `gh pr create` is the closing step of implement-issue and
+  # authoring on this repo IS the work product. It must also stay a superset
+  # of settings.json's `gh` allow patterns, or a hook decision silently
+  # revokes a permission the user granted. Counting per invocation catches
+  # `gh pr view && gh pr merge`, where matching the first would clear both.
   local gh_all gh_safe
-  # `grep -c` counts LINES, and a command is normally one line, so both
-  # counts would be 1 for that compound. Count occurrences with -o | wc -l.
-  # `gh[[:space:]]` missed a bare `gh` at end of string -- it matched neither
-  # counter, so both stayed 0 and the command was allowed. Anchor on
-  # ([[:space:]]|$) so the totals cannot silently agree at zero.
   gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]|$)" | wc -l | tr -d ' ' || true)
   gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready|checkout|review)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+(view|clone)|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|search|auth[[:space:]]+status|--version|--help|-h)|([[:space:]]|$))([[:space:]]|$)" | wc -l | tr -d ' ' || true)
   [ "$gh_all" -ne "$gh_safe" ] && return 0
 
-  # Any push that can move a shared ref. The ref has to be matched in every
-  # refspec form -- `main`, `HEAD:main`, `br:refs/heads/main`, `+main` --
-  # not just as a bare word, since the bare word is the spelling least
-  # likely to appear when something force-updates a ref.
-  #
-  # `--force-with-lease` is exempt: it is the one force form that REFUSES to
-  # clobber an update it has not seen, which is exactly the accident a
-  # prompt here would be guarding against. It is also routine after the
-  # Step 4 merge, so asking costs a stall on every run. Bare `--force`/`-f`
-  # keeps asking -- that one overwrites unconditionally. Order matters
-  # below: test the lease form first, or `--force` matches its prefix.
-  # Both tests are scoped to the push's OWN arguments, not the whole command
-  # string. Scanning the whole string made any `main` anywhere in a compound
-  # turn a safe push into a prompt -- including `git push -u origin feat/x &&
-  # gh pr create --base main ...`, which is implement-issue's closing step,
-  # i.e. exactly the stall this hook exists to remove.
-  # EVERY push is examined, not just the first. Stripping only up to the
-  # first occurrence let a second push ride along unchecked --
-  # `git push origin feat/x && git push origin main` was allowed, defeating
-  # the guard this comment describes.
+  # Every push is examined, not just the first: stripping only to the first
+  # occurrence let `git push origin feat/x && git push origin main` through.
   local norm rest push_args
   norm=$(normalise_git "$1")
   rest=$norm
@@ -176,96 +144,48 @@ is_globally_scoped() {
   return 1
 }
 
-# Decides whether one push's argument list names a ref shared with other
-# checkouts. Works on the refspec TOKENS rather than scanning the string:
-# a substring test cannot tell `main` from `feat/main-ish`, and widening it
-# to catch `beta-release-*` would have swallowed the latter.
-push_touches_shared_ref() {
-  local args="$1" tok dst
-
-  if ! printf '%s' "$args" | grep -qE '\-\-force-with-lease'; then
-    printf '%s' "$args" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
-  fi
-  printf '%s' "$args" | grep -qE "(--all|--mirror|--tags)" && return 0
-
-  set -f
-  for tok in $args; do
-    case "$tok" in -*) continue ;; esac
-    # `src:dst` pushes to dst; a bare token is its own destination. Strip the
-    # force marker and any fully-qualified prefix so every spelling of the
-    # same ref -- main, HEAD:main, br:refs/heads/main, +main -- reduces to
-    # the same name.
-    dst=${tok##*:}
-    dst=${dst#+}
-    dst=${dst#refs/heads/}
-    dst=${dst#refs/tags/}
-    case "$dst" in
-      # beta-release-* are shared release refs per the Release Workflow
-      # section, and were missed while `beta` itself was caught.
-      main | beta | beta-release* | release-* | v[0-9]*)
-        set +f
-        return 0
-        ;;
-    esac
-  done
-  set +f
-
-  return 1
-}
-
-# --- Shared repository state --------------------------------------------
+# A linked worktree has its own working tree but ONE object database, ONE
+# ref namespace, ONE stash and ONE .git/config with every other checkout.
+# These reach outside it without naming a path at all.
 #
-# A linked worktree has its own working tree, but shares ONE object
-# database and ONE ref namespace with the main checkout and every other
-# worktree. So these reach far outside the worktree even without `-C`:
-# deleting a branch another agent is on, expiring the reflog that would
-# have recovered it, or removing another agent's checkout outright.
+# This is a BLOCKLIST and cannot be inverted -- git's subcommand surface is
+# open-ended, so a safe-list would prompt on most ordinary git use. A
+# ref-mutating shape not named here is allowed; that is how `git branch -f`,
+# `update-ref` and `symbolic-ref` were missed once already. Add to it when a
+# new shared-state write appears rather than assuming absence means safety.
 mutates_shared_state() {
-  # `git branch -D` is deliberately NOT here. implement-issue Step 4 prunes
-  # merged worktrees in a loop, so asking turns one cleanup step into dozens
-  # of prompts -- and the danger it would be guarding is already handled
-  # upstream: git itself REFUSES to delete a branch checked out in another
-  # worktree ("error: cannot delete branch 'x' used by worktree at ...",
-  # exit 1), so it cannot cut another agent out from under itself. What is
-  # left is an unchecked-out branch, whose SHA git prints on delete and
-  # which stays reachable -- protected because `reflog expire`, `gc` and
-  # `filter-branch` below keep asking. `git tag -d` DOES stay: a tag is how
-  # a release is addressed, and nothing refuses to delete one.
+  # `git branch -D` is deliberately absent: git REFUSES to delete a branch
+  # checked out in another worktree, and an unchecked-out branch stays
+  # reachable by the SHA git prints -- protected because reflog expire / gc
+  # below keep asking. `git tag -d` stays: nothing refuses that, and a tag is
+  # how a release is addressed.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+tag[[:space:]]+(.*[[:space:]])?(-d|--delete)([[:space:]]|$)" && return 0
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|update-ref[[:space:]]+-d|filter-branch)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|filter-branch)([[:space:]]|$)" && return 0
 
-  # The stash is ONE `refs/stash` shared by every worktree, so these discard
-  # work stashed from the main checkout or another agent's session. Same
-  # class as the reflog/gc cases above, and this project leans on `git stash`
-  # for branch isolation, which makes the shared stack a live hazard rather
-  # than a theoretical one.
+  # ONE refs/stash for every worktree, and this project leans on stash for
+  # branch isolation, so the shared stack is a live hazard.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash[[:space:]]+(clear|drop|pop)([[:space:]]|$)" && return 0
 
-  # A linked worktree shares `.git/config` with the main checkout, and
-  # `--global` reaches `~/.gitconfig`, outside every worktree. Repointing or
-  # removing `origin` changes where every checkout pushes.
+  # Shared .git/config, and --global reaches ~/.gitconfig.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+config[[:space:]]+(.*[[:space:]])?(--global|--system)([[:space:]]|$)" && return 0
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+remote[[:space:]]+(set-url|remove|rm|rename|add)([[:space:]]|$)" && return 0
 
-  # Direct writes to the shared ref namespace. `git branch -D` is allowed
-  # because git refuses the dangerous case, but nothing refuses these: they
-  # MOVE a ref rather than delete it, so `git branch -f main HEAD` rewrites
-  # main for every checkout at once, and `update-ref`/`symbolic-ref` do the
-  # same one layer down. `update-ref` has no read form. `symbolic-ref` does
-  # (`--short HEAD`), so only the two-argument writing form matches.
+  # Direct writes to the ref namespace. These MOVE a ref rather than delete
+  # it, so nothing refuses them the way it refuses `branch -D`.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+branch[[:space:]]+(.*[[:space:]])?(-f|--force|-M|-m|--move)([[:space:]]|$)" && return 0
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+update-ref([[:space:]]|$)" && return 0
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+symbolic-ref[[:space:]]+[^-][^[:space:]]*[[:space:]]+[^[:space:]]" && return 0
-  # Same upstream-protection argument as `git branch -D`: plain `git worktree
-  # remove` REFUSES a worktree holding uncommitted or untracked files
-  # (verified: "contains modified or untracked files, use --force to delete
-  # it", exit 128), so it cannot destroy unsaved work, and a clean worktree
-  # has nothing to lose -- its branch survives. Step 4 removes merged
-  # worktrees in a loop, so asking here meant ~24 prompts in one step. Only
-  # `--force`, which is what actually discards the work, still asks.
+
+  # Plain `worktree remove` refuses a worktree holding uncommitted or
+  # untracked files, so only --force can actually discard work.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+remove([[:space:]]|$)" &&
     printf '%s' "$1" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
+
+  # `worktree prune` unregisters worktrees whose directory it cannot see --
+  # which includes one that is merely unmounted or temporarily moved, not
+  # only one that is really gone.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+prune([[:space:]]|$)" && return 0
+
   return 1
 }
 
@@ -275,260 +195,44 @@ if [ -z "$session_root" ]; then
   exit 0
 fi
 
-# First entry of `git worktree list --porcelain` is always the main
-# worktree (the original clone); every other entry is a linked worktree.
-# (Capture to a variable before awk -- piping directly into `awk 'exit'`
-# can SIGPIPE the git process under `set -o pipefail`.)
-# Strip the "worktree " prefix rather than taking $2 -- awk's $2 truncates
-# at the first space, so a checkout path containing a space would yield a
-# short main_root, the "am I the main checkout?" test below would wrongly
-# say no, and the hook would auto-allow everything IN THE MAIN CHECKOUT.
+# First entry of `git worktree list --porcelain` is always the main worktree;
+# every other entry is a linked one. (Capture before awk -- piping straight
+# into `awk 'exit'` can SIGPIPE git under `set -o pipefail`. And strip the
+# prefix rather than taking $2, which truncates a path containing a space and
+# would make the main checkout fail its own identity test.)
 worktree_list=$(git worktree list --porcelain)
 main_root=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{sub(/^worktree /, ""); print; exit}')
 
-# Every LINKED worktree of this repo, i.e. all of them except the main
-# checkout. These count as contained: a linked worktree is disposable by
-# exactly the argument that justifies auto-allowing commands inside this
-# one, and agents legitimately reach across them (cutting a release from a
-# changelog worktree, comparing two branches' output). Treating them as
-# foreign made ordinary cross-worktree work prompt, while protecting
-# nothing -- the checkout this guard exists for is the MAIN one, which is
-# shared, long-lived, and the only place a stale path does lasting damage.
-linked_roots=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{sub(/^worktree /, ""); print}' | tail -n +2)
-
-is_contained_path() {
-  local candidate="$1" root
-  case "$candidate" in
-    "$session_root" | "$session_root"/*) return 0 ;;
-    /tmp/* | /private/tmp/* | /private/var/folders/* | /dev/null) return 0 ;;
-  esac
-  # Never the main checkout, even though it is in the same repo.
-  case "$candidate" in
-    "$main_root" | "$main_root"/*) return 1 ;;
-  esac
-  while IFS= read -r root; do
-    [ -n "$root" ] || continue
-    case "$candidate" in
-      "$root" | "$root"/*) return 0 ;;
-    esac
-  done <<EOF
-$linked_roots
-EOF
-  return 1
-}
-
 # Everything below applies ONLY inside a linked worktree. In the main
-# checkout the hook stays completely silent, so that shared checkout keeps
-# every ask/deny rule in settings.json exactly as configured.
+# checkout this hook stays silent so settings.json governs it entirely.
 if [ -z "$main_root" ] || [ "$session_root" = "$main_root" ]; then
   echo '{"continue": true}'
   exit 0
 fi
 
+decide() {
+  jq -n --arg d "$1" --arg reason "$2" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: $d,
+      permissionDecisionReason: $reason
+    }
+  }'
+}
+
 if is_hard_denied "$command"; then
-  reason="Denied: this destroys the shared podman VM every worktree's E2E stack runs on. settings.json denies it outright; a worktree does not make it recoverable, and this hook must not downgrade that block to a prompt."
-  jq -n --arg reason "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
+  decide deny "Denied in settings.json: this destroys the shared podman VM that every worktree's E2E stack depends on. Being inside a disposable worktree does not contain it."
   exit 0
 fi
 
-if is_globally_scoped "$command" || mutates_shared_state "$command"; then
-  reason="Not auto-allowed: this command's effect reaches outside the worktree -- elevated privileges, GitHub, a shared git ref, or the object database and ref namespace this worktree shares with the main checkout. Being inside a disposable worktree does not contain it. Confirm it explicitly."
-  jq -n --arg reason "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "ask",
-      permissionDecisionReason: $reason
-    }
-  }'
+if is_globally_scoped "$command"; then
+  decide ask "Not auto-allowed: this command's effect is global -- elevated privileges, a GitHub mutation, or a push that moves a shared ref (main, beta, beta-release-*, a tag). A worktree cannot contain it, so confirm explicitly."
   exit 0
 fi
 
-# --- Containment check --------------------------------------------------
-#
-# Only commands that can actually write outside the worktree are scrutinized.
-# Purely relative, purely in-tree commands (pytest, npm ci, ruff, git status)
-# skip this entirely, which is what keeps the autonomy this hook exists to
-# provide.
-#
-# The trigger is deliberately NOT a list of writing verbs. That list is the
-# same enumeration bug as before, only inverted: on this side a miss is a
-# silent auto-allow, not an extra prompt, and the misses were the commonest
-# in-place writers there are -- `sed -i` into the main checkout, `touch`,
-# `mkdir -p`, `python3 -c "shutil.rmtree(...)"`. Trigger instead on the
-# thing that actually makes a command dangerous here: naming a path that
-# could sit outside the worktree. escapes_worktree then decides.
-#
-# The verb list survives only for the indirection case -- `rm -rf $HOME/x`
-# names no literal path but still resolves to one.
-needs_scrutiny() {
-  # Trigger on the ability to WRITE, not on merely naming a path.
-  #
-  # The previous trigger was "any absolute path, any `..`, any `~`", which
-  # made the containment check run over nearly every command -- and since
-  # that check cannot parse shell quoting, each unparseable-but-harmless
-  # shape became a prompt. Four distinct false positives reached the user:
-  # `cmd 2>/dev/null` plus any `$var`; a `cd` into a SIBLING worktree; a
-  # read-only `grep` whose literal pattern contained `$(` and `;;`; and
-  # inspection of files under $HOME. All were read-only or worktree-local.
-  #
-  # A command that cannot write cannot commit the accident this guards, so
-  # the write verbs ARE the right trigger. The cost is a known miss: an
-  # arbitrary-write shape not on this list is auto-allowed. Interpreters are
-  # therefore included wholesale (`python3 -c "shutil.rmtree(...)"` was the
-  # motivating miss), and `is_contained_path` -- not this list -- is what
-  # decides whether the path is actually foreign.
-  printf '%s' "$1" | grep -qE "${CMD_START}(rm|mv|cp|ln|dd|tee|shred|install|truncate|chmod|chown|rsync|find|xargs|sed|touch|mkdir|tar|unzip|python|python3|perl|ruby|node|osascript)([[:space:]]|$)" && return 0
-  printf '%s' "$1" | grep -qE "(^|[[:space:]])(-C|--git-dir|--work-tree)([[:space:]]|=)" && return 0
-  # A redirect that creates or truncates a file. `2>/dev/null` and `2>&1`
-  # are stripped first -- they write nothing and appear on ordinary reads.
-  printf '%s' "$1" |
-    sed -E 's/2>&1//g; s/[0-9]?>[[:space:]]*\/dev\/null//g' |
-    grep -qE '>' && return 0
-  return 1
-}
-
-# A scrutinized command must be transparently contained. Anything that hides
-# its target -- `..`, `~`, a variable, a command substitution -- cannot be
-# resolved from the command string, so it is not auto-allowed. These are
-# rare in generated commands and common in the accidents we care about
-# (`rm -rf ../../..`, `$HOME/GitHub/bess-manager`).
-escapes_worktree() {
-  local cmd="$1"
-
-  # Unresolvable indirection.
-  # `/` must be in the leading class too: without it, `/tmp/../Users/...`
-  # traverses out THROUGH an allowed temp prefix and passes the check below.
-  printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''=:/])\.\.(/|[[:space:]]|$)' && return 0
-  printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''=:])~' && return 0
-
-  # A variable or substitution is "unresolvable" only when it could actually
-  # BE a path. Rejecting every `$` and backtick was far too blunt once
-  # needs_scrutiny started firing on any redirect: `git show X 2>/dev/null |
-  # grep "case \"$command\""` is read-only, names no path, and still
-  # prompted. So reject command substitution (which can expand to anything),
-  # and a variable spliced into a path (`$HOME/GitHub/...`, `"$root"/x`) --
-  # but not a bare `$word` with no `/` around it, which is `$?`, `$1`, or a
-  # literal `$name` inside a search pattern.
-  printf '%s' "$cmd" | grep -qE '(\$\(|\$\{|`)' && return 0
-  printf '%s' "$cmd" | grep -qE '(\$[A-Za-z_][A-Za-z0-9_]*/|/[^[:space:]"'\'']*\$[A-Za-z_{])' && return 0
-
-  # Absolute paths must resolve under the worktree (or a disposable temp
-  # area). Quotes, parens, commas and `=` are turned into SEPARATORS first,
-  # not deleted: deleting them left `shutil.rmtree('/Users/x')` as the single
-  # token `shutil.rmtree(/Users/x)`, which does not start with `/`, so the
-  # check below never saw the path at all. Separating yields `/Users/x` as
-  # its own token. An ordinary `sed s/a/b/` is unaffected -- it still forms
-  # one token that does not begin with `/`.
-  # Word-split deliberately, but with globbing off: an unquoted `*` in the
-  # command would otherwise be pathname-expanded against the hook's own cwd
-  # before we ever inspect it.
-  local token
-  set -f
-  # Shell separators must be separators HERE too, not just quotes and
-  # parens. Without `;`, `cd /path/to/wt; cmd` yielded the token
-  # "/path/to/wt;" -- trailing semicolon attached -- which matches neither
-  # "$session_root" nor "$session_root"/*, so a worktree was judged foreign
-  # to ITSELF and every `cd <own worktree>; ...` prompted.
-  for token in $(printf '%s' "$cmd" | tr "\"'(),=;&|<>" "           "); do
-    case "$token" in
-      /*)
-        case "$token" in
-          *)
-            if ! is_contained_path "$token"; then
-              set +f
-              return 0
-            fi
-            ;;
-        esac
-        ;;
-    esac
-  done
-  set +f
-
-  return 1
-}
-
-# Pruning a merged worktree necessarily names a path outside this one, so
-# the containment check below would ask on every iteration of Step 4's
-# cleanup loop -- ~24 prompts for the step whose whole purpose is unattended
-# tidying. Exempt exactly that command and nothing else: a lone `git
-# worktree remove` with no `--force` (matched above in mutates_shared_state)
-# and no second invocation chained after it. git refuses to remove a
-# worktree holding uncommitted or untracked files, so this cannot discard
-# work; `rm -rf <other worktree>` gets no such exemption, because nothing
-# protects it.
-# --- Read-only inspection -----------------------------------------------
-#
-# needs_scrutiny fires on any absolute path or `~`, whether or not the
-# command can write. That made ordinary inspection outside the worktree
-# prompt -- `cat ~/Downloads/bess-debug.json` is the first step of
-# visualize-debug-log, and `head $MAIN/CHANGELOG.md` is routine -- trading
-# one stall class for another. The containment guard is about WRITES, so a
-# command that cannot write is exempt from it.
-#
-# This is an allowlist, so it fails closed: an unrecognised program (or
-# `python3 -c ...`, or `sed -i`) is not read-only and stays scrutinised.
-READ_ONLY_CMDS='cat|head|tail|less|more|grep|egrep|fgrep|rg|ag|ls|stat|file|wc|diff|jq|yq|sort|uniq|cut|tr|column|basename|dirname|realpath|readlink|echo|printf|pwd|date|which|type|shasum|md5sum|true|test'
-READ_ONLY_GIT='log|show|diff|status|rev-parse|ls-files|describe|blame|shortlog|cat-file|for-each-ref|check-ignore'
-
-is_read_only() {
-  local cleaned seg first sub
-  # Discard the harmless redirects first; any OTHER redirect writes a file,
-  # so the command is not read-only.
-  cleaned=$(printf '%s' "$1" | sed -E 's/2>&1//g; s/[0-9]?>[[:space:]]*\/dev\/null//g')
-  printf '%s' "$cleaned" | grep -q '>' && return 1
-
-  while IFS= read -r seg; do
-    seg=$(printf '%s' "$seg" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
-    [ -z "$seg" ] && continue
-    # Step over the same prefixes CMD_START skips.
-    seg=$(printf '%s' "$seg" | sed -E "s/^${CMD_PREFIX}//")
-    first=${seg%% *}
-    case "$first" in
-      git)
-        sub=$(printf '%s' "$seg" | awk '{print $2}')
-        printf '%s' "$sub" | grep -qE "^(${READ_ONLY_GIT})$" || return 1
-        ;;
-      *)
-        printf '%s' "$first" | grep -qE "^(${READ_ONLY_CMDS})$" || return 1
-        ;;
-    esac
-  done <<EOF
-$(printf '%s' "$cleaned" | tr ';|&' '\n')
-EOF
-  return 0
-}
-
-is_lone_worktree_removal() {
-  printf '%s' "$1" | grep -qE '^[[:space:]]*git[[:space:]]+worktree[[:space:]]+remove[[:space:]]+[^;&|]+$' &&
-    ! printf '%s' "$1" | grep -qE '(--force|[[:space:]]-f([[:space:]]|$))'
-}
-
-if ! is_read_only "$command" &&
-   ! is_lone_worktree_removal "$command" &&
-   needs_scrutiny "$command" && escapes_worktree "$command"; then
-  reason="Not auto-allowed: this command can write outside '${session_root}' -- it names an absolute path beyond the worktree, or hides its target behind '..', '~', a variable, or a command substitution. This is the Bash-side counterpart of the cross-checkout path confusion check-worktree-path.sh blocks for Edit/Write. Re-derive the path from \`pwd\` if that was unintended."
-  jq -n --arg reason "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "ask",
-      permissionDecisionReason: $reason
-    }
-  }'
+if mutates_shared_state "$command"; then
+  decide ask "Not auto-allowed: a linked worktree shares ONE object database, ref namespace, stash and .git/config with every other checkout, so this reaches outside '${session_root}' without naming a path. Confirm explicitly."
   exit 0
 fi
 
-reason="Auto-allowed: cwd '${session_root}' is a linked git worktree (main checkout is '${main_root}'). A worktree is disposable, so commands scoped to it need no confirmation per CLAUDE.md's Worktree Conventions. Commands whose blast radius leaves the worktree are excluded and still prompt."
-jq -n --arg reason "$reason" '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "allow",
-    permissionDecisionReason: $reason
-  }
-}'
+decide allow "Auto-allowed: cwd '${session_root}' is a linked git worktree (main checkout is '${main_root}'), which is disposable by construction. Effects that no worktree can contain -- the shared podman VM, GitHub, shared refs, shared git state -- are excluded and still prompt."

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -78,21 +78,6 @@ run allow "git push --force-with-lease origin feat/issue-561-thing"
 run ask "git push --force-with-lease origin main"
 run ask "git push --force-with-lease origin HEAD:refs/heads/beta"
 
-echo "== writes that reach the main checkout =="
-run ask "sed -i '' s/a/b/ $MAIN/backend/app.py"
-run ask "touch $MAIN/x"
-run ask "mkdir -p $MAIN/x"
-run ask "cp somefile $MAIN/somefile"
-# Absolute path quoted inside an argument, not at token start.
-run ask "python3 -c \"import shutil; shutil.rmtree('$MAIN')\""
-# Relative traversal, redirect and rm alike.
-run ask "echo x > ../../main/README.md"
-run ask "rm -rf ../../main"
-# Traversal out THROUGH an allowed temp prefix.
-run ask "rm -rf /tmp/../$MAIN"
-run ask "git -C $MAIN reset --hard"
-run ask "tar -C $MAIN -xf x.tar"
-
 echo "== state shared with the main checkout =="
 # A linked worktree has its own working tree but ONE object database and
 # ONE ref namespace, so these escape it even without -C.
@@ -113,10 +98,17 @@ run ask "git reflog expire --expire=now --all"
 run allow "git worktree remove $TMP/other"
 run ask "git worktree remove --force $TMP/other"
 run ask "git worktree remove -f $TMP/other"
-# The exemption is for a LONE removal only -- it must not carry an
-# unprotected second command through with it.
-run ask "git worktree remove $TMP/other && rm -rf $MAIN"
-run ask "rm -rf $TMP/other"
+# THE ACCEPTED TRADE. Filesystem containment was removed, so a command that
+# names a path outside this worktree -- including the main checkout -- is no
+# longer inspected. These two are pinned as `allow` deliberately: they are
+# what the reduced hook lets through, and if a future change makes them ask
+# again, that is a decision to take knowingly rather than by accident.
+# Tracked content in the main checkout is recoverable from git; uncommitted
+# work is not. The Edit/Write equivalent is still guarded by
+# check-worktree-path.sh, which compares two `git rev-parse` results and
+# parses nothing.
+run allow "git worktree remove $TMP/other && rm -rf $MAIN"
+run allow "rm -rf $TMP/other"
 run ask "git worktree prune"
 run allow "git branch --show-current"
 run allow "git status --short"
@@ -209,46 +201,6 @@ run ask "git config --global user.email x@y.z"
 run ask "git remote set-url origin git@github.com:other/repo.git"
 run ask "git remote remove origin"
 run allow "git config --get user.email"
-
-echo "== reading outside the worktree is not a write =="
-# visualize-debug-log opens a user's bundle from ~/Downloads; the
-# containment guard is about writes, so reads must not prompt.
-run allow "cat $TMP/outside.json"
-run allow "head -50 $MAIN/CHANGELOG.md"
-run allow "ls ~/Downloads"
-run allow "grep -rn foo /usr/local/lib"
-run allow "git log --oneline -5"
-run allow "cat $MAIN/x.json | jq .a"
-# ...but anything that can write is still scrutinised.
-run ask "python3 -c \"import shutil; shutil.rmtree('$MAIN')\""
-run ask "sed -i '' s/a/b/ $MAIN/app.py"
-run ask "cat x.json > $MAIN/out.json"
-
-echo "== shapes that reached the user as false prompts =="
-# Each of these blocked real work. They are pinned because every one was
-# introduced by a *fix* to the containment check, not by the original code.
-# A worktree must not be judged foreign to itself: `;` is a separator, so
-# `cd <own worktree>; cmd` must not yield the token "<worktree>;".
-run allow "cd $WT; .venv/bin/pytest -m 'not slow' -q 2>&1 | tail -8"
-run allow "cd $WT; python3 - <<'PY'
-open('config.yaml','w').write(s)
-PY"
-run allow "cd $WT; git add -A; git commit -m 'merge: reconcile beta/main'"
-# A literal \$( inside a quoted search pattern is not command substitution.
-run allow "grep -n 'main_root=\$(printf' .claude/hooks/x.sh"
-run allow "grep -n 'session_root\"/\*) ;;' .claude/hooks/x.sh"
-# Read-only work plus a discarded stderr redirect.
-run allow "git show origin/main:x.sh 2>/dev/null | grep -n 'case \"\$command\"'"
-# A SIBLING worktree is disposable too; only the main checkout is protected.
-run allow "cp report.md $TMP/sibling-wt/report.md"
-
-echo "== ...while the main checkout is still protected =="
-run ask "rm -rf $MAIN/core"
-run ask "sed -i '' s/a/b/ $MAIN/backend/app.py"
-run ask "python3 -c \"import shutil; shutil.rmtree('$MAIN')\""
-run ask "echo x > $MAIN/README.md"
-run ask "rm -rf \$HOME/GitHub/bess-manager"
-run ask "rm -rf ../../../bess-manager"
 
 echo "== the main checkout keeps its own rules =="
 # In the main checkout the hook must stay silent so settings.json applies

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,7 +60,7 @@
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/auto-allow-worktree-destructive.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/auto-allow-worktree-destructive.sh\""
           }
         ]
       },
@@ -69,11 +69,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/check-worktree-path.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/check-worktree-path.sh\""
           },
           {
             "type": "command",
-            "command": "python3 .claude/hooks/optimizer_core_principles.py",
+            "command": "python3 \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/optimizer_core_principles.py\"",
             "statusMessage": "Checking optimizer-core principles"
           }
         ]
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/link-worktree-local-settings.sh",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/link-worktree-local-settings.sh\"",
             "statusMessage": "Linking local settings into the worktree"
           }
         ]
@@ -95,7 +95,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/link-worktree-local-settings.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/link-worktree-local-settings.sh\""
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,11 +219,31 @@ by adding the offending command to an allowlist — an `ask` rule beats an `allo
 rule, so that never works, and enumerating command shapes is what the inverted
 hook exists to replace.
 
-Two classes still prompt inside a worktree: **globally-scoped** actions no
-worktree can contain (`sudo`, `podman machine rm`, `gh pr merge`/`release`,
-pushes moving `main`/`beta`/tags), and commands that **reach outside the
-worktree** — an absolute path beyond its root, or a target hidden behind `..`,
-`~`, a variable, or a command substitution.
+Inside a worktree the rule is: **do anything to the repo, except destroy the
+repo or its history.** What still prompts is a short, closed list of effects no
+worktree can contain — the shared podman VM (a `deny`, re-emitted so it can't be
+downgraded to one keystroke), elevated privileges, anything reaching GitHub,
+pushes that move a shared ref (`main`, `beta`, `beta-release-*`, tags), and
+writes to state shared across every checkout: the single object database, ref
+namespace, stash, and `.git/config`.
+
+**What it deliberately does not do is infer which files a command will touch.**
+An earlier version tried, using absolute paths, `..`, `~`, variables and
+substitutions to decide whether a command wrote outside the worktree. That is
+shell parsing by regex, and it does not work — quoting, globs, heredocs and `cd`
+all defeat it. It produced six distinct false positives in a single day, *every
+one introduced by the fix to the previous one*, including blocking a live beta
+release and judging a worktree foreign to itself because `;` wasn't treated as a
+separator. It was removed rather than patched again. The accepted cost: a stale
+absolute path in a Bash command can reach the main checkout unprompted; tracked
+content there is recoverable from git, uncommitted work isn't.
+
+If you want real containment, the mechanism is the sandbox
+(`sandbox.filesystem.allowWrite`/`denyWrite`), which the OS enforces — not more
+regex. **Anything added to this hook must classify by command shape, never by
+guessing at paths.** The Edit/Write guard `check-worktree-path.sh` is the shape
+to copy: it compares two `git rev-parse` results as strings and has never
+produced a false positive.
 
 **Don't add a prompt where git already refuses.** `git branch -D`, plain `git
 worktree remove` and `git push --force-with-lease` are auto-allowed on purpose:
@@ -237,14 +257,9 @@ ones that actually discard recoverable state. Likewise `gh` allows *authoring*
 (`pr create`/`edit`/`comment`, `issue comment`) — that's the work product, and
 `gh pr create` is the closing step of `implement-issue` — while publishing and
 reconfiguring (`pr merge`, `release`, `repo edit`, `secret`, `workflow run`,
-non-GET `gh api`) still ask.
-
-That second check guards against *accidents* — a stale absolute path from before
-a worktree switch, a `../..` counted from the wrong cwd — and is the Bash-side
-counterpart of `check-worktree-path.sh`. It is **not a sandbox**: a hook sees the
-command string, not the syscalls, so indirection can defeat it. The real
-containment is that a worktree is disposable. Don't extend it as if it were a
-security boundary, and don't weaken it on the grounds that it isn't one.
+non-GET `gh api`) still ask. The `gh` safe list must also stay a superset of
+settings.json's `gh` allow patterns, or a hook decision silently revokes a
+permission you granted.
 
 **Only tracked files travel into a worktree.** `.claude/settings.json` and
 `.claude/hooks/*` are tracked and follow automatically;


### PR DESCRIPTION
Follow-up to #573. **Net −329 lines.** The hook stops trying to infer which files a command will touch.

## Why

It tried to decide, from a command *string*, whether a command would write outside the worktree — absolute paths, `..`, `~`, variables, substitutions. That's shell parsing by regex, and it doesn't work: quoting, globs, heredocs and `cd` each defeat it.

Six distinct false positives reached the user in one day, and **every one was introduced by the fix to the previous one**:

| Blocked command | Why it fired |
|---|---|
| `cmd 2>/dev/null` + any `$var` | a redirect triggered scrutiny; `$` read as indirection |
| `cd` into a **sibling** worktree | every non-session path treated as foreign |
| `grep 'main_root=$(printf'` | literal `$(` in a quoted *search pattern* read as substitution |
| `cat ~/Downloads/bundle.json` | any `~` triggered scrutiny |
| `sed -n '1,30p' file` | `sed` listed for the sake of `sed -i` |
| `cd <own worktree>; cmd` | `;` wasn't a separator — the worktree was foreign to **itself** |

That last one blocked a live beta release: three commands in a row, all operating inside the worktree they were issued from.

A guard with that false-positive rate doesn't get read, it gets click-throughed — so it protects nothing while costing every run. Removed rather than patched a seventh time.

## What's left

The rule the hook now states: **inside a worktree, do anything to the repo, except destroy the repo or its history.** What remains classifies by *command shape*, which is tractable:

- the shared **podman VM** (a settings.json `deny`, re-emitted so a hook decision can't downgrade a hard block to one keystroke)
- **elevated privileges**, anything reaching **GitHub**, and pushes that move a **shared ref** (`main`, `beta`, `beta-release-*`, tags)
- writes to **state shared across every checkout**: one object database, one ref namespace, one stash, one `.git/config`

Deleted: `needs_scrutiny`, `escapes_worktree`, `is_read_only`, `is_contained_path`, `is_lone_worktree_removal`, and the token scan. 543 → 238 lines.

## The accepted cost

Stated plainly rather than glossed: **a stale absolute path in a Bash command can now reach the main checkout unprompted.** Tracked content there is recoverable from git; uncommitted work is not. Two test cases pin that as `allow` *on purpose*, so if it ever asks again that's a decision taken knowingly rather than by accident.

The Edit/Write equivalent is untouched and still reliable, because it parses nothing: `check-worktree-path.sh` compares two `git rev-parse` results as strings. CLAUDE.md now names it as the shape to copy, and points at the sandbox (`sandbox.filesystem.allowWrite`/`denyWrite`, OS-enforced) as the mechanism if real containment is wanted — not more regex.

## Also here

- **`git worktree prune`** returned to the shared-state list — it unregisters a worktree it merely cannot *see*, not only one that's really gone.
- **Hooks are invoked by absolute path** — `${CLAUDE_PROJECT_DIR}` with a `git rev-parse --show-toplevel` fallback — so resolution no longer depends on the session's cwd. That's the likely cause of the `No such file or directory` hook errors during the release while the script sat intact on disk. The expression was tested from the worktree, the main checkout, and an unrelated cwd, with and without the variable set.

## Verification

Suite trimmed to the behaviour that still exists, all passing and enforced by `quality-check.sh` (0 errors, 0 warnings). All six false-positive shapes now allow, the three release commands allow, and all 12 `implement-issue` commands run unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W29UVDwQPwVRRqBn2sMgHa
