### PR TITLE
fix: resolve hook tooling from the project root, not PATH or cwd

### DIFF
--- a/.claude/hooks/lint-edited-python.sh
+++ b/.claude/hooks/lint-edited-python.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Edit/Write: ruff-check the file that was just written.
+#
+# This was an inline `python3 -c` one-liner in settings.json calling bare
+# `ruff`. Two problems, both of which reached the user as a Python traceback
+# printed after every single .py edit:
+#
+#   1. `ruff` is not on PATH in this project -- it lives in .venv/bin, which
+#      is exactly what #562 fixed for scripts/quality-check.sh ("make
+#      quality-check find venv tools and fail when it cannot"). The hook was
+#      missed. subprocess.run(['ruff', ...]) then raised FileNotFoundError.
+#   2. It linted ANY .py path, including scratch scripts under the session
+#      scratchpad that are not project code and have no reason to be clean.
+#
+# Resolution does not depend on the session's cwd: hooks run with whatever
+# cwd the session has, which is not reliably the repo root.
+set -uo pipefail
+
+input=$(cat)
+file=$(printf '%s' "$input" | jq -r '.tool_response.filePath // .tool_input.file_path // empty')
+
+case "$file" in
+  *.py) ;;
+  *) exit 0 ;;
+esac
+
+root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+[ -n "$root" ] || exit 0
+
+# Only lint files that belong to this checkout. A scratch script under the
+# scratchpad or /tmp is not project code; linting it produced noise on every
+# edit and could not be acted on.
+case "$file" in
+  "$root"/*) ;;
+  *) exit 0 ;;
+esac
+
+ruff="$root/.venv/bin/ruff"
+if [ ! -x "$ruff" ]; then
+  # Loud and actionable, not a traceback, and not silent either -- a linter
+  # that quietly stops running is the silent degradation rules.md forbids
+  # and #562 removed elsewhere.
+  echo "ruff not found at $ruff -- run ./scripts/worktree-setup.sh (a fresh worktree has no .venv until it does)" >&2
+  exit 2
+fi
+
+exec "$ruff" check "$file"

--- a/.claude/hooks/pretest-on-commit.sh
+++ b/.claude/hooks/pretest-on-commit.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: before a `git commit`, run the scenario-discovery
+# test so a broken fixture is caught at commit time rather than in CI.
+#
+# Extracted from an inline `python3 -c` one-liner in settings.json, which had
+# the same cwd-dependence that made the ruff hook fail: it invoked
+# `.venv/bin/python` as a RELATIVE path, so it only worked when the session's
+# cwd happened to be the repo root. Hooks run with whatever cwd the session
+# has. Resolve from the project root instead.
+set -uo pipefail
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+case "$command" in
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+[ -n "$root" ] || exit 0
+
+python="$root/.venv/bin/python"
+if [ ! -x "$python" ]; then
+  echo "python not found at $python -- run ./scripts/worktree-setup.sh (a fresh worktree has no .venv until it does)" >&2
+  exit 2
+fi
+
+test_file="$root/core/bess/tests/unit/test_scenario_discovery.py"
+[ -f "$test_file" ] || exit 0
+
+cd "$root" || exit 0
+exec "$python" -m pytest "$test_file" -q --tb=short

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"import sys,json; d=json.load(sys.stdin); cmd=d.get('tool_input',{}).get('command',''); is_commit='git commit' in cmd; sys.exit(0) if not is_commit else None; import subprocess; r=subprocess.run(['.venv/bin/python','-m','pytest','core/bess/tests/unit/test_scenario_discovery.py','-q','--tb=short'],capture_output=True,text=True); print(r.stdout); print(r.stderr) if r.returncode else None; sys.exit(r.returncode)\""
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/pretest-on-commit.sh\""
           },
           {
             "type": "command",
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"import sys,json,subprocess; d=json.load(sys.stdin); f=d.get('tool_response',{}).get('filePath') or d.get('tool_input',{}).get('file_path',''); sys.exit(0) if not f.endswith('.py') else None; r=subprocess.run(['ruff','check',f]); sys.exit(r.returncode)\""
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/lint-edited-python.sh\""
           }
         ]
       }


### PR DESCRIPTION
Every `.py` edit printed a Python traceback:

```
PostToolUse:Edit hook error
Failed with non-blocking status code: Traceback (most recent call last):
```

Two causes, both in the inline `python3 -c` one-liners in `settings.json`.

**1. The lint hook called bare `ruff`.** ruff is **not on PATH** in this project — it lives in `.venv/bin/ruff` — so `subprocess.run(['ruff', ...])` raised `FileNotFoundError` and printed a traceback after every edit. This is exactly what #562 fixed for `scripts/quality-check.sh` ("make quality-check find venv tools and fail when it cannot"); the hooks were missed.

**2. It linted any `.py` path**, including scratch scripts under the session scratchpad. Those aren't project code, have no reason to be ruff-clean, and nothing could be done about the output — pure noise on every edit.

The **commit-gate hook had the same class of bug**: it invoked `.venv/bin/python` as a *relative* path, so it only worked when the session's cwd happened to be the repo root. Hooks run with whatever cwd the session has. Fixed too, rather than left as a duplicate of the same defect.

## What changed

Both are now real scripts instead of one-liners embedded in JSON, resolving tooling from `${CLAUDE_PROJECT_DIR}` with a `git rev-parse --show-toplevel` fallback:

- `.claude/hooks/lint-edited-python.sh`
- `.claude/hooks/pretest-on-commit.sh`

A missing `.venv` is reported as one actionable line naming `./scripts/worktree-setup.sh`, and exits non-zero — not a traceback, but not silent either, since a linter that quietly stops running is the silent degradation `rules.md` forbids and #562 removed elsewhere.

The `settings.json` diff is exactly two lines.

## Verification

Executed the actual command strings **read back out of `settings.json`**, through a shell, with real hook payloads on stdin, from both the worktree and an unrelated cwd:

| Case | Result |
|---|---|
| scratchpad `.py` (the traceback spam) | exit 0, silent |
| project `.py`, clean | `All checks passed!` |
| project `.py`, unused import | exit 1, `F401` — linting still works |
| non-commit command | exit 0, skipped |
| `git commit` from `/tmp` with only `CLAUDE_PROJECT_DIR` set | runs the scenario-discovery suite |

`quality-check.sh`: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W29UVDwQPwVRRqBn2sMgHa
