### PR TITLE
fix: close two bypasses in the worktree auto-allow hook

### DIFF
--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -59,12 +59,25 @@ fi
 CMD_PREFIX='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|(nohup|time|command|exec|env)[[:space:]]+)*'
 CMD_START="(^|[;&|(]|&&|\\|\\||\\n)[[:space:]]*${CMD_PREFIX}"
 
+# The mirror of CMD_START at the far end of a match. Every guard needs one --
+# without it `git gc --prune=now` matches while `git tag -d v1` matches only
+# the prefix, so `git tagfoo` would slip in either direction -- but the naive
+# spelling `([[:space:]]|$)` sees only a SPACE or end of string. A separator
+# written flush against the last word is neither, so `git stash drop;`,
+# `git gc&&echo x` and `sudo;` all read as unmatched and were auto-allowed
+# while their spaced spellings asked. Shell separators terminate a command
+# word exactly as whitespace does, so they belong in the same class.
+CMD_END='([[:space:]]|[;&|)<>]|$)'
+
 # git accepts global options between the program name and the subcommand,
 # so a literal `git`+space+`push` match is sidestepped by `git -C sub push`.
 # Strip them once, for MATCHING only; the command that runs is untouched.
+# The leading class matches CMD_START's separators, not just whitespace:
+# `git status;git -C sub gc` puts a `;` where the anchor wanted a space, and
+# every guard downstream would then read the un-normalised form.
 normalise_git() {
   printf '%s' "$1" | sed -E \
-    -e 's/(^|[[:space:]])git([[:space:]]+(-c[[:space:]]+[^[:space:]]+|-C[[:space:]]+[^[:space:]]+|--git-dir=[^[:space:]]+|--work-tree=[^[:space:]]+|--exec-path=[^[:space:]]*|--no-pager|--paginate|--bare|--literal-pathspecs))+/\1git/g' \
+    -e 's/(^|[[:space:];&|(])git([[:space:]]+(-c[[:space:]]+[^[:space:]]+|-C[[:space:]]+[^[:space:]]+|--git-dir=[^[:space:]]+|--work-tree=[^[:space:]]+|--exec-path=[^[:space:]]*|--no-pager|--paginate|--bare|--literal-pathspecs))+/\1git/g' \
     | tr -s ' '
 }
 
@@ -72,7 +85,7 @@ normalise_git() {
 # rule, so answering "ask" here would quietly downgrade that hard block to a
 # single keystroke. Re-emit the deny.
 is_hard_denied() {
-  printf '%s' "$1" | grep -qE "${CMD_START}podman[[:space:]]+(machine[[:space:]]+(rm|reset)|system[[:space:]]+reset)"
+  printf '%s' "$1" | grep -qE "${CMD_START}podman[[:space:]]+(machine[[:space:]]+(rm|reset)|system[[:space:]]+reset)${CMD_END}"
 }
 
 # Does one push's argument list name a ref shared with other checkouts?
@@ -86,7 +99,7 @@ push_touches_shared_ref() {
   # update it has not seen -- the accident a prompt here would guard -- and
   # it is routine after a merge. Bare --force/-f overwrites unconditionally.
   if ! printf '%s' "$args" | grep -qE '\-\-force-with-lease'; then
-    printf '%s' "$args" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
+    printf '%s' "$args" | grep -qE "(--force|[[:space:]]-f${CMD_END})" && return 0
   fi
   printf '%s' "$args" | grep -qE "(--all|--mirror|--tags)" && return 0
 
@@ -112,7 +125,7 @@ push_touches_shared_ref() {
 }
 
 is_globally_scoped() {
-  printf '%s' "$1" | grep -qE "${CMD_START}sudo[[:space:]]" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}sudo${CMD_END}" && return 0
 
   # `gh` reaches GitHub, which no worktree contains. Enumerating destructive
   # subcommands fails the wrong way -- `gh api -X DELETE` is the general form
@@ -124,16 +137,15 @@ is_globally_scoped() {
   # revokes a permission the user granted. Counting per invocation catches
   # `gh pr view && gh pr merge`, where matching the first would clear both.
   local gh_all gh_safe
-  gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]|$)" | wc -l | tr -d ' ' || true)
-  gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready|checkout|review)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+(view|clone)|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|search|auth[[:space:]]+status|--version|--help|-h)|([[:space:]]|$))([[:space:]]|$)" | wc -l | tr -d ' ' || true)
+  gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh${CMD_END}" | wc -l | tr -d ' ' || true)
+  gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready|checkout|review)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+(view|clone)|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|search|auth[[:space:]]+status|--version|--help|-h)|${CMD_END})${CMD_END}" | wc -l | tr -d ' ' || true)
   [ "$gh_all" -ne "$gh_safe" ] && return 0
 
   # Every push is examined, not just the first: stripping only to the first
   # occurrence let `git push origin feat/x && git push origin main` through.
-  local norm rest push_args
-  norm=$(normalise_git "$1")
-  rest=$norm
-  while printf '%s' "$rest" | grep -qE "${CMD_START}git[[:space:]]+push([[:space:]]|$)"; do
+  local rest push_args
+  rest=$1
+  while printf '%s' "$rest" | grep -qE "${CMD_START}git[[:space:]]+push${CMD_END}"; do
     rest=${rest#*git push}
     push_args=${rest%%&&*}
     push_args=${push_args%%||*}
@@ -159,32 +171,32 @@ mutates_shared_state() {
   # reachable by the SHA git prints -- protected because reflog expire / gc
   # below keep asking. `git tag -d` stays: nothing refuses that, and a tag is
   # how a release is addressed.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+tag[[:space:]]+(.*[[:space:]])?(-d|--delete)([[:space:]]|$)" && return 0
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|filter-branch)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+tag[[:space:]]+(.*[[:space:]])?(-d|--delete)${CMD_END}" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+(gc|prune|reflog[[:space:]]+expire|filter-branch)${CMD_END}" && return 0
 
   # ONE refs/stash for every worktree, and this project leans on stash for
   # branch isolation, so the shared stack is a live hazard.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash[[:space:]]+(clear|drop|pop)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+stash[[:space:]]+(clear|drop|pop)${CMD_END}" && return 0
 
   # Shared .git/config, and --global reaches ~/.gitconfig.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+config[[:space:]]+(.*[[:space:]])?(--global|--system)([[:space:]]|$)" && return 0
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+remote[[:space:]]+(set-url|remove|rm|rename|add)([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+config[[:space:]]+(.*[[:space:]])?(--global|--system)${CMD_END}" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+remote[[:space:]]+(set-url|remove|rm|rename|add)${CMD_END}" && return 0
 
   # Direct writes to the ref namespace. These MOVE a ref rather than delete
   # it, so nothing refuses them the way it refuses `branch -D`.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+branch[[:space:]]+(.*[[:space:]])?(-f|--force|-M|-m|--move)([[:space:]]|$)" && return 0
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+update-ref([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+branch[[:space:]]+(.*[[:space:]])?(-f|--force|-M|-m|--move)${CMD_END}" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+update-ref${CMD_END}" && return 0
   printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+symbolic-ref[[:space:]]+[^-][^[:space:]]*[[:space:]]+[^[:space:]]" && return 0
 
   # Plain `worktree remove` refuses a worktree holding uncommitted or
   # untracked files, so only --force can actually discard work.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+remove([[:space:]]|$)" &&
-    printf '%s' "$1" | grep -qE "(--force|[[:space:]]-f([[:space:]]|$))" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+remove${CMD_END}" &&
+    printf '%s' "$1" | grep -qE "(--force|[[:space:]]-f${CMD_END})" && return 0
 
   # `worktree prune` unregisters worktrees whose directory it cannot see --
   # which includes one that is merely unmounted or temporarily moved, not
   # only one that is really gone.
-  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+prune([[:space:]]|$)" && return 0
+  printf '%s' "$1" | grep -qE "${CMD_START}git[[:space:]]+worktree[[:space:]]+prune${CMD_END}" && return 0
 
   return 1
 }
@@ -220,17 +232,23 @@ decide() {
   }'
 }
 
-if is_hard_denied "$command"; then
+# Normalise ONCE, here, so every guard below matches the same string. Doing it
+# inside a single guard is what let `git -C sub gc`, `git -C sub stash drop`
+# and `git -c x=y config --global ...` through: only the push guard normalised,
+# so git's global options walked past every other one.
+normalised=$(normalise_git "$command")
+
+if is_hard_denied "$normalised"; then
   decide deny "Denied in settings.json: this destroys the shared podman VM that every worktree's E2E stack depends on. Being inside a disposable worktree does not contain it."
   exit 0
 fi
 
-if is_globally_scoped "$command"; then
+if is_globally_scoped "$normalised"; then
   decide ask "Not auto-allowed: this command's effect is global -- elevated privileges, a GitHub mutation, or a push that moves a shared ref (main, beta, beta-release-*, a tag). A worktree cannot contain it, so confirm explicitly."
   exit 0
 fi
 
-if mutates_shared_state "$command"; then
+if mutates_shared_state "$normalised"; then
   decide ask "Not auto-allowed: a linked worktree shares ONE object database, ref namespace, stash and .git/config with every other checkout, so this reaches outside '${session_root}' without naming a path. Confirm explicitly."
   exit 0
 fi

--- a/.claude/hooks/link-worktree-local-settings.sh
+++ b/.claude/hooks/link-worktree-local-settings.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# WorktreeCreate hook.
+# SessionStart hook.
 #
 # `.claude/settings.local.json` is gitignored (globally, via
 # `**/.claude/settings.local.json`), so it exists ONLY in the main checkout.
@@ -21,15 +21,19 @@
 # assumption about the hook's stdin shape, and self-heals worktrees that
 # predate this hook.
 #
-# Registered on two events, because there are two ways a worktree appears:
-#   WorktreeCreate -- native creation (EnterWorktree / --worktree). Fires
-#     before the session enters, so the link is in place when settings load.
-#   SessionStart   -- covers `git worktree add`, the git fallback path in
-#     superpowers:using-git-worktrees, which fires no WorktreeCreate at all.
-#     Settings are already loaded by the time SessionStart runs, so a
-#     fallback-created worktree picks its link up on its NEXT session; the
-#     fleet-wide sweep is what makes that self-correcting rather than
-#     permanent.
+# Registered on SessionStart ONLY, and deliberately not on WorktreeCreate.
+# WorktreeCreate looked like the better event -- it fires before the session
+# enters, so the link would be in place when settings load -- but that event
+# expects the hook to RETURN the worktree path on stdout, and a hook that
+# prints nothing breaks worktree creation outright: EnterWorktree fails with
+# "hook succeeded but returned no worktree path". A sweeping hook has no such
+# path to return.
+#
+# SessionStart also covers the case WorktreeCreate never did: `git worktree
+# add`, the fallback path in superpowers:using-git-worktrees, fires no
+# WorktreeCreate at all. Settings are already loaded by the time SessionStart
+# runs, so a new worktree picks its link up on its NEXT session; the
+# fleet-wide sweep is what makes that self-correcting rather than permanent.
 #
 # Scope note: .venv and frontend/node_modules have the same
 # doesn't-travel problem, but they are scripts/worktree-setup.sh's job

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -202,6 +202,50 @@ run ask "git remote set-url origin git@github.com:other/repo.git"
 run ask "git remote remove origin"
 run allow "git config --get user.email"
 
+echo "== a separator flush against the command word still terminates it =="
+# Every guard used to end in `([[:space:]]|$)`, which sees a SPACE or end of
+# string and nothing else. A `;` or `&&` written without a space before it is
+# neither, so each of these was AUTO-ALLOWED while its spaced spelling asked
+# -- the same bypass in every guard at once, reachable by deleting one space.
+run ask "git stash drop;"
+run ask "git stash drop; echo x"
+run ask "git stash clear;"
+run ask "git gc;"
+run ask "git gc&&echo x"
+run ask "git worktree prune;"
+run ask "git worktree prune&&echo x"
+run ask "git tag -d v1&&echo x"
+run ask "git update-ref refs/heads/main HEAD;"
+run ask "sudo;"
+run deny "podman machine rm;"
+# The spaced spelling of a compound must keep asking too: the guard fires on
+# the stash, not on the `checkout main` that follows it.
+run ask "git stash pop && git checkout main"
+# ...and a terminator must not manufacture a match out of a longer word.
+run allow "git stashfoo drop"
+run allow "git gcfoo"
+
+echo "== git global options must not slip past ANY guard =="
+# normalise_git strips git's global options for matching, but only the push
+# guard called it -- so every shared-state guard read the raw string and
+# `git -C sub <anything>` walked straight through. It is applied once, up
+# front, and every guard now matches the normalised form.
+run ask "git -C sub stash drop"
+run ask "git -C sub gc --prune=now"
+run ask "git -C sub tag -d v1.0.0"
+run ask "git -C sub config --global user.email x@y.z"
+run ask "git -C sub remote remove origin"
+run ask "git -C sub worktree prune"
+run ask "git -c core.x=1 stash clear"
+run ask "git --git-dir=sub/.git branch -f main HEAD"
+run ask "git --no-pager -C sub reflog expire --expire=now --all"
+# Normalisation is anchored like CMD_START, so a separator with no space
+# after it does not hide the `git` that follows.
+run ask "git status;git -C sub gc"
+# Ordinary work through a global option stays allowed.
+run allow "git -C sub status --short"
+run allow "git -C sub stash list"
+
 echo "== the main checkout keeps its own rules =="
 # In the main checkout the hook must stay silent so settings.json applies
 # unchanged -- an allow there would be the worst possible failure.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,17 +79,6 @@
         ]
       }
     ],
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}/.claude/hooks/link-worktree-local-settings.sh\"",
-            "statusMessage": "Linking local settings into the worktree"
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "hooks": [


### PR DESCRIPTION
Fixes two pre-existing bypasses in `auto-allow-worktree-destructive.sh` that the
review of #577 surfaced.

**This does not supersede #577.** That PR is a separate policy change (deny
`git stash` repo-wide, plus its CLAUDE.md section) and should still merge — on
top of this one, with the adjustment noted at the bottom.

The
first attempt at a fix replaced the whole hook with Claude Code's OS sandbox;
that does not work here, because `.claude/` is version-controlled in this repo
and the sandbox's default `denyWrite` covers it, so `git checkout`, a branch
switch and `git worktree add` all fail with "Operation not permitted". That
work stays on `chore/sandbox-migration` and is not being revived — `sandbox.enabled` stays off.

This PR is the minimal alternative: the two bugs, fixed, with the worktree
auto-allow design left intact. Removing auto-allow is not on the table —
that reintroduces the prompt-stall the hook exists to remove.

## 1. A shell separator did not terminate a command word

Every guard ended in `([[:space:]]|$)`, which sees a SPACE or end of string and
nothing else. A separator written flush against the last word is neither, so
each of these was **auto-allowed** while its spaced spelling asked — the same
bypass in every guard at once, reachable by deleting one space:

| command | before | after |
|---|---|---|
| `git stash drop;` | allow | ask |
| `git stash clear;` | allow | ask |
| `git gc;` / `git gc&&echo x` | allow | ask |
| `git worktree prune;` | allow | ask |
| `sudo;` | allow | ask |

Fixed with a shared `CMD_END` that treats shell separators as terminators —
mirroring what `CMD_START` already does at the front of a match — applied to
every guard, including the podman `deny`.

## 2. `normalise_git` was applied to exactly one guard

The helper strips git's global options so `git -C sub push` cannot sidestep a
`git push` match. Only the push guard called it. Every other guard read the raw
command, so git's own documented bypass class walked past all of them:

| command | before | after |
|---|---|---|
| `git -C sub stash drop` | allow | ask |
| `git -C sub gc --prune=now` | allow | ask |
| `git -C sub tag -d v1.0.0` | allow | ask |
| `git -C sub config --global user.email x@y.z` | allow | ask |
| `git -C sub remote remove origin` | allow | ask |
| `git -c core.x=1 stash clear` | allow | ask |
| `git --git-dir=sub/.git branch -f main HEAD` | allow | ask |

It is now applied **once**, up front, and all three guards match the normalised
string. Its own anchor was widened to `CMD_START`'s separator set, so
`git status;git -C sub gc` normalises too — otherwise fix 1 and fix 2 leave a
gap exactly where they meet.

## 3. `link-worktree-local-settings.sh` off the `WorktreeCreate` event

`WorktreeCreate` expects the hook to return a worktree path on stdout. This one
sweeps every linked worktree and has no such path to return, so registering it
there **broke worktree creation outright**:

```
EnterWorktree → WorktreeCreate hook failed: hook succeeded but returned no
worktree path (command: echo the path to stdout)
```

Reproduced on `main` in this session, and the hook is confirmed to write 0 bytes
to stdout. Its `SessionStart` registration — which is what actually links local
settings into worktrees, and covers the `git worktree add` path `WorktreeCreate`
never fired on — is unchanged.

## Verification

`bash .claude/hooks/tests/auto-allow-worktree-destructive.test.sh` — all checks
pass, including 26 new cases for 1 and 2 (`git stash pop && git checkout main`
and `git -C sub stash drop` among them). Every pre-existing case still passes
unchanged: no command that was allowed for a good reason now asks. The suite is
run by `scripts/quality-check.sh`.

The `EnterWorktree` fix could not be verified positively from here — a running
session reads `.claude/settings.json` from the main checkout, so the change only
takes effect once this merges. The negative case (the error above) is reproduced,
and the mechanical cause (empty stdout) is confirmed.

## Merge order with #577

Merge this first. #577 replaces the stash line in `mutates_shared_state` with a
new `uses_shared_stash` that runs before the worktree gate — and that new guard
is written in the old style, so it inherits **both** bugs fixed here:

| command | #577's `uses_shared_stash` |
|---|---|
| `git stash drop;` | missed → allow |
| `git -C sub stash pop` | missed → allow |
| `git -c x=y stash drop` | missed → allow |

Because #577 also deletes the old line, merging it unchanged would reopen these
bypasses for the one guard it most wants to be a hard `deny`. Rebasing it onto
this needs three things:

1. `uses_shared_stash` matches `${CMD_END}` instead of `([[:space:]]|$)`;
2. it reads `$normalised`, not `$command`;
3. the `normalised=` assignment is hoisted above the stash check, since that
   check deliberately runs before the worktree gate.

The two branches also conflict textually on exactly one hunk (the stash line in
`mutates_shared_state`) — resolve by taking #577's deletion.

## Deliberately not included

`guard-uncontained-effects.sh` and `verify-sandbox.sh` stay on the abandoned
sandbox branch — neither earns its keep without the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MA6r4XBD5piAR2YtvedvYk
