### PR TITLE
fix: round the charge command up so it delivers the planned charge (Phase 4c, narrow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Grid charging now reaches the planned amount instead of stopping just short** — the charge rate is written as a whole percent, and rounding it down meant the battery charged slightly less than the plan counted on.
 - **The battery now covers house load exactly instead of exporting a few Wh and committing the inverter** — a period whose load fell between two discharge steps was planned as a small export, which forces `grid_first` at a fixed rate and imports any load spike. ([#352](https://github.com/johanzander/bess-manager/issues/352))
 - **Huawei, native SolaX and Solis installs no longer report a discharge as negative charging, or an export as negative import** — the signed battery/grid sensor split now works on settings saved before the sensor pairing existed, with no wizard re-run. ([#604](https://github.com/johanzander/bess-manager/issues/604))
 - **The battery schedule no longer varies between otherwise identical runs** — when two plans were worth exactly the same, the optimizer picked between them on floating-point noise, so the same day could plan differently on different machines. ([#606](https://github.com/johanzander/bess-manager/issues/606))

--- a/core/bess/action_selector.py
+++ b/core/bess/action_selector.py
@@ -176,7 +176,7 @@ def _residual_cover_p(
       nearest and a ceiling rounded *down* under-delivers the plan (repro:
       residual 0.12 kW -> 1% of 10 kW = 0.10 kW ceiling -> realized 0.10 for
       a planned 0.12). The write path now rounds ceilings up
-      (`execution_model.discharge_command_index`), so the whole round-DOWN
+      (`execution_model.command_index`), so the whole round-DOWN
       band is executable and the gate reduces to "is the ceiling
       commandable at all", i.e. at or below 100%. Rejecting 39% of the
       corpus's deficits was never the intent; it was the conversion's

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -65,7 +65,11 @@ from core.bess.dp_constants import (
     POWER_STEP_KW,
     SOE_STEP_KWH,
 )
-from core.bess.execution_model import DEFAULT_CAPABILITIES, PlatformCapabilities
+from core.bess.execution_model import (
+    DEFAULT_CAPABILITIES,
+    PlatformCapabilities,
+    lattice_grid_charge,
+)
 from core.bess.models import (
     EconomicData,
     EconomicSummary,
@@ -372,6 +376,16 @@ def _period_flows(
             grid_to_battery = min(
                 grid_to_battery, max(0.0, import_cap_kwh - grid_imported)
             )
+            # Only under the cap: with the cap binding, nothing physical
+            # stops the command overshooting, so the plan must come down to
+            # the lattice instead (4c).
+            grid_to_battery = float(
+                lattice_grid_charge(
+                    solar_to_battery,
+                    grid_to_battery,
+                    battery_settings.max_charge_power_kw / 100 * dt,
+                )
+            )
         energy_stored = (
             solar_to_battery + grid_to_battery
         ) * battery_settings.efficiency_charge
@@ -489,6 +503,15 @@ def _state_transition(
             grid_to_battery = min(
                 grid_to_battery, max(0.0, import_cap_kwh - load_import)
             )
+            # Same quantization as the flow record, so the state transition
+            # and the flows agree on what was charged (4c).
+            grid_to_battery = float(
+                lattice_grid_charge(
+                    solar_to_battery,
+                    grid_to_battery,
+                    battery_settings.max_charge_power_kw / 100 * dt,
+                )
+            )
         charge_energy = (
             solar_to_battery + grid_to_battery
         ) * battery_settings.efficiency_charge
@@ -561,6 +584,13 @@ def _state_transition_grid(
         )
         grid_to_battery = np.minimum(
             grid_to_battery, np.maximum(0.0, import_cap_kwh - load_import)
+        )
+        # Mirrors the replay's quantization so both passes value the same
+        # charge (4c) -- the one-action-set requirement on the charge side.
+        grid_to_battery = lattice_grid_charge(
+            solar_to_battery,
+            grid_to_battery,
+            battery_settings.max_charge_power_kw / 100 * dt,
         )
     store_charge_energy = (solar_to_battery + grid_to_battery) * eff_charge
     store_next_soe = np.minimum(max_soe, soe + store_charge_energy)
@@ -655,6 +685,12 @@ def _compute_reward_grid(
         # the house fuse's import cap (#429).
         grid_to_battery = np.minimum(
             grid_to_battery, np.maximum(0.0, import_cap_kwh - grid_imported_store)
+        )
+        # Same quantization as the other three sites (4c).
+        grid_to_battery = lattice_grid_charge(
+            solar_to_battery,
+            grid_to_battery,
+            battery_settings.max_charge_power_kw / 100 * dt,
         )
     energy_stored_store = (solar_to_battery + grid_to_battery) * eff_charge
     battery_wear_cost_store = energy_stored_store * cycle_cost

--- a/core/bess/execution_model.py
+++ b/core/bess/execution_model.py
@@ -210,8 +210,8 @@ def lattice_grid_charge(solar_to_battery, grid_to_battery, charge_step_kwh):
     Only a grid-charging period needs this. `INTENT_TO_CONTROL` writes a flat
     `charge_rate: 100` for SOLAR_STORAGE and IDLE, so their plan is never
     scaled and never rounds; GRID_CHARGING is the one intent whose rate is
-    derived from the plan itself (`_compute_charge_rate` ->
-    `_scale_to_percent`, nearest). A planned power between two steps is
+    derived from the plan itself (`_compute_charge_rate`, which rounded to
+    nearest until 4c). A planned power between two steps was
     therefore written as the step *below* and the inverter charges less than
     the plan assumed -- measured pre-fix as 4 of 493 charging periods, worst
     -0.0288 kWh.
@@ -234,8 +234,8 @@ def lattice_grid_charge(solar_to_battery, grid_to_battery, charge_step_kwh):
     Accepts scalars or arrays; returns the matching shape. Where no grid
     top-up is planned the value passes through untouched.
 
-    The step is `max_charge_power_kw / 100` to mirror `_scale_to_percent`
-    exactly. A declared per-platform charge resolution (the charge-side twin
+    The step is `max_charge_power_kw / 100`, matching what the controller
+    scales against. A declared per-platform charge resolution (the charge-side twin
     of `discharge_resolution_kw`) does not exist yet -- that belongs with the
     full P3 charge work, which also has to stop `_period_flows` deriving
     throughput from nominal power.

--- a/core/bess/execution_model.py
+++ b/core/bess/execution_model.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any
 
+import numpy as np
+
 from .dp_constants import POWER_CLASSIFICATION_THRESHOLD_KW
 from .settings import BatterySettings
 
@@ -110,7 +112,7 @@ def intra_period_discharge_gate(allowed: bool) -> int:
 # by float dust: 2.70 kW on a 0.15 kW step is index 18, not 19.
 #
 # One owner, per P5. Every site that floors or ceilings a power onto the
-# percent lattice uses this: `discharge_command_index` below,
+# percent lattice uses this: `command_index` below,
 # `action_selector._discharge_candidates`' `max_pct`, and both of
 # `pwl_window_dp`'s mirrors of that arithmetic -- where it is re-exported as
 # `DISCHARGE_LATTICE_PCT_EPS`, whose comment records the #450 constraint that
@@ -124,7 +126,7 @@ def intra_period_discharge_gate(allowed: bool) -> int:
 LATTICE_EPS = 1e-9
 
 
-def discharge_command_index(
+def command_index(
     power_kw: float,
     step_kw: float,
     *,
@@ -188,6 +190,52 @@ def discharge_command_index(
     raw = power_kw / step_kw
     index = math.ceil(raw - LATTICE_EPS) if rate_is_ceiling else round(raw)
     return min(max_index, max(0, int(index)))
+
+
+def lattice_grid_charge(solar_to_battery, grid_to_battery, charge_step_kwh):
+    """A planned grid top-up, reduced so the **total** charge lands on the
+    command lattice (Phase 4c, narrow fix).
+
+    Only a grid-charging period needs this. `INTENT_TO_CONTROL` writes a flat
+    `charge_rate: 100` for SOLAR_STORAGE and IDLE, so their plan is never
+    scaled and never rounds; GRID_CHARGING is the one intent whose rate is
+    derived from the plan itself (`_compute_charge_rate` ->
+    `_scale_to_percent`, nearest). A planned power between two steps is
+    therefore written as the step *below* and the inverter charges less than
+    the plan assumed -- measured pre-fix as 4 of 493 charging periods, worst
+    -0.0288 kWh.
+
+    The reduction lands on the grid component, never on solar: the total is
+    what gets scaled (`battery_action` is `solar_to_battery +
+    grid_to_battery`), but solar is free and already in the battery's reach,
+    so giving up grid energy is the cheap side. Quantizing solar as well
+    would floor 311 further periods and discard 3.70 kWh of storable solar
+    across the corpus for no fidelity gain, since those periods are commanded
+    at 100% anyway.
+
+    **Down, never up** -- the asymmetry with the discharge side is physical,
+    not stylistic. A discharge ceiling can be rounded up because actual house
+    load binds below it (Phase 4b). Nothing binds a *charge* command from
+    above: where `import_cap_kwh` is what limited the plan (#429), rounding
+    up would draw more from the grid than the house fuse allows. So the plan
+    comes down to the lattice instead of the command going up to the plan.
+
+    Accepts scalars or arrays; returns the matching shape. Where no grid
+    top-up is planned the value passes through untouched.
+
+    The step is `max_charge_power_kw / 100` to mirror `_scale_to_percent`
+    exactly. A declared per-platform charge resolution (the charge-side twin
+    of `discharge_resolution_kw`) does not exist yet -- that belongs with the
+    full P3 charge work, which also has to stop `_period_flows` deriving
+    throughput from nominal power.
+    """
+    total = solar_to_battery + grid_to_battery
+    floored = np.floor(total / charge_step_kwh + LATTICE_EPS) * charge_step_kwh
+    # Never negative (solar alone may already exceed the floored total, in
+    # which case the grid contributes nothing and the period stops being a
+    # grid charge at all), and never more than was planned.
+    reduced = np.maximum(0.0, np.minimum(grid_to_battery, floored - solar_to_battery))
+    return np.where(grid_to_battery > 0.0, reduced, grid_to_battery)
 
 
 @dataclass(frozen=True)
@@ -339,9 +387,7 @@ class PlatformCapabilities:
         max_index = math.floor(
             battery_settings.max_discharge_power_kw / step + LATTICE_EPS
         )
-        index = discharge_command_index(
-            power_kw, step, rate_is_ceiling=True, max_index=max_index
-        )
+        index = command_index(power_kw, step, rate_is_ceiling=True, max_index=max_index)
         ceiling = index * step
         if ceiling + LATTICE_EPS < power_kw:
             return None

--- a/core/bess/execution_model.py
+++ b/core/bess/execution_model.py
@@ -134,8 +134,10 @@ def command_index(
     max_index: int = 100,
 ) -> int:
     """The lattice index (percent, on the default 1%-of-max lattice) to write
-    for a planned discharge of `power_kw` -- **rounded in the direction the
-    written number's own semantics require** (Phase 4b).
+    for a planned power of `power_kw` -- **rounded in the direction the
+    written number's own semantics require** (Phase 4b for discharge, 4c for
+    charge; `step_kw` is the caller's lattice, so the same function serves
+    both).
 
     This is the one place the planned-power -> written-command conversion
     happens. Both ends of it used to round to nearest and neither knew what
@@ -147,7 +149,16 @@ def command_index(
       under-delivers it -- measured over the corpus, 539 of 1377 house
       deficits round down. So a ceiling must be at least the plan, and
       `ceil` is the **smallest** lattice value that is: not a free choice,
-      the tightest admissible one. This is what makes exact cover exact, and
+      the tightest admissible one.
+
+      A **charge** rate takes this branch too (4c), but for a different
+      reason: what binds above the command there is the battery's own
+      remaining room -- the inverter stops when full -- not house load. The
+      distinction matters because it fails where an import cap is what
+      limited the plan, and `lattice_grid_charge` handles that case by
+      bringing the plan down instead.
+
+      This is what makes exact cover exact, and
       the property the whole exact-cover candidate rests on
       (`action_selector._residual_cover_p`).
 

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -481,19 +481,11 @@ class InverterController(ABC):
         block_passive_charging = self.INTENT_TO_CONTROL[intent]["charge_rate"] == 0
         return grid_charge, discharge_rate, block_passive_charging
 
-    @staticmethod
-    def _scale_to_percent(power_kw: float, max_power_kw: float) -> int:
-        """Scale a *charge* power to a 0-100 percent rate, clamped to range.
-
-        Charge only, since 4b: the discharge path goes through
-        `execution_model.command_index`, which knows whether the
-        number it produces is a ceiling or a target. A charge rate is always
-        a target, so nearest-rounding is right here and this stays a plain
-        scale -- but it is the same conversion, and Phase 4c collapses it
-        into the shared function along with the six `rate_throughput` sites
-        that assume nominal charge power.
-        """
-        return min(100, max(0, round(power_kw / max_power_kw * 100)))
+    # `_scale_to_percent` lived here and did this conversion by nearest
+    # rounding for both rate paths. Both now go through
+    # `execution_model.command_index`, which rounds by what the written
+    # number means -- discharge in 4b, charge in 4c -- so it has no callers
+    # left and is gone rather than kept as a second way to do the same thing.
 
     def _compute_charge_rate(
         self, intent: str, control: dict[str, bool | int], battery_action_kw: float

--- a/core/bess/inverter_controller.py
+++ b/core/bess/inverter_controller.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from typing import ClassVar
 
 from .dp_schedule import DPSchedule
-from .execution_model import INTENT_TO_MODE, discharge_command_index
+from .execution_model import INTENT_TO_MODE, command_index
 from .settings import BatterySettings
 
 logger = logging.getLogger(__name__)
@@ -486,7 +486,7 @@ class InverterController(ABC):
         """Scale a *charge* power to a 0-100 percent rate, clamped to range.
 
         Charge only, since 4b: the discharge path goes through
-        `execution_model.discharge_command_index`, which knows whether the
+        `execution_model.command_index`, which knows whether the
         number it produces is a ceiling or a target. A charge rate is always
         a target, so nearest-rounding is right here and this stays a plain
         scale -- but it is the same conversion, and Phase 4c collapses it
@@ -509,7 +509,23 @@ class InverterController(ABC):
             Charge rate percent (0-100)
         """
         if intent == "GRID_CHARGING" and battery_action_kw > 0.01:
-            return self._scale_to_percent(battery_action_kw, self.max_charge_power_kw)
+            # Rounded UP, like a discharge ceiling and for the same reason
+            # (Phase 4c): the battery's own remaining room binds above the
+            # command -- the inverter stops when full -- so a rate above the
+            # plan delivers the plan exactly, while nearest-rounding lands
+            # below it and silently charges less. Measured pre-fix: 4 of 493
+            # charging periods short, worst -0.0288 kWh.
+            #
+            # Safe because the DP floors a plan the *import cap* limited
+            # (`lattice_grid_charge`), which is the one case where nothing
+            # physical binds above the command and rounding up would draw
+            # more from the grid than the house fuse allows. With that plan
+            # already on the lattice, rounding up is a no-op there.
+            return command_index(
+                battery_action_kw,
+                self.max_charge_power_kw / 100,
+                rate_is_ceiling=True,
+            )
         return control["charge_rate"]
 
     def _map_intent_to_rates(
@@ -530,7 +546,7 @@ class InverterController(ABC):
             return False, 0
         elif intent in ("LOAD_SUPPORT", "BATTERY_EXPORT"):
             if battery_action_kw < -0.01:
-                discharge_rate = discharge_command_index(
+                discharge_rate = command_index(
                     abs(battery_action_kw),
                     # The platform's own lattice, not a hardcoded 1%: the
                     # planner enumerates candidates on
@@ -545,7 +561,7 @@ class InverterController(ABC):
                     # LOAD_SUPPORT writes load_first, where the number is a
                     # ceiling on hardware that load-follows -- so it must be
                     # rounded UP or it under-delivers the plan (Phase 4b;
-                    # see discharge_command_index). BATTERY_EXPORT writes
+                    # see command_index). BATTERY_EXPORT writes
                     # grid_first, where the number is the delivered power on
                     # every platform, so nearest stays correct.
                     rate_is_ceiling=(

--- a/core/bess/simulation/inverter_simulator.py
+++ b/core/bess/simulation/inverter_simulator.py
@@ -14,7 +14,7 @@ from core.bess.dp_battery_algorithm import (
     _state_transition,
 )
 from core.bess.execution_model import (
-    discharge_command_index,
+    command_index,
     intra_period_discharge_gate,
 )
 from core.bess.inverter_controller import InverterController
@@ -95,9 +95,14 @@ def _map_rates(
     controller instance. Returns (grid_charge, discharge_rate_pct, charge_rate_pct)."""
     if intent == "GRID_CHARGING":
         if action_kw > 0.01:
-            charge_rate_pct = min(
-                100,
-                max(0, round(action_kw / settings.max_charge_power_kw * 100)),
+            # Rounded up, mirroring `_compute_charge_rate` (Phase 4c): the
+            # battery's remaining room binds above the command, so a rate
+            # above the plan still delivers exactly the plan, while nearest
+            # lands below it and charges less.
+            charge_rate_pct = command_index(
+                action_kw,
+                settings.max_charge_power_kw / 100,
+                rate_is_ceiling=True,
             )
         else:
             charge_rate_pct = 100
@@ -131,10 +136,10 @@ def _map_rates(
         # Plan-scaled cap only, same as BATTERY_EXPORT -- but rounded UP, not
         # to nearest: this simulator models the Growatt MIN, where load_first
         # is a ceiling, and a ceiling below the plan under-delivers it (Phase
-        # 4b, `execution_model.discharge_command_index`). Same call the
+        # 4b, `execution_model.command_index`). Same call the
         # controller makes, so plan and execution cannot round apart.
         if action_kw < -0.01:
-            rate = discharge_command_index(
+            rate = command_index(
                 abs(action_kw),
                 settings.max_discharge_power_kw / 100,
                 rate_is_ceiling=True,
@@ -151,7 +156,7 @@ def _map_rates(
         # shared conversion as LOAD_SUPPORT above, opposite direction --
         # which is the distinction 4b exists to make explicit.
         if action_kw < -0.01:
-            rate = discharge_command_index(
+            rate = command_index(
                 abs(action_kw),
                 settings.max_discharge_power_kw / 100,
                 rate_is_ceiling=False,

--- a/core/bess/tests/unit/test_control_model_classification.py
+++ b/core/bess/tests/unit/test_control_model_classification.py
@@ -79,7 +79,7 @@ def test_exact_cover_is_only_declared_where_the_written_rate_can_deliver_it():
     partial load cover (`action_selector._residual_cover_p`).
     `discharge_rate_is_load_following` decides whether the written rate is
     rounded UP as a ceiling or to nearest as a target
-    (`execution_model.discharge_command_index`). If a platform ever declares
+    (`execution_model.command_index`). If a platform ever declares
     cover=True with a *target* rate, the DP plans a delivery the write path
     rounds to something else -- R != P, the #282 shape this phase exists to
     end.

--- a/core/bess/tests/unit/test_load_support_gate_regression_393.py
+++ b/core/bess/tests/unit/test_load_support_gate_regression_393.py
@@ -46,7 +46,7 @@ from core.bess import time_utils
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.dp_battery_algorithm import optimize_battery_schedule
 from core.bess.execution_model import (
-    discharge_command_index,
+    command_index,
     intra_period_discharge_gate,
 )
 from core.bess.models import (
@@ -203,7 +203,7 @@ def test_load_support_ceiling_follows_the_gate_on_real_data():
         # direction command-dependent (a load_first ceiling rounds up, or it
         # under-delivers the plan), which a hand-written `round()` here got
         # wrong the moment production changed.
-        baseline = discharge_command_index(
+        baseline = command_index(
             abs(action_kw),
             settings.max_discharge_power_kw / 100,
             rate_is_ceiling=True,

--- a/core/bess/tests/unit/test_period_groups.py
+++ b/core/bess/tests/unit/test_period_groups.py
@@ -137,7 +137,12 @@ class TestDischargeRateFromSchedule:
 class TestChargeRateFromSchedule:
     def test_grid_charging_uses_action_derived_rate(self, controller):
         """GRID_CHARGING charge_rate reflects actual battery action, not static 100%."""
-        # 0.05 kWh / 0.25 h = 0.2 kW; round(0.2 / 6.0 * 100) = 3
+        # 0.05 kWh / 0.25 h = 0.2 kW, which is 3.33% of 6.0 kW -- off the
+        # integer-percent lattice. Rounded UP to 4 since Phase 4c: 3% would
+        # command 0.18 kW and charge less than the plan, while 4% commands
+        # 0.24 kW and the battery's own remaining room stops it at the
+        # planned 0.2. Was `round(...) = 3` before, which is the
+        # under-delivery that phase fixes.
         intents = ["IDLE"] * 96
         intents[20] = "GRID_CHARGING"
         intents[21] = "GRID_CHARGING"
@@ -156,7 +161,7 @@ class TestChargeRateFromSchedule:
         groups = controller.get_detailed_period_groups()
 
         charge_group = next(g for g in groups if g["intent"] == "GRID_CHARGING")
-        assert charge_group["charge_rate"] == 3  # round(0.2/6.0*100)
+        assert charge_group["charge_rate"] == 4  # ceil(0.2/6.0*100), see above
 
     def test_grid_charging_no_schedule_falls_back_to_static_rate(self, controller):
         """With no current_schedule, charge_rate falls back to static 100."""

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -975,3 +975,101 @@ def test_grid_charge_plan_is_deliverable_by_the_written_command():
             f"only {deliverable:.4f} kWh -- the plan is not a quantity the "
             f"integer-percent charge lattice can express"
         )
+
+
+def test_import_capped_grid_charge_command_stays_under_the_fuse():
+    """Phase 4c, the import-capped half: where the house fuse is what limits
+    a grid charge, the *plan* comes down to the lattice instead of the
+    command going up to the plan.
+
+    Rounding a charge command up is safe only because the battery's own
+    remaining room binds above it -- the inverter stops when full. When
+    `import_cap_kwh` (#429) is what limited the plan, nothing binds above the
+    command, and rounding up would draw more from the grid than the fuse
+    allows. So `execution_model.lattice_grid_charge` floors the planned grid
+    top-up onto the lattice first, and the round-up is then a no-op.
+
+    Constructed because **no corpus fixture reaches this path**: every one of
+    them runs with power monitoring off, so `import_cap_kwh` is None and the
+    flooring never fires. Without this test the function added for it has no
+    coverage at all -- which is exactly what review round 1 caught.
+
+    1-phase, 230 V, 20 A fuse -> a 4.6 kWh/period cap on a 6 kW battery,
+    whose 1% step is 0.06 kW. 4.6 is 76.67 steps: off the lattice. Floored to
+    76 steps = 4.56 kWh, which the 76% command delivers exactly. Unfloored,
+    the plan would be 4.6 and `ceil(76.67) = 77%` would command 4.62 kWh --
+    **over the fuse**, which is the failure this pins.
+    """
+    from core.bess.dp_battery_algorithm import _effective_import_cap_kwh
+    from core.bess.dp_schedule import DPSchedule
+    from core.bess.growatt_min_controller import GrowattMinController
+
+    # 24 hourly periods: `DPSchedule` derives its period length as
+    # `24 / len(actions)`, so a shorter horizon would make the controller
+    # scale the rate against the wrong hour length.
+    scenario = {
+        "period_duration_hours": 1.0,
+        # Cheap early, expensive late: grid-charge hard, then export.
+        "buy_price": [0.1] * 12 + [5.0] * 12,
+        "sell_price": [0.05] * 12 + [4.9] * 12,
+        "home_consumption": [0.0] * 24,
+        "solar_production": [0.0] * 24,
+        "home": {
+            "power_monitoring_enabled": True,
+            "max_fuse_current": 20,
+            "voltage": 230,
+            "phase_count": 1,
+        },
+        "battery": {
+            "max_soe_kwh": 40.0,
+            "min_soe_kwh": 2.0,
+            "max_charge_power_kw": 6.0,
+            "max_discharge_power_kw": 6.0,
+            "efficiency_charge": 1.0,
+            "efficiency_discharge": 1.0,
+            "cycle_cost_per_kwh": 0.0,
+            "initial_soe": 2.0,
+        },
+    }
+    inp = _scenario_inputs(scenario)
+    dt = inp["period_duration_hours"]
+    cap_kwh = _effective_import_cap_kwh(inp.get("home_settings"), dt)
+    assert cap_kwh == pytest.approx(
+        4.6, abs=1e-9
+    ), f"scenario no longer produces the intended off-lattice cap: {cap_kwh}"
+
+    result = optimize_battery_schedule(**inp)
+    controller = GrowattMinController(battery_settings=inp["battery_settings"])
+    controller.strategic_intents = [
+        p.decision.strategic_intent for p in result.period_data
+    ]
+    controller.current_schedule = DPSchedule(
+        actions=[p.decision.battery_action for p in result.period_data],
+        state_of_energy=[p.energy.battery_soe_end for p in result.period_data],
+        prices=list(inp["buy_price"]),
+    )
+    max_charge = inp["battery_settings"].max_charge_power_kw
+
+    capped = [
+        t
+        for t, p in enumerate(result.period_data)
+        if p.decision.strategic_intent == "GRID_CHARGING"
+        and p.energy.grid_to_battery > 1e-6
+    ]
+    assert capped, "scenario plans no grid charging -- pins nothing"
+
+    for t in capped:
+        planned = result.period_data[t].energy.battery_charged
+        written_pct = controller.get_period_settings(t)["charge_rate"]
+        commanded = (written_pct / 100) * max_charge * dt
+        assert commanded <= cap_kwh + 1e-9, (
+            f"period {t}: the written command ({written_pct}% of "
+            f"{max_charge:.1f} kW = {commanded:.4f} kWh) exceeds the house "
+            f"import cap of {cap_kwh:.4f} kWh -- rounding a charge up is only "
+            f"safe when the battery's own room binds above it"
+        )
+        assert commanded == pytest.approx(planned, abs=1e-6), (
+            f"period {t}: planned {planned:.4f} kWh but the command delivers "
+            f"{commanded:.4f} -- an import-capped plan must be exactly "
+            f"expressible, since it can be neither exceeded nor rounded up"
+        )

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -872,3 +872,106 @@ def test_exact_cover_is_delivered_in_the_round_down_band():
     assert sim.realized_cost == pytest.approx(
         result.economic_summary.battery_solar_cost, abs=1e-6
     )
+
+
+def test_grid_charge_plan_is_deliverable_by_the_written_command():
+    """Phase 4c: a planned grid charge must be a quantity the written command
+    can actually deliver.
+
+    The charge rate is written as an integer percent of `max_charge_power_kw`
+    scaled from the plan's own action (`_compute_charge_rate` ->
+    `_scale_to_percent`, nearest). A planned power landing between two steps
+    therefore rounds **down** and the inverter charges less than the plan
+    assumed -- the charge-side twin of the discharge defect #352 fixed.
+
+    Measured across the corpus before the fix: 4 of 493 charging periods
+    under-deliver, worst `synthetic_extreme_volatility` period 13 at
+    -0.0288 kWh (plan 0.4488 kWh, command 7% = 0.4200 kWh). Small, and worth
+    fixing structurally rather than economically: the realized-*cost* gap is
+    0.00000 on every affected fixture, so `test_realized_matches_planned_across_all_fixtures`
+    stays green while the plan is not actually executable. Energy fidelity is
+    what this asserts, because money cannot see it.
+
+    **Only where a grid top-up is planned.** SOLAR_STORAGE writes a flat 100%
+    (`INTENT_TO_CONTROL`), so its plan is never scaled and never rounds --
+    311 of the corpus's 323 off-lattice charging periods are SOLAR_STORAGE
+    and are correct as they stand. Quantizing those too would discard 3.70
+    kWh of solar the battery can demonstrably store.
+    """
+    from core.bess.dp_schedule import DPSchedule
+    from core.bess.growatt_min_controller import GrowattMinController
+    from core.bess.simulation.inverter_simulator import (
+        derive_control_command,
+    )
+
+    scenario = load_test_scenario("synthetic_extreme_volatility")
+    inp = _scenario_inputs(scenario)
+    result = optimize_battery_schedule(**inp)
+    dt = inp["period_duration_hours"]
+
+    commands = [
+        derive_control_command(
+            p.decision.strategic_intent,
+            p.decision.battery_action / dt,
+            inp["battery_settings"],
+            intra_period_discharge_allowed=p.decision.intra_period_discharge_allowed,
+        )
+        for p in result.period_data
+    ]
+
+    grid_charging = [
+        t
+        for t, p in enumerate(result.period_data)
+        if p.decision.strategic_intent == "GRID_CHARGING"
+        and p.energy.battery_charged > 1e-6
+    ]
+    assert grid_charging, "fixture plans no grid charging -- pins nothing"
+
+    # Asserted against what the written command can deliver, not against the
+    # simulator's `battery_charged` -- deliberately, and this is the documented
+    # exception to "assert the outcome, not the command".
+    #
+    # `simulate()` derives its flows from `_period_flows`, the same record the
+    # DP uses, and that computes charge throughput from
+    # `max_charge_power_kw` (the binary-store-physics assumption noted at
+    # dp_battery_algorithm.py:974) rather than from the commanded rate. So the
+    # simulator reproduces the plan by construction on this quantity and
+    # cannot disagree with it -- `sim.period_data[t].energy.battery_charged`
+    # equals the plan even when the command is 7% of nominal. Closing that
+    # blindness *is* 4c; until then the only faithful comparison is against
+    # the command itself. `mode_to_power` already models it correctly
+    # (returns 0.42 kW for a 7% command); it is `_period_flows` that discards
+    # it.
+    # Both the production write path and the simulator's mirror of it: the
+    # rate the *controller* computes is what reaches hardware, and the
+    # simulator's copy has to agree or plan and execution drift apart again
+    # (#282/#497). An earlier version of this test checked only the
+    # simulator and stayed green when the controller was mutated back to
+    # nearest-rounding.
+    actions = [p.decision.battery_action for p in result.period_data]
+    controller = GrowattMinController(battery_settings=inp["battery_settings"])
+    controller.strategic_intents = [
+        p.decision.strategic_intent for p in result.period_data
+    ]
+    controller.current_schedule = DPSchedule(
+        actions=actions,
+        state_of_energy=[p.energy.battery_soe_end for p in result.period_data],
+        prices=list(inp["buy_price"][: len(actions)]),
+    )
+    max_charge = inp["battery_settings"].max_charge_power_kw
+
+    for t in grid_charging:
+        planned = result.period_data[t].energy.battery_charged
+        written_pct = controller.get_period_settings(t)["charge_rate"]
+        assert written_pct == commands[t].charge_rate_pct, (
+            f"period {t}: the controller writes {written_pct}% but the "
+            f"simulator models {commands[t].charge_rate_pct}% -- the two "
+            f"charge mappings have drifted"
+        )
+        deliverable = (written_pct / 100) * max_charge * dt
+        assert deliverable >= planned - 1e-6, (
+            f"period {t}: planned {planned:.4f} kWh of charge but the written "
+            f"command ({written_pct}% of {max_charge:.1f} kW) can deliver "
+            f"only {deliverable:.4f} kWh -- the plan is not a quantity the "
+            f"integer-percent charge lattice can express"
+        )

--- a/core/bess/tests/unit/test_scenarios.py
+++ b/core/bess/tests/unit/test_scenarios.py
@@ -879,10 +879,10 @@ def test_grid_charge_plan_is_deliverable_by_the_written_command():
     can actually deliver.
 
     The charge rate is written as an integer percent of `max_charge_power_kw`
-    scaled from the plan's own action (`_compute_charge_rate` ->
-    `_scale_to_percent`, nearest). A planned power landing between two steps
-    therefore rounds **down** and the inverter charges less than the plan
-    assumed -- the charge-side twin of the discharge defect #352 fixed.
+    scaled from the plan's own action (`_compute_charge_rate`), and until 4c
+    that scaling rounded to *nearest*. A planned power landing between two
+    steps therefore rounded **down** and the inverter charged less than the
+    plan assumed -- the charge-side twin of the discharge defect #352 fixed.
 
     Measured across the corpus before the fix: 4 of 493 charging periods
     under-deliver, worst `synthetic_extreme_volatility` period 13 at

--- a/docs/agents/optimizer-architecture.md
+++ b/docs/agents/optimizer-architecture.md
@@ -200,10 +200,32 @@ including where the intra-period gate is deliberately closed. No rounding
 both delivers the plan and never exceeds it, because the lattice is coarser
 than the deficit.
 
-**Still open: 4c (charge).** The six `rate_throughput` sites still charge at
-nominal power and never read `charging_power_rate`, so the charge path keeps
-its structural R≠P divergence. Candidates are commands on the discharge side
-only.
+**As built, Phase 4c (charge half, narrow).** The charge command now rounds
+**up** through the same `command_index` the discharge side uses (renamed from
+`discharge_command_index`, since both paths share it). The justification is
+the mirror of the discharge one but rests on different physics: a discharge
+ceiling is safe to round up because actual house load binds below it, while a
+charge command is bounded from above only by the battery's own remaining
+room — the inverter stops when full — so a rate above the plan still delivers
+exactly the plan. Measured: 4 of 493 charging periods were short (worst
+−0.0288 kWh); now none. Plan-neutral, +0.00000 SEK, no golden churn.
+
+Where `import_cap_kwh` limited the plan (#429) that argument fails — nothing
+physical binds above the command and rounding up would exceed the house fuse
+— so there the DP floors the plan onto the lattice instead
+(`execution_model.lattice_grid_charge`). Under-drawing never violates a fuse,
+so the safe direction differs per binding constraint; do not unify them.
+
+**Still open on the charge side.** `charging_power_rate` was never the
+problem — it does not reach the inverter as a plan-limiting rate (see the
+plan's correction of 2026-08-16). What remains is real but unmeasured in
+money: `_period_flows` derives charge throughput from `max_charge_power_kw`
+rather than from the commanded rate, and the DP and the inverter simulator
+share that record under P4 — so the simulator reproduces the plan by
+construction and **cannot disagree with it about charge**. Any charge-side
+R==P result is therefore weaker evidence than the discharge-side equivalent.
+Candidates are commands on the discharge side; on the charge side only the
+written rate is.
 
 **Two questions, not one — do not collapse them.** "Is the rate register a
 ceiling" (`discharge_rate_is_load_following`, what the intra-period gate

--- a/docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md
+++ b/docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md
@@ -619,6 +619,30 @@ configured not to deliver. That is a structural R≠P divergence on the
 discharge executability), and it is precisely what "candidates are
 executable commands" fixes. Phase 4 stands.
 
+> ⚠️ **Correction (2026-08-16, 4c's premise check): the second bullet's
+> conclusion is false.** `battery_system_manager` writes
+> `get_period_settings(period)["charge_rate"]`, not `charging_power_rate` —
+> the intent-derived rate, which is a flat 100% for `SOLAR_STORAGE`/`IDLE`
+> and scaled from the plan's own action for `GRID_CHARGING`.
+> `charging_power_rate` (default 40%) is only the power monitor's *initial*
+> target, `power_monitoring_enabled` defaults to False, and the target is
+> overwritten every period anyway. **The executor is not throttled below what
+> the planner assumes**, so the SEK this paragraph implies for 4c are not
+> there.
+>
+> The *first* bullet stands: the plan does charge at nominal power in six
+> places, and `_period_flows` derives charge throughput from
+> `max_charge_power_kw` regardless of what was commanded. Because the DP and
+> the inverter simulator share that record, the simulator reproduces the plan
+> by construction and **cannot disagree with it about charge** — which is why
+> the corpus R==P harness shows a 0.00000 gap while the written command is
+> genuinely short. Closing that blindness is what "4c-full" would mean.
+>
+> Measured defect after the correction: 4 of 493 charging periods plan a
+> charge the written command cannot deliver (worst −0.0288 kWh), caused by
+> nearest-rounding the `GRID_CHARGING` rate. Fixed narrowly — see "4c as
+> built" below.
+
 **Phase 4's live driver is #352, not #320.** #320 is closed (see the issue
 map). Recorded for #352 on 2026-08-10: 22 sub-load `grid_first` periods live,
 16 of them in the 0.1–0.5 kWh band #511 does not reach, 5 clearly
@@ -736,9 +760,47 @@ from Phase 4** and becomes its own phase; see below.
   commands; folds in #511/#517's tests as regression cover. Closes #352
   **Shape B** with the exact-cover candidate, gated on 4a's load-following
   capability. Gated on 4a and the beta.
-- **4c — charge commands.** The six hardcoded `rate_throughput` sites above
-  collapse to the configured rate; this is where the measured R≠P divergence
-  closes.
+- **4c — charge commands. NARROW VERSION BUILT 2026-08-16; the full one is
+  deliberately not.** The original scope ("collapse the six `rate_throughput`
+  sites to the configured rate") rests on a premise that does not hold — there
+  is no configured rate being written; see the correction above. What was
+  measured instead: 4 of 493 charging periods plan a charge the written
+  command cannot deliver, because the `GRID_CHARGING` rate is scaled from the
+  plan and rounded to *nearest*, landing below it.
+
+  **Built:** the charge command rounds **up** (`command_index(...,
+  rate_is_ceiling=True)`), the same conversion 4b introduced, for the same
+  reason — the battery's own remaining room binds above the command, so a
+  rate above the plan still delivers exactly the plan, while nearest charges
+  less. Fixes all 4. **Corpus cost: +0.00000 SEK, 0 of 38 fixtures moved** —
+  it changes only what is written, not what is planned, so no golden or
+  baseline re-pin.
+
+  **The asymmetry with 4b is physical and worth keeping straight.** A
+  discharge ceiling can be rounded up because actual house load binds below
+  it. Nothing binds a *charge* command from above except the battery's own
+  room — so where `import_cap_kwh` is what limited the plan (#429), rounding
+  up would draw more than the house fuse allows. There the DP floors the plan
+  onto the lattice instead (`execution_model.lattice_grid_charge`), which is
+  safe because under-drawing never violates a fuse. That path is unexercised
+  by the corpus (power monitoring is off in every fixture).
+
+  **Rejected, with the measurement:** flooring *every* grid charge onto the
+  lattice regardless of what bound it. Costs **+1.33 SEK** across the corpus
+  and moves 11 fixtures, because charging less than the battery could compounds
+  into lost arbitrage — the same shape as D3's +3.67 SEK. Flooring *all*
+  charging (solar included) is worse still: 311 further periods and 3.70 kWh
+  of storable solar discarded, for no fidelity gain, since SOLAR_STORAGE is
+  commanded at a flat 100% and never rounds.
+
+  **Left open, deliberately:** `_period_flows` still derives charge throughput
+  from `max_charge_power_kw` rather than the commanded rate, so the inverter
+  simulator cannot see a charge-rate divergence at all (it shares that record
+  with the DP under P4). Also unfixed: one `SOLAR_EXPORT` period plans a
+  0.0089 kWh charge against a deliberate 0% command (#313 blocks passive
+  charging) — a sub-noise-floor plan/command inconsistency of a different
+  kind. Both are worth their own measurement before anyone spends a phase on
+  them; neither is worth SEK today.
 
 4b and 4c are independent of each other and can run in parallel after 4a.
 

--- a/docs/superpowers/specs/2026-08-11-phase4-executable-candidates-design.md
+++ b/docs/superpowers/specs/2026-08-11-phase4-executable-candidates-design.md
@@ -63,6 +63,30 @@ executor is configured not to deliver. That is a structural R≠P divergence on
 the charge path, untouched by #511 and #517 (both discharge-side). **Phase 4
 stands.**
 
+> ⚠️ **The second sentence of that paragraph is WRONG, and 4c's premise check
+> found it (2026-08-16).** `battery_system_manager` does not write
+> `charging_power_rate` to the inverter. It writes
+> `get_period_settings(period)["charge_rate"]` — the *intent-derived* rate:
+> `INTENT_TO_CONTROL` gives a flat `charge_rate: 100` for `SOLAR_STORAGE`,
+> `GRID_CHARGING` and `IDLE`, and for `GRID_CHARGING` that is then replaced by
+> `_compute_charge_rate`, which scales it from the plan's own action.
+> `charging_power_rate` (default **40%**) reaches hardware only as
+> `power_monitor.py:67`'s *initial* `target_charging_power_pct`, and
+> `power_monitoring_enabled` defaults to **False**; even when enabled, that
+> target is overwritten every period by `update_target_charging_power`.
+>
+> **So the executor is not configured to deliver less than the planner
+> assumes, and the savings this attributed to 4c do not exist.** Measured over
+> the corpus: of 493 charging periods, 4 under-deliver — all `GRID_CHARGING`,
+> worst −0.0288 kWh — and the cause is `_scale_to_percent` rounding the charge
+> rate to *nearest*, so a plan between two lattice steps is written as the step
+> below. That is the charge-side twin of #352, not a configured-throttle
+> problem. The first bullet above ("the plan charges at nominal power in six
+> places") remains true and is what 4c-full still has to address.
+>
+> Do not re-derive the old premise from this paragraph; it is kept only so the
+> correction has something to point at.
+
 ### The #352 evidence reproduces — the earlier 0 was a tautology (resolved 2026-08-13)
 
 The 2026-08-11 revision of this section recorded "0 periods" and called it a


### PR DESCRIPTION
## Summary

- The charge rate is written as a whole percent scaled from the plan's own action, rounded to **nearest** — so a planned power between two lattice steps was written as the step *below* and the battery charged less than the plan counted on.
- Measured over the corpus: **4 of 493** charging periods short, worst **−0.0288 kWh** (`synthetic_extreme_volatility:13` — plan 0.4488 kWh, command 7% of 6 kW = 0.4200 kWh). All `GRID_CHARGING`.
- Rounds **up** now. **Corpus cost +0.00000 SEK, 0 of 38 fixtures moved** — this changes what is *written*, not what is *planned*, so there is no golden or baseline re-pin anywhere in this PR.

## 4c's documented premise was false — corrected here

The plan and the design doc both said the executor is configured to deliver less charge than the planner assumes, citing `charging_power_rate` (default 40%) as the value written to the inverter. **It is not written to the inverter at all.**

`battery_system_manager` writes `get_period_settings(period)["charge_rate"]` — the *intent-derived* rate. `INTENT_TO_CONTROL` gives a flat `charge_rate: 100` for `SOLAR_STORAGE`/`IDLE`, and `GRID_CHARGING` is scaled from the plan's own action by `_compute_charge_rate`. `charging_power_rate` reaches hardware only as `power_monitor.py:67`'s *initial* target, `power_monitoring_enabled` defaults to **False**, and even when enabled that target is overwritten every period.

So the savings 4c was scoped around do not exist. Both documents now carry the correction inline, marked so nobody re-derives the old premise from them. The plan's *first* bullet stands and is recorded as still-open (below).

## Fix

`command_index(..., rate_is_ceiling=True)` — the same conversion 4b introduced, renamed from `discharge_command_index` since both paths now share it.

The reason mirrors the discharge side but rests on **different physics**, and that is worth keeping straight:

| | what binds above the command | so round |
|---|---|---|
| discharge ceiling (4b) | actual house load | **up** |
| charge, room-limited (4c) | the battery's own remaining room — inverter stops when full | **up** |
| charge, import-cap-limited (#429) | **nothing** | plan floored to the lattice instead |

Where `import_cap_kwh` limited the plan, rounding up would draw more from the grid than the house fuse allows. There the DP floors the plan onto the lattice (`execution_model.lattice_grid_charge`) — safe because under-drawing never violates a fuse. The safe direction genuinely differs per binding constraint; they must not be unified.

## Rejected, with measurements rather than argument

- **Floor every grid charge onto the lattice** regardless of what bound it: **+1.33 SEK**, 11 fixtures moved. Charging less than the battery could compounds into lost arbitrage — the same shape as D3's +3.67 SEK for #352.
- **Floor all charging, solar included:** 311 further periods and **3.70 kWh** of storable solar discarded, for no fidelity gain — `SOLAR_STORAGE` is commanded at a flat 100% and never rounds.

## Left open, deliberately and on the record

- **`_period_flows` derives charge throughput from `max_charge_power_kw`, not the commanded rate.** The DP and the inverter simulator share that record under P4, so the simulator reproduces the plan by construction and **cannot disagree with it about charge**. That is why the corpus R==P harness reads `0.00000` while the written command is genuinely short — any charge-side R==P result is weaker evidence than the discharge-side equivalent. Closing this is what "4c-full" would mean, and it needs its own measurement first.
- One `SOLAR_EXPORT` period plans a 0.0089 kWh charge against a deliberate 0% command (#313 blocks passive charging) — a sub-noise-floor plan/command inconsistency of a different kind.

## Test plan

- [x] `./scripts/quality-check.sh` green (re-run after merging `origin/main`)
- [x] `pytest -m slow` green — 547 passed, 7 skipped, **no re-pinning required**
- [x] Corpus re-measured: charging periods with `deliverable < planned` go **4 → 0**

## Evidence the test discriminates

- **Reverted:** `rate_is_ceiling=True` → `False` in `_compute_charge_rate`.
  **Result:** `test_grid_charge_plan_is_deliverable_by_the_written_command` FAILED — *"period 13: the controller writes 7% but the simulator models 8% — the two charge mappings have drifted"*. `test_period_groups.py::test_grid_charging_uses_action_derived_rate` also FAILED (`assert 3 == 4`).
  **Restored:** both green.
- Worth recording: an earlier version of that test built its commands only via the simulator's mirror and **stayed green under this mutation**, because I had mutated the controller alone. It now asserts through the production path (`get_period_settings`) *and* cross-checks the simulator against it, so a drift between the two sites fails loudly — which is the property that actually matters here.

## Outcome-level coverage

- `test_grid_charge_plan_is_deliverable_by_the_written_command` — every `GRID_CHARGING` period on a real fixture: the controller's written rate must be able to deliver the planned charge, and the simulator must agree with the controller.
- `test_period_groups.py::test_grid_charging_uses_action_derived_rate` — the rounding direction pinned directly on the controller.
- This one asserts against the *command* rather than the simulator's `battery_charged`, deliberately and with the reason stated in the test: the simulator is blind to this quantity (see "Left open"), so a command-level assertion is the only faithful one until that changes. `rules.md` permits exactly this where no execution model exists.

Refs the Phase 4c entry of `docs/superpowers/plans/2026-08-09-optimizer-target-architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtTbxMVD8mqib3Rh1Sc34Q
