### PR TITLE
fix: bump @playwright/test to 1.62.1 so browser installs stop hanging

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,23 +9,23 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.59.1"
+        "@playwright/test": "^1.62.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/fsevents": {
@@ -44,35 +44,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     }
   }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,6 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "^1.62.1"
   }
 }


### PR DESCRIPTION
Playwright 1.59.1 cannot install its browsers on this machine. The failure is in **extraction, not the download** — which is why waiting it out never worked, and why `worktree-setup.sh`'s timeout message ("made no progress") sends readers to the network.

## The measurement

| Playwright | Browser build | Result |
|---|---|---|
| 1.59.1 (current pin) | `chromium-1217` | stalls at **exactly** 84 files / 448K — 3 runs |
| 1.62.1 | `chromium-1234` | completes in ~2 min — 3 runs |

Same machine, same network, minutes apart. In every stalled run:

- the full 173MB zip had **already landed** in `$TMPDIR/playwright-download-*`
- `sample`ing the process showed `oopDownloadBrowserMain.js` idle at **0% CPU**, every libuv worker parked in `__psynch_cvwait`

So it is not throttling, not TLS, and not the sandbox — the fetch completes and the unpack never finishes.

## Why it matters

This is what blocks `scripts/worktree-setup.sh`. It kills the install at its timeout and exits 1, so a fresh worktree never gets browsers. With this bump the script runs to completion.

## Verification

Not just the install — the real stack, via `e2e/run-e2e.sh`:

| Phase | Result |
|---|---|
| smoke (`--project=chromium`) | **70 passed, 0 failed**, exit 0 |
| wizard (`--project=wizard`) | **all 14 scenarios passed**, exit 0 |

`scripts/quality-check.sh` — 0 errors, 0 warnings.

## One thing to know when running this locally

The suite must be run with `MOCK_HA_PORT=8123`. `e2e/tests/mock-ha.spec.ts:3` and `e2e/tests/health-recovery.spec.ts:14` hardcode `http://localhost:8123`, while `docker-compose.ci.yml:55` publishes `${MOCK_HA_PORT:-8123}` and `run-e2e.sh` derives that port from the worktree directory name. CI leaves `MOCK_HA_PORT` unset so it lands on 8123 and passes; **any worktree whose name hashes elsewhere fails 7 tests** with `ECONNREFUSED ::1:8123`.

That is exactly what the first run here did (7 failed / 63 passed). Forcing the port turned it into 70/0 with no code change, which is also what rules the bump out as the cause.

Pre-existing and unrelated, so not fixed here. Two further local-runnability gaps turned up alongside it, also untouched:

- `run-e2e.sh` calls `docker compose`; on podman it needs `DOCKER_HOST` pointed at the machine socket
- `run-e2e.sh` uses GNU `timeout`, which macOS does not ship

Happy to fix all three in a follow-up if you want local `run-e2e.sh` to work out of the box.
