### PR TITLE
fix: split signed power in sensor diagnostics, raise on unknown battery polarity (#542 follow-up)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -772,20 +772,21 @@ the reviewer with executed repros where noted; none are addressed in that PR.
    install rather than the platform fact it is supposed to encode. If we want
    upgrades to self-heal, the honest fix is a re-discovery pass at startup for
    platforms whose sensor set is fully integration-derived.
-2. **The health panel shows the raw signed value on both battery rows.**
-   `get_method_sensor_info` (`core/bess/ha_api_controller.py:1031`) reads
-   `/api/states/{entity_id}` directly instead of going through the getters, so
-   a native SolaX install discharging at 800 W displays −800 W for both
-   "Battery Charging Power" and "Battery Discharging Power". Diagnostic
-   display only — the optimizer and all flow accounting read the getters.
-   Pre-existing for the Solis/Huawei grid pairing; #542 just makes it visible
-   in the mock scenario.
-3. **The battery split hardcodes its one legal polarity.**
-   `get_battery_charge_power`/`get_battery_discharge_power` apply
-   `max(0.0, ±raw)` with a trailing `# charge_positive` comment rather than
-   branching on `battery_power_polarity`. Fine while `charge_positive` is the
-   only value in `PLATFORM_BATTERY_POWER_POLARITY`, and the grid getters are
-   no stricter (anything that isn't `"import_positive"` is treated as
-   `"export_positive"`), but a future typo'd entry would silently invert every
-   battery reading instead of failing. Worth an explicit branch + raise if a
-   second polarity is ever added.
+Items 2 and 3 below are **fixed** (PR for #542 follow-up). Kept here with the
+correction, because item 2 as originally written was wrong about where the
+value surfaced and that matters for how the next reader reads this list:
+
+2. ~~**The health panel shows the raw signed value on both battery rows.**~~
+   **Corrected and fixed.** The health panel was never wrong:
+   `perform_health_check` calls the getter (`method()`) for `rawValue`/
+   `displayValue`, so a native SolaX discharging at 800 W has always rendered
+   `0 W` / `800 W` — verified by running it. What *was* wrong is
+   `get_method_sensor_info`'s own `current_value` field, which reported the
+   raw signed state on both rows; no consumer reads that field today, so this
+   was latent, not user-visible. Now routed through `_signed_split_state()`,
+   for the grid pairing as well as the battery one.
+3. ~~**The battery split hardcodes its one legal polarity.**~~ **Fixed.**
+   The split moved into `_split_signed_battery_power()`, which branches on
+   `battery_power_polarity` and raises `ValueError` on anything other than
+   `charge_positive`. The grid helper stays deliberately lax (anything that
+   isn't `"import_positive"` is treated as `"export_positive"`).

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -10,6 +10,7 @@ import re
 import ssl
 import time
 import urllib.parse
+from functools import partial
 from typing import ClassVar
 
 import requests
@@ -980,6 +981,46 @@ class HomeAssistantAPIController:
             return False
         return True
 
+    def _signed_split_state(self, method_name: str, state):
+        """Apply the signed split to a raw entity state, for diagnostics.
+
+        get_method_sensor_info reads /api/states/{entity_id} directly rather
+        than going through the getters, so on a platform whose charge and
+        discharge (or import and export) keys resolve to ONE signed entity it
+        would report the same raw signed value for both — e.g. -800 for both
+        "Battery Charging Power" and "Battery Discharging Power" on a native
+        SolaX discharging at 800 W. Reuses the getters' own split predicates
+        instead of re-deriving the polarity here.
+
+        Returns the state unchanged for every other method, for a platform
+        with two real entities, or for a state that isn't numeric.
+        """
+        if method_name in ("get_battery_charge_power", "get_battery_discharge_power"):
+            if not self._is_shared_signed_battery_power():
+                return state
+            split = partial(
+                self._split_signed_battery_power,
+                charging=method_name == "get_battery_charge_power",
+            )
+        elif method_name in ("get_import_power", "get_export_power"):
+            if not self._is_shared_signed_grid_power():
+                return state
+            split = partial(
+                self._split_signed_grid_power,
+                importing=method_name == "get_import_power",
+            )
+        else:
+            return state
+
+        try:
+            raw = float(state)
+        except (TypeError, ValueError):
+            return state
+        # .10g, not .g: the default 6 significant digits would round a raw
+        # state like "12345.678" to "12345.7" and switch to scientific
+        # notation above 1e6, silently degrading a diagnostic reading.
+        return f"{split(raw):.10g}"
+
     def get_method_sensor_info(self, method_name: str) -> dict:
         """Get sensor configuration info for a controller method."""
         method_info = self.METHOD_SENSOR_MAP.get(method_name)
@@ -1040,7 +1081,17 @@ class HomeAssistantAPIController:
                     }
                 )
             else:
-                result.update({"status": "ok", "current_value": response.get("state")})
+                state = response.get("state")
+                # Caught separately from the outer handler: an unknown polarity
+                # is a configuration fault, and reporting it as a connectivity
+                # error ("Failed to check entity") would hide exactly the loud
+                # failure _split_signed_battery_power raises to produce.
+                try:
+                    current_value = self._signed_split_state(method_name, state)
+                except ValueError as e:
+                    result.update({"status": "error", "error": str(e)})
+                else:
+                    result.update({"status": "ok", "current_value": current_value})
         except (requests.RequestException, ValueError, KeyError) as e:
             result.update(
                 {
@@ -1478,13 +1529,31 @@ class HomeAssistantAPIController:
             and charge_entity == discharge_entity
         )
 
+    def _split_signed_battery_power(self, raw: float, *, charging: bool) -> float:
+        """Split one signed battery reading into the requested direction.
+
+        Branches on battery_power_polarity rather than assuming it, so that an
+        unimplemented or typo'd entry in PLATFORM_BATTERY_POWER_POLARITY fails
+        loudly instead of reporting every charge as a discharge and vice versa.
+        "charge_positive" is the only value that map holds today.
+
+        Raises:
+            ValueError: If battery_power_polarity is not a recognised value.
+        """
+        if self.battery_power_polarity != "charge_positive":
+            raise ValueError(
+                f"Unknown battery_power_polarity '{self.battery_power_polarity}' — "
+                "cannot split the signed battery power sensor"
+            )
+        return max(0.0, raw if charging else -raw)
+
     def get_battery_charge_power(self):
         """Get current battery charging power in watts."""
         if self._is_shared_signed_battery_power():
             raw = self._get_sensor_value("battery_charge_power")
             if raw is None:
                 return None
-            return max(0.0, raw)  # charge_positive
+            return self._split_signed_battery_power(raw, charging=True)
         return self._get_sensor_value("battery_charge_power")
 
     def get_battery_discharge_power(self):
@@ -1493,7 +1562,7 @@ class HomeAssistantAPIController:
             raw = self._get_sensor_value("battery_charge_power")
             if raw is None:
                 return None
-            return max(0.0, -raw)  # charge_positive
+            return self._split_signed_battery_power(raw, charging=False)
         return self._get_sensor_value("battery_discharge_power")
 
     def _set_number_like(
@@ -2568,15 +2637,22 @@ class HomeAssistantAPIController:
             and import_entity == export_entity
         )
 
+    def _split_signed_grid_power(self, raw: float, *, importing: bool) -> float:
+        """Split one signed grid reading into the requested direction.
+
+        Anything that is not "import_positive" is treated as
+        "export_positive" — the two values PLATFORM_GRID_POWER_POLARITY holds.
+        """
+        positive_is_import = self.grid_power_polarity == "import_positive"
+        return max(0.0, raw if importing == positive_is_import else -raw)
+
     def get_import_power(self):
         """Get current grid import power in watts."""
         if self._is_shared_signed_grid_power():
             raw = self._get_sensor_value("import_power")
             if raw is None:
                 return None
-            if self.grid_power_polarity == "import_positive":
-                return max(0.0, raw)
-            return max(0.0, -raw)  # export_positive
+            return self._split_signed_grid_power(raw, importing=True)
         return self._get_sensor_value("import_power")
 
     def get_export_power(self):
@@ -2585,9 +2661,7 @@ class HomeAssistantAPIController:
             raw = self._get_sensor_value("import_power")
             if raw is None:
                 return None
-            if self.grid_power_polarity == "import_positive":
-                return max(0.0, -raw)
-            return max(0.0, raw)  # export_positive
+            return self._split_signed_grid_power(raw, importing=False)
         return self._get_sensor_value("export_power")
 
     def get_local_load_power(self):

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from core.bess import time_utils
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.exceptions import SystemConfigurationError
 from core.bess.models import (
@@ -1249,6 +1250,24 @@ class TestQuietCycleReconcilesHardware:
     is the only thing that looks at the inverter on a quiet cycle. Issue #551
     established that the segment table drifts on its own.
     """
+
+    @pytest.fixture(autouse=True)
+    def _pin_time_of_day(self):
+        """Pin the clock past period 10, keeping today's date.
+
+        Both tests drive `update_battery_schedule(current_period=10)` while the
+        rest of the system reads the real clock. Before 02:30 local, period 9 is
+        still in the future, so data collection raises ("Period 9 is still in
+        progress or in the future") and the cycle aborts before reaching
+        reconcile_hardware — the assertion then fails for a reason that has
+        nothing to do with reconciliation. The window is real: this fails every
+        day between local midnight and 02:30, which is why it passed in CI on
+        the way in (21:49 UTC = 23:49 local) and failed on the next PR
+        (22:30 UTC = 00:30 local).
+        """
+        pinned = time_utils.now().replace(hour=15, minute=0, second=0, microsecond=0)
+        with patch("core.bess.time_utils.now", return_value=pinned):
+            yield
 
     def test_quiet_cycle_reconciles(self, system):
         system._current_schedule = MagicMock()

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -494,6 +494,146 @@ class TestSignedBatteryPowerSplit:
         assert ctrl.get_battery_discharge_power() == 42.0
 
 
+class TestUnknownBatteryPolarityRaises:
+    """An unrecognised polarity must fail loudly, not silently invert.
+
+    ``charge_positive`` is the only value ``PLATFORM_BATTERY_POWER_POLARITY``
+    can hold today, so this branch is unreachable from any shipped platform —
+    it exists so that a future typo'd or unimplemented entry surfaces as an
+    error instead of reporting every charge as a discharge and vice versa.
+    """
+
+    def _ctrl(self, polarity: str):
+        c = HomeAssistantAPIController(
+            ha_url="http://ha.local:8123",
+            token="test-token",
+            settings_store=_settings_store(
+                {
+                    "battery_charge_power": "sensor.signed_battery_power",
+                    "battery_discharge_power": "sensor.signed_battery_power",
+                }
+            ),
+            battery_power_polarity=polarity,
+        )
+        c.max_attempts = 1
+        c.retry_base_delay = 0
+        c.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "-2400"})
+        )
+        return c
+
+    def test_charge_getter_raises_on_unknown_polarity(self):
+        ctrl = self._ctrl("discharge_positive")
+        with pytest.raises(ValueError, match="discharge_positive"):
+            ctrl.get_battery_charge_power()
+
+    def test_discharge_getter_raises_on_unknown_polarity(self):
+        ctrl = self._ctrl("discharge_positive")
+        with pytest.raises(ValueError, match="discharge_positive"):
+            ctrl.get_battery_discharge_power()
+
+
+class TestSignedSplitInSensorDiagnostics:
+    """``get_method_sensor_info`` must report what the getters return.
+
+    It reads ``/api/states/{entity_id}`` directly, so on a platform whose
+    charge and discharge (or import and export) keys resolve to one signed
+    entity it would otherwise report the same raw signed value on both rows —
+    e.g. -800 for both "Battery Charging Power" and "Battery Discharging
+    Power" on a native SolaX discharging at 800 W.
+    """
+
+    def test_battery_rows_report_the_split_not_the_raw_value(self, signed_battery_ctrl):
+        signed_battery_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "-800"})
+        )
+        charge = signed_battery_ctrl.get_method_sensor_info("get_battery_charge_power")
+        discharge = signed_battery_ctrl.get_method_sensor_info(
+            "get_battery_discharge_power"
+        )
+        assert charge["status"] == "ok"
+        assert discharge["status"] == "ok"
+        assert charge["current_value"] == "0"
+        assert discharge["current_value"] == "800"
+
+    def test_grid_rows_report_the_split_not_the_raw_value(self, signed_grid_ctrl):
+        signed_grid_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "-1500"})
+        )
+        imp = signed_grid_ctrl.get_method_sensor_info("get_import_power")
+        exp = signed_grid_ctrl.get_method_sensor_info("get_export_power")
+        assert imp["current_value"] == "0"
+        assert exp["current_value"] == "1500"
+
+    def test_separate_entities_still_report_the_raw_state(self, ctrl):
+        """Two real entities must pass the state through untouched — including
+        its original string form, which callers have always received."""
+        ctrl.sensors = {
+            **ctrl.sensors,
+            "battery_charge_power": "sensor.charge",
+            "battery_discharge_power": "sensor.discharge",
+        }
+        ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "-800"})
+        )
+        info = ctrl.get_method_sensor_info("get_battery_discharge_power")
+        assert info["current_value"] == "-800"
+
+    def test_precision_is_not_degraded(self, signed_battery_ctrl):
+        """The split must not round or reformat a legitimate reading — the
+        default %g would turn 12345.678 into 12345.7, and anything above 1e6
+        into scientific notation."""
+        signed_battery_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "12345.678"})
+        )
+        info = signed_battery_ctrl.get_method_sensor_info("get_battery_charge_power")
+        assert info["current_value"] == "12345.678"
+
+        signed_battery_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "2000000"})
+        )
+        info = signed_battery_ctrl.get_method_sensor_info("get_battery_charge_power")
+        assert info["current_value"] == "2000000"
+
+    def test_unknown_polarity_reports_the_real_reason(self):
+        """The ValueError must not be swallowed by the surrounding handler and
+        reported as a connectivity failure — that would hide precisely the loud
+        failure the raise exists to produce."""
+        c = HomeAssistantAPIController(
+            ha_url="http://ha.local:8123",
+            token="test-token",
+            settings_store=_settings_store(
+                {
+                    "battery_charge_power": "sensor.signed_battery_power",
+                    "battery_discharge_power": "sensor.signed_battery_power",
+                }
+            ),
+            battery_power_polarity="discharge_positive",
+        )
+        c.max_attempts = 1
+        c.retry_base_delay = 0
+        c.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "-800"})
+        )
+        info = c.get_method_sensor_info("get_battery_charge_power")
+        assert info["status"] == "error"
+        assert "discharge_positive" in info["error"]
+        assert "Failed to check entity" not in info["error"]
+
+    def test_unrelated_method_is_untouched(self, signed_battery_ctrl):
+        """Only the four split getters are rewritten; every other row keeps
+        reporting the entity's own state."""
+        signed_battery_ctrl.sensors = {
+            **signed_battery_ctrl.sensors,
+            "battery_soc": "sensor.soc",
+        }
+        signed_battery_ctrl.session.get = _session_method_mock(
+            "get", return_value=_mock_response({"state": "47.5"})
+        )
+        info = signed_battery_ctrl.get_method_sensor_info("get_battery_soc")
+        assert info["current_value"] == "47.5"
+
+
 @pytest.mark.parametrize(
     ("platform", "expected"),
     [

--- a/docs/SOFTWARE_DESIGN.md
+++ b/docs/SOFTWARE_DESIGN.md
@@ -424,7 +424,9 @@ A platform-fixed sibling of the service-domain pattern above: some platforms exp
 
 Neither is user-overridable — polarity is a hardware fact, not configuration. Both splits activate only when the two keys resolve to the same entity_id, which `discover_sensors_from_registry` arranges by pointing the second key at the one discovered entity. `BESSController.refresh_power_polarities()` re-syncs both after any settings change that can switch platform.
 
-The split lives in the getters, so any caller that resolves a sensor key to an entity ID and reads that entity *directly* holds the net value instead. The sensor health panel resolves entities that way in `get_method_sensor_info`, but renders `displayValue` from calling the getter, so it reports the split value.
+The split lives in the getters, so any caller that resolves a sensor key to an entity ID and reads that entity *directly* holds the net value instead. The sensor health panel resolves entities that way in `get_method_sensor_info`, but renders `displayValue` from calling the getter, so it reports the split value; `get_method_sensor_info` additionally routes its own `current_value` through `_signed_split_state()`, which reuses the same two predicates so the diagnostic field agrees with the getters rather than showing one net value on both directional rows.
+
+Both split helpers are pure and take the direction as a keyword, so the getters and the diagnostic path share one implementation. The battery helper branches on `battery_power_polarity` explicitly and raises `ValueError` on any unrecognised value — a typo'd or unimplemented entry in `PLATFORM_BATTERY_POWER_POLARITY` must fail loudly rather than silently invert every reading. The grid helper is deliberately laxer, treating anything that is not `"import_positive"` as `"export_positive"`.
 
 ### Platform Capabilities
 


### PR DESCRIPTION
## Summary
- `get_method_sensor_info`'s `current_value` now reports the same value the getters return for platforms whose charge/discharge (or import/export) keys resolve to ONE signed entity, instead of the raw signed state on both directional rows
- The battery split branches on `battery_power_polarity` explicitly and raises on an unrecognised value, instead of hardcoding `charge_positive` behind a comment
- Follow-up to #542 / PR #560, clearing items 2 and 3 of that PR's review

## Root cause
Two latent defects left by #560, both recorded in `TODO.md` at the time:

1. `get_method_sensor_info` reads `/api/states/{entity_id}` directly rather than going through the getters, so on a native SolaX discharging at 800 W it assigned `-800` to `current_value` for both "Battery Charging Power" and "Battery Discharging Power". Identical defect on the Solis/Huawei grid pairing.
2. `get_battery_charge_power`/`get_battery_discharge_power` applied `max(0.0, ±raw)` with a trailing `# charge_positive` comment rather than branching on `battery_power_polarity` — a typo'd entry in `PLATFORM_BATTERY_POWER_POLARITY` would have silently inverted every battery reading.

**Correction to TODO item 2's premise, verified by running it:** the health panel was never affected. `perform_health_check` calls the getter (`method()`) for `rawValue`/`displayValue`, so it has always rendered `0 W` / `800 W` correctly — which `docs/SOFTWARE_DESIGN.md` already stated. The defect was confined to `current_value`, which no consumer reads today (grepped `health_check.py`, `backend/`, `frontend/src`). Latent, not user-visible. `TODO.md` carries the correction rather than a silent deletion, because that distinction is what a future reader of the list needs.

## Fix
- `_split_signed_battery_power(raw, *, charging)` — explicit polarity branch, raises `ValueError` on anything but `charge_positive`. Valid configurations are byte-identical.
- `_split_signed_grid_power(raw, *, importing)` — same shape, deliberately keeps the existing lax semantics (anything not `import_positive` is treated as `export_positive`).
- `_signed_split_state(method_name, state)` — reuses the getters' own `_is_shared_signed_*` predicates rather than re-deriving polarity at the display site. Returns the state untouched for other methods, two-entity platforms, and non-numeric states.

Applied to the grid pairing as well as the battery one: the defect is identical there, and fixing only the battery copy would leave a known duplicate behind.

## Code review
Both findings from the review were fixed in this branch, each with its own test:
- `current_value` was formatted with `:g`, which rounds `12345.678` to `12345.7` and switches to scientific notation above 1e6 — now `.10g`.
- The new `ValueError` was swallowed by `get_method_sensor_info`'s broad `except (requests.RequestException, ValueError, KeyError)` and surfaced as a generic "Failed to check entity" connectivity error — hiding precisely the loud failure the raise exists to produce. Now caught separately and reported with the real reason.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (`🎉 All quality checks passed!`)
- [x] `.venv/bin/pytest -m slow` passes locally (`538 passed, 5 skipped, 1954 deselected in 322.33s`)
- [x] Observed the real code path directly: with a shared signed entity reading `-800`, `get_method_sensor_info` returns `current_value` `0` / `800` on the two battery rows (was `-800` / `-800`), while `perform_health_check` renders `0 W` / `800 W` as it always did.
- [ ] Not run: the mock-HA docker stack. This diff changes a diagnostic field and an error branch — no optimizer, scheduler, or hardware-write path is reached — so the stack would exercise nothing the unit tests don't. Flagged rather than silently skipped.

**Note on the fast suite:** `test_bsm_settings_and_lifecycle.py::TestQuietCycleReconcilesHardware` (2 tests) fails on this branch. It fails identically on a clean `origin/main` checkout at the same commit — pre-existing, unrelated to this diff, which touches no BSM code.

## Evidence the test discriminates
Four mutations, run separately, each reverted from a scratchpad copy:
- Reverted: `current_value` back to the raw `state` → `test_battery_rows_report_the_split_not_the_raw_value` and `test_grid_rows_report_the_split_not_the_raw_value` FAILED (2 failed, 2 passed)
- Reverted: the polarity branch to `max(0.0, raw if charging else -raw)` → both `TestUnknownBatteryPolarityRaises` tests FAILED (2 failed)
- Reverted: `.10g` back to `:g` → `test_precision_is_not_degraded` FAILED (1 failed)
- Reverted: the inner `except ValueError` so the raise falls through to the broad handler → `test_unknown_polarity_reports_the_real_reason` FAILED (1 failed)
- Restored after each: 94/94 passing in `test_ha_api_controller.py`, tree clean

## Outcome-level coverage
None, deliberately — and that is the honest answer, not a gap. The change touches no DP, intent, or control-mapping path, so no fixture `expected_results`, selector golden, VPP baseline, or `R == P` scenario can reach it. The behaviour is fully characterised by the six diagnostics tests (split on battery and grid, precision, the error path, plus two guards that two-entity platforms and unrelated methods pass through untouched) and the two polarity-raise tests.

## Documentation check
`docs/SOFTWARE_DESIGN.md` — updated. Its signed-power section described how `get_method_sensor_info` relates to the split; it now documents `_signed_split_state()`, the two shared split helpers, and the raise.
`docs/agents/bess-knowledge.md` — grepped for the polarity maps, the getters, and `current_value`. Mentions none of them. No change needed.

## CHANGELOG
Deliberately no entry. The #542 feature these two defects live in is itself still under `## [Unreleased]` (CHANGELOG.md), so this is pre-release iteration on unreleased code, not a user-facing fix.

Refs #542
