### PR TITLE
fix: allow read-only `gh api` in the worktree auto-allow hook

### DIFF
--- a/.claude/hooks/auto-allow-worktree-destructive.sh
+++ b/.claude/hooks/auto-allow-worktree-destructive.sh
@@ -191,9 +191,30 @@ is_globally_scoped() {
   # of settings.json's `gh` allow patterns, or a hook decision silently
   # revokes a permission the user granted. Counting per invocation catches
   # `gh pr view && gh pr merge`, where matching the first would clear both.
+  #
+  # `gh api` is on that safe list, but only in its read shape. gh sends GET
+  # unless the invocation says otherwise, and there are exactly two ways it
+  # can: `-X/--method` names a verb outright, and `-f/-F/--field/--raw-field/
+  # --input` attach a body, which flips the default to POST. A `gh api`
+  # segment carrying any of them is a mutation and still asks -- classified
+  # by the flags in the command, not by guessing what the endpoint does.
+  # Without this, one read-only `gh api` poisoned an otherwise safe chain:
+  # `gh pr view ... && gh api .../comments` counted 3 safe out of 4.
+  local rest api_args
+  rest=$1
+  while printf '%s' "$rest" | grep -qE "${CMD_START}gh[[:space:]]+api${CMD_END}"; do
+    rest=${rest#*gh api}
+    api_args=${rest%%&&*}
+    api_args=${api_args%%||*}
+    api_args=${api_args%%;*}
+    api_args=${api_args%%|*}
+    printf '%s' "$api_args" |
+      grep -qE "[[:space:]](-X|--method|-f|-F|--field|--raw-field|--input)([[:space:]]|=)" && return 0
+  done
+
   local gh_all gh_safe
   gh_all=$(printf '%s' "$1" | grep -oE "${CMD_START}gh${CMD_END}" | wc -l | tr -d ' ' || true)
-  gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready|checkout|review)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+(view|clone)|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|search|auth[[:space:]]+status|--version|--help|-h)|${CMD_END})${CMD_END}" | wc -l | tr -d ' ' || true)
+  gh_safe=$(printf '%s' "$1" | grep -oE "${CMD_START}gh([[:space:]]+(pr[[:space:]]+(view|list|diff|checks|status|create|edit|comment|ready|checkout|review)|issue[[:space:]]+(view|list|create|edit|comment|close|reopen)|run[[:space:]]+(view|list|watch)|release[[:space:]]+(view|list)|repo[[:space:]]+(view|clone)|workflow[[:space:]]+(view|list)|label[[:space:]]+(list|create)|api|search|auth[[:space:]]+status|--version|--help|-h)|${CMD_END})${CMD_END}" | wc -l | tr -d ' ' || true)
   [ "$gh_all" -ne "$gh_safe" ] && return 0
 
   # Every push is examined, not just the first: stripping only to the first

--- a/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
+++ b/.claude/hooks/tests/auto-allow-worktree-destructive.test.sh
@@ -122,7 +122,6 @@ run allow "git status --short"
 
 echo "== gh reaches GitHub, which no worktree contains =="
 run ask "gh api -X DELETE repos/o/r"
-run ask "gh api repos/o/r"
 run ask "gh workflow run issue-fix.yml"
 run ask "gh secret set FOO"
 run ask "gh repo edit --visibility private"
@@ -144,6 +143,30 @@ run allow "gh issue edit 558 --add-label analyzed"
 # Authoring first must still not clear a publishing invocation after it.
 run ask "gh pr create --draft --title x && gh pr merge 561"
 run allow "gh run watch 123"
+
+# `gh api` sends GET unless the invocation says otherwise, so the read shape
+# is as safe as `gh pr view` -- and asking on it was not free: one read-only
+# `gh api .../comments` in a four-part PR-review fetch made the whole chain
+# prompt. What still asks is classified by the flags present, not by reading
+# the endpoint: `-X/--method` names a verb, and a field/body flag flips gh's
+# own default to POST.
+run allow "gh api repos/o/r/pulls/572/comments"
+run allow "gh api repos/:owner/:repo/pulls/572/comments --jq '.[] | .body'"
+run allow "gh api --paginate -H 'Accept: application/vnd.github+json' repos/o/r/issues"
+run ask "gh api -X PATCH repos/o/r/issues/1"
+run ask "gh api --method POST repos/o/r/issues"
+# No -X, but a field flag makes gh POST anyway.
+run ask "gh api repos/o/r/issues -f title=x"
+run ask "gh api repos/o/r/issues -F body=@note.md"
+run ask "gh api repos/o/r/issues --field title=x"
+run ask "gh api repos/o/r/issues --raw-field title=x"
+run ask "gh api repos/o/r/issues --input payload.json"
+run ask "gh api graphql -f query='mutation { ... }'"
+# The whole point: a read-only `gh api` must not poison an otherwise safe
+# chain, and must not clear a mutating one either -- in both orders.
+run allow "gh pr view 572 --json title && gh api repos/o/r/pulls/572/comments"
+run ask "gh api repos/o/r/pulls/1/comments && gh pr merge 1"
+run ask "gh api repos/o/r/x && gh api -X DELETE repos/o/r/y"
 
 echo "== the shared stash is denied outright =="
 # ONE refs/stash per repository, shared by the main checkout and every


### PR DESCRIPTION
## Problem

`CLAUDE.md:292` specifies that only **non-GET** `gh api` should prompt. The hook had no `api` entry on its safe list at all, so every `gh api` asked — GETs included. The hook was stricter than its own spec.

This bites harder than one extra prompt. The check counts safe `gh` invocations against total ones, so a single read-only `gh api` poisons an otherwise-safe chain. Fetching a PR's reviews and comments matched 3 of 4 and stalled on a prompt.

## Fix

`api` joins the safe list, gated by a per-invocation scan for the flags that make `gh` mutate:

- `-X` / `--method` — names a verb outright
- `-f` / `-F` / `--field` / `--raw-field` / `--input` — attach a body, which flips gh's own default from GET to POST

A `gh api` segment carrying any of them still asks. The classification is by flags present in the command, never by guessing what an endpoint does — the shape rule this hook is built on, and the reason the old path-inference guard was removed.

## Tests

Drops the `gh api repos/o/r` → ask pin, which encoded the over-broad reading. Adds 14 cases covering read forms (`--jq`, `--paginate`, `-H`), each mutating flag individually, and mixed chains in both orders.

Full suite green. The original four-part command was verified `ask` → `allow` by diffing against the `HEAD` copy of the hook.

## Rollout

Hooks load at session start, so running sessions keep enforcing the old copy until this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQw1cQXpkQDZT8gdVjZLye
