### PR TITLE
docs: record the two gate fixes queued behind Phase 4a

### DIFF
--- a/docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md
+++ b/docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md
@@ -684,6 +684,32 @@ from Phase 4** and becomes its own phase; see below.
 - **4a — capability model.** Per-platform lattice / mode vocabulary /
   minimum gear / load-following semantics, in a **new `PlatformCapabilities`**
   rather than folded into `BatterySettings` (D2). No candidate changes yet.
+
+  **Two gate fixes are queued behind 4a and should move with it** — both sit in
+  the value-estimator code D1 relocates, so landing either first means measuring
+  its delta twice:
+
+  - **#579 (open, `blocked`)** — `_record_marginal_value` snapped with `round()`
+    while `_interpolate_value` floors, so a SoE in the lower half of a cell was
+    priced off the cell below. Fixed and green; 142 of 2168 golden gate booleans
+    flip (141 opening). It introduces `_value_slope_below` as a **third** peer
+    dV/dSoE estimator — the behaviour change the "as-built" note above defers —
+    and a **new public `has_value_cell_below`** on `dp_battery_algorithm.py`
+    that the gate tests call so they stop mirroring the DP's index rule.
+    **4a should absorb both into `execution_model.py` rather than inherit them
+    at their current home.**
+  - **#571 (open, `blocked`, not yet fixed)** — a *different* defect at the same
+    seam: `np.round` snapping makes `V` locally non-concave and the gate reads
+    the corrupted cell. #579 does **not** fix it — at the reported state
+    `idx = 324.0` is exactly on a grid point, so `round()` and `ceil()-1` select
+    the same cell. Candidate fix is to read the slope off the upper concave
+    envelope; scored against a 0.005 kWh reference it roughly halves the error
+    on the 217 concavity-violating states without regressing the 1642 clean
+    ones. Reproduce from **period 58** of the bundle (horizon 134,
+    `initial_soe` 9.9), not period 59.
+
+  Neither *depends* on 4a technically — this is sequencing, and 4a's
+  behaviour-neutrality requirement is the reason.
 - **4b — discharge commands.** Candidates become executable discharge
   commands; folds in #511/#517's tests as regression cover. Closes #352
   **Shape B** with the exact-cover candidate, gated on 4a's load-following


### PR DESCRIPTION
## Summary

- Phase 4a relocates `intra_period_discharge_gate` into `core/bess/execution_model.py` (D1) and must stay behaviour-neutral so 4b's delta stays readable. Two open gate fixes sit in exactly that code and the plan didn't say so.
- Adds a queued-work block under **4a — capability model** naming both, with the one structural consequence 4a has to act on.

## Why this, and not just the issues

Both fixes were recorded only on their own issues and in a commit message. 4a's author has no reason to read either, and the plan is what a session reads first — the same failure mode #582 fixed for the stale Phase 4 figures.

## What it records

**#579 (open, `blocked`)** — the `round()`/`floor()` half-cell offset. Fixed and green, 142 of 2168 golden gate booleans flip. The part 4a must act on: it introduces `_value_slope_below` as a **third** peer dV/dSoE estimator, and a **new public** `has_value_cell_below` on `dp_battery_algorithm.py`, exposed so the gate tests stop mirroring the DP's index rule. Both are new surface on a module 4a is about to empty, so 4a should absorb them rather than inherit them.

**#571 (open, `blocked`, unfixed)** — recorded because it is easy to assume #579 closed it. It does not: at the reported state `idx = 324.0` is exactly on a grid point, so `round()` and `ceil()-1` select the same cell. Its mechanism is `np.round` snapping making `V` locally non-concave. The reproduce-from-**period 58** note is included because the period-59 fixture is a different run that matches nothing in the bundle — that already cost one session a wrong "does not reproduce" conclusion.

It also states plainly that **neither fix depends on 4a technically** — this is sequencing — so the hold can later be overruled on its merits rather than mistaken for a hard dependency.

## Test plan

- [x] `./scripts/quality-check.sh` passes (exit 0, 0 errors, 0 warnings)
- [x] Rendered the changed section and checked the list nesting survives — the block sits inside the `4a` bullet, so 4b/4c stay siblings

## Evidence the test discriminates

N/A — documentation only, no code or test changes. Nothing to mutate.

## Outcome-level coverage

N/A — no behaviour changes. The claims it records are pinned elsewhere: #579's 142-flip delta by the action-selector goldens on its own branch, and #571's numbers by the reproduction in its issue comment.

## Documentation

This PR *is* the documentation check for the two gate fixes. `docs/agents/bess-knowledge.md` was already updated by #579 for the mechanism it changed; `docs/SOFTWARE_DESIGN.md` mentions neither `shadow_price` nor the gate, so nothing to change there.

Refs #571, #579. Closes neither.