### PR TITLE
fix: make backlog grooming reflect what actually blocks an issue

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -20,20 +20,28 @@ Open an individual issue only when you are deciding about that issue.
 
 ## Prerequisites
 
-Board reads need `PROJECT_NUMBER` set and the board created (deferred —
-`scripts/backlog-board-init.sh`). Board writes need `BESS_PO_TOKEN` with
-`project` scope (also deferred). Until both exist, a pass fails loudly at the
-first board access in `backlog-digest.sh` — that failure is expected, not a
-bug to route around.
+The board exists: **Project #1, "BESS Manager Backlog"**. `PROJECT_NUMBER=1`
+lives in the repo's `.env`, which `backlog-digest.sh` does **not** source — so
+export it first, or the digest exits with a "board has not been created yet"
+message that is misleading rather than wrong:
 
-**One thing to verify the first time a board exists.** No board has ever
-existed, so the JSON shape `gh project item-list --format json` uses for a
-custom field is unconfirmed; the digest assumes each item carries a top-level
-`.priority`. On the first real run, check that `priority` is populated rather
-than `null` for an item you have set a priority on. If it is `null`, fix the
-jq path in `scripts/backlog-digest.sh` — do not add a fallback that tries
-several shapes. A silently-null `priority` disables ranking axis 2 without
-any error.
+    set -a; . ./.env; set +a; ./scripts/backlog-digest.sh
+
+Board writes need `BESS_PO_TOKEN` with `project` scope. The custom-field JSON
+shape is confirmed: `gh project item-list --format json` puts each single-select
+value at the item's top level, so `.priority` and `.awaiting` both read directly.
+
+Field options, as they actually exist — do not invent values outside these sets:
+
+| Field | Options |
+|---|---|
+| `Status` | `Backlog`, `Analysis`, `Ready for Dev`, `In Progress`, `In Review`, `Done` |
+| `Priority` | `P1`, `P2`, `P3`, `P4` — **there is no `P0`** |
+| `Awaiting` | `reporter`, `discussion`, `upstream`, `analysis` |
+| `Source` | `issue`, `TODO` |
+
+The digest's `column` values match `Status` exactly, so reconciling a card is a
+string comparison, not a translation.
 
 ## When to Use
 
@@ -54,6 +62,28 @@ Post as the PO identity: `scripts/gh-agent.sh --as po issue comment ...`.
 If a board write fails for missing scope, stop and report
 `gh auth refresh -s project`. Never fall back to a file.
 
+## What the digest tells you, and why each field exists
+
+Four fields carry the grooming signal. Each was added because its absence
+caused a real misclassification:
+
+| Field | Meaning |
+|---|---|
+| `awaiting` | The blocking wait. **Outranks `analyzed`** — an item whose scope is unsettled is in *Analysis* no matter how far it got. Comes from the board field when set, else from a blocking label. |
+| `awaiting_source` | `board` or `label`. A `label` source with no board value is a triage action: set the field. |
+| `awaiting_suggested` | What the labels imply, so an unset field can be reconciled without guessing. |
+| `last_comment` | `{author, days, is_reporter, is_bot}`. **The reporter-replied signal.** A comment count and a last-activity date cannot tell "the reporter answered us" from "we posted a nudge", which is why the follow-up chase never fired. |
+| `stale_worktree` | The worktree's own branch has already merged, so it is rot, not progress. Hand it to `sweep-prs`. |
+| `blocked` | `blocked` label or an unresolved `Blocked by #N`. Fails Ready outright. |
+
+**A human comment is not a wait.** `awaiting: discussion` used to be returned
+for any human comment, which pushed items to *Analysis* for ordinary traffic —
+thanks, a "me too", a follow-up question. Only a recorded wait or a blocking
+label does that now; `last_comment` is what you read to judge the rest.
+
+**`Ready for Dev` requires a `Priority`.** An analysed item with no priority is
+un-ranked, so it cannot be "next" — it stays in *Analysis* as a triage action.
+
 ## Definition of Ready
 
 Nothing is dispatched that has not crossed this line. A bug is Ready when:
@@ -63,6 +93,16 @@ Nothing is dispatched that has not crossed this line. A bug is Ready when:
 3. Expected versus actual behaviour is stated explicitly, in system terms
 4. An approach is agreed (Stage 2 analysis, or the maintainer's say-so)
 5. No unresolved blocker
+
+**Criterion 4 is the one that gets skipped, and the `analyzed` label is not
+proof of it.** Stage 2 can diagnose a request correctly and still leave its
+design open — #96 was labelled `analyzed`, prioritised `P2`, carried no blocking
+label, and was still not implementable, because *how* to build it was undecided.
+It reported *Ready*, an implementation session was dispatched at it, and that
+session deadlocked on three design questions nobody was there to answer. When
+an approach is genuinely undecided, record it: set `Awaiting` and post the open
+questions on the issue, so a later attempt can rehydrate them rather than
+rediscover them.
 
 An enhancement is Ready when 3–5 hold and the user-visible outcome is stated.
 An item failing any criterion stays in Backlog or Analysis and becomes your
@@ -90,8 +130,10 @@ always wins** — never trust a card's current position. Act on each mismatch:
 
 | Mismatch | Action |
 |---|---|
-| card *In progress*, no worktree, no PR | abandoned — move to *Ready*, report it |
-| worktree present, no session, no PR | the session died mid-issue. Report it and offer to relaunch; the branch's commits survive. **Never silently relaunch** — a session that died twice is telling you something |
+| card *In Progress*, no worktree, no PR | abandoned — move to *Ready for Dev*, report it |
+| `stale_worktree: true` | the branch already merged; the worktree is rot, not work. Hand to `sweep-prs`, and do not read it as progress |
+| worktree present, no session, no PR | the session died mid-issue. The branch's commits survive — resuming is `/implement-issue <n>`, whose Step 0 detects the prior work and re-enters at the right step. **Never silently relaunch**: a session that died twice is telling you something, and a background dispatch that reports `working` may have written nothing at all — verify by work product (`git -C <wt> log`, file mtimes), never by session state |
+| `last_comment.is_reporter` and `awaiting: reporter` | the reporter answered. Re-check the Definition of Ready — this wait may be satisfied, and it is the transition nothing used to notice |
 | PR `CONFLICTING` | hand to `sweep-prs` |
 | worktree whose PR merged | prune via `sweep-prs` |
 | issue closed, card not *Done* | move the card |

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -74,7 +74,15 @@ caused a real misclassification:
 | `awaiting_suggested` | What the labels imply, so an unset field can be reconciled without guessing. |
 | `last_comment` | `{author, days, is_reporter, is_bot}`. **The reporter-replied signal.** A comment count and a last-activity date cannot tell "the reporter answered us" from "we posted a nudge", which is why the follow-up chase never fired. |
 | `stale_worktree` | The worktree's own branch has already merged, so it is rot, not progress. Hand it to `sweep-prs`. |
-| `blocked` | `blocked` label or an unresolved `Blocked by #N`. Fails Ready outright. |
+| `blocked` | `blocked` label, or a `Blocked by #N` whose blocker is **still open**. Fails Ready outright. |
+| `blocked_by` / `blocked_by_open` | Every parsed reference, and the subset still open. Only the latter blocks — a `Blocked by #N` line is never edited out once N lands, so treating the raw scan as unresolved pins an item out of Ready forever. |
+
+**A wait outranks a live worktree, deliberately.** An item with a recorded wait
+reports *Analysis* even when a worktree is checked out for it, because unsettled
+scope must not read as progress. The worktree is still reported on the item
+(`worktree`, `worktree_branch`), so active undelivered code stays visible — the
+wait changes the column, not the evidence. Check those fields before assuming an
+*Analysis* item has no code behind it.
 
 **A human comment is not a wait.** `awaiting: discussion` used to be returned
 for any human comment, which pushed items to *Analysis* for ordinary traffic —

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -14,7 +14,8 @@ never implement, and you never assign. Implementers pull the top of Ready.
 Every pass starts from one command. Do not read issues one by one to build a
 picture:
 
-    ./scripts/backlog-digest.sh
+    ./scripts/backlog-rhythm.sh      # what is DUE now — start here
+    ./scripts/backlog-digest.sh      # the full evidence, when you need detail
 
 Open an individual issue only when you are deciding about that issue.
 
@@ -155,6 +156,53 @@ something an upstream vendor owns.
 Also review the digest's `orphans` list (worktrees with no matching open
 issue, PRs with no `fixes/closes/resolves` reference) and hand any worktree
 or PR rot found there to `sweep-prs`.
+
+## Verb: rhythm — the unattended pass
+
+The one that carries work from incoming to a **ready PR**. Start here on every
+`/loop /backlog` tick:
+
+    scripts/backlog-rhythm.sh
+
+It answers "what is due right now" deterministically — every rule is a
+comparison over the digest, so a quiet backlog costs one process instead of a
+model pass, and `RHYTHM: nothing due.` is a legitimate noop tick. **Do not
+re-derive these by reading issues; act on what it lists.**
+
+Why it exists: every follow-up rule in this skill had been written down and
+**none had ever fired.** They each needed a model to notice them and nothing
+scheduled one, so the 14-day chase, the 28-day park and the reporter-replied
+re-check were decoration.
+
+Actions, and who does what:
+
+| Action | Do |
+|---|---|
+| `mark_ready` | `gh pr ready <n>` — **this is the step that produces something to approve.** Unattended by design |
+| `awaiting_maintainer` | nothing; report it. Approved and out of draft is the finish line |
+| `request_review` | `scripts/request-pr-review.sh <n>`, then `mark_ready` on `APPROVED`. A draft cannot become ready without a review |
+| `rework` | resume with `/implement-issue <n>` — its Step 0 re-enters at the review loop |
+| `resolve_conflict` | hand to `sweep-prs` |
+| `recheck_ready` | the reporter answered: re-check Definition of Ready, clear `Awaiting` if satisfied |
+| `nudge_reporter` | one nudge, as the PO identity |
+| `park` | move to *Backlog* — the chase went unanswered |
+| `surface_discussion` | summarise the thread, put the open question to the maintainer. **Never auto-park an open conversation** |
+| `set_awaiting` / `set_priority` / `triage_labels` | grooming debt: write the board field or label |
+| `dispatchable` | propose for dispatch — needs the maintainer's go-ahead |
+
+**Ordering matters.** Work the PR actions first: they are closest to the finish
+line, and a `mark_ready` is worth more than any amount of triage. `recheck_ready`
+outranks the chases, because nudging someone who has already replied is the worst
+output this pass can produce.
+
+**Quiet time is measured from the last comment, not `updatedAt`** — a label
+change or a board move bumps `updatedAt`, so an issue nobody has spoken on for a
+month would otherwise look active and never age into a chase.
+
+**A `dispatchable` item is a proposal, not a launch.** Dispatch spends real
+money and needs the go-ahead. And verify the item truly meets criterion 4 first:
+`Ready for Dev` is derived, and a design-heavy item will stop and ask a question
+no unattended session can answer.
 
 ## Verb: next
 

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -178,10 +178,8 @@ Actions, and who does what:
 
 | Action | Do |
 |---|---|
-| `mark_ready` | `gh pr ready <n>` — **this is the step that produces something to approve.** Unattended by design |
-| `awaiting_maintainer` | nothing; report it. Approved and out of draft is the finish line |
-| `request_review` | `scripts/request-pr-review.sh <n>`, then `mark_ready` on `APPROVED`. A draft cannot become ready without a review |
-| `rework` | resume with `/implement-issue <n>` — its Step 0 re-enters at the review loop |
+| `resume_implementation` | `/implement-issue <n>`. **The action that produces a ready PR** — Step 11 requests the review, acts on the verdict and runs `gh pr ready`. Covers a draft needing a first review, a rework, an approved PR that never got flipped, *and* a worktree whose session died |
+| `awaiting_maintainer` | nothing; report it. Out of draft is the finish line |
 | `resolve_conflict` | hand to `sweep-prs` |
 | `recheck_ready` | the reporter answered: re-check Definition of Ready, clear `Awaiting` if satisfied |
 | `nudge_reporter` | one nudge, as the PO identity |
@@ -190,10 +188,29 @@ Actions, and who does what:
 | `set_awaiting` / `set_priority` / `triage_labels` | grooming debt: write the board field or label |
 | `dispatchable` | propose for dispatch — needs the maintainer's go-ahead |
 
-**Ordering matters.** Work the PR actions first: they are closest to the finish
-line, and a `mark_ready` is worth more than any amount of triage. `recheck_ready`
-outranks the chases, because nudging someone who has already replied is the worst
-output this pass can produce.
+**This pass does not drive the review loop, and must not learn to.**
+`implement-issue` owns a PR from its first commit to `gh pr ready`; Step 11
+already requests the review, acts on the verdict and flips the PR. So every
+unfinished draft resolves to one action — hand it back — and a second copy of
+that loop is never built here. It is the same argument that put resume in Step 0
+instead of a separate skill: two copies of one loop means one of them goes stale.
+
+**Restarting a stalled issue is always a resume, never a fresh start.** Step 0
+re-enters at the earliest incomplete step. A restart runs Step 4, which branches
+from `origin/main` and deletes commits that exist nowhere else — an audit found 8
+abandoned branches carrying real work, one with 32 commits.
+
+**A session reporting `working` may have written nothing.** Three background
+dispatches in one day produced zero tracked-file writes while reporting healthy
+state, and `claude logs` returns only spinner frames. Read `claude agents --json`
+**unsandboxed** (`~/.claude/jobs` is sandbox-denied, so a sandboxed listing
+silently truncates — it returned 1 session where the truth was 17), and confirm
+progress by work product: commits, `MERGE_HEAD`, file mtimes.
+
+**Ordering matters.** Work `resume_implementation` first — it is the only action
+that ends in something approvable. `recheck_ready` outranks the chases, because
+nudging someone who has already replied is the worst output this pass can
+produce.
 
 **Quiet time is measured from the last comment, not `updatedAt`** — a label
 change or a board move bumps `updatedAt`, so an issue nobody has spoken on for a

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -28,9 +28,21 @@ message that is misleading rather than wrong:
 
     set -a; . ./.env; set +a; ./scripts/backlog-digest.sh
 
-Board writes need `BESS_PO_TOKEN` with `project` scope. The custom-field JSON
-shape is confirmed: `gh project item-list --format json` puts each single-select
-value at the item's top level, so `.priority` and `.awaiting` both read directly.
+Board writes need `BESS_PO_TOKEN` with `project` scope.
+
+The custom-field JSON shape is **confirmed against the live board**, not
+assumed: `gh project item-list --format json` puts each single-select value at
+the item's top level, so `.priority` and `.awaiting` read directly. Re-verify
+with the command itself rather than trusting this paragraph — the tests fabricate
+that shape, so they cannot prove it:
+
+    gh project item-list 1 --owner johanzander --format json \
+      | jq '[.items[] | {n: .content.number, p: .priority, a: .awaiting}] | .[0:3]'
+
+That returned populated `P1`–`P3` values and 17 items with `Awaiting` set. It
+matters because a wrong path fails silently — `.priority?` / `.awaiting?` resolve
+to `null` for every item with no error, which reads exactly like an ungroomed
+board.
 
 Field options, as they actually exist — do not invent values outside these sets:
 

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -288,14 +288,64 @@ def test_blocked_label_is_never_ready(bin_dir: Path) -> None:
     assert item["blocked"] is True
 
 
-def test_blocked_by_reference_is_never_ready(bin_dir: Path) -> None:
+def test_open_blocked_by_reference_is_never_ready(bin_dir: Path) -> None:
+    """The blocker (#500) is itself open, so the wait is real."""
     issue = _issue(702, labels=[{"name": "analyzed"}], body="Blocked by #500\n")
+    blocker = _issue(500)
     board = [{"content": {"number": 702}, "priority": "P1"}]
+    _write_shim(bin_dir, "gh", _gh_shim([issue, blocker], [], board))
+
+    item = next(i for i in _run(bin_dir)["items"] if i["number"] == 702)
+    assert item["column"] == "Analysis"
+    assert item["blocked_by"] == [500]
+    assert item["blocked_by_open"] == [500]
+    assert item["blocked"] is True
+
+
+def test_closed_blocked_by_reference_does_not_block(bin_dir: Path) -> None:
+    """A `Blocked by #N` line is never edited out once N lands, so a pure text
+    scan pins the item out of Ready for Dev forever.
+
+    That is the same failure this script exists to fix, pointing the other way:
+    an item reading wrong relative to its real state. Only blockers still on the
+    open-issue list count. The reference stays visible in `blocked_by`.
+    """
+    issue = _issue(703, labels=[{"name": "analyzed"}], body="Blocked by #499\n")
+    board = [{"content": {"number": 703}, "priority": "P1"}]
+    # #499 is absent from the open-issue list, i.e. closed.
     _write_shim(bin_dir, "gh", _gh_shim([issue], [], board))
 
     item = _run(bin_dir)["items"][0]
+    assert item["blocked_by"] == [499]
+    assert item["blocked_by_open"] == []
+    assert item["blocked"] is False
+    assert item["column"] == "Ready for Dev"
+
+
+def test_a_wait_outranks_a_live_worktree_but_the_worktree_stays_visible(
+    bin_dir: Path,
+) -> None:
+    """Confirming intent, per review of #623.
+
+    A recorded wait beats a live worktree in `column`, because an item whose
+    scope is unsettled must not read as progressing — that is the whole point of
+    the precedence fix. The risk is hiding active undelivered code, so the
+    worktree is still reported on the item; only the column defers to the wait.
+    """
+    issue = _issue(704, labels=[{"name": "needs-debug-log"}])
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], []))
+    _write_shim(
+        bin_dir, "git", _git_shim(_porcelain(("/repo/wt/704", "fix/issue-704-live")))
+    )
+
+    item = _run(bin_dir)["items"][0]
+
     assert item["column"] == "Analysis"
-    assert item["blocked_by"] == [500]
+    assert item["awaiting"] == "reporter"
+    # The code is still visible — the wait changes the column, not the evidence.
+    assert item["worktree"] == "/repo/wt/704"
+    assert item["worktree_branch"] == "fix/issue-704-live"
+    assert item["stale_worktree"] is False
 
 
 def test_worktree_whose_branch_merged_is_not_in_progress(bin_dir: Path) -> None:

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -34,8 +34,18 @@ def _run(bin_dir: Path, **extra_env: str) -> dict:
         **extra_env,
     )
     proc = subprocess.run(
-        ["bash", str(SCRIPT)], capture_output=True, text=True, env=env, check=True
+        ["bash", str(SCRIPT)], capture_output=True, text=True, env=env
     )
+    # `check=True` raised a CalledProcessError whose message carries only the
+    # exit status, so a jq failure inside the digest surfaced as a bare
+    # "returned non-zero exit status 5" with the actual error swallowed. The
+    # digest writes its diagnostics to stderr; a test harness that hides them
+    # makes every failure a guessing game.
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"backlog-digest.sh exited {proc.returncode}\n"
+            f"--- stderr ---\n{proc.stderr}\n--- stdout ---\n{proc.stdout[:2000]}"
+        )
     # Typed intermediate: json.loads returns Any, and warn_return_any is on.
     digest: dict = json.loads(proc.stdout)
     return digest
@@ -81,19 +91,35 @@ def bin_dir(tmp_path: Path) -> Path:
     return d
 
 
-def _gh_shim(issues: list, prs: list, project_items: list) -> str:
-    """A `gh` that answers the three subcommands the digest calls."""
+def _gh_shim(
+    issues: list,
+    prs: list,
+    project_items: list,
+    merged_prs: list | None = None,
+) -> str:
+    """A `gh` that answers the four subcommands the digest calls.
+
+    `pr list` is called twice with different `--state` values, so this shim
+    branches on the whole argument string rather than just `$1 $2`. Matching
+    only the subcommand returned the OPEN list for both calls, which made every
+    open PR look merged and reported every issue as having landed.
+    """
     return f"""
-case "$1 $2" in
-  "issue list") cat <<'EOF'
+merged=$(cat <<'EOF'
+{json.dumps(merged_prs or [])}
+EOF
+)
+case "$*" in
+  *"issue list"*) cat <<'EOF'
 {json.dumps(issues)}
 EOF
     ;;
-  "pr list") cat <<'EOF'
+  *"pr list"*"--state merged"*) printf '%s\\n' "$merged" ;;
+  *"pr list"*) cat <<'EOF'
 {json.dumps(prs)}
 EOF
     ;;
-  "project item-list") cat <<'EOF'
+  *"project item-list"*) cat <<'EOF'
 {json.dumps({"items": project_items})}
 EOF
     ;;
@@ -122,104 +148,206 @@ def test_untouched_issue_lands_in_backlog(bin_dir: Path) -> None:
     assert digest["items"][0]["awaiting"] is None
 
 
-def test_unlabeled_issue_with_discussion_lands_in_analysis(bin_dir: Path) -> None:
-    """#592 and #593 are real examples: open, actively discussed, no labels.
-    A label-only rule files them under Backlog while a live conversation runs."""
-    issue = {
-        "number": 592,
-        "title": "VPP idle mode",
+def _issue(number: int, **over: object) -> dict:
+    """An issue as `gh issue list --json ...` really returns it.
+
+    Every field the digest reads is present, `createdAt` on comments included —
+    real gh always sends it, and fixtures that omitted it made `days_since`
+    fail with "strptime/1 requires string inputs" rather than exercising
+    anything.
+    """
+    issue: dict = {
+        "number": number,
+        "title": f"issue {number}",
         "labels": [],
         "author": {"login": "reporter"},
         "createdAt": "2026-08-01T00:00:00Z",
         "updatedAt": "2026-08-14T00:00:00Z",
-        "comments": [
-            {"body": "what do you mean by idle?", "author": {"login": "areader"}}
-        ],
+        "comments": [],
         "body": "",
     }
+    issue.update(over)
+    return issue
+
+
+def _comment(login: str, body: str = "...", at: str = "2026-08-10T00:00:00Z") -> dict:
+    return {"body": body, "author": {"login": login}, "createdAt": at}
+
+
+def test_human_comment_alone_does_not_move_the_column(bin_dir: Path) -> None:
+    """A human comment is NOT a blocker, and used to be treated as one.
+
+    `awaiting: discussion` was returned whenever any human comment existed,
+    which pushed an item to Analysis for ordinary traffic — reporter thanks, a
+    follow-up question, a "me too". Only a genuine wait belongs in Analysis;
+    who spoke last is reported separately so the PO can judge.
+    """
+    issue = _issue(592, labels=[], comments=[_comment("areader", "what is idle?")])
     _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
 
     digest = _run(bin_dir)
+    item = digest["items"][0]
 
-    assert digest["items"][0]["column"] == "Analysis"
-    assert digest["items"][0]["awaiting"] == "discussion"
+    assert item["column"] == "Backlog"
+    assert item["awaiting"] is None
+    # ...but the comment is still visible, which is the point.
+    assert item["last_comment"]["author"] == "areader"
+    assert item["last_comment"]["is_bot"] is False
 
 
-def test_bot_only_comment_does_not_trigger_discussion(bin_dir: Path) -> None:
-    """Stage 1 triage (issue-triage.yml) posts a comment on every issue it
-    processes. A bot comment alone must not read as human discussion, or the
-    heuristic degenerates to 'everything is a discussion' once triage runs
-    on every issue."""
-    issue = {
-        "number": 612,
-        "title": "Only ever touched by triage",
-        "labels": [],
-        "author": {"login": "reporter"},
-        "createdAt": "2026-08-01T00:00:00Z",
-        "updatedAt": "2026-08-14T00:00:00Z",
-        "comments": [
-            {
-                "body": "Triaged as bug, needs-debug-log.",
-                "author": {"login": "bess-manager-claude-bot"},
-            }
-        ],
-        "body": "",
-    }
+def test_bot_comment_is_marked_as_bot(bin_dir: Path) -> None:
+    """Stage 1 triage comments on every issue it processes, so a bot comment
+    must never read as a human signal."""
+    issue = _issue(612, comments=[_comment("bess-manager-claude-bot", "Triaged.")])
     _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
 
     digest = _run(bin_dir)
+    item = digest["items"][0]
 
-    assert digest["items"][0]["column"] == "Backlog"
-    assert digest["items"][0]["awaiting"] is None
+    assert item["column"] == "Backlog"
+    assert item["awaiting"] is None
+    assert item["last_comment"]["is_bot"] is True
+    assert item["last_comment"]["is_reporter"] is False
 
 
-def test_human_comment_still_triggers_discussion(bin_dir: Path) -> None:
-    issue = {
-        "number": 613,
-        "title": "A real human weighed in",
-        "labels": [],
-        "author": {"login": "reporter"},
-        "createdAt": "2026-08-01T00:00:00Z",
-        "updatedAt": "2026-08-14T00:00:00Z",
-        "comments": [
-            {
-                "body": "I think this is actually two bugs.",
-                "author": {"login": "areader"},
-            }
+def test_reporter_reply_is_identifiable(bin_dir: Path) -> None:
+    """The transition the digest could not previously represent.
+
+    #621 crossed the Definition of Ready line when its reporter attached a
+    debug bundle. A comment COUNT and a last-activity DATE cannot distinguish
+    that from a nudge we posted ourselves, so the follow-up chase had nothing
+    to select on.
+    """
+    issue = _issue(
+        621,
+        author={"login": "valexi7"},
+        labels=[{"name": "bug"}],
+        comments=[
+            _comment(
+                "bess-product-owner", "please attach a bundle", "2026-08-09T00:00:00Z"
+            ),
+            _comment("valexi7", "here is the export", "2026-08-12T00:00:00Z"),
         ],
-        "body": "",
-    }
+    )
     _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
 
     digest = _run(bin_dir)
+    last = digest["items"][0]["last_comment"]
 
-    assert digest["items"][0]["column"] == "Analysis"
-    assert digest["items"][0]["awaiting"] == "discussion"
+    assert last["author"] == "valexi7"
+    assert last["is_reporter"] is True
+    assert last["is_bot"] is False
 
 
-def test_bot_and_human_comment_still_triggers_discussion(bin_dir: Path) -> None:
-    issue = {
-        "number": 614,
-        "title": "Triaged, then a human replied",
-        "labels": [],
-        "author": {"login": "reporter"},
-        "createdAt": "2026-08-01T00:00:00Z",
-        "updatedAt": "2026-08-14T00:00:00Z",
-        "comments": [
-            {"body": "Triaged as bug.", "author": {"login": "bess-manager-claude-bot"}},
-            {
-                "body": "Actually I can't reproduce this.",
-                "author": {"login": "areader"},
-            },
-        ],
-        "body": "",
-    }
-    _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
+def test_board_awaiting_overrides_analyzed(bin_dir: Path) -> None:
+    """#96, exactly: labelled `analyzed`, prioritised, no blocking label — and
+    still not implementable, because its approach was undecided. It reported
+    Ready, an implementation session was dispatched at it, and that session
+    deadlocked on three design questions it had no way to answer.
+
+    A wait recorded on the board must outrank `analyzed`.
+    """
+    issue = _issue(96, labels=[{"name": "analyzed"}])
+    board = [{"content": {"number": 96}, "priority": "P2", "awaiting": "discussion"}]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], board))
 
     digest = _run(bin_dir)
+    item = digest["items"][0]
 
-    assert digest["items"][0]["column"] == "Analysis"
-    assert digest["items"][0]["awaiting"] == "discussion"
+    assert item["column"] == "Analysis"
+    assert item["awaiting"] == "discussion"
+    assert item["awaiting_source"] == "board"
+
+
+def test_analyzed_with_priority_is_ready_for_dev(bin_dir: Path) -> None:
+    issue = _issue(700, labels=[{"name": "analyzed"}])
+    board = [{"content": {"number": 700}, "priority": "P1"}]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], board))
+
+    assert _run(bin_dir)["items"][0]["column"] == "Ready for Dev"
+
+
+def test_analyzed_without_priority_is_not_ready(bin_dir: Path) -> None:
+    """The design always required a Priority for Ready. The condition was left
+    out because no board existed, and never added once one did."""
+    issue = _issue(701, labels=[{"name": "analyzed"}])
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
+
+    assert _run(bin_dir)["items"][0]["column"] == "Analysis"
+
+
+def test_blocked_label_is_never_ready(bin_dir: Path) -> None:
+    """Definition of Ready criterion 5. #571 reported `Ready for Dev` while
+    carrying the `blocked` label."""
+    issue = _issue(571, labels=[{"name": "analyzed"}, {"name": "blocked"}])
+    board = [{"content": {"number": 571}, "priority": "P2"}]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], board))
+
+    item = _run(bin_dir)["items"][0]
+    assert item["column"] == "Analysis"
+    assert item["blocked"] is True
+
+
+def test_blocked_by_reference_is_never_ready(bin_dir: Path) -> None:
+    issue = _issue(702, labels=[{"name": "analyzed"}], body="Blocked by #500\n")
+    board = [{"content": {"number": 702}, "priority": "P1"}]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], board))
+
+    item = _run(bin_dir)["items"][0]
+    assert item["column"] == "Analysis"
+    assert item["blocked_by"] == [500]
+
+
+def test_worktree_whose_branch_merged_is_not_in_progress(bin_dir: Path) -> None:
+    """#593, #571, #542 and #466 all reported In Progress while their PRs had
+    already merged, because an un-pruned worktree was treated as live work."""
+    issue = _issue(593, labels=[{"name": "bug"}])
+    merged = [
+        {"number": 618, "headRefName": "fix/issue-593-vpp-write-order", "body": ""}
+    ]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], merged))
+    _write_shim(
+        bin_dir,
+        "git",
+        _git_shim(_porcelain(("/repo/wt/593", "fix/issue-593-vpp-write-order"))),
+    )
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["stale_worktree"] is True
+    assert item["column"] != "In Progress"
+    assert item["column"] == "Backlog"
+
+
+def test_worktree_on_an_unmerged_branch_is_in_progress(bin_dir: Path) -> None:
+    """The other half: a live worktree must still read as In Progress, or the
+    stale-detection fix would hide real work."""
+    issue = _issue(594, labels=[{"name": "bug"}])
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], []))
+    _write_shim(
+        bin_dir, "git", _git_shim(_porcelain(("/repo/wt/594", "fix/issue-594-live")))
+    )
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["stale_worktree"] is False
+    assert item["column"] == "In Progress"
+
+
+def test_merged_pr_does_not_close_an_open_issue(bin_dir: Path) -> None:
+    """A merged PR that closes an issue must NOT be read as Done while the
+    issue is open. This project's beta PRs deliberately omit `Closes #N` until
+    the fix graduates, so an open issue with a merged fix is the normal state —
+    treating it as finished reclassified 7 live issues, #118 and #403 included.
+    """
+    issue = _issue(118, labels=[{"name": "bug"}])
+    merged = [{"number": 504, "headRefName": "fix/whatever", "body": "fixes #118"}]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], merged))
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["merged_pr"] == 504
+    assert item["column"] != "Done"
 
 
 def test_needs_debug_log_is_awaiting_reporter(bin_dir: Path) -> None:
@@ -230,7 +358,7 @@ def test_needs_debug_log_is_awaiting_reporter(bin_dir: Path) -> None:
         "author": {"login": "reporter"},
         "createdAt": "2026-08-01T00:00:00Z",
         "updatedAt": "2026-08-02T00:00:00Z",
-        "comments": [{"body": "please attach a debug bundle"}],
+        "comments": [_comment("owner", "please attach a debug bundle")],
         "body": "",
     }
     _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
@@ -284,7 +412,7 @@ def test_conflicting_pr_is_reported_on_its_issue(bin_dir: Path) -> None:
     item = digest["items"][0]
     assert item["pr"] == 610
     assert item["pr_state"] == "CONFLICTING"
-    assert item["column"] == "In review"
+    assert item["column"] == "In Review"
 
 
 def test_issue_matched_by_two_prs_emits_one_item_with_a_scalar_pr(
@@ -368,7 +496,7 @@ def test_worktree_branch_without_issue_prefix_joins_by_delimited_number(
     digest = _run(bin_dir)
 
     item = digest["items"][0]
-    assert item["column"] == "In progress"
+    assert item["column"] == "In Progress"
     assert item["worktree"] == "/repo/worktrees/wt1"
 
 
@@ -432,7 +560,7 @@ def test_worktree_matched_only_by_similar_number_is_not_joined(bin_dir: Path) ->
 
     digest = _run(bin_dir)
 
-    assert digest["items"][0]["column"] != "In progress"
+    assert digest["items"][0]["column"] != "In Progress"
     assert digest["items"][0]["worktree"] is None
 
 

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -302,6 +302,55 @@ def test_open_blocked_by_reference_is_never_ready(bin_dir: Path) -> None:
     assert item["blocked"] is True
 
 
+def test_a_bulleted_blocked_by_line_still_counts(bin_dir: Path) -> None:
+    """Anchoring to the line start must still allow the markdown form people
+    actually write."""
+    issue = _issue(705, labels=[{"name": "analyzed"}], body="- Blocked by #500\n")
+    board = [{"content": {"number": 705}, "priority": "P1"}]
+    _write_shim(bin_dir, "gh", _gh_shim([issue, _issue(500)], [], board))
+
+    item = next(i for i in _run(bin_dir)["items"] if i["number"] == 705)
+    assert item["blocked_by"] == [500]
+    assert item["blocked"] is True
+
+
+def test_a_negated_blocked_by_is_not_a_blocker(bin_dir: Path) -> None:
+    """ "not blocked by #500 anymore" and "no longer blocked by #500" are the
+    natural way to update an issue once its blocker resolves — so a free
+    substring scan fires exactly when the blocker is GONE.
+
+    Matched per line and anchored to the line start, which rejects these without
+    a negation blacklist that would only cover the phrasings someone thought of.
+    This was inert on main (`blocked_by` was extracted and never used); gating
+    `column()` on it is what gave the bad parse teeth.
+    """
+    for body in (
+        "This is not blocked by #500 anymore.\n",
+        "We are no longer blocked by #500.\n",
+        "Was blocked by #500 but that shipped.\n",
+    ):
+        issue = _issue(706, labels=[{"name": "analyzed"}], body=body)
+        board = [{"content": {"number": 706}, "priority": "P1"}]
+        _write_shim(bin_dir, "gh", _gh_shim([issue, _issue(500)], [], board))
+
+        item = next(i for i in _run(bin_dir)["items"] if i["number"] == 706)
+        assert item["blocked_by"] == [], body
+        assert item["blocked"] is False, body
+        assert item["column"] == "Ready for Dev", body
+
+
+def test_an_incidental_mid_sentence_mention_does_not_reclassify(bin_dir: Path) -> None:
+    """`$blocked` is tested before the analyzed/priority branch, so an untriaged
+    issue that merely mentions a blocker in prose would move Backlog -> Analysis
+    with no human triage behind it."""
+    issue = _issue(707, labels=[], body="Might be blocked by #500, not sure yet.\n")
+    _write_shim(bin_dir, "gh", _gh_shim([issue, _issue(500)], [], []))
+
+    item = next(i for i in _run(bin_dir)["items"] if i["number"] == 707)
+    assert item["blocked"] is False
+    assert item["column"] == "Backlog"
+
+
 def test_closed_blocked_by_reference_does_not_block(bin_dir: Path) -> None:
     """A `Blocked by #N` line is never edited out once N lands, so a pure text
     scan pins the item out of Ready for Dev forever.

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -321,12 +321,24 @@ def test_the_handoff_names_the_issue_to_resume(tmp_path: Path) -> None:
     assert "/implement-issue 592" in action["detail"]
 
 
-def test_a_draft_with_no_linked_issue_says_so(tmp_path: Path) -> None:
-    """Rather than emitting an un-actionable `/implement-issue null`."""
+def test_a_draft_with_no_linked_issue_resumes_by_pr(tmp_path: Path) -> None:
+    """`implement-issue` is used for TODO.md items and refactors too, so a PR
+    with no linked issue is normal, not a defect.
+
+    Reporting "no issue, finish it by hand" left every self-directed PR with no
+    owner in the loop — which is how #620, #622 and #623 all ended up driven by
+    hand.
+
+    No flag distinguishes the two: GitHub numbers issues and PRs from one
+    sequence per repo, so a bare number is unambiguous and Step 0 resolves
+    whichever it is.
+    """
     pr = _pr(700, reviews=[])
     action = next(a for a in _run(tmp_path, [], [pr])["actions"] if a.get("pr") == 700)
+
     assert action["issue"] is None
-    assert "no issue references this PR" in action["detail"]
+    assert "/implement-issue 700" in action["detail"]
+    assert "--pr" not in action["detail"]
 
 
 def test_approved_non_draft_is_the_maintainers(tmp_path: Path) -> None:

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -1,0 +1,257 @@
+"""Tests for scripts/backlog-rhythm.sh — the Product Owner's "what is due now" pass.
+
+Every rule in `.claude/skills/backlog` had been written down and none had ever
+fired, because noticing them required a model and nothing scheduled one. The
+noticing now lives in this script as pure comparisons over the digest, so it
+can run on a timer for the cost of a process. These tests pin the comparisons.
+
+`RHYTHM_DIGEST_FILE` / `RHYTHM_PRS_FILE` are the script's test seams (the same
+shape as `BESS_ENV_FILE` in gh-agent.sh), so no network or live board is needed.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "backlog-rhythm.sh"
+
+
+def _item(number: int, **over: object) -> dict:
+    """A digest item with every field the rhythm rules read."""
+    item: dict = {
+        "number": number,
+        "title": f"issue {number}",
+        "labels": ["bug"],
+        "author": "reporter",
+        "age_days": 30,
+        "last_activity_days": 1,
+        "comments": 0,
+        "column": "Backlog",
+        "awaiting": None,
+        "awaiting_source": None,
+        "awaiting_suggested": None,
+        "last_comment": None,
+        "priority": "P2",
+        "pr": None,
+        "pr_state": None,
+        "merged_pr": None,
+        "worktree": None,
+        "worktree_branch": None,
+        "stale_worktree": False,
+        "session": None,
+        "blocked_by": [],
+        "blocked_by_open": [],
+        "blocked": False,
+    }
+    item.update(over)
+    return item
+
+
+def _comment(days: int, *, is_reporter: bool = False, is_bot: bool = False) -> dict:
+    return {
+        "author": "someone",
+        "days": days,
+        "is_reporter": is_reporter,
+        "is_bot": is_bot,
+    }
+
+
+def _run(tmp_path: Path, items: list, prs: list | None = None, **env: str) -> dict:
+    digest = tmp_path / "digest.json"
+    digest.write_text(json.dumps({"counts": {}, "items": items, "orphans": []}))
+    prs_file = tmp_path / "prs.json"
+    prs_file.write_text(json.dumps(prs or []))
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "--json"],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+            "RHYTHM_DIGEST_FILE": str(digest),
+            "RHYTHM_PRS_FILE": str(prs_file),
+            **env,
+        },
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"exited {proc.returncode}\nstderr:\n{proc.stderr}")
+    result: dict = json.loads(proc.stdout)
+    return result
+
+
+def _actions_for(result: dict, number: int) -> set[str]:
+    return {
+        a["action"]
+        for a in result["actions"]
+        if a.get("issue") == number or a.get("pr") == number
+    }
+
+
+def test_quiet_backlog_is_a_noop(tmp_path: Path) -> None:
+    """A quiet fleet must cost nothing to observe, or the loop is not worth
+    running on a timer."""
+    result = _run(tmp_path, [_item(1, labels=["bug"], last_comment=_comment(1))])
+    assert result["due"] == 0
+    assert result["actions"] == []
+
+
+def test_reporter_reply_beats_the_chase(tmp_path: Path) -> None:
+    """The worst output this pass could produce is nudging someone who has
+    already answered. A reply must win over the quiet-time chase, even when the
+    issue is well past the nudge threshold."""
+    item = _item(
+        621,
+        labels=["bug"],
+        awaiting="reporter",
+        last_comment=_comment(20, is_reporter=True),
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 621)
+
+    assert "recheck_ready" in actions
+    assert "nudge_reporter" not in actions
+    assert "park" not in actions
+
+
+def test_nudge_at_threshold_then_park(tmp_path: Path) -> None:
+    ours = _comment(14)  # last word was ours, so the ball is with them
+    nudge = _actions_for(
+        _run(
+            tmp_path, [_item(2, labels=["b"], awaiting="reporter", last_comment=ours)]
+        ),
+        2,
+    )
+    assert "nudge_reporter" in nudge and "park" not in nudge
+
+    parked = _actions_for(
+        _run(
+            tmp_path,
+            [_item(3, labels=["b"], awaiting="reporter", last_comment=_comment(28))],
+        ),
+        3,
+    )
+    assert "park" in parked and "nudge_reporter" not in parked
+
+
+def test_below_threshold_does_not_chase(tmp_path: Path) -> None:
+    item = _item(4, labels=["b"], awaiting="reporter", last_comment=_comment(13))
+    assert _actions_for(_run(tmp_path, [item]), 4) == set()
+
+
+def test_quiet_time_is_measured_from_the_last_comment(tmp_path: Path) -> None:
+    """Not from updatedAt. A label change, a board move or a bot touch all bump
+    updatedAt, so an issue nobody has spoken on for a month can look active and
+    never age into a chase."""
+    item = _item(
+        5,
+        labels=["b"],
+        awaiting="reporter",
+        last_activity_days=0,  # something touched it today...
+        last_comment=_comment(40),  # ...but nobody has spoken in 40 days
+    )
+    assert "park" in _actions_for(_run(tmp_path, [item]), 5)
+
+
+def test_stalled_discussion_is_surfaced_never_parked(tmp_path: Path) -> None:
+    """An open conversation is not an unanswered chase."""
+    item = _item(6, labels=["b"], awaiting="discussion", last_comment=_comment(40))
+    actions = _actions_for(_run(tmp_path, [item]), 6)
+    assert "surface_discussion" in actions
+    assert "park" not in actions
+
+
+def test_label_derived_awaiting_asks_for_the_board_field(tmp_path: Path) -> None:
+    item = _item(
+        7,
+        labels=["needs-debug-log"],
+        awaiting="reporter",
+        awaiting_source="label",
+        awaiting_suggested="reporter",
+        last_comment=_comment(1),
+    )
+    assert "set_awaiting" in _actions_for(_run(tmp_path, [item]), 7)
+
+
+def test_missing_priority_and_missing_labels_are_grooming_debt(tmp_path: Path) -> None:
+    item = _item(8, labels=[], priority=None, last_comment=_comment(1))
+    actions = _actions_for(_run(tmp_path, [item]), 8)
+    assert {"set_priority", "triage_labels"} <= actions
+
+
+def test_stale_worktree_is_handed_to_sweep_prs(tmp_path: Path) -> None:
+    item = _item(
+        9,
+        labels=["b"],
+        stale_worktree=True,
+        worktree_branch="fix/issue-9",
+        last_comment=_comment(1),
+    )
+    assert "prune_worktree" in _actions_for(_run(tmp_path, [item]), 9)
+
+
+def test_ready_for_dev_is_reported_as_dispatchable(tmp_path: Path) -> None:
+    item = _item(
+        10, labels=["analyzed"], column="Ready for Dev", last_comment=_comment(1)
+    )
+    assert "dispatchable" in _actions_for(_run(tmp_path, [item]), 10)
+
+
+# --- the PR half: reaching a READY PR ------------------------------------
+
+
+def _pr(number: int, **over: object) -> dict:
+    pr: dict = {
+        "number": number,
+        "title": f"pr {number}",
+        "isDraft": True,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": None,
+        "reviews": [],
+        "author": {"login": "johanzander"},
+    }
+    pr.update(over)
+    return pr
+
+
+def test_approved_draft_is_flagged_to_mark_ready(tmp_path: Path) -> None:
+    """The step that actually hands the maintainer something to approve.
+
+    #615 was APPROVED and still a draft overnight; #617 the same. Nothing was
+    watching for this transition, which is the entire point of the loop.
+    """
+    pr = _pr(615, isDraft=True, reviews=[{"state": "APPROVED"}])
+    actions = _actions_for(_run(tmp_path, [], [pr]), 615)
+    assert actions == {"mark_ready"}
+
+
+def test_approved_non_draft_is_the_maintainers(tmp_path: Path) -> None:
+    pr = _pr(490, isDraft=False, reviews=[{"state": "APPROVED"}])
+    assert "awaiting_maintainer" in _actions_for(_run(tmp_path, [], [pr]), 490)
+
+
+def test_draft_with_no_review_asks_for_one(tmp_path: Path) -> None:
+    """A draft cannot become ready without a review, and #619 sat unreviewed."""
+    assert "request_review" in _actions_for(_run(tmp_path, [], [_pr(619)]), 619)
+
+
+def test_changes_requested_becomes_rework(tmp_path: Path) -> None:
+    pr = _pr(614, reviews=[{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}])
+    assert "rework" in _actions_for(_run(tmp_path, [], [pr]), 614)
+
+
+def test_a_bare_commented_review_does_not_count_as_a_verdict(tmp_path: Path) -> None:
+    """The review bot posts its inline notes as a COMMENTED review before the
+    summary, so COMMENTED alone decides nothing — the PR still needs a review.
+    Treating it as a verdict is how an approved PR stayed a draft.
+    """
+    pr = _pr(623, reviews=[{"state": "COMMENTED"}])
+    actions = _actions_for(_run(tmp_path, [], [pr]), 623)
+    assert "mark_ready" not in actions
+    assert "rework" not in actions
+
+
+def test_conflicting_pr_is_flagged_over_its_review_state(tmp_path: Path) -> None:
+    """A CONFLICTING PR produces no CI run at all, so it presents as "checks
+    never fired" and nobody investigates."""
+    pr = _pr(437, mergeable="CONFLICTING", reviews=[])
+    assert "resolve_conflict" in _actions_for(_run(tmp_path, [], [pr]), 437)

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -189,6 +189,79 @@ def test_stale_worktree_is_handed_to_sweep_prs(tmp_path: Path) -> None:
     assert "prune_worktree" in _actions_for(_run(tmp_path, [item]), 9)
 
 
+def test_a_worktree_with_no_session_is_stalled_work(tmp_path: Path) -> None:
+    """The machine-died case, and the one the fleet was full of.
+
+    A live worktree with no session behind it is an implementation that stopped
+    mid-flight — restart, kill, or an agent that exited between steps. An audit
+    found 34 such worktrees, 8 holding real unpushed commits (one with 32), and
+    nothing picked any of them up.
+    """
+    item = _item(
+        589,
+        worktree="/repo/wt/589",
+        worktree_branch="feat/issue-589",
+        session=None,
+        last_comment=_comment(1),
+    )
+    action = next(
+        a
+        for a in _run(tmp_path, [item])["actions"]
+        if a["action"] == "resume_implementation"
+    )
+    assert action["issue"] == 589
+    # A resume, never a restart: Step 4 would branch fresh from origin/main and
+    # delete the commits that only exist on this branch.
+    assert "never restart" in action["detail"]
+
+
+def test_a_worktree_with_a_live_session_is_left_alone(tmp_path: Path) -> None:
+    item = _item(
+        590,
+        worktree="/repo/wt/590",
+        worktree_branch="feat/issue-590",
+        session="issue-590",
+        last_comment=_comment(1),
+    )
+    assert "resume_implementation" not in _actions_for(_run(tmp_path, [item]), 590)
+
+
+def test_a_stale_worktree_is_pruned_not_resumed(tmp_path: Path) -> None:
+    """Its branch already merged, so there is nothing to resume — only rot to
+    clear. Resuming here would re-enter a finished issue."""
+    item = _item(
+        593,
+        worktree="/repo/wt/593",
+        worktree_branch="fix/issue-593",
+        stale_worktree=True,
+        session=None,
+        last_comment=_comment(1),
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 593)
+    assert "prune_worktree" in actions
+    assert "resume_implementation" not in actions
+
+
+def test_work_with_a_pr_is_reported_once_by_the_pr_branch(tmp_path: Path) -> None:
+    """Both halves could fire on the same work. The PR branch owns the handoff
+    once a PR exists, so the issue rule stands down to avoid listing it twice."""
+    item = _item(
+        592,
+        pr=619,
+        worktree="/repo/wt/592",
+        worktree_branch="fix/issue-592",
+        session=None,
+        column="In Review",
+        last_comment=_comment(1),
+    )
+    pr = _pr(619, reviews=[])
+
+    result = _run(tmp_path, [item], [pr])
+    resumes = [a for a in result["actions"] if a["action"] == "resume_implementation"]
+    assert len(resumes) == 1
+    assert resumes[0]["pr"] == 619
+
+
 def test_ready_for_dev_is_reported_as_dispatchable(tmp_path: Path) -> None:
     item = _item(
         10, labels=["analyzed"], column="Ready for Dev", last_comment=_comment(1)
@@ -213,41 +286,52 @@ def _pr(number: int, **over: object) -> dict:
     return pr
 
 
-def test_approved_draft_is_flagged_to_mark_ready(tmp_path: Path) -> None:
-    """The step that actually hands the maintainer something to approve.
+def test_every_unfinished_draft_resolves_to_one_handoff(tmp_path: Path) -> None:
+    """This pass does NOT drive the review loop; `implement-issue` owns a PR
+    through to `gh pr ready`, and its Step 11 already requests the review, acts
+    on the verdict and flips the PR.
 
-    #615 was APPROVED and still a draft overnight; #617 the same. Nothing was
-    watching for this transition, which is the entire point of the loop.
+    So a draft needing a FIRST review, a draft needing REWORK, and a draft that
+    is already APPROVED but never got flipped all resolve to the same action:
+    hand it back to the skill that owns it. Step 0 re-enters at the right step.
+    Re-implementing any of that here would be a second copy of one loop, which
+    is how one of them goes stale.
     """
-    pr = _pr(615, isDraft=True, reviews=[{"state": "APPROVED"}])
-    actions = _actions_for(_run(tmp_path, [], [pr]), 615)
-    assert actions == {"mark_ready"}
+    approved_but_draft = _pr(615, reviews=[{"state": "APPROVED"}])
+    never_reviewed = _pr(619, reviews=[])
+    changes_requested = _pr(
+        614, reviews=[{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}]
+    )
+
+    for pr in (approved_but_draft, never_reviewed, changes_requested):
+        actions = _actions_for(_run(tmp_path, [], [pr]), pr["number"])
+        assert actions == {"resume_implementation"}, pr["number"]
+
+
+def test_the_handoff_names_the_issue_to_resume(tmp_path: Path) -> None:
+    """`/implement-issue <n>` takes an issue number, so the action has to carry
+    one — otherwise the loop reports work nobody can pick up."""
+    item = _item(592, pr=615, column="In Review", last_comment=_comment(1))
+    pr = _pr(615, reviews=[{"state": "APPROVED"}])
+
+    action = next(
+        a for a in _run(tmp_path, [item], [pr])["actions"] if a.get("pr") == 615
+    )
+    assert action["issue"] == 592
+    assert "/implement-issue 592" in action["detail"]
+
+
+def test_a_draft_with_no_linked_issue_says_so(tmp_path: Path) -> None:
+    """Rather than emitting an un-actionable `/implement-issue null`."""
+    pr = _pr(700, reviews=[])
+    action = next(a for a in _run(tmp_path, [], [pr])["actions"] if a.get("pr") == 700)
+    assert action["issue"] is None
+    assert "no issue references this PR" in action["detail"]
 
 
 def test_approved_non_draft_is_the_maintainers(tmp_path: Path) -> None:
     pr = _pr(490, isDraft=False, reviews=[{"state": "APPROVED"}])
     assert "awaiting_maintainer" in _actions_for(_run(tmp_path, [], [pr]), 490)
-
-
-def test_draft_with_no_review_asks_for_one(tmp_path: Path) -> None:
-    """A draft cannot become ready without a review, and #619 sat unreviewed."""
-    assert "request_review" in _actions_for(_run(tmp_path, [], [_pr(619)]), 619)
-
-
-def test_changes_requested_becomes_rework(tmp_path: Path) -> None:
-    pr = _pr(614, reviews=[{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}])
-    assert "rework" in _actions_for(_run(tmp_path, [], [pr]), 614)
-
-
-def test_a_bare_commented_review_does_not_count_as_a_verdict(tmp_path: Path) -> None:
-    """The review bot posts its inline notes as a COMMENTED review before the
-    summary, so COMMENTED alone decides nothing — the PR still needs a review.
-    Treating it as a verdict is how an approved PR stayed a draft.
-    """
-    pr = _pr(623, reviews=[{"state": "COMMENTED"}])
-    actions = _actions_for(_run(tmp_path, [], [pr]), 623)
-    assert "mark_ready" not in actions
-    assert "rework" not in actions
 
 
 def test_conflicting_pr_is_flagged_over_its_review_state(tmp_path: Path) -> None:

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -99,16 +99,12 @@ jq -n \
 
   def label_names: [.labels[].name];
 
-  # Automation identities whose comments do not count as human discussion.
-  # Stage 1 triage (issue-triage.yml) posts a comment on every issue it
-  # processes, in every one of its four buckets, and a deferred task turns
-  # that workflow into this very agent, as its own intake arm — at which point every
-  # issue would carry a bot comment and a raw comment-count heuristic would
-  # degenerate to "everything is a discussion". bess-product-owner and
-  # bess-developer are the renamed/future identities (see scripts/gh-agent.sh).
+  # Automation identities, so `last_comment.is_bot` can mark a comment that
+  # carries no human signal. Stage 1 triage (issue-triage.yml) comments on every
+  # issue it processes, so without this every issue looks like it has been
+  # spoken on. bess-product-owner and bess-developer are the renamed/future
+  # identities (see scripts/gh-agent.sh).
   def bot_authors: ["bess-manager-claude-bot", "bess-agent", "bess-product-owner", "bess-developer"];
-
-  def human_comments($comments): [ $comments[] | select((.author.login // "") as $a | (bot_authors | index($a)) | not) ];
 
   def pr_matches_issue($p; $n):
     ($p.body // "" | test("(?i)(fixes|closes|resolves) #\($n)\\b"))
@@ -156,8 +152,24 @@ jq -n \
     ([ $sessions[] | select(.name? == "issue-\($n)") | .name ]) as $matches
     | if ($matches | length) == 0 then null else $matches[0] end;
 
+  # Matched per LINE and anchored to its start, because `Blocked by #N` is a
+  # convention -- a line in the body, optionally bulleted -- not a phrase to be
+  # found anywhere in prose.
+  #
+  # A free `scan` over the whole body matched the substring regardless of what
+  # preceded it, so "not blocked by #50 anymore" and "no longer blocked by #12"
+  # both registered as live blockers. Those are the natural way to update an
+  # issue once a blocker resolves, so the false positive fires exactly when the
+  # blocker is gone. Anchoring rejects them without a negation blacklist, which
+  # would only ever cover the phrasings someone thought of.
+  #
+  # This matters more than it looks: on main `blocked_by` was extracted and
+  # never used, so the bad parse was inert. Gating `column()` on it is what
+  # gives it teeth.
   def blocked_by:
-    [ (.body // "") | scan("(?i)blocked by #(\\d+)") | .[0] | tonumber ];
+    [ (.body // "") | split("\n")[]
+      | select(test("^[[:space:]]*(?:[-*][[:space:]]*)?blocked by #[0-9]+"; "i"))
+      | capture("blocked by #(?<n>[0-9]+)"; "i") | .n | tonumber ];
 
   # Only blockers that are STILL OPEN count. `$issues` is the open-issue list,
   # so membership decides it — no extra API call.
@@ -287,10 +299,10 @@ jq -n \
           author: .author.login,
           age_days: days_since(.createdAt),
           last_activity_days: days_since(.updatedAt),
-          # Total comment count (bots included) — an activity signal, not
-          # the discussion trigger. `awaiting: discussion` above is driven
-          # by human_comments only; this field stays a raw total so the
-          # digest still shows how much traffic (bot or human) an issue has.
+          # Total comment count, bots included — a volume signal only. Nothing
+          # derives a column from it: `awaiting` no longer comes from comment
+          # activity at all, and `last_comment` below is what carries the
+          # actionable detail (who spoke, when, whether it was the reporter).
           comments: (.comments | length),
           column: $col,
           # Reported for EVERY column, not just Analysis. Suppressing it

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -25,6 +25,28 @@ issues=$(gh issue list --repo "$repo" --state open --limit 200 \
 prs=$(gh pr list --repo "$repo" --state open --limit 100 \
   --json number,title,headRefName,mergeable,body)
 
+# Merged PRs are needed to tell a LIVE worktree from a DEAD one. Without this,
+# any worktree left on disk pins its issue to In Progress forever: #602, #593
+# and #542 all reported In Progress while their PRs (#610, #618, #591) had
+# already merged, because the worktree was never pruned. `--state merged` is
+# the only authoritative signal here — this repo squash-merges, so a merged
+# branch is never an ancestor of main and `git branch --merged` reports
+# nothing as merged.
+#
+# The bodies are REDUCED to the issue numbers they reference before being passed
+# to jq. Passing 200 merged PR bodies through `--argjson` overflows the argument
+# list ("/usr/bin/jq: Argument list too long") — this repo's PR bodies run to
+# several KB each. Only the closing references and the branch name are needed to
+# decide whether a merged PR belongs to an issue, so extract those here and hand
+# jq a few hundred bytes instead of a megabyte.
+merged_prs=$(gh pr list --repo "$repo" --state merged --limit 200 \
+  --json number,headRefName,body \
+  | jq -c '[ .[] | {
+      number,
+      headRefName,
+      refs: [ (.body // "") | scan("(?i)(?:fixes|closes|resolves) #([0-9]+)") | .[0] | tonumber ]
+    } ]')
+
 # Emits, per worktree, a JSON object of {path, branch}. `git worktree list`
 # always emits the main checkout as its first record, and it is excluded
 # here — it is never a task worktree, so it must not appear in the orphan
@@ -68,6 +90,7 @@ board=$(gh project item-list "$PROJECT_NUMBER" --owner "${PROJECT_OWNER:-johanza
 jq -n \
   --argjson issues "$issues" \
   --argjson prs "$prs" \
+  --argjson merged_prs "$merged_prs" \
   --argjson worktrees "$worktrees" \
   --argjson sessions "$sessions" \
   --argjson board "$board" \
@@ -105,9 +128,29 @@ jq -n \
   def matches_issue($w; $n):
     ($w.path | test(issue_boundary($n))) or ($w.branch | test(issue_boundary($n)));
 
+  # Returns the whole worktree record, not just its path: the branch is needed
+  # to decide whether that worktree is still live (see stale_worktree below).
   def worktree_for($n):
-    ([ $worktrees[] | select(matches_issue(.; $n)) | .path ]) as $matches
+    ([ $worktrees[] | select(matches_issue(.; $n)) ]) as $matches
     | if ($matches | length) == 0 then null else $matches[0] end;
+
+  # A worktree is STALE when its own branch has already been merged. This is an
+  # exact branch-name comparison against the merged-PR list, deliberately not
+  # the fuzzy issue-number match used to associate a worktree with an issue:
+  #
+  #   - fuzzy matching is right for "which issue does this worktree belong to",
+  #     since branch names embed the issue number in several shapes
+  #   - it is WRONG for "has this work landed", because a merged PR whose branch
+  #     merely mentions the issue number proves nothing about THIS branch
+  #
+  # Getting that distinction wrong reclassified 7 open issues as Done, including
+  # #118, #120 and #403 whose fixes had not shipped. It also contradicts this
+  # project`s rule that a beta PR never carries `Closes #N` — an open issue with
+  # a merged PR is the NORMAL state during beta graduation, not a finished one.
+  def worktree_is_stale($wt):
+    $wt != null
+    and ($wt.branch // "") != ""
+    and ([ $merged_prs[] | select(.headRefName == $wt.branch) ] | length) > 0;
 
   def session_for($n):
     ([ $sessions[] | select(.name? == "issue-\($n)") | .name ]) as $matches
@@ -116,23 +159,87 @@ jq -n \
   def blocked_by:
     [ (.body // "") | scan("(?i)blocked by #(\\d+)") | .[0] | tonumber ];
 
-  def awaiting($labels; $comments):
+  # WHO SPOKE LAST. Without this the digest could not represent the single
+  # transition that matters most to grooming: the reporter answering the
+  # question we asked them. A comment COUNT and a last-activity DATE cannot
+  # distinguish "the reporter supplied the debug log" from "we posted a nudge"
+  # from "the reporter asked something new" — all three just increment a
+  # number. #621 crossed the Definition of Ready line when @valexi7 attached
+  # his bundle, and nothing in the digest could see it.
+  def last_comment($comments; $author):
+    ($comments | sort_by(.createdAt) | last) as $c
+    | if $c == null then null
+      else {
+        author: ($c.author.login // "unknown"),
+        days: days_since($c.createdAt),
+        # "Reporter replied" is the actionable case: they are answering us, so
+        # a wait on them may now be satisfied.
+        is_reporter: (($c.author.login // "") == $author),
+        is_bot: ((bot_authors | index($c.author.login // "")) != null)
+      }
+      end;
+
+  # BLOCKING waits, derived from labels. Each of these means development
+  # genuinely cannot start, so each one holds an item in Analysis.
+  #
+  # `discussion` is deliberately NOT in here any more. It used to be returned
+  # whenever any human comment existed, which is not a blocker — a Ready item
+  # picks up reporter thanks and follow-up questions all the time, and treating
+  # those as a wait would strand it. "A human commented" is reported separately
+  # below (last_comment_*) so the PO can judge; it no longer moves a column by
+  # itself.
+  def awaiting_from_labels($labels):
       if ($labels | index("needs-debug-log")) then "reporter"
       elif ($labels | index("ready-for-analysis")) then "analysis"
       elif ($labels | index("upstream")) then "upstream"
-      elif (human_comments($comments) | length) > 0 then "discussion"
       else null end;
 
-  # Ready keys off the `analyzed` label alone, deliberately. The design also
-  # requires "Priority is set", but no board exists yet so priority is null for
-  # everything — gating on it here would make Ready permanently unreachable and
-  # strand every analysed item. Add the priority condition in the same change
-  # that creates the board.
-  def column($labels; $pr; $wt; $awaiting):
-      if $pr != null then "In review"
-      elif $wt != null then "In progress"
-      elif ($labels | index("analyzed")) then "Ready"
+  # The board `Awaiting` field is AUTHORITATIVE when set, because it carries the
+  # one wait no label can express: "blocked on a maintainer decision". #96 is
+  # the case that forced this — it was labelled `analyzed`, carried no blocking
+  # label, and still could not be implemented because its approach was
+  # undecided. An implementation session was dispatched against it and
+  # deadlocked immediately on three design questions.
+  #
+  # This is not a fallback chain over one fact. The two inputs answer different
+  # questions: the label says "the pipeline is waiting on an external party",
+  # the field says "the PO recorded a wait". `awaiting_suggested` below reports
+  # what the label implies so a triage pass can reconcile an unset field,
+  # rather than the digest silently inventing a value.
+  def awaiting_from_board($n):
+      [ $board.items[]? | select(.content.number? == $n) | .awaiting? | select(. != null) ][0] // null;
+
+  # A worktree only means work-in-progress while nothing has superseded it.
+  # A merged PR for the same issue means the branch already landed and the
+  # worktree is just un-pruned rot.
+  # Merged PRs that explicitly CLOSE this issue. Matches only on the extracted
+  # closing references, never on a branch name — see worktree_is_stale for why
+  # branch-name matching is unsafe here. Reported for information; it does not
+  # move a column, because an open issue with a merged fix is the expected state
+  # until the fix graduates to a stable release.
+  def merged_pr_for($n):
+    ([ $merged_prs[] | select((.refs | index($n)) != null) ]) as $matches
+    | if ($matches | length) == 0 then null else $matches[0].number end;
+
+  # Column names match the board`s Status options exactly (Backlog, Analysis,
+  # Ready for Dev, In Progress, In Review, Done) so reconciling a card against
+  # this value is a string comparison and not a translation table.
+  #
+  # PRECEDENCE IS THE FIX. `analyzed` used to be tested BEFORE any wait, so an
+  # analysed-but-blocked item reported "Ready" and looked dispatchable. Waits
+  # now win: an item whose scope is unsettled goes back to Analysis no matter
+  # how far it got.
+  #
+  # `Ready for Dev` also now requires a Priority. The design always said so;
+  # the condition was left out because no board existed and it would have made
+  # Ready unreachable. The board exists, and every item carries P1-P4.
+  def column($labels; $pr; $wt_live; $awaiting; $priority; $blocked):
+      if $pr != null then "In Review"
+      elif $blocked then "Analysis"
       elif $awaiting != null then "Analysis"
+      elif $wt_live then "In Progress"
+      elif ($labels | index("analyzed")) and $priority != null then "Ready for Dev"
+      elif ($labels | index("analyzed")) then "Analysis"
       else "Backlog" end;
 
   {
@@ -145,9 +252,20 @@ jq -n \
     items: [ $issues[] | . as $i
       | (label_names) as $labels
       | (pr_for(.number)) as $pr
+      | (merged_pr_for(.number)) as $merged_pr
       | (worktree_for(.number)) as $wt
-      | (awaiting($labels; .comments)) as $aw
-      | (column($labels; $pr; $wt; $aw)) as $col
+      | (worktree_is_stale($wt)) as $wt_stale
+      | (($wt != null) and ($wt_stale | not)) as $wt_live
+      | ([ $board.items[]? | select(.content.number? == $i.number) | .priority? ][0] // null) as $prio
+      | (awaiting_from_labels($labels)) as $aw_label
+      | (awaiting_from_board(.number)) as $aw_board
+      | (($aw_board // $aw_label)) as $aw
+      # Definition of Ready criterion 5: no unresolved blocker. The `blocked`
+      # label and an unresolved `Blocked by #N` line both fail it, so neither
+      # item can be Ready however far its analysis got. #571 was reporting
+      # `Ready for Dev` while labelled `blocked`.
+      | (($labels | index("blocked")) != null or ((blocked_by | length) > 0)) as $blocked
+      | (column($labels; $pr; $wt_live; $aw; $prio; $blocked)) as $col
       | {
           number: .number,
           title: .title,
@@ -161,15 +279,34 @@ jq -n \
           # digest still shows how much traffic (bot or human) an issue has.
           comments: (.comments | length),
           column: $col,
-          awaiting: (if $col == "Analysis" then $aw else null end),
-          priority: (
-            [ $board.items[]? | select(.content.number? == $i.number) | .priority? ][0] // null
-          ),
+          # Reported for EVERY column, not just Analysis. Suppressing it
+          # elsewhere hid the most common case there is: a Backlog item waiting
+          # on a reporter reported `awaiting: null`, so the 14-day chase had
+          # nothing to select on and never ran.
+          awaiting: $aw,
+          # Where that value came from, and what triage should set when the
+          # board field is empty. Kept explicit rather than collapsed so a
+          # reconciliation pass can see a divergence instead of guessing.
+          awaiting_source: (if $aw == null then null
+                            elif $aw_board != null then "board"
+                            else "label" end),
+          awaiting_suggested: $aw_label,
+          last_comment: last_comment(.comments; .author.login),
+          priority: $prio,
           pr: ($pr.number // null),
           pr_state: ($pr.mergeable // null),
-          worktree: $wt,
+          merged_pr: $merged_pr,
+          worktree: ($wt.path // null),
+          worktree_branch: ($wt.branch // null),
+          # A worktree whose own branch has already merged is rot, and
+          # `sweep-prs` is what removes it. Flagged so a board pass reports it
+          # instead of reading it as active work: #593, #571, #542 and #466 all
+          # showed "In progress" for exactly this reason while their PRs (#618,
+          # #579, #591, #517) had already merged.
+          stale_worktree: $wt_stale,
           session: session_for(.number),
-          blocked_by: blocked_by
+          blocked_by: blocked_by,
+          blocked: $blocked
         }
     ],
     orphans: (

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -159,6 +159,18 @@ jq -n \
   def blocked_by:
     [ (.body // "") | scan("(?i)blocked by #(\\d+)") | .[0] | tonumber ];
 
+  # Only blockers that are STILL OPEN count. `$issues` is the open-issue list,
+  # so membership decides it — no extra API call.
+  #
+  # A raw text scan cannot tell a live blocker from a settled one, and a
+  # `Blocked by #N` line is never edited out once N merges. Treating the raw
+  # scan as "unresolved" pins an item out of Ready for Dev permanently, which
+  # is the same failure this script exists to fix, pointing the other way:
+  # an item reading wrong relative to its real state. `blocked_by` stays the
+  # raw parse so the reference remains visible.
+  def blocked_by_open($refs):
+    [ $refs[] | select(. as $n | ($issues | any(.number == $n))) ];
+
   # WHO SPOKE LAST. Without this the digest could not represent the single
   # transition that matters most to grooming: the reporter answering the
   # question we asked them. A comment COUNT and a last-activity DATE cannot
@@ -261,10 +273,12 @@ jq -n \
       | (awaiting_from_board(.number)) as $aw_board
       | (($aw_board // $aw_label)) as $aw
       # Definition of Ready criterion 5: no unresolved blocker. The `blocked`
-      # label and an unresolved `Blocked by #N` line both fail it, so neither
-      # item can be Ready however far its analysis got. #571 was reporting
-      # `Ready for Dev` while labelled `blocked`.
-      | (($labels | index("blocked")) != null or ((blocked_by | length) > 0)) as $blocked
+      # label and a still-open `Blocked by #N` both fail it, so neither item can
+      # be Ready however far its analysis got. #571 was reporting `Ready for Dev`
+      # while labelled `blocked`.
+      | (blocked_by) as $bb
+      | (blocked_by_open($bb)) as $bb_open
+      | (($labels | index("blocked")) != null or (($bb_open | length) > 0)) as $blocked
       | (column($labels; $pr; $wt_live; $aw; $prio; $blocked)) as $col
       | {
           number: .number,
@@ -305,7 +319,9 @@ jq -n \
           # #579, #591, #517) had already merged.
           stale_worktree: $wt_stale,
           session: session_for(.number),
-          blocked_by: blocked_by,
+          blocked_by: $bb,
+          # The subset still open, and the only one that fails Ready.
+          blocked_by_open: $bb_open,
           blocked: $blocked
         }
     ],

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -200,9 +200,21 @@ actions=$(printf '%s' "$digest" | jq \
                detail: "nothing left but your merge"}
          else {pr: .number, issue: $issue_no, action: "resume_implementation",
                why: "draft PR, review loop unfinished",
+               # `implement-issue` is used for TODO.md items and refactors too,
+               # not only for issues, so a PR with no linked issue is normal
+               # rather than a defect -- reporting "no issue, finish it by hand"
+               # left every self-directed PR with no owner in the loop.
+               #
+               # No flag distinguishes the two: GitHub numbers issues and PRs
+               # from ONE sequence per repo, so a bare number is already
+               # unambiguous and Step 0 resolves whichever it is. Where an issue
+               # is linked it is named, because it carries the diagnosis; where
+               # none is, the PR number is the handle, and it is a strong one --
+               # it holds the branch, the diff, the scope assessment and the
+               # review verdict, which is everything Step 0 reads.
                detail: (if $issue_no != null
                         then "/implement-issue \($issue_no) — Step 0 re-enters at the review loop and drives it to gh pr ready"
-                        else "no issue references this PR; finish it by hand or link it" end)}
+                        else "/implement-issue \(.number) — the PR number; no linked issue (TODO item or refactor)" end)}
          end)
     ]
 

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -72,7 +72,8 @@ actions=$(printf '%s' "$digest" | jq \
   # has spoken on for a month can look active and never age into a chase.
   def quiet_days: if .last_comment == null then .age_days else .last_comment.days end;
 
-  [ .items[]
+  (.items) as $items
+  | [ $items[]
 
     # The reporter answered us. This is the transition that matters most and
     # the one the digest could not previously see: a wait on the reporter may
@@ -139,6 +140,25 @@ actions=$(printf '%s' "$digest" | jq \
            detail: "classify it"}
      else empty end),
 
+    # STALLED WORK. A live worktree with no session behind it is an
+    # implementation that stopped mid-flight: the machine restarted, the
+    # session was killed, or the agent exited between steps. Nothing used to
+    # pick these up, and a fleet audit found 34 such worktrees -- 8 of them
+    # holding real unpushed commits, one with 32.
+    #
+    # `pr == null` guards against double-reporting: once a PR exists the PR
+    # branch below owns the handoff, and both firing would list the same work
+    # twice.
+    #
+    # The branch survives, so this is a resume and never a restart -- Step 0
+    # re-enters at the earliest incomplete step. Restarting would run Step 4,
+    # which branches fresh from origin/main and would delete those commits.
+    (if .worktree != null and (.stale_worktree | not) and .session == null and .pr == null
+     then {issue: .number, action: "resume_implementation",
+           why: "worktree \(.worktree_branch) on disk, no live session",
+           detail: "/implement-issue \(.number) — Step 0 resumes it; never restart, the branch commits are the only copy"}
+     else empty end),
+
     # The positive case: actually dispatchable.
     (if .column == "Ready for Dev"
      then {issue: .number, action: "dispatchable",
@@ -147,37 +167,43 @@ actions=$(printf '%s' "$digest" | jq \
      else empty end)
   ]
 
-  # --- the PR half: driving work to a READY PR ---------------------------
+  # --- the PR half -------------------------------------------------------
   #
-  # Ordered by how close each state is to the finish line, because the whole
-  # point of the loop is to hand over something approvable.
+  # This pass does NOT drive the review loop. `implement-issue` owns a PR from
+  # its first commit to `gh pr ready`, and Step 11 already requests the review,
+  # acts on the verdict and flips the PR when it is approved. Re-implementing
+  # any of that here would be a second copy of one loop, which is how one of
+  # them goes stale -- the same argument that put resume in Step 0 rather than
+  # in a separate skill.
+  #
+  # So an unfinished PR resolves to ONE action: hand it back to the skill that
+  # owns it. Step 0 detects the prior work and re-enters at the right step,
+  # whether the PR needs a first review, a rework, or just the ready flag it
+  # never got. #615 and #617 sat APPROVED-but-draft not because nothing was
+  # watching for that state, but because the sessions that owned them exited
+  # before Step 11 completed.
+  #
+  # Two exceptions stay here, because they are fleet-level and
+  # `implement-issue` deliberately does not widen to them (its Step 10 owns
+  # exactly one PR).
   + [ $prs[]
-      | (.reviews // []) as $rv
-      # The last review that DECIDED something. A bare COMMENTED may be the
-      # bot inline-notes placeholder rather than a verdict, so it does not
-      # count as one here.
-      | ([ $rv[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED") ] | last) as $decided
-      | (if .isDraft and ($decided.state? == "APPROVED")
-         then {pr: .number, action: "mark_ready",
-               why: "approved but still a draft",
-               detail: "gh pr ready \(.number) — this is what makes it approvable"}
-         elif (.isDraft | not) and ($decided.state? == "APPROVED")
-         then {pr: .number, action: "awaiting_maintainer",
-               why: "approved and out of draft",
-               detail: "nothing left but your merge"}
-         elif .mergeable == "CONFLICTING"
+      | . as $p
+      # The issue this PR belongs to, so the handoff can name it.
+      | ([ $items[] | select(.pr == $p.number) | .number ] | first) as $issue_no
+      | (if .mergeable == "CONFLICTING"
          then {pr: .number, action: "resolve_conflict",
                why: "CONFLICTING — note a conflicted PR produces no CI run at all",
                detail: "hand to sweep-prs, or resolve if the diff is ours"}
-         elif ($decided.state? == "CHANGES_REQUESTED")
-         then {pr: .number, action: "rework",
-               why: "changes requested",
-               detail: "resume with /implement-issue — its Step 0 re-enters at the review loop"}
-         elif .isDraft and ($rv | length) == 0
-         then {pr: .number, action: "request_review",
-               why: "draft with no review at all",
-               detail: "scripts/request-pr-review.sh \(.number) — a draft cannot become ready without one"}
-         else empty end)
+         elif (.isDraft | not)
+         then {pr: .number, action: "awaiting_maintainer",
+               why: "out of draft",
+               detail: "nothing left but your merge"}
+         else {pr: .number, issue: $issue_no, action: "resume_implementation",
+               why: "draft PR, review loop unfinished",
+               detail: (if $issue_no != null
+                        then "/implement-issue \($issue_no) — Step 0 re-enters at the review loop and drives it to gh pr ready"
+                        else "no issue references this PR; finish it by hand or link it" end)}
+         end)
     ]
 
   | {

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# The Product Owner's Rhythm pass: decide what grooming is DUE right now.
+#
+# This exists because none of the follow-up rules in .claude/skills/backlog
+# had ever fired. The 14-day reporter chase, the 28-day park, the
+# reporter-replied re-check and the stale-worktree handoff were all written
+# down and none of them ran, because nothing scheduled them and every rule
+# needed a model to notice it.
+#
+# So the NOTICING is deterministic and lives here. Every rule below is a
+# comparison over `backlog-digest.sh` output — no judgement, no tokens. The
+# PO agent is only needed to ACT (write a nudge, summarise a thread, decide a
+# priority), and only when this script says something is due. A quiet backlog
+# therefore costs one cheap process instead of a model pass.
+#
+# Usage:
+#   scripts/backlog-rhythm.sh            # human-readable actions, or "nothing due"
+#   scripts/backlog-rhythm.sh --json     # machine-readable, for a scheduled loop
+#
+# Exit codes:
+#   0  ran successfully (whether or not anything is due — check the output)
+#   1  the digest failed; its stderr is passed through
+#
+# It never writes to GitHub. Deciding is cheap and safe to run on a timer;
+# acting is the PO's, and needs the identity and the judgement.
+set -euo pipefail
+
+as_json=false
+if [ "${1:-}" = "--json" ]; then
+    as_json=true
+fi
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Thresholds. NUDGE_DAYS/PARK_DAYS mirror the skill's board table (nudge once
+# at 14 days, park at 28); they are variables so the tests can drive the
+# boundaries without waiting a fortnight.
+NUDGE_DAYS="${RHYTHM_NUDGE_DAYS:-14}"
+PARK_DAYS="${RHYTHM_PARK_DAYS:-28}"
+
+# `RHYTHM_DIGEST_FILE` and `RHYTHM_PRS_FILE` are test seams, the same shape as
+# `BESS_ENV_FILE` in gh-agent.sh: they let the rules be exercised against
+# fixtures without a network round-trip or a live board. Unset in normal use.
+if [ -n "${RHYTHM_DIGEST_FILE:-}" ]; then
+    digest=$(cat "$RHYTHM_DIGEST_FILE")
+else
+    digest=$("$here/backlog-digest.sh")
+fi
+
+# The PR side of the loop. The goal is a READY PR for the maintainer to
+# approve, and a draft PR only becomes ready by earning an APPROVED review —
+# so the two states that actually move work to the finish line are "draft with
+# no review requested" and "draft that has been approved". Neither is visible
+# in the issue digest, and both were invisible in practice: three PRs sat green
+# and reviewed with nobody flipping them, and #619 was never reviewed at all.
+repo="${REPO:-johanzander/bess-manager}"
+if [ -n "${RHYTHM_PRS_FILE:-}" ]; then
+    prs=$(cat "$RHYTHM_PRS_FILE")
+else
+    prs=$(gh pr list --repo "$repo" --state open --limit 100 \
+        --json number,title,isDraft,mergeable,reviewDecision,reviews,author)
+fi
+
+actions=$(printf '%s' "$digest" | jq \
+    --argjson nudge "$NUDGE_DAYS" \
+    --argjson park "$PARK_DAYS" \
+    --argjson prs "$prs" '
+
+  # Quiet time is measured from the LAST COMMENT, not from updatedAt. A label
+  # change, a board move or a bot touch all bump updatedAt, so an issue nobody
+  # has spoken on for a month can look active and never age into a chase.
+  def quiet_days: if .last_comment == null then .age_days else .last_comment.days end;
+
+  [ .items[]
+
+    # The reporter answered us. This is the transition that matters most and
+    # the one the digest could not previously see: a wait on the reporter may
+    # now be satisfied, so the Definition of Ready needs re-checking. It is
+    # listed before the chases on purpose — chasing someone who has already
+    # replied is the worst output this pass could produce.
+    | (if .awaiting == "reporter" and (.last_comment.is_reporter // false)
+       then {issue: .number, action: "recheck_ready",
+             why: "reporter replied \(.last_comment.days)d ago while awaiting them",
+             detail: "re-check Definition of Ready; clear Awaiting if satisfied"}
+       else empty end),
+
+    # Chase once, then park. `is_reporter` false means the last word was ours,
+    # so the ball is still with them.
+    (if .awaiting == "reporter"
+        and ((.last_comment.is_reporter // false) | not)
+        and quiet_days >= $park
+     then {issue: .number, action: "park",
+           why: "awaiting reporter, quiet \(quiet_days)d (>= \($park))",
+           detail: "move to Backlog; the chase has gone unanswered"}
+     elif .awaiting == "reporter"
+        and ((.last_comment.is_reporter // false) | not)
+        and quiet_days >= $nudge
+     then {issue: .number, action: "nudge_reporter",
+           why: "awaiting reporter, quiet \(quiet_days)d (>= \($nudge))",
+           detail: "nudge once, as the PO identity"}
+     else empty end),
+
+    # A discussion nobody has advanced is a question for the maintainer, not a
+    # reason to keep waiting. Never auto-parked: an open conversation is not
+    # the same as an unanswered chase.
+    (if .awaiting == "discussion" and quiet_days >= $nudge
+     then {issue: .number, action: "surface_discussion",
+           why: "discussion stalled \(quiet_days)d",
+           detail: "summarise the thread and put the open question to the maintainer"}
+     else empty end),
+
+    # Grooming debt: the board field is unset while a label implies a wait, so
+    # the authoritative value is missing and only the label is holding it.
+    (if .awaiting != null and .awaiting_source == "label"
+     then {issue: .number, action: "set_awaiting",
+           why: "labels imply awaiting=\(.awaiting_suggested) but the board field is empty",
+           detail: "set Awaiting on the card"}
+     else empty end),
+
+    # No priority means the item cannot be ranked, so it can never be "next".
+    (if .priority == null
+     then {issue: .number, action: "set_priority",
+           why: "no Priority on the board",
+           detail: "set P1-P4; without it the item is unrankable and never Ready"}
+     else empty end),
+
+    # Un-pruned worktrees are what made four issues read as In Progress.
+    (if .stale_worktree
+     then {issue: .number, action: "prune_worktree",
+           why: "worktree \(.worktree_branch) already merged",
+           detail: "hand to sweep-prs"}
+     else empty end),
+
+    # An open issue with no labels at all is unfiled. Real and common.
+    (if (.labels | length) == 0
+     then {issue: .number, action: "triage_labels",
+           why: "no labels",
+           detail: "classify it"}
+     else empty end),
+
+    # The positive case: actually dispatchable.
+    (if .column == "Ready for Dev"
+     then {issue: .number, action: "dispatchable",
+           why: "Ready for Dev, priority \(.priority)",
+           detail: "meets Definition of Ready; propose for dispatch"}
+     else empty end)
+  ]
+
+  # --- the PR half: driving work to a READY PR ---------------------------
+  #
+  # Ordered by how close each state is to the finish line, because the whole
+  # point of the loop is to hand over something approvable.
+  + [ $prs[]
+      | (.reviews // []) as $rv
+      # The last review that DECIDED something. A bare COMMENTED may be the
+      # bot inline-notes placeholder rather than a verdict, so it does not
+      # count as one here.
+      | ([ $rv[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED") ] | last) as $decided
+      | (if .isDraft and ($decided.state? == "APPROVED")
+         then {pr: .number, action: "mark_ready",
+               why: "approved but still a draft",
+               detail: "gh pr ready \(.number) — this is what makes it approvable"}
+         elif (.isDraft | not) and ($decided.state? == "APPROVED")
+         then {pr: .number, action: "awaiting_maintainer",
+               why: "approved and out of draft",
+               detail: "nothing left but your merge"}
+         elif .mergeable == "CONFLICTING"
+         then {pr: .number, action: "resolve_conflict",
+               why: "CONFLICTING — note a conflicted PR produces no CI run at all",
+               detail: "hand to sweep-prs, or resolve if the diff is ours"}
+         elif ($decided.state? == "CHANGES_REQUESTED")
+         then {pr: .number, action: "rework",
+               why: "changes requested",
+               detail: "resume with /implement-issue — its Step 0 re-enters at the review loop"}
+         elif .isDraft and ($rv | length) == 0
+         then {pr: .number, action: "request_review",
+               why: "draft with no review at all",
+               detail: "scripts/request-pr-review.sh \(.number) — a draft cannot become ready without one"}
+         else empty end)
+    ]
+
+  | {
+      due: length,
+      by_action: (group_by(.action) | map({key: .[0].action, value: length}) | from_entries),
+      actions: sort_by(.action, (.issue // .pr))
+    }
+')
+
+if [ "$as_json" = true ]; then
+    printf '%s\n' "$actions"
+    exit 0
+fi
+
+due=$(printf '%s' "$actions" | jq -r '.due')
+if [ "$due" -eq 0 ]; then
+    echo "RHYTHM: nothing due."
+    exit 0
+fi
+
+echo "RHYTHM: $due action(s) due"
+printf '%s' "$actions" | jq -r '
+  "",
+  (.by_action | to_entries | map("  \(.key): \(.value)") | join("\n")),
+  "",
+  (.actions[] | "  \(if .pr then "PR #\(.pr)" else "##\(.issue)" end) \(.action)\n      why: \(.why)\n      do : \(.detail)")
+'


### PR DESCRIPTION
## Problem

The digest misclassified enough of the board that grooming couldn't be trusted — and every misclassification pushed the same way: **work looked more ready than it was.**

Measured against the live board (Project #1):

| column | before | after |
|---|---|---|
| Analysis | 13 | **17** |
| Backlog | 13 | 15 |
| **Ready for Dev** | **1** | **0** |
| **In Progress** | **5** | **1** |
| In Review | 4 | 4 |

`Ready for Dev: 0` is the real finding. Nothing in the backlog is dispatchable — everything analysed is blocked or awaiting something. The single item that looked ready was a false positive, which is exactly why dispatching kept failing.

## Five defects, each traced to a real item

**1. `analyzed` was tested before any wait.** So an analysed-but-blocked item reported `Ready`. #96 was labelled `analyzed`, prioritised `P2`, carried no blocking label — and still wasn't implementable, because *how* to build it was undecided. It read as dispatchable, a session was dispatched at it, and that session deadlocked on three design questions with nobody there to answer. **Waits now outrank `analyzed`.**

**2. The board's `Awaiting` field was never read.** 17 items have it set (`discussion` ×11, `reporter` ×6); the digest derived its own value from labels instead. So grooming that had *already been done* had no effect on anything. The field is now authoritative, with `awaiting_source` and `awaiting_suggested` exposed so an unset field gets reconciled rather than silently invented.

**3. `awaiting: discussion` fired on any human comment** — which is not a blocker. Thanks, a "me too", a follow-up question all pushed an item into Analysis. Only a recorded wait or a blocking label does that now.

**4. A worktree left on disk pinned its issue to `In Progress` forever.** #593, #571, #542 and #466 all reported `In Progress` while their PRs (#618, #579, #591, #517) had already merged. Staleness is now decided by comparing the worktree's **own branch** against merged PRs — an exact match, deliberately *not* the fuzzy issue-number match used to associate a worktree with an issue. Those answer different questions and conflating them is what caused defect 6 below.

**5. `blocked` didn't fail Ready.** #571 reported `Ready for Dev` while carrying the `blocked` label. Definition of Ready criterion 5 now holds, including an unresolved `Blocked by #N`.

Plus: **`Ready for Dev` finally requires a `Priority`** — which the design always specified and the code deferred *"until a board exists"*. It exists, and every item carries P1–P4.

## New signal: who spoke last

`last_comment: {author, days, is_reporter, is_bot}`.

Without it the digest could not represent the transition that matters most to grooming — **the reporter answering us**. A comment *count* and a last-activity *date* cannot distinguish "the reporter attached the debug log we asked for" from "we posted a nudge" from "the reporter asked something new". All three just increment a number. #621 crossed the Definition of Ready line and nothing noticed.

## A change I made and then rejected

I initially mapped a merged PR to `Done`. It reclassified **7 open issues as finished** (#118, #120, #403 among them), and it contradicts this project's own rule that beta PRs omit `Closes #N` until graduation — so **an open issue with a merged fix is the normal state**, not a completed one. `merged_pr` is now reported for information, moves no column, and a test pins that.

## Verification

`./scripts/quality-check.sh` green — `Errors: 0`, `Warnings: 0`. **25 tests pass** (was 18), including one per defect above and both halves of the stale-worktree rule, so the fix can't hide live work.

Three test-harness bugs fixed along the way, each of which had been masking real behaviour:

- The `gh` shim matched on `$1 $2`, so both `pr list` calls returned the **open** list — every open PR would have looked merged. It now branches on the full argument string.
- Comment fixtures had no `createdAt`, which real `gh` always sends. Their absence failed `strptime` instead of testing anything.
- `_run` used `check=True`, so a jq failure surfaced as a bare `returned non-zero exit status 5` with the actual error swallowed. It now reports the digest's stderr.

One implementation note: merged PR bodies are reduced to their closing references *before* reaching jq — passing 200 of them through `--argjson` overflows the argument list (`/usr/bin/jq: Argument list too long`).

## Not in this PR

**Nothing runs any of this yet.** The design (`docs/superpowers/specs/2026-08-15-backlogger-agent-design.md:86-91`) puts follow-up on a local `/loop /backlog` "Rhythm" surface and predicted this exact failure — *"If reports start going stale, that is the signal to move Rhythm to an Actions cron"*. That condition has fired. Scheduling it is the remaining half and is deliberately separate, since this PR is what makes the signals worth acting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)