### PR TITLE
Stop Stage 2 reading the sub-agent's own system prompt, and give step 4 a check that fires

### DIFF
--- a/.github/workflows/issue-analyze.yml
+++ b/.github/workflows/issue-analyze.yml
@@ -56,7 +56,11 @@ jobs:
             ──────────────────────────────────────────────────────────────────
             1. docs/agents/rules.md           — hard constraints
             2. docs/agents/architecture.md    — codebase layout & data flow
-            3. .claude/agents/bess-analyst.md — domain expertise checklist
+
+            Do NOT read `.claude/agents/bess-analyst.md`. It is the
+            `bess-analyst` sub-agent's own system prompt — it already has it in
+            full, and you never run the procedure it describes. Reading it costs
+            25 KB of your context on every turn and tells you nothing you act on.
 
             ──────────────────────────────────────────────────────────────────
             PROCESS
@@ -120,6 +124,32 @@ jobs:
                reading the file:line locations it cited. Do not just trust
                the summary — quote the actual code.
 
+               The report does NOT pass verification if:
+                 - it claims a CODE bug but cites no `file:line` — there is
+                   nothing to check. A diagnosis that the real problem is an
+                   unavailable sensor, the wrong inverter type, an HA
+                   integration mismatch or a stale add-on version is a
+                   legitimate root cause and needs no code citation;
+                 - a cited location does not say what the report claims it says;
+                 - actual behavior diverged from the plan (unplanned import,
+                   floor breach, spike) and the report gives ONE blended verdict
+                   instead of a separate verdict for each of:
+                     - **P-optimality** — was the allocation optimal against the
+                       inputs the DP actually had at the decision point, judged
+                       WITHOUT hindsight?
+                     - **Forecast error (P≠R)** — the Plan was optimal for its
+                       own forecast, but that forecast differed from what was
+                       Realized.
+                     - **Control/execution noise** — the plan's commanded rate
+                       was never actually achieved by the inverter.
+                   Blending these has repeatedly produced wrong conclusions in
+                   this repo.
+
+               A report that fails verification is an inconclusive result, not a
+               diagnosis. Publish what you found and what is still missing via
+               the IF YOU CAN'T REACH A CONCLUSION path below — do not dress it
+               up as a root cause.
+
             5. **Publish the analysis by RUNNING these two commands.** Writing
                the diagnosis as your reply does NOT publish it — you are running
                headless, nothing is watching your output, and a final message
@@ -169,7 +199,7 @@ jobs:
                  ANALYSIS_EOF
 
                  gh issue comment ${{ github.event.issue.number }} --body-file /tmp/analysis.md
-                 gh issue edit ${{ github.event.issue.number }} --add-label needs-human-review
+                 gh issue edit ${{ github.event.issue.number }} --add-label needs-human-review --remove-label ready-for-analysis
 
             Be honest — "I couldn't find the bug in the current code" is a
             valid outcome. Do not invent a root cause to fill the template.

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -516,6 +516,68 @@ then
 fi
 
 echo ""
+echo "📋 Checking bot workflow context contract..."
+echo "-------------------------------------------"
+
+# A workflow prompt must not tell its MAIN agent to read a `.claude/agents/*.md`
+# file. Those files are sub-agent system prompts: the sub-agent already has one
+# in full, so naming it as the main agent's REQUIRED READING loads a second copy
+# into a different context window, on every turn, for an agent that never runs
+# the procedure it describes.
+#
+# Stage 2 did exactly that with bess-analyst.md (25,681 B) and nothing consumed
+# it (#654). Its six steps are: get context, identify the current problem,
+# delegate, verify the cited file:line, publish, label -- no step applies a
+# "domain expertise checklist". Worse, the section of that file which could
+# plausibly serve as a judging standard (Separate Evidence from Claims) was
+# already restated inline in the sub-agent task the same prompt passes, so the
+# content was loaded three times over.
+#
+# The paired assertion matters as much as the removal: Stage 2 must still
+# DELEGATE. Dropping the read is the saving; dropping the delegation would gut
+# the stage, and the same "trim the prompt" instinct reaches for both.
+if ! python3 - <<'PY_CTX'
+import re, sys, pathlib
+
+WF = pathlib.Path(".github/workflows")
+bad = []
+
+for f in sorted(set(WF.glob("*.yml")) | set(WF.glob("*.yaml"))):
+    text = f.read_text()
+    for i, line in enumerate(text.splitlines(), 1):
+        # Match the shape the regression actually takes: a NUMBERED entry in a
+        # reading list, e.g. "3. .claude/agents/bess-analyst.md — checklist".
+        # Deliberately narrow. A prose line that merely names the path is not
+        # flagged, because the prompt now carries an explicit "Do NOT read
+        # .claude/agents/bess-analyst.md" note and a gate that fought its own
+        # documentation would be worse than one with a known edge. An
+        # unnumbered "read <path>" instruction would slip through; that is an
+        # accepted narrowness, not a claim of completeness.
+        if re.match(r"^\s*\d+\.\s+\.claude/agents/", line):
+            bad.append(f"{f}:{i}: main agent told to read a sub-agent definition: {line.strip()}")
+
+analyze = (WF / "issue-analyze.yml").read_text()
+_, _, prompt_block = analyze.partition("prompt: |")
+if not re.search(r"subagent_type[\s:`'\"]*bess-analyst", prompt_block):
+    bad.append("issue-analyze.yml: Stage 2 no longer delegates to the bess-analyst "
+               "sub-agent -- that delegation IS the stage")
+
+if bad:
+    for b in bad:
+        print(f"   {b}")
+    sys.exit(1)
+
+print("✅ Bot workflow context contract intact (no sub-agent definition read by a "
+      "main agent, Stage 2 still delegates)")
+PY_CTX
+then
+    echo "❌ Bot workflow context contract violated"
+    echo "   A sub-agent's definition is its own system prompt. Do not also list"
+    echo "   it as the main agent's REQUIRED READING (#654)."
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
 echo "📋 Checking agent context budget..."
 echo "-------------------------------------------"
 


### PR DESCRIPTION
## Summary
- Stage 2's main agent no longer reads `.claude/agents/bess-analyst.md` (25,681 B) — that file is the sub-agent's own system prompt
- Step 4's "independently verify" gains concrete rejection criteria, so the removal trades dead weight for an instruction that fires
- `quality-check.sh` gains a context-contract gate (written RED first, both assertions mutation-tested)
- Net **≈ −24.9 KB** off the main agent per turn

## Root cause

`.claude/agents/bess-analyst.md` **is** the `bess-analyst` sub-agent's system prompt — frontmatter `name: bess-analyst`, `tools: Read, Grep, Glob, Bash, WebFetch`. Listing it as the main agent's REQUIRED READING loaded a second copy of another agent's instructions into a different context window, on every turn.

**Nothing consumed it.** The six PROCESS steps: get issue context → identify the current problem → delegate → verify the cited `file:line` → publish → label. No step applies a "domain expertise checklist"; step 4 needs the cited *code*, not a triage procedure the main agent never runs.

**It was loaded three times.** The section most plausibly serving as a judging standard, `## CRITICAL: Separate Evidence from Claims`, is already restated almost verbatim in the sub-agent task the same prompt passes:

| `bess-analyst.md` | already inline in the prompt |
|---|---|
| "The reporter's description is a **hypothesis**, not a diagnosis" | "The reporter's explanation is a HYPOTHESIS" |
| "Never start from 'where in the code could this bug be?'" | Step 2 "Triage the LATEST debug bundle FIRST" |
| "verify that BESS Manager actually uses code path Y for this user's setup" | Step 2 "whether the reporter's HA integration matches the code path BESS Manager uses" |
| "If the debug bundle shows fundamental issues … flag those FIRST" | Step 2 "If sensors are unavailable … that is likely the real problem" |
| "A design choice that is intentional and documented is not a bug" | Step 4(b) "the behavior isn't intentional per the design docs" |

**The artifacts agree.** All four landed Stage 2 analyses (#118, #252, #624, #627) use the *workflow's* four headings — never `bess-analyst.md`'s seven-item Output Format or its six-item type-B shape. The main agent follows the prompt, not the file.

## Fix

Remove item 3, with an explicit note saying why, and give step 4 the check that was missing. A report fails verification if it claims a **code** bug with no `file:line`, if a cited location doesn't say what's claimed, or if it blends P-optimality / forecast error / control noise into one verdict when actual behavior diverged from plan. A failed report routes to the existing inconclusive path rather than being dressed up as a root cause — no new mechanism.

## Review findings fixed

Three were defects in my own first draft:

| Finding | Why it mattered |
|---|---|
| "cites no `file:line`" would reject **correct** diagnoses | The same prompt tells the analyst that unavailable sensors / wrong inverter type / HA integration mismatch are likely the real cause — and those cite no code. Now qualified to code-bug claims only. |
| Inconclusive path never removed `ready-for-analysis` | `backlog-digest.sh:275` checks that label **before** `needs-human-review`, so the issue reads as un-analysed and gets re-dispatched — **re-billing the stage**. Widening that path without fixing it would have made a cost bug worse. Verified against the source; now clears the label. |
| New criterion used vocabulary defined only in the file it stops the agent reading | P-optimality had a gloss; `P≠R` never expanded `P` or `R`; control noise had none. All three glossed inline. |

Two hardened the gate: `WF.glob("*.yml")` missed `.yaml` workflows, and the delegation pin was a bare substring over the whole file — a benign reformat would raise a hard ERROR falsely claiming the delegation was gone, while a leftover mention in a comment would satisfy it after the real instruction was deleted.

## Test plan
- [x] `./scripts/quality-check.sh` — Errors: 0, Warnings: 0
- [x] `.venv/bin/pytest -m slow` — 554 passed, 8 skipped (419 s)
- [x] Workflow YAML re-parsed after the block-scalar edits; prompt extracted and asserted on 9 properties (delegation present, no numbered agent-file read, all three glosses, publish command intact, inconclusive path clears the label)

No mock-HA surface — this is a prompt change with no runtime behaviour. What was observed instead is the gate's RED→GREEN transition, the mutation results below, and the parsed prompt.

## Evidence the test discriminates

Both assertions were written before the fix and mutation-tested:

**Read-list assertion**
- Pre-fix file: **1 hit** — `3. .claude/agents/bess-analyst.md — domain expertise checklist` → gate RED
- Post-fix file: **0 hits** → GREEN

**Delegation assertion**
- `subagent_type: bess-analyst` → `general-purpose`: gate RED, `restored: True`
- Backtick reformat `` subagent_type: `bess-analyst` ``: **passes** (no false ERROR)
- Quoted reformat `subagent_type: "bess-analyst"`: **passes**
- String present only *outside* the `prompt:` block: **fails** (a comment can't satisfy it)

The last three are the ones the first bare-substring version got wrong.

## Outcome-level coverage

- `quality-check.sh`'s context-contract gate pins both halves: no sub-agent definition as a numbered required read in any workflow, and Stage 2 still delegating. No optimizer fixture or golden applies — the diff touches no runtime code.
- Deliberately narrow: the read-list matcher keys on the *numbered-list* shape. An unnumbered "read `<path>`" instruction would slip through. That's accepted — the prompt now carries an explicit "Do NOT read" note, and a matcher broad enough to catch every phrasing would flag that note too, i.e. fight its own documentation.

## Documentation check

Neither `docs/agents/bess-knowledge.md` nor `docs/SOFTWARE_DESIGN.md` documents the P-optimality / forecast-error / control-noise taxonomy — it lives only in `.claude/agents/bess-analyst.md`, so there was nothing to update. Worth flagging: this diff creates a second, abbreviated definition site in the workflow prompt, which can drift from the analyst file. Consolidating the taxonomy into `bess-knowledge.md` and referencing it from both would fix that, and is out of scope here.

## Size

Saving is **up to 25,681 B** off the main agent per turn. The prompt itself grew 7,098 → 7,821 B, so net is ≈ **−24.9 KB**. "Up to", because whether a given run obeyed the read instruction isn't observable — #646 showed it need not.

## Scope assessment

Adds no parameter, flag, default-fallback, second construction site or extra trigger. The failed-verification path reuses the existing inconclusive route rather than inventing a retry loop. Scope is **local** — Stage 2's prompt and one gate.

Closes #654
