### PR TITLE
fix: let a sandboxed session read the agent list, which silently truncates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,7 @@
       "allowWrite": [
         ".",
         "~/GitHub/bess-manager",
+        "~/.claude/jobs",
         "~/Library/Caches/ms-playwright",
         "~/.cache/ms-playwright",
         "~/.npm"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,6 +617,21 @@ redundant:
   **An under-count, not an error, is the dangerous shape**: nothing about a
   short list looks wrong, so the wrong answer is acted on with full confidence.
 
+  **`allowWrite`, not `allowRead`, and that is measured rather than assumed** —
+  the obvious objection is that `claude agents --json` only *reads* the list.
+  Two probes in a sandboxed session settle it:
+
+  ```
+  ls ~/.claude/jobs             ->  16 entries              # read:  ALLOWED
+  touch ~/.claude/jobs/.probe   ->  Operation not permitted # write: DENIED
+  ```
+
+  Reads were never blocked; the read policy denies only `~/.claude/ide`.
+  Enumeration needs to WRITE, and a dropped entry rather than an error is what
+  produces the truncation. Same lesson as the podman entry below, where
+  `filesystem.allowRead` was tried and disproved: read the actual error instead
+  of reasoning about what ought to be blocked.
+
 - **`filesystem.allowWrite`: the two user-level caches `worktree-setup.sh`
   writes** — `~/Library/Caches/ms-playwright` (plus its Linux spelling
   `~/.cache/ms-playwright`) and `~/.npm`. Setup runs `npm install` when a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,23 @@ redundant:
   one from outside. `verify-sandbox.sh` skips its symlink check outside a
   linked worktree rather than reporting a PASS that proves nothing.
 
+- **`filesystem.allowWrite: "~/.claude/jobs"`** — `claude agents --json` reads
+  the session list from there, and a sandboxed call does not fail, it silently
+  **TRUNCATES**. Measured in one session, seconds apart: **sandboxed returns 1
+  agent, unsandboxed returns 14, of which 7 are live sessions sitting in
+  worktrees.** All seven read as dead.
+
+  That is not cosmetic. `backlog-rhythm.sh` keys `resume_implementation` off
+  "worktree on disk, no live session", so with a truncated listing it told the
+  maintainer to re-enter a worktree a live session was actively working — a
+  second session on one branch, against commits the advice itself calls the
+  only copy. `implement-issue` Step 0 reads the same list before touching a
+  resumed branch, and both skills already carry a warning to run it
+  unsandboxed. This makes the warning unnecessary rather than merely repeated.
+
+  **An under-count, not an error, is the dangerous shape**: nothing about a
+  short list looks wrong, so the wrong answer is acted on with full confidence.
+
 - **`filesystem.allowWrite`: the two user-level caches `worktree-setup.sh`
   writes** — `~/Library/Caches/ms-playwright` (plus its Linux spelling
   `~/.cache/ms-playwright`) and `~/.npm`. Setup runs `npm install` when a


### PR DESCRIPTION
## Problem

`claude agents --json` reads the session list from `~/.claude/jobs`, which is not in the sandbox allow list. **A sandboxed call does not fail — it silently truncates.**

Measured in one session, seconds apart:

```
sandboxed:    1 agent
unsandboxed: 14 agents, 7 of them live sessions sitting in worktrees
```

All seven read as dead.

## Why it matters

`backlog-rhythm.sh` keys `resume_implementation` off *"worktree on disk, no live session"*. With a truncated listing it told the maintainer to re-enter a worktree that a **live session was actively working** — putting a second session on one branch, against commits the advice itself calls *the only copy*.

That happened tonight, on **#619**. `implement-issue` Step 0 reads the same list before touching a resumed branch.

**An under-count rather than an error is the dangerous shape:** nothing about a short list looks wrong, so the wrong answer is acted on with full confidence. It also defeated two layers of documentation — both `backlog` and `implement-issue` already carry a "run this unsandboxed" warning, and it still bit, because the warning only helps whoever remembers to read it.

## Fix

One entry: `~/.claude/jobs` in `sandbox.filesystem.allowWrite`, with the rationale added to CLAUDE.md's per-knob list, where every other non-default entry is already explained.

This makes the warnings unnecessary rather than merely repeated.

## Test plan

- [x] `./scripts/quality-check.sh` green
- [x] The 1-vs-14 measurement above, taken in this session

## ⚠️ Not verified in this session, and it cannot be

The sandbox **captures its policy once at activation and ignores every later edit** (CLAUDE.md, "The sandbox captures its policy ONCE"). So the numbers above come from the *old* policy, and re-measuring here would prove nothing — it would return the same 1 no matter what this diff says, which is exactly the trap that section documents.

Verifying needs a genuinely fresh session, then:

```bash
bash scripts/verify-sandbox.sh          # via the Bash tool, not a ! prefix
claude agents --json | jq length        # sandboxed; expect >1
```

Flagging this rather than claiming a green I cannot produce.

## Scope

`.claude/settings.json` (one line) and `CLAUDE.md` (the rationale). No CHANGELOG entry: agent tooling, no user-visible effect.

## Context

This is the one piece of #620 that survives. #635 superseded the rest of that PR by guarding pushes server-side with GitHub rulesets, which is a better answer than the pattern enumeration #620 was shrinking — but `~/.claude/jobs` was unrelated to pushes and went with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
