### PR TITLE
fix: write Growatt VPP power before arming remote control (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Growatt VPP no longer briefly executes the previous period's power command when switching modes** — enabling remote control commits immediately, so the power target is now written before it, and cleared on release. ([#593](https://github.com/johanzander/bess-manager/issues/593))
 - **The battery now covers house load exactly instead of exporting a few Wh and committing the inverter** — a period whose load fell between two discharge steps was planned as a small export, which forces `grid_first` at a fixed rate and imports any load spike. ([#352](https://github.com/johanzander/bess-manager/issues/352))
 - **Huawei, native SolaX and Solis installs no longer report a discharge as negative charging, or an export as negative import** — the signed battery/grid sensor split now works on settings saved before the sensor pairing existed, with no wizard re-run. ([#604](https://github.com/johanzander/bess-manager/issues/604))
 - **The battery schedule no longer varies between otherwise identical runs** — when two plans were worth exactly the same, the optimizer picked between them on floating-point noise, so the same day could plan differently on different machines. ([#606](https://github.com/johanzander/bess-manager/issues/606))

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -2361,20 +2361,32 @@ class HomeAssistantAPIController:
     def set_growatt_vpp_period(
         self, remote_control_enabled: bool, power_pct: int, fallback_minutes: int
     ) -> None:
-        """Write one period's VPP command: remote control, power, and fallback timer.
+        """Write one period's VPP command: power, fallback timer, remote control.
+
+        Register 30407 (remote control) is the commit: Growatt VPP has no
+        separate trigger entity, so enabling it executes whatever 30409/30408
+        currently hold. Both are therefore written *before* arming, and the
+        power latch is cleared on release — otherwise the next activation
+        arms against the previous active period's value, which can be ±100%
+        (issue #593).
 
         ``vpp_time`` is rewritten every period the command is active, resetting
         the inverter's own fallback timer (register 30408) — if BESS stops
         writing (crash, restart), the inverter reverts to ``load_first`` on its
         own once the timer lapses, giving a hardware dead-man's-switch.
 
+        Either way a power/timer failure is fail-safe: on activation it leaves
+        remote control untouched, so the period degrades to ``load_first``
+        self-use instead of executing a stale command; on release the disable
+        has already landed, so only the latch-clearing courtesy is lost.
+
         Args:
             remote_control_enabled: Whether VPP Remote Control (30407) should
                 be enabled for this period. False reverts the inverter to
-                load_first.
+                load_first and zeroes 30409.
             power_pct: Target power as a percentage (-100..100). Negative =
                 discharge/export, positive = charge from grid. Ignored when
-                ``remote_control_enabled`` is False.
+                ``remote_control_enabled`` is False, which always writes 0.
             fallback_minutes: Value to (re)write to ``vpp_time`` (30408) when
                 ``remote_control_enabled`` is True.
         """
@@ -2387,17 +2399,35 @@ class HomeAssistantAPIController:
             option,
             f", power={power_pct}%" if remote_control_enabled else "",
         )
-        self._service_call_with_retry(
-            "select",
-            "select_option",
-            operation=f"Growatt VPP remote control -> {option}",
-            entity_id=remote_control_entity,
-            option=option,
-        )
+
+        def _arm(value: str) -> None:
+            self._service_call_with_retry(
+                "select",
+                "select_option",
+                operation=f"Growatt VPP remote control -> {value}",
+                entity_id=remote_control_entity,
+                option=value,
+            )
 
         if not remote_control_enabled:
+            # Release first, then clear the latch. Writing 0 while remote
+            # control is still Enabled would select the grid_first hold for
+            # the duration, changing release behaviour on every load_first
+            # entry; this order leaves release identical to before.
+            #
+            # The power entity is resolved only *after* the disable has
+            # landed: getting back to load_first is the safety-critical half,
+            # and clearing the latch is a courtesy to the next activation, so
+            # a mis-provisioned power entity must not block the release.
+            _arm("Disabled")
+            power_entity = self._get_entity_for_service("growatt_vpp_power")
+            self._set_number_like(
+                power_entity, 0, "Growatt VPP clear power latch -> 0%"
+            )
             return
 
+        # Resolved before any write, so a mis-provisioned install fails with
+        # the inverter untouched rather than armed on a stale command.
         power_entity = self._get_entity_for_service("growatt_vpp_power")
         self._set_number_like(
             power_entity, power_pct, f"Growatt VPP set power -> {power_pct}%"
@@ -2409,6 +2439,9 @@ class HomeAssistantAPIController:
             fallback_minutes,
             f"Growatt VPP reset fallback timer -> {fallback_minutes} min",
         )
+
+        # Arm last: enabling remote control IS the commit on Growatt VPP.
+        _arm("Enabled")
 
     # ── Growatt export-limit curtailment (registers 122/123) ──────────────────
     #

--- a/core/bess/solax_modbus_growatt_controller.py
+++ b/core/bess/solax_modbus_growatt_controller.py
@@ -476,7 +476,8 @@ class SolaxModbusGrowattController(GrowattMinController):
                 fallback_minutes=_VPP_FALLBACK_MINUTES,
             )
             self._last_written_vpp_remote_control = remote_control_enabled
-            self._last_written_vpp_power = power_pct if remote_control_enabled else None
+            # Release zeroes 30409 (#593), so 0 -- not None -- is the truth.
+            self._last_written_vpp_power = power_pct if remote_control_enabled else 0
             return True, ""
         except Exception as e:
             logger.error("FAILED: Growatt VPP period write: %s", e)

--- a/core/bess/tests/unit/test_growatt_vpp_write_order.py
+++ b/core/bess/tests/unit/test_growatt_vpp_write_order.py
@@ -1,0 +1,185 @@
+"""Register write ordering for Growatt VPP periods (issue #593).
+
+On Growatt VPP there is no separate trigger/commit register: enabling
+``growatt_vpp_remote_control`` (30407) *is* the commit. So the power value
+(30409) and the fallback timer (30408) must both be in place before remote
+control is enabled, or the inverter arms against whatever the previous
+active period left behind -- up to +/-100%, i.e. a full-rated spike on
+every mode switch.
+
+Why these assert on the service calls rather than on an outcome: this is a
+write-sequencing defect, and no execution model covers write order.
+``simulation/vpp_simulator.py`` derives one ``VppCommand`` per period and
+models the resulting energy, so it cannot observe that two writes reached
+the inverter in the wrong order -- by construction it sees the committed
+pair. The ordering is only visible at the service-call layer, which is why
+these live here and not as a plan-faithfulness scenario. No plan economics
+change, so nothing in the DP/intent path moves.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from core.bess.ha_api_controller import HomeAssistantAPIController
+from core.bess.settings_store import SettingsStore
+
+_SENSORS = {
+    "growatt_vpp_remote_control": "select.growatt_vpp_remote_control",
+    "growatt_vpp_power": "number.growatt_vpp_power",
+    "growatt_vpp_time": "number.growatt_vpp_time",
+}
+
+
+def _controller(sensors: dict | None = None) -> HomeAssistantAPIController:
+    store = SettingsStore()
+    store.data["sensors"] = dict(_SENSORS if sensors is None else sensors)
+    ctrl = HomeAssistantAPIController(
+        ha_url="http://ha.local", token="tok", settings_store=store
+    )
+    ctrl.test_mode = False
+    return ctrl
+
+
+def _writes(mock_request) -> list[tuple[str, str, object]]:
+    """Reduce recorded _api_request calls to (path, entity_id, value)."""
+    recorded = []
+    for args, kwargs in mock_request.call_args_list:
+        payload = kwargs["json"]
+        recorded.append(
+            (args[1], payload["entity_id"], payload.get("option", payload.get("value")))
+        )
+    return recorded
+
+
+class TestActivationOrdering:
+    """Arming (30407 -> Enabled) must come last, after power and timer."""
+
+    def test_power_and_timer_are_written_before_remote_control_is_enabled(self) -> None:
+        ctrl = _controller()
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.return_value = {}
+            ctrl.set_growatt_vpp_period(
+                remote_control_enabled=True, power_pct=-40, fallback_minutes=30
+            )
+
+        assert _writes(mock_request) == [
+            ("/api/services/number/set_value", "number.growatt_vpp_power", -40),
+            ("/api/services/number/set_value", "number.growatt_vpp_time", 30),
+            (
+                "/api/services/select/select_option",
+                "select.growatt_vpp_remote_control",
+                "Enabled",
+            ),
+        ]
+
+    def test_power_write_failure_leaves_remote_control_unarmed(self) -> None:
+        """A failed power write must not leave the inverter executing a stale
+        command. Arming last makes the failure degrade to load_first self-use.
+        """
+        ctrl = _controller()
+
+        def _fail_only_the_power_write(*args, **kwargs):
+            if kwargs["json"]["entity_id"] == "number.growatt_vpp_power":
+                raise RuntimeError("HA unreachable")
+            return {}
+
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.side_effect = _fail_only_the_power_write
+            with pytest.raises(RuntimeError):
+                ctrl.set_growatt_vpp_period(
+                    remote_control_enabled=True, power_pct=-100, fallback_minutes=30
+                )
+
+        armed = [
+            w
+            for w in _writes(mock_request)
+            if w[1] == "select.growatt_vpp_remote_control" and w[2] == "Enabled"
+        ]
+        assert armed == []
+
+    def test_missing_power_entity_raises_before_anything_is_written(self) -> None:
+        """An unconfigured power entity must abort before the arming write.
+
+        A mis-provisioned install must not arm the inverter and *then* throw,
+        which would leave it on the previous period's power value until the
+        next period retry.
+        """
+        sensors = dict(_SENSORS)
+        del sensors["growatt_vpp_power"]
+        ctrl = _controller(sensors)
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.return_value = {}
+            with pytest.raises(ValueError):
+                ctrl.set_growatt_vpp_period(
+                    remote_control_enabled=True, power_pct=50, fallback_minutes=30
+                )
+
+        assert _writes(mock_request) == []
+
+
+class TestReleaseOrdering:
+    """Release (30407 -> Disabled) must come first, then power is zeroed."""
+
+    def test_remote_control_is_disabled_before_power_is_zeroed(self) -> None:
+        """Zeroing clears the latch for the next activation.
+
+        Order matters the other way round here: a 0 written while remote
+        control is still Enabled selects the documented grid_first hold, so
+        it would change release behaviour on every load_first entry.
+        Disabling first keeps release identical to today.
+        """
+        ctrl = _controller()
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.return_value = {}
+            ctrl.set_growatt_vpp_period(
+                remote_control_enabled=False, power_pct=0, fallback_minutes=30
+            )
+
+        assert _writes(mock_request) == [
+            (
+                "/api/services/select/select_option",
+                "select.growatt_vpp_remote_control",
+                "Disabled",
+            ),
+            ("/api/services/number/set_value", "number.growatt_vpp_power", 0),
+        ]
+
+    def test_missing_power_entity_still_disables_remote_control(self) -> None:
+        """Release must never be blocked by the power entity.
+
+        Zeroing the latch is a courtesy to the *next* activation; getting the
+        inverter back to load_first is the safety-critical part. So an
+        unconfigured power entity must not stop the disable from landing --
+        the failure has to come after it, not instead of it.
+        """
+        sensors = dict(_SENSORS)
+        del sensors["growatt_vpp_power"]
+        ctrl = _controller(sensors)
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.return_value = {}
+            with pytest.raises(ValueError):
+                ctrl.set_growatt_vpp_period(
+                    remote_control_enabled=False, power_pct=0, fallback_minutes=30
+                )
+
+        assert _writes(mock_request) == [
+            (
+                "/api/services/select/select_option",
+                "select.growatt_vpp_remote_control",
+                "Disabled",
+            ),
+        ]
+
+    def test_release_does_not_rewrite_the_fallback_timer(self) -> None:
+        """Nothing is armed after release, so there is no timer to refresh."""
+        ctrl = _controller()
+        with patch.object(ctrl, "_api_request") as mock_request:
+            mock_request.return_value = {}
+            ctrl.set_growatt_vpp_period(
+                remote_control_enabled=False, power_pct=0, fallback_minutes=30
+            )
+
+        assert not [
+            w for w in _writes(mock_request) if w[1] == "number.growatt_vpp_time"
+        ]

--- a/docs/INVERTER_PLATFORMS.md
+++ b/docs/INVERTER_PLATFORMS.md
@@ -274,6 +274,26 @@ semantics" below):
 - `SOLAR_EXPORT` (rate=0, `block_passive_charging=True`) → `vpp_power=0`,
   remote control **enabled** (`grid_first` hold)
 
+**Register write ordering (issue [#593](https://github.com/johanzander/bess-manager/issues/593)):**
+Growatt VPP has no separate trigger entity — writing `vpp_remote_control`
+(30407) *is* the commit, so the inverter immediately executes whatever
+30409/30408 already hold. The write order is therefore load-bearing, not
+stylistic:
+
+- **Activating** a period: `vpp_power` (30409) → `vpp_time` (30408) →
+  `vpp_remote_control=Enabled` (30407) **last**. Arming first would execute
+  the previous active period's power value until the new one lands — up to
+  ±100%, i.e. a full-rated charge or export spike on every mode switch.
+- **Releasing** to `load_first`: `vpp_remote_control=Disabled` **first**, then
+  `vpp_power=0`. The zero clears the latch so the *next* activation can't
+  inherit a stale value; it must come after the disable, because a 0 written
+  while remote control is still enabled selects the `grid_first` hold (see
+  "SOLAR_EXPORT semantics" below) rather than being inert.
+
+A consequence worth knowing when reading logs: a failed power or timer write
+now leaves remote control untouched, so the period degrades to `load_first`
+self-use instead of executing a stale command.
+
 **LOAD_SUPPORT semantics (fixed — issue [#413](https://github.com/johanzander/bess-manager/issues/413)):**
 Unlike TOU mode (where `LOAD_SUPPORT` maps to `load_first`, letting the
 inverter's own control loop follow actual house load), VPP mode previously


### PR DESCRIPTION
## Summary
- Growatt VPP now writes the power target *before* arming remote control, and clears it on release, so a mode switch can no longer briefly execute the previous period's command.

## Root cause
Growatt VPP has no separate trigger entity — writing `growatt_vpp_remote_control` (30407) **is** the commit, so the inverter immediately executes whatever 30409 (power) and 30408 (timer) already hold. `set_growatt_vpp_period` wrote remote control first and power second, and returned early on release without writing power at all:

```python
self._service_call_with_retry("select", "select_option", ...)   # 30407 -- the commit
if not remote_control_enabled:
    return                                                       # 30409 never cleared
power_entity = self._get_entity_for_service("growatt_vpp_power") # 30409, too late
```

`LOAD_SUPPORT` and `SOLAR_STORAGE` both map to `remote_control_enabled=False`, so 30409 retained the last *active* period's value — across a multi-hour load-first stretch. Every Disabled→Enabled transition then armed against that stale value: `-100` after `BATTERY_EXPORT` (full-rated export) or `+100` after `GRID_CHARGING` (full-rated charge). That is the spike reported in #593.

It is invisible in logs because BESS emits one line *before both* writes, describing the intended pair — which is why the reporter's HA logging couldn't find it.

## Fix
- **Activation:** power (30409) → timer (30408) → arm (30407) **last**. The timer moves for the same reason as power: written after the commit, a re-enable after a long release armed against a lapsed dead-man's timer.
- **Release:** disable (30407) **first**, then write power 0. The issue proposed zeroing first; that isn't inert — a 0 written while remote control is still enabled selects the documented `grid_first` hold, changing release behaviour on every `LOAD_SUPPORT` entry. This order clears the latch for the next activation while leaving release identical to before.
- The power entity is resolved **per branch**, not once up front: on activation before any write (a mis-provisioned install fails with the inverter untouched); on release only *after* the disable has landed (returning to `load_first` is the safety-critical half; clearing the latch is a courtesy to the next activation).
- `_last_written_vpp_power` is now `0` on release rather than `None`, since the fix makes 0 the hardware truth. Untested by design — its only consumer reads it exclusively when remote control is enabled, so it is unobservable on the release path.

Intent→VPP mapping, the DP, and intent classification are untouched; no plan economics move.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (0 errors, 0 warnings)
- [x] `pytest -m slow`: 546 passed, 7 skipped
- [x] **Observed end-to-end** on the real backend against mock-HA (`docker-compose.ci.yml`, scenario `ci-growatt-vpp`, VPP settings fixture, clock pinned with libfaketime), reading mock-HA's ordered `/mock/service_log`:

  Activation — `IDLE` period at 08:30:
  ```
  number.set_value      number.growatt_min_vpp_power             1
  number.set_value      number.growatt_min_vpp_time              20
  select.select_option  select.growatt_min_vpp_remote_control    Enabled
  ```
  Release — `LOAD_SUPPORT` period at 10:05:
  ```
  select.select_option  select.growatt_min_vpp_remote_control    Disabled
  number.set_value      number.growatt_min_vpp_power             0
  ```

## Evidence the test discriminates
- Reverted: re-inserted the original arm-first ordering (`_arm(option)` before the release branch, i.e. 30407 written first on both paths).
- Result: **5 of 6 tests FAILED** — both ordering tests, both missing-entity tests, and the power-write-failure test.
- Restored: tree clean, 6 passed.

The sixth (`test_release_does_not_rewrite_the_fallback_timer`) passes before and after — it is a guard against a future regression, not evidence for this fix, and is labelled as such.

Four of the six were also written RED-first and watched fail before the fix existed. One of those first drafts was itself wrong and got fixed: `test_power_write_failure_leaves_remote_control_unarmed` originally failed *every* write, which would not have isolated a power-write failure; it now fails only the power write.

## Outcome-level coverage
**None, and deliberately so** — these assert on service calls, not outcomes. No execution model covers write *order*: `simulation/vpp_simulator.py` derives one `VppCommand(power_pct, remote_control_enabled)` per period and models the resulting energy, so by construction it only ever sees a fully-committed pair and cannot represent an intermediate state such as "armed, power not yet written". The service-call layer is the only place this defect is observable. The module docstring records that reasoning so the next reader doesn't mistake a mapping check for behavioural evidence.

Per `docs/agents/testing.md` this is not a DP/intent/control-mapping change — no plan economics move — so no `R == P` scenario, no new fixture, and no golden/VPP-baseline re-pin is required.

## Documentation
`docs/INVERTER_PLATFORMS.md` gains a "Register write ordering" section — it documented the intent→VPP mapping but never the ordering, which this fix makes load-bearing. `docs/agents/bess-knowledge.md` and `docs/SOFTWARE_DESIGN.md` were both checked; neither describes the VPP write sequence, so neither needed changes.

## Caveat
Writing 30409 while 30407 is Disabled is documented as inert but is **not real-hardware-validated** — same experimental status as #355/#466. Confirmation from a real debug export around a mode switch is still owed, and would also settle whether this ordering defect actually explains the reporter's spikes. The defect stands on the code either way.

Also note the changed failure mode: a failed power/timer write now leaves remote control untouched and the period degrades to `load_first` self-use, instead of executing a stale command.
