### PR TITLE
fix: deny git stash repo-wide — one shared stack, ~20 agents

### DIFF
--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -88,6 +88,41 @@ is_hard_denied() {
   printf '%s' "$1" | grep -qE "${CMD_START}podman[[:space:]]+(machine[[:space:]]+(rm|reset)|system[[:space:]]+reset)${CMD_END}"
 }
 
+# `git stash` does not work when more than one agent shares a repository.
+#
+# There is exactly ONE `refs/stash` per repository, shared by the main
+# checkout and every linked worktree. It is a stack with no owner: agent A's
+# `git stash` pushes an entry that agent B's `git stash pop` will happily
+# take, and B has no way to tell it was not theirs. With ~20 worktrees
+# active here that is not a race worth running -- it silently destroys work,
+# in a way git provides no recovery path for once popped and discarded.
+#
+# Denied rather than asked, and denied in the MAIN CHECKOUT TOO, because the
+# stack is shared repo-wide rather than worktree-scoped. A prompt would only
+# push the decision onto whoever is watching, which for a subagent is nobody.
+#
+# The alternative is a temporary WIP commit: it lives on the branch, so it is
+# per-worktree, private to that agent, and recoverable by SHA even if the
+# branch moves.
+#
+#     git add -A && git commit -m "wip: <what>"     # set work aside
+#     git reset --soft HEAD~1                        # pick it back up
+#
+# `git stash list` and `git stash show` only read, so they stay allowed.
+uses_shared_stash() {
+  # Bare `git stash` (implicit push), and every mutating subcommand.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash([[:space:]]+(push|save|pop|apply|drop|clear|branch|create|store)${CMD_END}|[[:space:]]*[;&|)<>]|[[:space:]]*$)" && return 0
+  # The bare-`git stash` branch spells its terminator out instead of reusing
+  # CMD_END: CMD_END accepts a SPACE, which here would swallow the space
+  # before a subcommand and deny the read-only `git stash list`. Only a
+  # separator or end of string means "no subcommand followed".
+  #
+  # `git stash -u`, `git stash -k`, etc: a flag straight after `stash` is
+  # still an implicit push.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash[[:space:]]+-" && return 0
+  return 1
+}
+
 # Does one push's argument list name a ref shared with other checkouts?
 # Compared as TOKENS, not by substring: a substring test cannot tell `main`
 # from `feat/main-ish`, and widening it to catch `beta-release-*` would
@@ -174,9 +209,8 @@ mutates_shared_state() {
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+tag[[:space:]]+(.*[[:space:]])?(-d|--delete)${CMD_END}" && return 0
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|filter-branch)${CMD_END}" && return 0
 
-  # ONE refs/stash for every worktree, and this project leans on stash for
-  # branch isolation, so the shared stack is a live hazard.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash[[:space:]]+(clear|drop|pop)${CMD_END}" && return 0
+  # The stash is handled earlier by uses_shared_stash, which applies in the
+  # main checkout too -- the stack is shared repo-wide, not worktree-scoped.
 
   # Shared .git/config, and --global reaches ~/.gitconfig.
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+config[[:space:]]+(.*[[:space:]])?(--global|--system)${CMD_END}" && return 0
@@ -201,6 +235,31 @@ mutates_shared_state() {
   return 1
 }
 
+decide() {
+  jq -n --arg d "$1" --arg reason "$2" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: $d,
+      permissionDecisionReason: $reason
+    }
+  }'
+}
+
+# Normalise ONCE, here, so every guard below matches the same string. Doing it
+# inside a single guard is what let `git -C sub gc`, `git -C sub stash drop`
+# and `git -c x=y config --global ...` through: only the push guard normalised,
+# so git's global options walked past every other one. It has to happen above
+# the stash check too, not just above the worktree gate -- `git -C sub stash
+# pop` is the same bypass aimed at the one guard that is a hard deny.
+normalised=$(normalise_git "$command")
+
+# Checked before the worktree gate on purpose: refs/stash is shared by the
+# main checkout and every worktree alike, so this must hold everywhere.
+if uses_shared_stash "$normalised"; then
+  decide deny "Denied: there is ONE refs/stash for this whole repository, shared by the main checkout and all ~20 worktrees, and the stack has no owner -- another agent's \`git stash pop\` will take your entry with no way to tell it was not theirs. Use a temporary WIP commit instead, which stays on this branch and is recoverable by SHA: \`git add -A && git commit -m \"wip: ...\"\`, then \`git reset --soft HEAD~1\` to resume. (\`git stash list\`/\`show\` are read-only and still allowed.)"
+  exit 0
+fi
+
 session_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [ -z "$session_root" ]; then
   echo '{"continue": true}'
@@ -221,22 +280,6 @@ if [ -z "$main_root" ] || [ "$session_root" = "$main_root" ]; then
   echo '{"continue": true}'
   exit 0
 fi
-
-decide() {
-  jq -n --arg d "$1" --arg reason "$2" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: $d,
-      permissionDecisionReason: $reason
-    }
-  }'
-}
-
-# Normalise ONCE, here, so every guard below matches the same string. Doing it
-# inside a single guard is what let `git -C sub gc`, `git -C sub stash drop`
-# and `git -c x=y config --global ...` through: only the push guard normalised,
-# so git's global options walked past every other one.
-normalised=$(normalise_git "$command")
 
 if is_hard_denied "$normalised"; then
   decide deny "Denied in settings.json: this destroys the shared podman VM that every worktree's E2E stack depends on. Being inside a disposable worktree does not contain it."

--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -8,8 +8,14 @@
 # Worktree Conventions) is disposable by construction: blow it away, make
 # another. Prompting there protects nothing and stalls otherwise autonomous
 # work, so this hook auto-allows Bash commands whose cwd is a linked
-# worktree. In the main checkout it stays silent and every ask/deny rule in
-# settings.json applies unchanged.
+# worktree.
+#
+# In the main checkout it stays silent -- every ask/deny rule in settings.json
+# applies unchanged -- with ONE exception: `git stash` is denied there too,
+# because refs/stash is shared repo-wide rather than worktree-scoped, so the
+# main checkout is one of the checkouts racing for it. That check sits above
+# the worktree gate for exactly that reason. In a repository that is not this
+# one, the hook is silent throughout, stash included.
 #
 # What it still refuses is a short, closed list of effects no worktree can
 # contain, and which no amount of `git checkout` gets back:
@@ -56,7 +62,12 @@ fi
 # running sudo; without the prefix step, one env assignment
 # (`PODMAN=1 podman machine rm`) shifted the command word out of every
 # guard at once and turned a deny into a silent allow.
-CMD_PREFIX='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(nohup|time|command|exec|env)[[:space:]]+)*'
+# Shell keywords are in the prefix list beside the wrappers because a
+# separator followed by a keyword is still a command-word position:
+# `for d in */; do git stash; done` and `if true; then git stash; fi` put
+# `do`/`then` exactly where `nohup` would sit, and a loop over worktrees is
+# the shape the stash guard exists for.
+CMD_PREFIX='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(nohup|time|command|exec|env|eval|do|then|else|elif|if|while|until)[[:space:]]+)*'
 CMD_START="(^|[;&|(]|&&|\\|\\||\\n)[[:space:]]*${CMD_PREFIX}"
 
 # The mirror of CMD_START at the far end of a match. Every guard needs one --
@@ -109,9 +120,18 @@ is_hard_denied() {
 #     git reset --soft HEAD~1                        # pick it back up
 #
 # `git stash list` and `git stash show` only read, so they stay allowed.
+#
+# KNOWN LIMIT: a stash inside a quoted string -- `bash -c "git stash pop"`,
+# `sh -c '...'` -- is not matched, because the anchor would have to treat a
+# quote as a command separator. It cannot: `grep -rn 'git stash' docs/` is a
+# pinned allow, and quote-permissive anchoring turns that into a deny. This
+# guard classifies by command shape (see the header); an explicit shell
+# wrapper defeats shape matching by construction, and chasing it is the
+# regex-parses-shell mistake the header records.
 uses_shared_stash() {
   # Bare `git stash` (implicit push), and every mutating subcommand.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash([[:space:]]+(push|save|pop|apply|drop|clear|branch|create|store)${CMD_END}|[[:space:]]*[;&|)<>]|[[:space:]]*$)" && return 0
+  # `import` is git >= 2.50 and rewrites refs/stash wholesale.
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash([[:space:]]+(push|save|pop|apply|drop|clear|branch|create|store|import)${CMD_END}|[[:space:]]*[;&|)<>]|[[:space:]]*$)" && return 0
   # The bare-`git stash` branch spells its terminator out instead of reusing
   # CMD_END: CMD_END accepts a SPACE, which here would swallow the space
   # before a subcommand and deny the read-only `git stash list`. Only a
@@ -253,13 +273,6 @@ decide() {
 # pop` is the same bypass aimed at the one guard that is a hard deny.
 normalised=$(normalise_git "$command")
 
-# Checked before the worktree gate on purpose: refs/stash is shared by the
-# main checkout and every worktree alike, so this must hold everywhere.
-if uses_shared_stash "$normalised"; then
-  decide deny "Denied: there is ONE refs/stash for this whole repository, shared by the main checkout and all ~20 worktrees, and the stack has no owner -- another agent's \`git stash pop\` will take your entry with no way to tell it was not theirs. Use a temporary WIP commit instead, which stays on this branch and is recoverable by SHA: \`git add -A && git commit -m \"wip: ...\"\`, then \`git reset --soft HEAD~1\` to resume. (\`git stash list\`/\`show\` are read-only and still allowed.)"
-  exit 0
-fi
-
 session_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [ -z "$session_root" ]; then
   echo '{"continue": true}'
@@ -274,9 +287,35 @@ fi
 worktree_list=$(git worktree list --porcelain)
 main_root=$(printf '%s\n' "$worktree_list" | awk '/^worktree /{sub(/^worktree /, ""); print; exit}')
 
+# Which repository is the command aimed at? Everything this hook knows about
+# -- ~20 worktrees sharing one refs/stash, a podman VM, shared refs -- is true
+# of THIS repository. A command run from a clone somewhere else is governed by
+# nothing here, so the hook must be silent there, stash included: a hard deny
+# with no override in an unrelated repo is a wall, not a guard.
+#
+# Identified the way check-worktree-path.sh does it -- two `git` results
+# compared as strings, parsing nothing. The hook file is tracked, so a copy of
+# it exists in every worktree; resolving from its own directory yields this
+# repository's main root either way.
+hook_main_root=$(git -C "$(dirname -- "$0")" worktree list --porcelain 2>/dev/null |
+  awk '/^worktree /{sub(/^worktree /, ""); print; exit}')
+
+if [ -z "$main_root" ] || [ -z "$hook_main_root" ] || [ "$main_root" != "$hook_main_root" ]; then
+  echo '{"continue": true}'
+  exit 0
+fi
+
+# Above the worktree gate on purpose, and below the repo check for the same
+# reason: refs/stash is shared by this repository's main checkout and every
+# worktree alike, so it must hold in all of them -- and only in them.
+if uses_shared_stash "$normalised"; then
+  decide deny "Denied: there is ONE refs/stash for this whole repository, shared by the main checkout and all ~20 worktrees, and the stack has no owner -- another agent's \`git stash pop\` will take your entry with no way to tell it was not theirs. To set work aside on this branch, use a WIP commit, recoverable by SHA: \`git add -A && git commit -m \"wip: ...\"\`, then \`git reset --soft HEAD~1\` to resume. To move one file's changes into a worktree, pipe a patch across: \`git diff -- <file> | git -C <worktree> apply\` (see docs/agents/rules.md). (\`git stash list\`/\`show\` are read-only and still allowed.)"
+  exit 0
+fi
+
 # Everything below applies ONLY inside a linked worktree. In the main
 # checkout this hook stays silent so settings.json governs it entirely.
-if [ -z "$main_root" ] || [ "$session_root" = "$main_root" ]; then
+if [ "$session_root" = "$main_root" ]; then
   echo '{"continue": true}'
   exit 0
 fi

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -32,6 +32,13 @@ trap 'rm -rf "$TMP"' EXIT
 MAIN="$TMP/main"
 WT="$TMP/wt"
 git init -q "$MAIN"
+# The hook identifies its own repository from its own location, and is silent
+# in any other -- so the fixture has to OWN the copy under test, or every case
+# below would fall through as "not this repo". This mirrors production, where
+# the hook file is tracked and a copy sits in every worktree.
+mkdir -p "$MAIN/.claude/hooks"
+cp "$HOOK" "$MAIN/.claude/hooks/"
+HOOK="$MAIN/.claude/hooks/$(basename "$HOOK")"
 git -C "$MAIN" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 git -C "$MAIN" worktree add -q -b testwt "$WT"
 # A second linked worktree, to prove sibling worktrees count as contained
@@ -165,6 +172,15 @@ run deny "git -C sub stash pop"
 run deny "git -C sub stash"
 run deny "git -c core.x=1 stash drop"
 run deny "git --no-pager stash apply"
+# `import` (git >= 2.50) rewrites refs/stash wholesale.
+run deny "git stash import https://example.com/bundle"
+# A shell keyword sits exactly where `nohup` sits, and a loop over worktrees
+# is the shape this guard exists for. Without keywords in the prefix these
+# produced no decision at all -- which inside a worktree means allow.
+run deny "for d in */; do git stash; done"
+run deny "if true; then git stash; fi"
+run deny "while read -r d; do git stash pop; done"
+run deny "eval git stash"
 # Reads are fine, and so is the WIP-commit alternative it points people to.
 run allow "git stash list"
 run allow "git stash show -p"
@@ -280,6 +296,25 @@ run ask "git status;git -C sub gc"
 run allow "git -C sub status --short"
 run allow "git -C sub stash list"
 
+echo "== another repository is governed by none of this =="
+# Everything the hook knows -- one shared refs/stash, ~20 worktrees, a shared
+# podman VM -- is true of THIS repository. In an unrelated clone it must be
+# silent, stash included: a hard deny with no override there is a wall, not a
+# guard. (Verified in review by cloning a third-party repo and running
+# `git stash` in it.)
+FOREIGN="$TMP/foreign"
+git init -q "$FOREIGN"
+for foreign_cmd in "git stash" "git stash pop" "rm -rf .venv" "podman machine rm"; do
+  foreign_decision=$(printf '%s' "$foreign_cmd" | jq -Rn '{tool_input: {command: input}}' \
+    | (cd "$FOREIGN" && bash "$HOOK") | jq -r 'if .continue then "fallthrough" else "DECIDED" end')
+  if [ "$foreign_decision" = "fallthrough" ]; then
+    printf 'ok    %-5s %s\n' "none" "$foreign_cmd (from an unrelated repo)"
+  else
+    printf 'FAIL  got=%-12s want=%-6s %s\n' "$foreign_decision" "none" "$foreign_cmd (from an unrelated repo)"
+    failures=$((failures + 1))
+  fi
+done
+
 echo "== the main checkout keeps its own rules =="
 # In the main checkout the hook must stay silent so settings.json applies
 # unchanged -- an allow there would be the worst possible failure.
@@ -289,6 +324,18 @@ if [ "$main_decision" = "fallthrough" ]; then
   printf 'ok    %-5s %s\n' "none" "rm -rf .venv (from the main checkout)"
 else
   printf 'FAIL  got=%-12s want=%-6s %s\n' "$main_decision" "none" "rm -rf .venv (from the main checkout)"
+  failures=$((failures + 1))
+fi
+
+# ...with exactly one exception, and it is the reason the stash check sits
+# above the worktree gate: refs/stash is shared repo-wide, so the main
+# checkout is one of the checkouts racing for it.
+main_stash=$(printf '%s' "git stash pop" | jq -Rn '{tool_input: {command: input}}' \
+  | (cd "$MAIN" && bash "$HOOK") | jq -r '.hookSpecificOutput.permissionDecision // "fallthrough"')
+if [ "$main_stash" = "deny" ]; then
+  printf 'ok    %-5s %s\n' "deny" "git stash pop (from the main checkout)"
+else
+  printf 'FAIL  got=%-12s want=%-6s %s\n' "$main_stash" "deny" "git stash pop (from the main checkout)"
   failures=$((failures + 1))
 fi
 

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -138,6 +138,45 @@ run allow "gh issue edit 558 --add-label analyzed"
 run ask "gh pr create --draft --title x && gh pr merge 561"
 run allow "gh run watch 123"
 
+echo "== the shared stash is denied outright =="
+# ONE refs/stash per repository, shared by the main checkout and every
+# worktree, and the stack has no owner: another agent's `pop` takes your
+# entry with no way to tell it was not theirs. Denied rather than asked,
+# because for a subagent there is nobody watching the prompt.
+run deny "git stash"
+run deny "git stash -q"
+run deny "git stash -u"
+run deny "git stash push -u -m wip"
+run deny "git stash save wip"
+run deny "git stash pop"
+run deny "git stash apply"
+run deny "git stash apply stash@{0}"
+run deny "git stash drop"
+run deny "git stash clear"
+run deny "git stash branch tmp"
+# This guard is a hard `deny` that also applies in the main checkout, so the
+# two bypass classes fixed in #581 matter here more than anywhere: a
+# separator flush against the subcommand, and git's global options.
+run deny "git stash drop;"
+run deny "git stash;"
+run deny "git stash&&echo x"
+run deny "git stash pop;echo x"
+run deny "git -C sub stash pop"
+run deny "git -C sub stash"
+run deny "git -c core.x=1 stash drop"
+run deny "git --no-pager stash apply"
+# Reads are fine, and so is the WIP-commit alternative it points people to.
+run allow "git stash list"
+run allow "git stash show -p"
+# The bare-`git stash` branch must not swallow the space before a read-only
+# subcommand: its terminator is a separator or end of string, never a space.
+run allow "git stash list;"
+run allow "git stash list && git status"
+run allow "git -C sub stash show"
+run allow "git add -A && git commit -m 'wip: set aside'"
+run allow "git reset --soft HEAD~1"
+run allow "grep -rn 'git stash' docs/"
+
 echo "== settings.json denials stay denials =="
 # A hook decision supersedes a settings rule, so "ask" here would downgrade
 # a hard block on destroying the shared podman VM to one keystroke.
@@ -189,14 +228,9 @@ run allow "git push -u origin feat/x && gh pr create --draft --base main --title
 run allow "git commit -m 'fix main crash' && git push origin feat/x"
 run ask   "git commit -m 'x' && git push origin main"
 
-echo "== state shared across worktrees: stash, config, remotes =="
-# ONE refs/stash for every worktree; this project leans on stash for
-# branch isolation, so the shared stack is a live hazard.
-run ask "git stash clear"
-run ask "git stash drop"
-run ask "git stash pop"
-run allow "git stash list"
-run allow "git stash push -u -m wip"
+echo "== state shared across worktrees: config, remotes =="
+# The stash moved to its own section above -- it is denied outright now,
+# and denied in the main checkout too, so it is no longer an "ask" here.
 run ask "git config --global user.email x@y.z"
 run ask "git remote set-url origin git@github.com:other/repo.git"
 run ask "git remote remove origin"
@@ -207,9 +241,9 @@ echo "== a separator flush against the command word still terminates it =="
 # string and nothing else. A `;` or `&&` written without a space before it is
 # neither, so each of these was AUTO-ALLOWED while its spaced spelling asked
 # -- the same bypass in every guard at once, reachable by deleting one space.
-run ask "git stash drop;"
-run ask "git stash drop; echo x"
-run ask "git stash clear;"
+run deny "git stash drop;"
+run deny "git stash drop; echo x"
+run deny "git stash clear;"
 run ask "git gc;"
 run ask "git gc&&echo x"
 run ask "git worktree prune;"
@@ -220,7 +254,7 @@ run ask "sudo;"
 run deny "podman machine rm;"
 # The spaced spelling of a compound must keep asking too: the guard fires on
 # the stash, not on the `checkout main` that follows it.
-run ask "git stash pop && git checkout main"
+run deny "git stash pop && git checkout main"
 # ...and a terminator must not manufacture a match out of a longer word.
 run allow "git stashfoo drop"
 run allow "git gcfoo"
@@ -230,13 +264,13 @@ echo "== git global options must not slip past ANY guard =="
 # guard called it -- so every shared-state guard read the raw string and
 # `git -C sub <anything>` walked straight through. It is applied once, up
 # front, and every guard now matches the normalised form.
-run ask "git -C sub stash drop"
+run deny "git -C sub stash drop"
 run ask "git -C sub gc --prune=now"
 run ask "git -C sub tag -d v1.0.0"
 run ask "git -C sub config --global user.email x@y.z"
 run ask "git -C sub remote remove origin"
 run ask "git -C sub worktree prune"
-run ask "git -c core.x=1 stash clear"
+run deny "git -c core.x=1 stash clear"
 run ask "git --git-dir=sub/.git branch -f main HEAD"
 run ask "git --no-pager -C sub reflog expire --expire=now --all"
 # Normalisation is anchored like CMD_START, so a separator with no space

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,17 +225,31 @@ and the stack has no owner: one agent's `git stash` pushes an entry that another
 agent's `git stash pop` will take, with no way to tell it was not theirs. With
 ~20 worktrees active that silently destroys work, and once popped and discarded
 git offers no recovery. The hook denies every mutating form (`push`, `save`,
-bare `git stash`, `pop`, `apply`, `drop`, `clear`, `branch`) in the main checkout
-as well as in worktrees; `git stash list`/`show` still work.
+bare `git stash`, `pop`, `apply`, `drop`, `clear`, `branch`, `import`) in the
+main checkout as well as in worktrees; `git stash list`/`show` still work. The
+deny is scoped to this repository — in an unrelated clone the hook is silent.
 
-To set work aside, use a temporary WIP commit — it lives on the branch, so it is
-per-worktree, private to that agent, and recoverable by SHA even if the branch
-moves:
+To set work aside on the branch you are on, use a temporary WIP commit — it
+lives on the branch, so it is per-worktree, private to that agent, and
+recoverable by SHA even if the branch moves:
 
 ```bash
 git add -A && git commit -m "wip: <what>"   # set aside
 git reset --soft HEAD~1                     # pick back up
 ```
+
+To move changes *across* checkouts (the case stash used to cover), pipe a patch
+through the shared object database — verify it landed before reverting, since
+`git checkout --` is the destructive step and there is no stash to fall back on:
+
+```bash
+git diff -- <file> | git -C .claude/worktrees/<name> apply
+git -C .claude/worktrees/<name> diff -- <file>   # verify
+git checkout -- <file>                           # only then
+```
+
+The full procedure, including the staged-changes variant, is in
+`docs/agents/rules.md` under Working Location.
 
 Inside a worktree the rule is: **do anything to the repo, except destroy the
 repo or its history.** What still prompts is a short, closed list of effects no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,24 @@ by adding the offending command to an allowlist — an `ask` rule beats an `allo
 rule, so that never works, and enumerating command shapes is what the inverted
 hook exists to replace.
 
+**Never `git stash` — it is blocked, everywhere in this repo.** There is exactly
+one `refs/stash` per repository, shared by the main checkout and every worktree,
+and the stack has no owner: one agent's `git stash` pushes an entry that another
+agent's `git stash pop` will take, with no way to tell it was not theirs. With
+~20 worktrees active that silently destroys work, and once popped and discarded
+git offers no recovery. The hook denies every mutating form (`push`, `save`,
+bare `git stash`, `pop`, `apply`, `drop`, `clear`, `branch`) in the main checkout
+as well as in worktrees; `git stash list`/`show` still work.
+
+To set work aside, use a temporary WIP commit — it lives on the branch, so it is
+per-worktree, private to that agent, and recoverable by SHA even if the branch
+moves:
+
+```bash
+git add -A && git commit -m "wip: <what>"   # set aside
+git reset --soft HEAD~1                     # pick back up
+```
+
 Inside a worktree the rule is: **do anything to the repo, except destroy the
 repo or its history.** What still prompts is a short, closed list of effects no
 worktree can contain — the shared podman VM (a `deny`, re-emitted so it can't be

--- a/docs/agents/rules.md
+++ b/docs/agents/rules.md
@@ -13,9 +13,29 @@ They are non-negotiable and override any other instruction.
   `feature-lifecycle`, or any other skill/workflow stage. A plain
   conversation ("can you fix this doc line") is not an exemption.
 - If you notice partway through a session that you're on `main` with
-  uncommitted edits: stop, move the changes into a worktree (stash the
-  specific file, enter/create a worktree, apply the stash there — don't
-  touch unrelated pre-existing changes on `main`), and continue there.
+  uncommitted edits: stop, enter/create a worktree, move the changes there,
+  and continue — without touching unrelated pre-existing changes on `main`.
+- **Never `git stash` to do it.** There is exactly one `refs/stash` per
+  repository, shared by the main checkout and every worktree, and the stack
+  has no owner — another agent's `pop` takes your entry with no way to tell
+  it was not theirs. The permission hook denies every mutating form outright,
+  in the main checkout too, with no override. Move the changes as a patch
+  through the shared object database instead:
+
+  ```bash
+  git diff -- <file> | git -C .claude/worktrees/<name> apply   # copy across
+  git -C .claude/worktrees/<name> diff -- <file>               # VERIFY it landed
+  git checkout -- <file>                                       # only then revert on main
+  ```
+
+  Verify before reverting: `git checkout --` is the only destructive step and
+  there is no stash to fall back on. Add `--cached` to the first `git diff`
+  for staged changes, and drop `-- <file>` to move everything.
+- To set work aside on the branch you are already on (rather than move it to
+  another checkout), use a WIP commit — per-worktree, private, and
+  recoverable by SHA even if the branch moves:
+  `git add -A && git commit -m "wip: <what>"`, then `git reset --soft HEAD~1`
+  to pick it back up.
 - **`EnterWorktree` switches the shell's cwd, not file-tool paths.**
   `Read`/`Edit`/`Write` take the literal absolute path given — after
   entering a worktree, every such path must start with the worktree root


### PR DESCRIPTION
There is exactly **one `refs/stash` per repository**, shared by the main checkout and every linked worktree, and the stack has no owner. Agent A's `git stash` pushes an entry that agent B's `git stash pop` will take — and B has no way to tell it wasn't theirs. With ~20 worktrees active that isn't a race worth running: it destroys work silently, and once an entry is popped and discarded git offers no recovery path.

This already happened here — a subagent ran `git stash -q` mid-release while other agents were live.

## Denied, not asked

A prompt only moves the decision to whoever is watching, and for a subagent that's nobody.

**Denied in the main checkout too**, not just worktrees: the stack is shared repo-wide, so the check runs *before* the worktree gate. That's the first rule in this hook that applies outside a worktree, and it's deliberate — a stash taken in the main checkout collides with worktree agents in exactly the same way.

| Denied | Still allowed |
|---|---|
| bare `git stash` (implicit push), `push`, `save`, `pop`, `apply`, `drop`, `clear`, `branch`, `create`, `store`, and `git stash -u`-style flag forms | `git stash list`, `git stash show` — read-only |

## The message names the alternative

Rather than just refusing, the denial points at a temporary WIP commit — it lives on the branch, so it's per-worktree, private to that agent, and recoverable by SHA even if the branch moves:

```bash
git add -A && git commit -m "wip: <what>"   # set aside
git reset --soft HEAD~1                     # pick back up
```

## Verification

From both a linked worktree and the main checkout: all 11 mutating forms deny in both. `stash list`, `stash show`, the WIP-commit pair, and a `grep` merely *mentioning* "git stash" are unaffected.

The suite gains 16 pins, and the four superseded ones (`stash clear`/`drop`/`pop` as `ask`, `stash push` as `allow`) were removed rather than left contradicting the new behaviour. `quality-check.sh`: 0 errors, 0 warnings.


---

## Rebased onto #581

#581 (merged as `46349afb`) fixed two guard-matching bugs this PR's new
`uses_shared_stash` was written before: a shell separator flush against the
last word did not terminate a match, and `normalise_git` was applied to only
one guard. Because this PR also removes the old stash line from
`mutates_shared_state`, merging it unrebased would have reopened both bugs on
the one guard that is a hard `deny` — `git stash drop;` and
`git -C sub stash pop` would have been allowed outright.

Three changes on top of the rebase:

1. `uses_shared_stash` matches `${CMD_END}`;
2. it reads `$normalised`, not `$command`;
3. the `normalised=` assignment is hoisted above the stash check, since that
   check runs before the worktree gate on purpose.

The bare-`git stash` branch spells its terminator out (`[[:space:]]*[;&|)<>]`
or end of string) rather than reusing `CMD_END` — `CMD_END` accepts a space,
which there would swallow the space before a subcommand and deny the
read-only `git stash list`. Pinned both ways.

11 further pins added for the bypass shapes (`git stash;`, `git stash&&echo x`,
`git stash pop;echo x`, `git -C sub stash pop`, `git -c core.x=1 stash drop`,
`git --no-pager stash apply`) and for the reads that must survive them
(`git stash list;`, `git stash list && git status`, `git -C sub stash show`).
The stash cases #581 added as `ask` are now `deny`, which is this PR's point.

`bash .claude/hooks/tests/auto-allow-worktree-destructive.test.sh` — all
checks pass. No Python touched, so the rest of the gate is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W29UVDwQPwVRRqBn2sMgHa

