### PR TITLE
fix: make a backlog pass runnable without a shell preamble

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -204,7 +204,9 @@ Actions, and who does what:
 | Action | Do |
 |---|---|
 | `resume_implementation` | `/implement-issue <n>`. **The action that produces a ready PR** — Step 11 requests the review, acts on the verdict and runs `gh pr ready`. Covers a draft needing a first review, a rework, an approved PR that never got flipped, *and* a worktree whose session died |
-| `awaiting_maintainer` | nothing; report it. Out of draft is the finish line |
+| `awaiting_maintainer` | nothing; report it. Out of draft **and carrying an APPROVED review** is the finish line |
+| `request_review` | out of draft but Stage 4 never ran. `scripts/request-pr-review.sh <n>`. **Never report an unreviewed PR as ready to merge** — the draft flag is not a review, and a maintainer who flips it because a PR looks stuck routes around the one gate the pipeline is built on |
+| `rework_review` | out of draft with changes requested: `/implement-issue <n>` to address them, then a fresh review |
 | `resolve_conflict` | hand to `sweep-prs` |
 | `recheck_ready` | the reporter answered: re-check Definition of Ready, clear `Awaiting` if satisfied |
 | `nudge_reporter` | one nudge, as the PO identity |

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -22,11 +22,17 @@ Open an individual issue only when you are deciding about that issue.
 ## Prerequisites
 
 The board exists: **Project #1, "BESS Manager Backlog"**. `PROJECT_NUMBER=1`
-lives in the repo's `.env`, which `backlog-digest.sh` does **not** source — so
-export it first, or the digest exits with a "board has not been created yet"
-message that is misleading rather than wrong:
+and `BESS_PO_TOKEN` live in the repo's `.env`, and `backlog-digest.sh` sources
+it itself — **run it plainly, with no `set -a` preamble**. The file is
+gitignored and so exists only in the main checkout; the script resolves it via
+`git rev-parse --git-common-dir`, which points there from inside a worktree
+too.
 
-    set -a; . ./.env; set +a; ./scripts/backlog-digest.sh
+An earlier version required the caller to export those first, which is why an
+unattended `/loop /backlog` pass died on its first line every time: the thing
+invoking the script is a skill, not a shell someone typed into. If the digest
+now exits complaining about `PROJECT_NUMBER`, the variable is genuinely absent
+from `.env` — do not work around it by exporting one.
 
 Board writes need `BESS_PO_TOKEN` with `project` scope.
 
@@ -147,10 +153,16 @@ For each item the digest puts in Backlog or Analysis:
 ## Verb: board
 
 Reconcile every card against the digest's derived `column`. **The digest
-always wins** — never trust a card's current position. Act on each mismatch:
+always wins** — never trust a card's current position.
+
+The comparison is in the digest: every item carries `board_status` (where the
+card sits now) alongside `column` (where the evidence says it belongs), using
+the same six Status strings, so a mismatch is `board_status != column` and
+nothing needs a second `gh project item-list` call. Act on each mismatch:
 
 | Mismatch | Action |
 |---|---|
+| `board_status: null` | the issue has **no card at all**. It carries no Priority, and *Ready for Dev* requires one — so it can never become dispatchable however well it is analysed, while reading as an ordinary Backlog item. Add the card, then triage it normally. Also listed under `orphans` as `issue_no_card` |
 | card *In Progress*, no worktree, no PR | abandoned — move to *Ready for Dev*, report it |
 | `stale_worktree: true` | the branch already merged; the worktree is rot, not work. Hand to `sweep-prs`, and do not read it as progress |
 | worktree present, no session, no PR | the session died mid-issue. The branch's commits survive — resuming is `/implement-issue <n>`, whose Step 0 detects the prior work and re-enters at the right step. **Never silently relaunch**: a session that died twice is telling you something, and a background dispatch that reports `working` may have written nothing at all — verify by work product (`git -C <wt> log`, file mtimes), never by session state |
@@ -165,9 +177,10 @@ always wins** — never trust a card's current position. Act on each mismatch:
 Never auto-park an active conversation, and never chase a reporter for
 something an upstream vendor owns.
 
-Also review the digest's `orphans` list (worktrees with no matching open
-issue, PRs with no `fixes/closes/resolves` reference) and hand any worktree
-or PR rot found there to `sweep-prs`.
+Also review the digest's `orphans` list — worktrees with no matching open
+issue, PRs with no `fixes/closes/resolves` reference, and open issues with no
+board card (`issue_no_card`). Hand worktree or PR rot to `sweep-prs`; a missing
+card is yours to add.
 
 ## Verb: rhythm — the unattended pass
 

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -59,15 +59,24 @@ def _run_expect_failure(bin_dir: Path, **extra_env: str) -> subprocess.Completed
     )
 
 
-def _porcelain(*worktrees: tuple[str, str | None]) -> str:
+def _porcelain(*worktrees: tuple[str, str | None], locked: tuple[str, ...] = ()) -> str:
     """Build `git worktree list --porcelain` output for a main checkout
-    followed by the given (path, branch) pairs. branch=None means detached."""
+    followed by the given (path, branch) pairs. branch=None means detached.
+
+    Paths named in `locked` get a `locked` record in the real shape Claude Code
+    writes it -- `locked claude session <name> (pid N start ...)`, a reason
+    string rather than the bare keyword, which a `== "locked"` match would miss.
+    """
     records = [
         "worktree /repo\nHEAD 0000000000000000000000000000000000000\nbranch refs/heads/main"
     ]
     for path, branch in worktrees:
         lines = [f"worktree {path}", "HEAD 1111111111111111111111111111111111111"]
         lines.append(f"branch refs/heads/{branch}" if branch else "detached")
+        if path in locked:
+            lines.append(
+                "locked claude session wt (pid 97626 start Mon Aug 17 15:50:14 2026)"
+            )
         records.append("\n".join(lines))
     return "\n\n".join(records) + "\n"
 
@@ -890,6 +899,46 @@ def test_issue_with_no_card_reports_null_status_and_is_an_orphan(
     assert digest["items"][0]["board_status"] is None
     orphans = [o for o in digest["orphans"] if o["kind"] == "issue_no_card"]
     assert [o["ref"] for o in orphans] == ["624"]
+
+
+def test_a_locked_worktree_is_reported_as_locked(bin_dir: Path) -> None:
+    """The lock is the liveness signal `claude agents` cannot provide: it lists
+    background agents only, so a foreground `/implement-issue` is invisible and
+    its worktree reads as abandoned."""
+    issue = _issue(624)
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
+    _write_shim(
+        bin_dir,
+        "git",
+        _git_shim(
+            _porcelain(
+                ("/repo/worktrees/issue-624", "fix/issue-624-pwl"),
+                locked=("/repo/worktrees/issue-624",),
+            )
+        ),
+    )
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["worktree"] == "/repo/worktrees/issue-624"
+    assert item["worktree_locked"] is True
+    # ...and the name-matched session is still null, which is the whole point.
+    assert item["session"] is None
+
+
+def test_an_unlocked_worktree_is_reported_as_unlocked(bin_dir: Path) -> None:
+    issue = _issue(625)
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
+    _write_shim(
+        bin_dir,
+        "git",
+        _git_shim(_porcelain(("/repo/worktrees/issue-625", "fix/issue-625"))),
+    )
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["worktree"] == "/repo/worktrees/issue-625"
+    assert item["worktree_locked"] is False
 
 
 def test_issue_with_a_card_is_not_an_orphan(bin_dir: Path) -> None:

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -72,11 +72,22 @@ def _porcelain(*worktrees: tuple[str, str | None]) -> str:
     return "\n\n".join(records) + "\n"
 
 
-def _git_shim(porcelain: str) -> str:
+def _git_shim(porcelain: str, common_dir: str = "/nonexistent/repo/.git") -> str:
+    """A `git` answering the two calls the digest makes.
+
+    `rev-parse --git-common-dir` is how the digest locates the repo's `.env`,
+    and answering it from the shim is what keeps that lookup deterministic: a
+    test that let the real git through would resolve to the maintainer's
+    actual checkout and read their real `.env`, so the outcome would depend on
+    a gitignored file that CI does not have. The default points at a directory
+    holding no `.env`, which is the "nothing to source" case every pre-existing
+    test wants.
+    """
     escaped = porcelain.replace("'", "'\\''")
     return f"""
 case "$1 $2 $3" in
   "worktree list --porcelain") printf '%s' '{escaped}' ;;
+  "rev-parse --path-format=absolute --git-common-dir") printf '%s\\n' '{common_dir}' ;;
   *) echo "unexpected git call: $*" >&2; exit 1 ;;
 esac
 """
@@ -784,3 +795,108 @@ def test_missing_project_number_fails_loudly(bin_dir: Path) -> None:
 
     assert result.returncode != 0
     assert "PROJECT_NUMBER" in result.stderr
+
+
+def _dotenv(bin_dir: Path, tmp_path: Path, contents: str) -> None:
+    """Point the git shim at a repo root holding the given `.env`."""
+    repo_root = tmp_path / "checkout"
+    repo_root.mkdir(exist_ok=True)
+    (repo_root / ".env").write_text(contents)
+    _write_shim(
+        bin_dir, "git", _git_shim(_porcelain(), common_dir=str(repo_root / ".git"))
+    )
+
+
+def test_project_number_is_read_from_dotenv(bin_dir: Path, tmp_path: Path) -> None:
+    """The whole point: an unattended pass exports nothing, so the digest has
+    to find PROJECT_NUMBER itself or it never runs at all. `.env` is
+    gitignored, so no caller inherits it."""
+    _write_shim(bin_dir, "gh", _gh_shim([], [], []))
+    _dotenv(bin_dir, tmp_path, "PROJECT_NUMBER=1\nBESS_PO_TOKEN=tok\n")
+
+    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    env.pop("PROJECT_NUMBER", None)
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, env=env
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["counts"]["issues"] == 0
+
+
+def test_environment_wins_over_dotenv(bin_dir: Path, tmp_path: Path) -> None:
+    """An explicit PROJECT_NUMBER must not be overwritten by the file, or the
+    variable becomes un-overridable and a pinned value silently reads the
+    maintainer's real board."""
+    _dotenv(bin_dir, tmp_path, "PROJECT_NUMBER=1\n")
+    # A `gh` that refuses any project but 7. The assertion is that the digest
+    # asked for 7, which is observable nowhere except in the call itself.
+    _write_shim(
+        bin_dir,
+        "gh",
+        'case "$*" in\n'
+        '  *"project item-list 7"*) echo \'{"items": []}\' ;;\n'
+        '  *"project item-list"*) echo "wrong project: $*" >&2; exit 1 ;;\n'
+        '  *"issue list"*|*"pr list"*) echo \'[]\' ;;\n'
+        '  *) echo "unexpected gh call: $*" >&2; exit 1 ;;\n'
+        "esac\n",
+    )
+
+    digest = _run(bin_dir, PROJECT_NUMBER="7")
+
+    assert digest["counts"]["issues"] == 0
+
+
+def test_a_dotenv_without_the_variable_still_fails_loudly(
+    bin_dir: Path, tmp_path: Path
+) -> None:
+    """A `.env` that exists but carries no PROJECT_NUMBER must not be mistaken
+    for a configured one."""
+    _write_shim(bin_dir, "gh", _gh_shim([], [], []))
+    _dotenv(bin_dir, tmp_path, "BESS_PO_TOKEN=tok\n")
+
+    result = _run_expect_failure(bin_dir)
+
+    assert result.returncode != 0
+    assert "PROJECT_NUMBER" in result.stderr
+
+
+def test_board_status_reports_the_cards_current_column(bin_dir: Path) -> None:
+    """`column` is where the evidence says the card belongs; `board_status` is
+    where it actually sits. The board verb reconciles the two, so the digest
+    has to carry both — otherwise reconciling means a second API call by
+    hand, which is the one thing this script exists to prevent."""
+    issue = _issue(602, labels=[{"name": "bug"}])
+    card = {"content": {"number": 602}, "status": "Ready for Dev", "priority": "P1"}
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [card]))
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["board_status"] == "Ready for Dev"
+    assert item["column"] == "Backlog"
+
+
+def test_issue_with_no_card_reports_null_status_and_is_an_orphan(
+    bin_dir: Path,
+) -> None:
+    """An off-board issue carries no Priority, and `Ready for Dev` requires
+    one — so it can never become dispatchable however well it is analysed. It
+    has to be surfaced, not read as a quiet Backlog item."""
+    issue = _issue(624, labels=[{"name": "bug"}])
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], []))
+
+    digest = _run(bin_dir)
+
+    assert digest["items"][0]["board_status"] is None
+    orphans = [o for o in digest["orphans"] if o["kind"] == "issue_no_card"]
+    assert [o["ref"] for o in orphans] == ["624"]
+
+
+def test_issue_with_a_card_is_not_an_orphan(bin_dir: Path) -> None:
+    issue = _issue(602)
+    card = {"content": {"number": 602}, "status": "Backlog", "priority": "P1"}
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [card]))
+
+    digest = _run(bin_dir)
+
+    assert [o for o in digest["orphans"] if o["kind"] == "issue_no_card"] == []

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -378,6 +378,55 @@ def test_approved_non_draft_is_the_maintainers(tmp_path: Path) -> None:
     assert "awaiting_maintainer" in _actions_for(_run(tmp_path, [], [pr]), 490)
 
 
+def test_an_unreviewed_non_draft_is_never_reported_as_mergeable(
+    tmp_path: Path,
+) -> None:
+    """The draft flag is not a review. #626 was flipped out of draft by hand
+    because it looked stuck, had zero reviews, and was reported as "nothing
+    left but your merge" — routing straight around Stage 4, which is the gate
+    the whole pipeline is built on."""
+    pr = _pr(626, isDraft=False, reviews=[])
+    actions = _actions_for(_run(tmp_path, [], [pr]), 626)
+    assert "request_review" in actions
+    assert "awaiting_maintainer" not in actions
+
+
+def test_a_commented_review_alone_is_not_an_approval(tmp_path: Path) -> None:
+    """The bot posts its inline notes as a COMMENTED review BEFORE its real
+    verdict, so COMMENTED alone means the review is still in flight."""
+    pr = _pr(627, isDraft=False, reviews=[{"state": "COMMENTED"}])
+    actions = _actions_for(_run(tmp_path, [], [pr]), 627)
+    assert "request_review" in actions
+    assert "awaiting_maintainer" not in actions
+
+
+def test_a_non_draft_with_changes_requested_needs_rework(tmp_path: Path) -> None:
+    pr = _pr(
+        628,
+        isDraft=False,
+        reviewDecision="CHANGES_REQUESTED",
+        reviews=[{"state": "CHANGES_REQUESTED"}],
+    )
+    actions = _actions_for(_run(tmp_path, [], [pr]), 628)
+    assert "rework_review" in actions
+    assert "awaiting_maintainer" not in actions
+
+
+def test_an_approval_followed_by_notes_still_counts(tmp_path: Path) -> None:
+    """A trailing COMMENTED must not un-approve a PR — #490 carries exactly
+    this shape (COMMENTED, APPROVED, COMMENTED, APPROVED)."""
+    pr = _pr(
+        490,
+        isDraft=False,
+        reviews=[
+            {"state": "COMMENTED"},
+            {"state": "APPROVED"},
+            {"state": "COMMENTED"},
+        ],
+    )
+    assert "awaiting_maintainer" in _actions_for(_run(tmp_path, [], [pr]), 490)
+
+
 def test_conflicting_pr_is_flagged_over_its_review_state(tmp_path: Path) -> None:
     """A CONFLICTING PR produces no CI run at all, so it presents as "checks
     never fired" and nobody investigates."""

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -42,6 +42,9 @@ def _item(number: int, **over: object) -> dict:
         "merged_pr": None,
         "worktree": None,
         "worktree_branch": None,
+        # A live session holds its worktree locked. Defaults to unlocked so the
+        # pre-existing stalled-work tests keep asserting what they always did.
+        "worktree_locked": False,
         "stale_worktree": False,
         "session": None,
         "blocked_by": [],
@@ -247,6 +250,36 @@ def test_a_worktree_with_no_session_is_stalled_work(tmp_path: Path) -> None:
     assert "never restart" in action["detail"]
 
 
+def test_a_locked_worktree_is_never_reported_as_stalled(tmp_path: Path) -> None:
+    """`claude agents` lists background agents only, so a foreground
+    `/implement-issue` started from the terminal is invisible and its worktree
+    reads as abandoned. #624 was reported "no live session" while actively
+    being worked, advising a second session onto the same branch. The lock is
+    what a live session actually holds."""
+    item = _item(
+        624,
+        worktree="/repo/worktrees/fix-issue-624",
+        worktree_branch="fix/issue-624-pwl-window-bisect",
+        worktree_locked=True,
+        session=None,
+    )
+    assert "resume_implementation" not in _actions_for(_run(tmp_path, [item]), 624)
+
+
+def test_an_unlocked_worktree_with_no_session_is_still_stalled(
+    tmp_path: Path,
+) -> None:
+    """The lock must not swallow the case this rule exists for."""
+    item = _item(
+        625,
+        worktree="/repo/worktrees/fix-issue-625",
+        worktree_branch="fix/issue-625",
+        worktree_locked=False,
+        session=None,
+    )
+    assert "resume_implementation" in _actions_for(_run(tmp_path, [item]), 625)
+
+
 def test_a_worktree_with_a_live_session_is_left_alone(tmp_path: Path) -> None:
     item = _item(
         590,
@@ -408,6 +441,67 @@ def test_a_non_draft_with_changes_requested_needs_rework(tmp_path: Path) -> None
         reviews=[{"state": "CHANGES_REQUESTED"}],
     )
     actions = _actions_for(_run(tmp_path, [], [pr]), 628)
+    assert "rework_review" in actions
+    assert "awaiting_maintainer" not in actions
+
+
+def test_a_stale_approval_does_not_survive_a_later_changes_requested(
+    tmp_path: Path,
+) -> None:
+    """GitHub never rewrites an old review when a later round requests
+    changes, so an approved-then-reworked PR keeps its APPROVED entry forever.
+    Asking "is there an APPROVED anywhere" reported a PR with changes
+    outstanding as ready to merge — the same failure, reintroduced by the first
+    attempt at fixing it."""
+    pr = _pr(
+        700,
+        isDraft=False,
+        reviewDecision="CHANGES_REQUESTED",
+        reviews=[{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}],
+    )
+    actions = _actions_for(_run(tmp_path, [], [pr]), 700)
+    assert "rework_review" in actions
+    assert "awaiting_maintainer" not in actions
+
+
+def test_an_approval_is_honoured_when_review_decision_is_empty(
+    tmp_path: Path,
+) -> None:
+    """`reviewDecision` is only populated when the repo REQUIRES reviews, and
+    this one does not — #490 carries two real APPROVED reviews and still reads
+    "". Keying on reviewDecision alone would report it as never reviewed."""
+    pr = _pr(
+        490,
+        isDraft=False,
+        reviewDecision="",
+        reviews=[
+            {"state": "COMMENTED"},
+            {"state": "APPROVED"},
+            {"state": "COMMENTED"},
+            {"state": "APPROVED"},
+        ],
+    )
+    actions = _actions_for(_run(tmp_path, [], [pr]), 490)
+    assert "awaiting_maintainer" in actions
+    assert "request_review" not in actions
+
+
+def test_a_stale_approval_loses_to_changes_requested_without_review_decision(
+    tmp_path: Path,
+) -> None:
+    """The same staleness trap with no reviewDecision to lean on: the LAST
+    non-COMMENTED verdict decides, not the presence of an APPROVED."""
+    pr = _pr(
+        701,
+        isDraft=False,
+        reviewDecision="",
+        reviews=[
+            {"state": "APPROVED"},
+            {"state": "COMMENTED"},
+            {"state": "CHANGES_REQUESTED"},
+        ],
+    )
+    actions = _actions_for(_run(tmp_path, [], [pr]), 701)
     assert "rework_review" in actions
     assert "awaiting_maintainer" not in actions
 

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -28,6 +28,10 @@ def _item(number: int, **over: object) -> dict:
         "last_activity_days": 1,
         "comments": 0,
         "column": "Backlog",
+        # Defaults to matching `column`, so the default item is a reconciled
+        # card and no board action fires. A test that overrides one and not the
+        # other is asserting a mismatch on purpose.
+        "board_status": "Backlog",
         "awaiting": None,
         "awaiting_source": None,
         "awaiting_suggested": None,
@@ -176,6 +180,34 @@ def test_missing_priority_and_missing_labels_are_grooming_debt(tmp_path: Path) -
     item = _item(8, labels=[], priority=None, last_comment=_comment(1))
     actions = _actions_for(_run(tmp_path, [item]), 8)
     assert {"set_priority", "triage_labels"} <= actions
+
+
+def test_an_issue_with_no_card_asks_for_a_card_not_a_priority(
+    tmp_path: Path,
+) -> None:
+    """Both causes leave Priority null, and conflating them sent the PO to set
+    a field on a card that does not exist."""
+    item = _item(621, board_status=None, priority=None)
+    actions = _actions_for(_run(tmp_path, [item]), 621)
+    assert "add_card" in actions
+    assert "set_priority" not in actions
+
+
+def test_a_card_in_the_wrong_column_is_a_move(tmp_path: Path) -> None:
+    item = _item(602, board_status="Ready for Dev", column="In Progress")
+    result = _run(tmp_path, [item])
+    assert "move_card" in _actions_for(result, 602)
+    move = next(
+        a
+        for a in result["actions"]
+        if a.get("issue") == 602 and a["action"] == "move_card"
+    )
+    assert "In Progress" in move["detail"]
+
+
+def test_a_reconciled_card_is_not_moved(tmp_path: Path) -> None:
+    item = _item(603, board_status="Analysis", column="Analysis")
+    assert "move_card" not in _actions_for(_run(tmp_path, [item]), 603)
 
 
 def test_stale_worktree_is_handed_to_sweep_prs(tmp_path: Path) -> None:

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -12,10 +12,43 @@ set -euo pipefail
 
 repo="${REPO:-johanzander/bess-manager}"
 
+# PROJECT_NUMBER and BESS_PO_TOKEN live in the repo's `.env`. Reading it here
+# is the difference between the script working and the script never running:
+# `.env` is gitignored, so nothing exports it, and every fresh shell — every
+# `/loop /backlog` tick, every new session — hit the "board has not been
+# created yet" exit on line one. That message was the worst kind of wrong:
+# the board exists, is populated, and nothing about it needs fixing. The
+# documented workaround (`set -a; . ./.env; set +a; ./scripts/backlog-digest.sh`)
+# cannot survive an unattended pass, because the thing invoking the script is
+# a skill, not a shell the maintainer typed into.
+#
+# `--git-common-dir` is what makes this ONE rule instead of a search over
+# candidate paths. `.env` is gitignored, so it exists only in the main
+# checkout and never in a worktree — and the common dir resolves to the main
+# checkout's `.git` from either location, so its parent is the single
+# directory where `.env` can be. `--path-format=absolute` is required:
+# without it git may answer the relative `.git`, whose dirname is `.`, which
+# silently resolves against the caller's cwd instead of the repo.
+env_file="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.env"
+if [ -f "$env_file" ]; then
+  # The ENVIRONMENT WINS over the file. `set -a` sourcing would otherwise let
+  # `.env` overwrite an explicit `PROJECT_NUMBER=2 scripts/backlog-digest.sh`,
+  # which makes the variable un-overridable and makes any test that pins a
+  # value silently read the maintainer's real board instead.
+  env_project_number="${PROJECT_NUMBER:-}"
+  env_po_token="${BESS_PO_TOKEN:-}"
+  set -a
+  # shellcheck disable=SC1090  # runtime path, by construction
+  . "$env_file"
+  set +a
+  if [ -n "$env_project_number" ]; then PROJECT_NUMBER="$env_project_number"; fi
+  if [ -n "$env_po_token" ]; then BESS_PO_TOKEN="$env_po_token"; fi
+fi
+
 if [ -z "${PROJECT_NUMBER:-}" ]; then
-  echo "backlog-digest.sh: PROJECT_NUMBER is not set — the backlog board has" >&2
-  echo "not been created yet. Run scripts/backlog-board-init.sh (deferred) to" >&2
-  echo "create it, then set PROJECT_NUMBER." >&2
+  echo "backlog-digest.sh: PROJECT_NUMBER is not set, and no PROJECT_NUMBER was" >&2
+  echo "found in $env_file. The board is Project #1 (\"BESS Manager Backlog\");" >&2
+  echo "add PROJECT_NUMBER=1 to that .env, or export it for this shell." >&2
   exit 1
 fi
 
@@ -233,6 +266,26 @@ jq -n \
   def awaiting_from_board($n):
       [ $board.items[]? | select(.content.number? == $n) | .awaiting? | select(. != null) ][0] // null;
 
+  # The CURRENT column of the card, straight off the board. `column` below is
+  # the column the evidence says it should be in; without this field the two
+  # could never be compared, and the `board` verb — "reconcile every card
+  # against the derived column, the digest always wins" — had nothing to
+  # reconcile against. A pass had to make a second `gh project item-list` call
+  # by hand to recover exactly this, which is the one thing this script exists
+  # to stop.
+  #
+  # NOTE: no apostrophes anywhere in this jq program. It is a single-quoted
+  # shell string, so one apostrophe in a comment ends it early and jq reports
+  # the useless "Top-level program not given".
+  #
+  # `null` means NO CARD, not "no status": an issue that never made it onto the
+  # board. That is a live trap rather than a cosmetic gap, because
+  # `Ready for Dev` now requires a Priority and priority is a board field — so
+  # an off-board issue can never become dispatchable however well it is
+  # analysed. #621 and #624 were both in that state.
+  def board_status($n):
+      [ $board.items[]? | select(.content.number? == $n) | .status? | select(. != null) ][0] // null;
+
   # A worktree only means work-in-progress while nothing has superseded it.
   # A merged PR for the same issue means the branch already landed and the
   # worktree is just un-pruned rot.
@@ -305,6 +358,9 @@ jq -n \
           # actionable detail (who spoke, when, whether it was the reporter).
           comments: (.comments | length),
           column: $col,
+          # Where the card actually sits today, so a board pass can diff it
+          # against `column` above. null = the issue has no card at all.
+          board_status: board_status(.number),
           # Reported for EVERY column, not just Analysis. Suppressing it
           # elsewhere hid the most common case there is: a Backlog item waiting
           # on a reporter reported `awaiting: null`, so the 14-day chase had
@@ -343,6 +399,14 @@ jq -n \
       +
       [ $prs[] | select(. as $p | ($issues | map(.number) | any(. as $n | pr_matches_issue($p; $n))) | not)
         | {kind: "pr_no_issue", ref: (.number | tostring), detail: .title} ]
+      +
+      # An open issue with no card. Reported as an orphan because it is
+      # invisible everywhere else: it carries no Priority and no Awaiting, so
+      # it cannot reach `Ready for Dev`, cannot be ranked by `next`, and reads
+      # as a quiet un-groomed Backlog item rather than as a missing card.
+      # Adding it to the board is a triage action, not a bug in the item.
+      [ $issues[] | select(board_status(.number) == null)
+        | {kind: "issue_no_card", ref: (.number | tostring), detail: .title} ]
     )
   }
 '

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -80,23 +80,48 @@ merged_prs=$(gh pr list --repo "$repo" --state merged --limit 200 \
       refs: [ (.body // "") | scan("(?i)(?:fixes|closes|resolves) #([0-9]+)") | .[0] | tonumber ]
     } ]')
 
-# Emits, per worktree, a JSON object of {path, branch}. `git worktree list`
-# always emits the main checkout as its first record, and it is excluded
+# Emits, per worktree, a JSON object of {path, branch, locked}. `git worktree
+# list` always emits the main checkout as its first record, and it is excluded
 # here — it is never a task worktree, so it must not appear in the orphan
 # scan below.
+#
+# `locked` is the LIVENESS signal, and it is the only one that works. See the
+# session note below.
 worktrees=$(git worktree list --porcelain | awk '
   BEGIN { RS=""; FS="\n" }
   NR==1 { next }
   {
-    path=""; branch=""
+    path=""; branch=""; locked="false"
     for (i = 1; i <= NF; i++) {
       if ($i ~ /^worktree /)      { path = substr($i, 10) }
       else if ($i ~ /^branch /)   { branch = substr($i, 8); sub(/^refs\/heads\//, "", branch) }
+      else if ($i ~ /^locked/)    { locked = "true" }
     }
-    if (path != "") print path "\t" branch
+    if (path != "") print path "\t" branch "\t" locked
   }
-' | jq -R 'split("\t") | {path: .[0], branch: (.[1] // "")}' | jq -s .)
+' | jq -R 'split("\t") | {path: .[0], branch: (.[1] // ""), locked: (.[2] == "true")}' | jq -s .)
 
+# `claude agents` lists BACKGROUND agents only, and this is the trap that made
+# the rhythm pass tell the maintainer to restart work that was actively
+# running. Two independent reasons it cannot answer "is someone on this":
+#
+#   1. A session started in the terminal — `claude` in a CLI, then
+#      `/implement-issue <n>` — is a foreground session and never appears here
+#      at all. That is how #624 was dispatched.
+#   2. Even a background agent carries a generated descriptive name ("Review PR
+#      and create branch for bess-manager"), not the `issue-<n>` the dispatch
+#      convention promises, so the exact-name match below misses it too.
+#
+# Measured: 41 worktrees on disk, `claude agents --json` returning ONE entry.
+# So `session` was null for essentially every item, every worktree read as
+# abandoned, and `resume_implementation` fired on live sessions — against work
+# whose branch commits the skill itself calls the only copy.
+#
+# The worktree LOCK is the signal that actually tracks a live session: 4 of
+# those 41 were locked, and they were exactly the four live sessions. It is
+# local, needs no process list, and covers foreground and background alike.
+# `session` is kept because a name match is strictly more informative when it
+# does happen; it is no longer what liveness rests on.
 sessions=$(claude agents --json)
 
 # No `--field "Priority"` here: verified against the real CLI just now,
@@ -380,6 +405,10 @@ jq -n \
           merged_pr: $merged_pr,
           worktree: ($wt.path // null),
           worktree_branch: ($wt.branch // null),
+          # A LIVE session holds its worktree locked. This, not `session`, is
+          # what says whether anyone is on the item — see the note where the
+          # worktree list is built.
+          worktree_locked: ($wt.locked // false),
           # A worktree whose own branch has already merged is rot, and
           # `sweep-prs` is what removes it. Flagged so a board pass reports it
           # instead of reading it as active work: #593, #571, #542 and #466 all

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -212,10 +212,34 @@ actions=$(printf '%s' "$digest" | jq \
          then {pr: .number, action: "resolve_conflict",
                why: "CONFLICTING — note a conflicted PR produces no CI run at all",
                detail: "hand to sweep-prs, or resolve if the diff is ours"}
+         # OUT OF DRAFT IS NOT THE SAME AS REVIEWED, and treating it as such
+         # told the maintainer to merge an unreviewed PR. The old rule was
+         # `isDraft == false -> nothing left but your merge`, resting on the
+         # assumption that only Step 11 clears the draft flag, and only after
+         # an APPROVED verdict. Two things break that: a maintainer can flip
+         # the flag by hand (#626 was flipped because it LOOKED stuck, and had
+         # zero reviews at the time), and a Stage 3 CI-mode PR never runs Step
+         # 11 at all. Stage 4 is the gate the whole pipeline is built around;
+         # a surface that routes around it is worse than no surface.
+         #
+         # An APPROVED review is the bar, matching Step 11 exactly. Not
+         # `reviewDecision`, which is "" both for never-reviewed and for
+         # approved-then-dismissed, and not COMMENTED, which the bot also
+         # posts as a placeholder before its real verdict (see
+         # request-pr-review.sh).
          elif (.isDraft | not)
-         then {pr: .number, action: "awaiting_maintainer",
-               why: "out of draft",
-               detail: "nothing left but your merge"}
+         then (if ([ .reviews[]? | select(.state == "APPROVED") ] | length) > 0
+               then {pr: .number, action: "awaiting_maintainer",
+                     why: "out of draft and approved",
+                     detail: "nothing left but your merge"}
+               elif .reviewDecision == "CHANGES_REQUESTED"
+               then {pr: .number, issue: $issue_no, action: "rework_review",
+                     why: "out of draft but review asked for changes",
+                     detail: "address the review, then request a fresh one"}
+               else {pr: .number, issue: $issue_no, action: "request_review",
+                     why: "out of draft but never reviewed — Stage 4 has not run",
+                     detail: "scripts/request-pr-review.sh \(.number) — do NOT merge on the draft flag alone"}
+               end)
          else {pr: .number, issue: $issue_no, action: "resume_implementation",
                why: "draft PR, review loop unfinished",
                # `implement-issue` is used for TODO.md items and refactors too,

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -120,10 +120,28 @@ actions=$(printf '%s' "$digest" | jq \
      else empty end),
 
     # No priority means the item cannot be ranked, so it can never be "next".
-    (if .priority == null
+    #
+    # The two causes need different actions, and conflating them sent the PO
+    # to set a field on a card that does not exist. `board_status: null` is
+    # the stronger one: no card at all, so there is nothing to set a Priority
+    # on until one is added. #621 and #624 were both in that state while
+    # reporting the milder "no Priority on the board".
+    (if .board_status == null
+     then {issue: .number, action: "add_card",
+           why: "open issue with no card on the board",
+           detail: "add it to Project #1, then set Priority — until then it is unrankable and invisible to every board pass"}
+     elif .priority == null
      then {issue: .number, action: "set_priority",
            why: "no Priority on the board",
            detail: "set P1-P4; without it the item is unrankable and never Ready"}
+     else empty end),
+
+    # The card sits somewhere the evidence does not support. The digest wins;
+    # this is always a card move, never a re-derivation.
+    (if .board_status != null and .board_status != .column
+     then {issue: .number, action: "move_card",
+           why: "card is \(.board_status) but the evidence says \(.column)",
+           detail: "move the card to \(.column)"}
      else empty end),
 
     # Un-pruned worktrees are what made four issues read as In Progress.

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -171,9 +171,18 @@ actions=$(printf '%s' "$digest" | jq \
     # The branch survives, so this is a resume and never a restart -- Step 0
     # re-enters at the earliest incomplete step. Restarting would run Step 4,
     # which branches fresh from origin/main and would delete those commits.
-    (if .worktree != null and (.stale_worktree | not) and .session == null and .pr == null
+    #
+    # A LOCKED worktree means a session is holding it right now, and that check
+    # is what stops this rule from firing on live work. `session` alone could
+    # not: `claude agents` sees background agents only, so a foreground
+    # `/implement-issue` started from the terminal was invisible and its
+    # worktree read as abandoned. #624 was reported "no live session" while
+    # actively being worked, with the advice to re-enter it -- a second session
+    # on the same branch, against work the detail line itself calls the only
+    # copy.
+    (if .worktree != null and (.stale_worktree | not) and (.worktree_locked | not) and .session == null and .pr == null
      then {issue: .number, action: "resume_implementation",
-           why: "worktree \(.worktree_branch) on disk, no live session",
+           why: "worktree \(.worktree_branch) on disk, unlocked, no live session",
            detail: "/implement-issue \(.number) — Step 0 resumes it; never restart, the branch commits are the only copy"}
      else empty end),
 
@@ -222,24 +231,43 @@ actions=$(printf '%s' "$digest" | jq \
          # 11 at all. Stage 4 is the gate the whole pipeline is built around;
          # a surface that routes around it is worse than no surface.
          #
-         # An APPROVED review is the bar, matching Step 11 exactly. Not
-         # `reviewDecision`, which is "" both for never-reviewed and for
-         # approved-then-dismissed, and not COMMENTED, which the bot also
-         # posts as a placeholder before its real verdict (see
-         # request-pr-review.sh).
+         # NEITHER SIGNAL ALONE IS CORRECT, and each fails in the merge-happy
+         # direction, so the ORDER below is the whole content of this rule.
+         #
+         # `reviews[]` is history, not state: GitHub never rewrites an old
+         # review when a later round requests changes, so an
+         # approved-then-reworked PR keeps its stale APPROVED entry forever.
+         # Asking "is there an APPROVED anywhere" first therefore reported
+         # "nothing left but your merge" for a PR with changes outstanding --
+         # exactly the failure this rule exists to prevent, reintroduced by the
+         # first attempt at fixing it.
+         #
+         # `reviewDecision` is the current state, but it is only populated when
+         # the repo REQUIRES reviews, and this one does not: it reads
+         # CHANGES_REQUESTED for #619/#620/#614 and "" for #490, which carries
+         # two real APPROVED reviews. So keying on it alone would report a
+         # genuinely approved PR as never reviewed.
+         #
+         # Hence: trust `reviewDecision` whenever it is set, and only then fall
+         # back to the LAST non-COMMENTED review. Last, not any -- same staleness
+         # trap. COMMENTED is skipped because the bot posts its inline notes as
+         # a COMMENTED review before its real verdict (see request-pr-review.sh).
          elif (.isDraft | not)
-         then (if ([ .reviews[]? | select(.state == "APPROVED") ] | length) > 0
-               then {pr: .number, action: "awaiting_maintainer",
-                     why: "out of draft and approved",
-                     detail: "nothing left but your merge"}
-               elif .reviewDecision == "CHANGES_REQUESTED"
-               then {pr: .number, issue: $issue_no, action: "rework_review",
-                     why: "out of draft but review asked for changes",
-                     detail: "address the review, then request a fresh one"}
-               else {pr: .number, issue: $issue_no, action: "request_review",
-                     why: "out of draft but never reviewed — Stage 4 has not run",
-                     detail: "scripts/request-pr-review.sh \(.number) — do NOT merge on the draft flag alone"}
-               end)
+         then ([ .reviews[]? | select(.state != "COMMENTED") ] | last | .state?) as $last_verdict
+              | (if .reviewDecision == "CHANGES_REQUESTED" or
+                    (.reviewDecision == "" and $last_verdict == "CHANGES_REQUESTED") or
+                    (.reviewDecision == null and $last_verdict == "CHANGES_REQUESTED")
+                 then {pr: .number, issue: $issue_no, action: "rework_review",
+                       why: "out of draft but the current review asks for changes",
+                       detail: "address the review, then request a fresh one"}
+                 elif .reviewDecision == "APPROVED" or $last_verdict == "APPROVED"
+                 then {pr: .number, action: "awaiting_maintainer",
+                       why: "out of draft and approved",
+                       detail: "nothing left but your merge"}
+                 else {pr: .number, issue: $issue_no, action: "request_review",
+                       why: "out of draft but never reviewed — Stage 4 has not run",
+                       detail: "scripts/request-pr-review.sh \(.number) — do NOT merge on the draft flag alone"}
+                 end)
          else {pr: .number, issue: $issue_no, action: "resume_implementation",
                why: "draft PR, review loop unfinished",
                # `implement-issue` is used for TODO.md items and refactors too,


### PR DESCRIPTION
Three fixes to the Product Owner tooling, all found by actually running `/loop 30m /backlog` against the live fleet. Each had the same shape: **the surface asserted a state it had not checked**, and every failure pointed the same way — toward acting on work that was already handled.

---

## 1. A backlog pass could not run at all

`/loop /backlog` died on its first line, every tick:

```
backlog-digest.sh: PROJECT_NUMBER is not set — the backlog board has
not been created yet. Run scripts/backlog-board-init.sh (deferred) to
create it, then set PROJECT_NUMBER.
```

Every clause of that is wrong. The board is **Project #1, populated, 37 cards**. `PROJECT_NUMBER=1` lives in the gitignored `.env`, which nothing exports, and `backlog-board-init.sh` does not exist because the board was created by hand.

The skill documented a workaround — `set -a; . ./.env; set +a; ./scripts/backlog-digest.sh` — but a workaround needing a shell preamble cannot survive an unattended pass, because the caller is a skill, not a shell someone typed into.

**Fix:** the digest sources `.env` itself, located via `git rev-parse --path-format=absolute --git-common-dir`. That is one rule, not a search over candidate paths: `.env` is gitignored, so it exists only in the main checkout and never in a worktree, and the common dir resolves to the main checkout from either. `--path-format=absolute` is load-bearing — git otherwise answers the relative `.git`, whose dirname is `.`, silently resolving against the caller's cwd. The environment still wins over the file, or a pinned `PROJECT_NUMBER=2` would be un-overridable.

### Two gaps this exposed

Both were things the `board` verb needed and had to recover with a second `gh project item-list` call by hand — the one thing the digest exists to stop.

**`board_status`** — where the card sits *now*, next to `column` (where the evidence says it belongs), in the same six Status strings. The skill says "reconcile every card against the derived column, the digest always wins" and the digest carried nothing to reconcile *against*. Seven live mismatches were invisible: #602, #593, #592, #578, #571, and #621/#624 which had no card at all.

**`issue_no_card`** — an open issue with no card. `Ready for Dev` requires a Priority, and Priority is a board field, so an off-board issue can **never** become dispatchable however well analysed, while reading as an ordinary Backlog item.

---

## 2. An unreviewed PR was reported as ready to merge

The rhythm resolved *any* non-draft PR to `awaiting_maintainer`, "nothing left but your merge". It never looked at reviews.

That rests on an assumption which does not hold: that only Step 11 clears the draft flag, and only after an APPROVED verdict. **This PR broke it.** It was flipped out of draft by hand because it *looked* stuck, had zero reviews at the time, and the next pass duly reported it as ready to merge — routing straight around Stage 4, the gate the whole pipeline is built on. A Stage 3 CI-mode PR has the same hole from the other side: it never runs Step 11 at all.

**Fix:** an approving review is the bar, matching Step 11. Two new actions carry what used to collapse into "merge it": `request_review` (Stage 4 never ran) and `rework_review` (changes requested). Both fields were already fetched by `gh pr list` and simply unused.

---

## 3. Live work reported as stalled, and stale approvals as merge-ready

### 3a. Review state — neither signal alone is correct

The first attempt at fix 2 asked "is there an APPROVED review anywhere" *before* consulting `reviewDecision`. **The Stage 4 review caught this and reproduced it**, correctly: GitHub never rewrites an old review when a later round requests changes, so an approved-then-reworked PR keeps its stale APPROVED entry forever and was reported "nothing left but your merge" — the exact failure fix 2 set out to close, reintroduced by the fix for it.

The review proposed keying on `reviewDecision` instead. **That alone is also wrong here, and measurably so:** `reviewDecision` is only populated when the repo *requires* reviews, and this one does not. It reads `CHANGES_REQUESTED` for #619/#620/#614 but `""` for #490, which carries two genuine APPROVED reviews — so keying on it alone reports an approved PR as never reviewed.

Neither signal is sufficient and each fails toward "merge it", so **the order is the whole content of the rule**: trust `reviewDecision` when set, otherwise fall back to the **last** non-COMMENTED review. Last, not any — same staleness trap. COMMENTED is skipped because the bot posts inline notes as a COMMENTED review before its real verdict (see `request-pr-review.sh`).

### 3b. Session liveness — `claude agents` cannot answer the question

`resume_implementation` keyed off `session == null`, and `session` comes from `claude agents`, which lists **background agents only**. Two independent failures:

1. A session started in the terminal — `claude`, then `/implement-issue <n>` — is a foreground session and never appears at all. That is how #624 was dispatched.
2. Even a background agent carries a generated descriptive name (`"Review PR and create branch for bess-manager"`), not the `issue-<n>` the dispatch convention promises, so the exact-name match misses it too.

**Measured: 41 worktrees on disk, `claude agents --json` returning one entry.** So `session` was null for essentially everything, every worktree read as abandoned, and `resume_implementation` fired on live sessions — advising a second session onto a branch its own detail line calls *the only copy*.

**Fix:** the worktree **lock** is what tracks a live session. Git records it as `locked claude session <name> (pid 97626 start ...)`, written by Claude Code itself. 4 of those 41 were locked — exactly the four live sessions, foreground and background alike. It is local and needs no process list. `session` is kept because a name match is strictly more informative when it does happen; it is just no longer what liveness rests on.

---

## Live effect on the current fleet

| Item | Before | After |
|---|---|---|
| #624 (being worked right now) | `resume_implementation` — "no live session" | silent; worktree is locked |
| #626 (this PR) | `awaiting_maintainer` — "nothing left but your merge" | `rework_review` |
| #490 (genuinely approved, `reviewDecision: ""`) | `awaiting_maintainer` | `awaiting_maintainer` |
| #621, #624 (no card) | invisible | `add_card` |

## Verification

- `./scripts/backlog-digest.sh` and `./scripts/backlog-rhythm.sh` both run end-to-end from a clean shell with nothing exported.
- **2052 passed**, 50 skipped (`pytest -m "not slow"`); `./scripts/quality-check.sh` green.
- 20 new tests, including the reviewer's exact reproduction (`test_a_stale_approval_does_not_survive_a_later_changes_requested`) and the case their proposed fix would have broken (`test_an_approval_is_honoured_when_review_decision_is_empty`).
- The digest's git shim answers `rev-parse` so `.env` discovery is deterministic — letting the real git through would read the maintainer's own gitignored file, which CI does not have. The porcelain fixture uses the real `locked <reason>` shape, not the bare keyword.

## Scope

Four files, all inside the domain these two scripts already own: `scripts/backlog-digest.sh`, `scripts/backlog-rhythm.sh`, their two test files, and `.claude/skills/backlog/SKILL.md` (the stale `.env` preamble and the changed `awaiting_maintainer` semantics). No product code touched, so no CHANGELOG entry — this is agent tooling with no user-visible effect.

## Note for reviewers

The jq program is a single-quoted shell string, so **one apostrophe in a comment ends it early** and jq reports the useless `Top-level program not given`. That cost a debugging round here; there is now a comment saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
