### PR TITLE
chore: align the Ruff target with the 3.13 base (#610 follow-up)

### DIFF
--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import traceback
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, ClassVar
 
 from . import time_utils
@@ -1412,7 +1412,6 @@ class BatterySystemManager:
         the flat "sensor" strategy, this captures intra-day variation
         (morning/evening peaks, overnight baseline).
         """
-        from datetime import timezone
 
         target_sensor, stats = self._fetch_ha_statistics_raw()
         tz = time_utils.TIMEZONE
@@ -1430,7 +1429,7 @@ class BatterySystemManager:
                 if isinstance(start_val, (int, float)):
                     # HA returns millisecond epoch timestamps
                     ts = start_val / 1000 if start_val > 1e12 else start_val
-                    dt = datetime.fromtimestamp(ts, tz=timezone.utc).astimezone(tz)
+                    dt = datetime.fromtimestamp(ts, tz=UTC).astimezone(tz)
                 else:
                     dt = datetime.fromisoformat(str(start_val)).astimezone(tz)
                 hourly_buckets[dt.hour].append(float(change))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ exclude = [
     "frontend",
     "node_modules",
 ]
-target-version = "py310"
+target-version = "py313"
 
 [tool.ruff.lint.isort]
 known-first-party = ["core", "app"]

--- a/scripts/mock_ha/server.py
+++ b/scripts/mock_ha/server.py
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 import re
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -141,7 +141,7 @@ def _real_recorder_statistics(
     # caller, _fetch_ha_statistics_raw, builds them with an explicit tzinfo),
     # but fall back to UTC rather than the host's local zone if that ever
     # isn't true.
-    fallback_tz = start_dt.tzinfo or timezone.utc
+    fallback_tz = start_dt.tzinfo or UTC
     filtered = []
     for entry in stats:
         start_val = entry.get("start")


### PR DESCRIPTION
## Summary

- Bumps `[tool.ruff] target-version` from `py310` to `py313`, the last live version marker left behind by #610.
- Applies the two `UP017` findings that bump surfaces, plus the dead import each one stranded.

## Root cause

#610 recovered the Python 3.13 add-on base and moved every *runtime* marker to 3.13 — `build.json`, `release-addon.yml`, `docker-compose.prod-test.yml`, the `Dockerfile` ARG, `.python-version`, the Stage 3/5 bot workflows, mock-HA — and, on review feedback, `[tool.mypy] python_version`.

It left the *lint* config on `py310`. That is not cosmetic: `target-version` is what tells Ruff which language features the interpreter has, so at `py310` it withholds every modernization that needs 3.11+. The repo was shipping on 3.13 while being linted as though it were 3.10.

The Stage 4 review on #610 flagged the mypy marker as a possible follow-up and did not spot this one.

## Fix

`py310` → `py313` on `[tool.ruff] target-version`, then `ruff check --fix`. That reported **6 fixes across 2 files**, which is more than the 2 `UP017` diagnostics suggest — the alias swap strands the imports that existed only to supply the old spelling:

- `core/bess/battery_system_manager.py:1433` — `timezone.utc` → `UTC`, retiring a function-local `from datetime import timezone` into the module-level import.
- `scripts/mock_ha/server.py:144` — same swap, `timezone` dropped from the existing module-level import.

**`[tool.black] target-version` is deliberately NOT bumped.** It is the same drift, but measured it buys nothing and costs something:

| | py310 (kept) | py313 |
|---|---|---|
| files reformatted | 0 of 223 | 0 of 223 |
| CI (`ci.yml` is on 3.13) | clean | clean |
| local run | clean | warns every run |

The warning is `Python 3.12 cannot parse code formatted for Python 3.13` — the shared `.venv` is still 3.12.13 while `.python-version` says 3.13.14. That venv recreation is the outstanding item #610 already flagged; this PR does not depend on it, and bumping Black would make every local `quality-check.sh` noisy until it happens. Worth doing in the same PR that recreates the venv.

## Test plan

- [x] `./scripts/quality-check.sh` — 0 errors, 0 warnings
- [x] Fast suite — 1962 passed, 50 skipped
- [x] Slow suite — 543 passed, 7 skipped
- [x] `ruff check .` clean at the new target (was 2 errors before the fix)

## Evidence the test discriminates

**No test is added, and that is the claim being made — not an omission.** The change is a provable identity, not a behaviour change:

```
$ python -c "from datetime import UTC, timezone; print(UTC is timezone.utc)"
True
```

`datetime.UTC` is not an equivalent object to `timezone.utc`; it is the *same singleton* under a name added in 3.11. There is no input for which the two expressions differ, so no test can be written that passes after this diff and fails before it. A test asserting otherwise would be vacuous — the failure mode this repo has hit three times.

This matters because `battery_system_manager.py` is on the control-mapping path, where the `implement-issue` protocol requires a plan-faithfulness (`R == P`) scenario test rather than a unit test. That requirement is about changes to behaviour; the existing suites (543 slow tests, which do exercise this path) passing unchanged is the appropriate evidence for a no-op.

## Outcome-level coverage

None added, because no outcome moved — see above. The existing scenario fixtures and goldens already cover `battery_system_manager.py`'s consumption-forecast path and are unchanged by this diff, which is the positive signal that the alias swap is inert.

## Documentation check

Grepped `docs/agents/bess-knowledge.md` and `docs/SOFTWARE_DESIGN.md` for the touched symbols (`timezone.utc`, `_fetch_ha_statistics_raw`, the consumption-forecast strategy). Neither documents the datetime spelling or the lint target, so there is nothing to update.

## CHANGELOG

No entry. This is a lint-configuration alignment with zero user-visible effect — the class of pure-internal change the changelog deliberately omits.

Refs #610, #547.