### PR TITLE
fix: raise the PR review turn cap from 60 to 120

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -49,7 +49,19 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot"
-          claude_args: "--max-turns 60 --permission-mode bypassPermissions"
+          # 60 turns was not enough and failed SILENTLY-ish: on PR #623 the run
+          # ended `Execution failed: Reached maximum number of turns (60)` after
+          # posting only an early scratch comment, so the PR showed a stray
+          # review and no verdict for 16 minutes while the run was already dead.
+          # A caller waiting on a verdict cannot tell that from a slow review.
+          #
+          # The cap is hit because this reviewer earns its keep: it checks the
+          # branch out, runs the suite, REVERTS the fix to confirm the tests go
+          # red without it, then runs black/ruff/mypy/shellcheck. That is the
+          # behaviour worth paying for, and it costs turns proportional to the
+          # diff. 120 leaves headroom for a multi-file PR while still bounding a
+          # runaway.
+          claude_args: "--max-turns 120 --permission-mode bypassPermissions"
           prompt: |
             You are the **PR Review** bot for PR #${{ github.event.issue.number }} in johanzander/bess-manager.
 


### PR DESCRIPTION
## The reviewer was not slow — it was dead

On PR #623 the Stage 4 run ended:

```
##[error]Execution failed: Reached maximum number of turns (60)
```

It had posted only an early scratch comment (`test-permission-check (will be replaced)`) and never got back to replacing it. So the PR sat for 16 minutes showing a stray review and no verdict, while the run had already failed. **A caller waiting on a verdict cannot distinguish a dead run from a thinking one** — both are silence — so `scripts/request-pr-review.sh` waits out its full timeout for nothing.

This is not the first time it looked like flakiness. #619's two "silent" rounds and #623's stub round were all read as bot noise; at least this one was a hard failure with a clear cause in the log.

## Why the cap is reached

Because the reviewer earns its keep. On the previous #623 round it:

- checked the branch out and ran `pytest` (27 passed),
- **reverted the fix and re-ran the suite** to confirm 13 tests go red without it — the "must be seen to fail" rule from `docs/agents/testing.md`,
- ran `black --check`, `ruff`, `mypy` and `shellcheck`,
- and independently verified a claim in the PR body against a real repo.

That is exactly the behaviour worth paying for, and its turn cost scales with the diff. 60 is fine for a one-file fix and not for a multi-file one.

120 leaves headroom while still bounding a runaway.

## Why this is a one-line PR

**Workflows triggered by `issue_comment` run from the default branch**, so this has no effect on any review until it is on `main`. Every other open PR is queued behind it — including the two that carry the rest of the Product Owner loop.

Worth noting while merging: branch protection on `main` requires only the `Merge gate` status check (`required_pull_request_reviews: null`), so this does not need a bot approval to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)