### PR TITLE
fix: make the mypy gate a ratchet, so it can actually be passed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,17 +476,11 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin main
-          base=$(git merge-base FETCH_HEAD HEAD)
-          # --diff-filter=d drops deletions: a file removed on this branch is
-          # still named by the diff and mypy cannot check what is not there.
-          mapfile -t changed < <(git diff --name-only --diff-filter=d "$base" HEAD -- '*.py')
-          if [ ${#changed[@]} -eq 0 ]; then
-            echo "No changed Python files — nothing to type-check."
-            exit 0
-          fi
-          printf 'Checking %s file(s):\n' "${#changed[@]}"
-          printf '  %s\n' "${changed[@]}"
-          mypy --explicit-package-bases --ignore-missing-imports "${changed[@]}"
+          # Same script quality-check.sh runs, so a green local gate and a
+          # green CI gate mean the same thing. Without --include-worktree:
+          # CI has only the commit, and an untracked-file scan here would
+          # pick up build artefacts rather than authored code.
+          scripts/mypy-changed.sh mypy
 
   # ── Docker build & boot: verify production image starts ──────────
   docker-build-test:

--- a/backend/tests/test_quality_check_mypy_gate.py
+++ b/backend/tests/test_quality_check_mypy_gate.py
@@ -1,10 +1,16 @@
-"""Tests for the mypy gate in scripts/quality-check.sh.
+"""Tests for the mypy gate in scripts/quality-check.sh and scripts/mypy-changed.sh.
 
-The gate scopes mypy to files changed against `origin/main`. Two things have
-to hold for that to be worth anything: a real type error in a changed file
-must fail the run, and a run that could not resolve the ref must not be able
-to report success — warnings exit 0, so the severity of that branch IS the
-behaviour.
+The gate scopes mypy to files changed against `origin/main` and fails only on
+errors the branch INTRODUCED, measured against the same files at the
+merge-base. Four things have to hold for that to be worth anything:
+
+- a newly introduced type error must fail the run;
+- an error that already existed at the merge-base must NOT;
+- a run that could not resolve the ref must not be able to report success;
+- a run whose BASELINE could not be computed must not report success either —
+  an empty baseline makes every pre-existing error look new, which is the
+  concrete bug this gate hit in development (a relative mypy path stopped
+  resolving once the baseline pass cd'd into the extracted tree).
 
 `git`, `black`, `ruff` and `pytest` are shims on PATH (same approach as
 test_backlog_digest.py), but **mypy is the real one**: shimming it would
@@ -13,6 +19,10 @@ builds — unexercised, which is how a test passes while proving less than it
 claims. The git shim names a changed file for the same reason; with an empty
 file list the gate takes its "no changed Python files" path and never calls
 mypy at all.
+
+The git shim also serves `archive`, which is how the baseline tree is
+extracted. It tars up whatever BASELINE_DIR points at, so a test sets the
+"before" state simply by writing a different module there.
 """
 
 import os
@@ -35,15 +45,17 @@ SCRIPT = REPO_ROOT / "scripts" / "quality-check.sh"
 # rather than assert against a gate that cannot run.
 pytest.importorskip("mypy")
 
-# Only the merge-base arm differs between these two, so any difference in a
-# run is attributable to that arm alone. `ls-files --others` names the fixture
-# because a brand-new file is untracked until its first commit — the case the
-# gate exists to catch.
+# `archive` tars BASELINE_DIR; `rev-parse --show-toplevel` must name the
+# project, since mypy-changed.sh cds there before doing anything else.
+# `ls-files --others` names the fixture because a brand-new file is untracked
+# until its first commit — the case the gate exists to catch.
 GIT_RESOLVES = """
 case "$1 $2" in
+  "rev-parse --show-toplevel") echo "$PROJECT_DIR" ;;
   "merge-base origin/main") echo deadbeef ;;
   "diff --name-only") ;;
   "ls-files --others") echo mod.py ;;
+  "archive deadbeef") tar -cf - -C "$BASELINE_DIR" . ;;
   *) ;;
 esac
 exit 0
@@ -53,9 +65,11 @@ exit 0
 # space-joined file list silently splits into two arguments.
 GIT_RESOLVES_SPACED_PATH = """
 case "$1 $2" in
+  "rev-parse --show-toplevel") echo "$PROJECT_DIR" ;;
   "merge-base origin/main") echo deadbeef ;;
   "diff --name-only") ;;
   "ls-files --others") echo "mod with space.py" ;;
+  "archive deadbeef") tar -cf - -C "$BASELINE_DIR" . ;;
   *) ;;
 esac
 exit 0
@@ -63,9 +77,24 @@ exit 0
 
 GIT_CANNOT_RESOLVE = """
 case "$1 $2" in
+  "rev-parse --show-toplevel") echo "$PROJECT_DIR" ;;
   "merge-base origin/main") exit 128 ;;
+  "merge-base FETCH_HEAD") exit 128 ;;
   "diff --name-only") ;;
   "ls-files --others") echo mod.py ;;
+  *) ;;
+esac
+exit 0
+"""
+
+# Resolves the ref but cannot produce the baseline tree.
+GIT_ARCHIVE_FAILS = """
+case "$1 $2" in
+  "rev-parse --show-toplevel") echo "$PROJECT_DIR" ;;
+  "merge-base origin/main") echo deadbeef ;;
+  "diff --name-only") ;;
+  "ls-files --others") echo mod.py ;;
+  "archive deadbeef") exit 128 ;;
   *) ;;
 esac
 exit 0
@@ -95,9 +124,17 @@ def _write_shim(bin_dir: Path, name: str, body: str) -> None:
 
 
 def _run(
-    tmp_path: Path, git_body: str, module_source: str = WELL_TYPED
+    tmp_path: Path,
+    git_body: str,
+    module_source: str = WELL_TYPED,
+    baseline_source: str = WELL_TYPED,
 ) -> subprocess.CompletedProcess:
-    """Run the gate in a throwaway project with the given git/module setup."""
+    """Run the gate in a throwaway project.
+
+    `module_source` is the file as this branch has it; `baseline_source` is
+    the same file as of the merge-base. Equal sources mean "touched but
+    unchanged in type terms", which is the common real case.
+    """
     project = tmp_path / "project"
     project.mkdir(parents=True, exist_ok=True)
     # The script refuses to run anywhere without CLAUDE.md, and its Python
@@ -105,6 +142,11 @@ def _run(
     (project / "CLAUDE.md").write_text("# stub\n")
     (project / "mod.py").write_text(module_source)
     (project / "mod with space.py").write_text(module_source)
+
+    baseline = tmp_path / "baseline"
+    baseline.mkdir(parents=True, exist_ok=True)
+    (baseline / "mod.py").write_text(baseline_source)
+    (baseline / "mod with space.py").write_text(baseline_source)
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
@@ -115,7 +157,12 @@ def _run(
     # PATH when the cwd has no .venv, and the temp project never will.
     _write_shim(bin_dir, "mypy", f'exec "{sys.executable}" -m mypy "$@"\n')
 
-    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    env = dict(
+        os.environ,
+        PATH=f"{bin_dir}:{os.environ['PATH']}",
+        PROJECT_DIR=str(project),
+        BASELINE_DIR=str(baseline),
+    )
     return subprocess.run(
         ["bash", str(SCRIPT)],
         cwd=project,
@@ -131,42 +178,78 @@ def _error_count(proc: subprocess.CompletedProcess) -> int:
     return int(m.group(1))
 
 
-def test_type_error_in_a_changed_file_fails_the_gate(tmp_path: Path) -> None:
-    """The gate's whole purpose: a real type error must cost an error.
+def test_newly_introduced_type_error_fails_the_gate(tmp_path: Path) -> None:
+    """The gate's whole purpose: an error this branch added must cost an error.
 
     Asserted as a delta against an identical run over a well-typed file, so
     unrelated checks failing in a stub directory can neither mask nor
     manufacture the signal.
     """
-    clean = _run(tmp_path / "clean", GIT_RESOLVES, WELL_TYPED)
-    dirty = _run(tmp_path / "dirty", GIT_RESOLVES, ILL_TYPED)
+    clean = _run(tmp_path / "clean", GIT_RESOLVES, WELL_TYPED, WELL_TYPED)
+    dirty = _run(tmp_path / "dirty", GIT_RESOLVES, ILL_TYPED, WELL_TYPED)
 
     assert _error_count(dirty) == _error_count(clean) + 1
     assert dirty.returncode != 0
-    assert "mypy errors in changed files" in dirty.stdout
+    assert "new type error(s) introduced by this branch" in dirty.stdout
+
+
+def test_a_preexisting_error_does_not_fail_the_gate(tmp_path: Path) -> None:
+    """The ratchet half, and the reason this gate was rewritten.
+
+    The same error present at the merge-base must not be charged to whoever
+    next edits the file. Without this, touching any legacy module meant
+    adopting its whole backlog -- #643's six-line fix faced 404 errors across
+    31 files while introducing none of them.
+
+    Paired with the test above, which uses the identical HEAD source and only
+    a different baseline: the two differ in the baseline arm alone, so a pass
+    here cannot come from mypy simply never running.
+    """
+    proc = _run(tmp_path / "legacy", GIT_RESOLVES, ILL_TYPED, ILL_TYPED)
+
+    assert "no new errors" in proc.stdout
+    assert "1 pre-existing in touched files" in proc.stdout
+    assert "new type error(s) introduced" not in proc.stdout
 
 
 def test_a_changed_file_actually_reaches_mypy(tmp_path: Path) -> None:
-    """Guards the vacuity the delta test cannot see.
+    """Guards the vacuity the delta tests cannot see.
 
-    Both runs above would agree if the file list were empty and mypy never
-    ran — the gate would report "no changed Python files" twice and the delta
-    would simply be zero. This pins that the well-typed run took the
-    checked-files path.
+    Runs would agree if the file list were empty and mypy never ran — the
+    gate would report "no changed Python files" and every delta would be
+    zero. This pins that the well-typed run took the checked-files path.
     """
-    proc = _run(tmp_path / "clean", GIT_RESOLVES, WELL_TYPED)
+    proc = _run(tmp_path / "clean", GIT_RESOLVES, WELL_TYPED, WELL_TYPED)
     assert "✅ mypy OK (changed files)" in proc.stdout
     assert "no changed Python files" not in proc.stdout
 
 
 def test_unresolvable_origin_main_fails_the_gate(tmp_path: Path) -> None:
     """A run that type-checked nothing must not be able to exit 0."""
-    resolvable = _run(tmp_path / "ok", GIT_RESOLVES, WELL_TYPED)
+    resolvable = _run(tmp_path / "ok", GIT_RESOLVES, WELL_TYPED, WELL_TYPED)
     unresolvable = _run(tmp_path / "broken", GIT_CANNOT_RESOLVE, WELL_TYPED)
 
     assert _error_count(unresolvable) == _error_count(resolvable) + 1
     assert unresolvable.returncode != 0
-    assert "Cannot resolve origin/main" in unresolvable.stdout
+    assert "Cannot resolve a merge-base" in unresolvable.stdout
+
+
+def test_an_uncomputable_baseline_fails_the_gate(tmp_path: Path) -> None:
+    """A missing baseline must fail closed, not silently pass everything.
+
+    This is the failure mode that actually occurred while building the gate:
+    the baseline pass ran from inside the extracted tree, where the relative
+    `.venv/bin/mypy` no longer existed, so it produced no output. Read as
+    "the baseline had no errors", that turns every pre-existing error into a
+    newly introduced one -- and the symmetric version of the same mistake
+    (treating a failed baseline as "nothing to compare") would wave real
+    errors through instead.
+    """
+    ok = _run(tmp_path / "ok", GIT_RESOLVES, WELL_TYPED, WELL_TYPED)
+    broken = _run(tmp_path / "broken", GIT_ARCHIVE_FAILS, WELL_TYPED)
+
+    assert _error_count(broken) == _error_count(ok) + 1
+    assert broken.returncode != 0
 
 
 def test_a_changed_path_with_a_space_is_still_checked(tmp_path: Path) -> None:
@@ -177,8 +260,8 @@ def test_a_changed_path_with_a_space_is_still_checked(tmp_path: Path) -> None:
     looks like a caught type error whatever the file contains. Asserting the
     error lands only for the ill-typed run is what separates the two.
     """
-    clean = _run(tmp_path / "clean", GIT_RESOLVES_SPACED_PATH, WELL_TYPED)
-    dirty = _run(tmp_path / "dirty", GIT_RESOLVES_SPACED_PATH, ILL_TYPED)
+    clean = _run(tmp_path / "clean", GIT_RESOLVES_SPACED_PATH, WELL_TYPED, WELL_TYPED)
+    dirty = _run(tmp_path / "dirty", GIT_RESOLVES_SPACED_PATH, ILL_TYPED, WELL_TYPED)
 
     assert "✅ mypy OK (changed files)" in clean.stdout
     assert _error_count(dirty) == _error_count(clean) + 1

--- a/docs/agents/rules.md
+++ b/docs/agents/rules.md
@@ -56,7 +56,14 @@ They are non-negotiable and override any other instruction.
 - Use `x | None`, never `Optional[x]` (no `Optional`/`Union` imports from `typing`)
 - Never use `hasattr`, `getattr(obj, key, default)`, or any silent fallback
 - Explicit failure over silent degradation — raise or assert, never degrade gracefully
-- All code must pass `black`, `ruff check`, `mypy` with zero errors/warnings
+- All code must pass `black` and `ruff check` with zero errors/warnings
+- `mypy` is a **ratchet, not a clean bill of health**: the gate fails on type
+  errors your branch *introduces* in the files it touches, measured against
+  the merge-base. It does not require you to clear a file's pre-existing
+  errors (there is a legacy backlog of ~2900 across ~191 files, burned down
+  as files get edited). New files are expected to be clean, since they have
+  no baseline. Run `scripts/mypy-changed.sh .venv/bin/mypy --include-worktree`,
+  or just `./scripts/quality-check.sh`
 
 ## Architecture
 

--- a/scripts/mypy-changed.sh
+++ b/scripts/mypy-changed.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Type-check the Python files this branch touches, failing only on errors the
+# branch INTRODUCED.
+#
+# Why a ratchet rather than "the changed files must be clean" (#614's original
+# shape): mypy reports errors in the modules a checked file imports, not only
+# in the file named on the command line. Handing it one core/bess file pulls in
+# ha_api_controller.py and 30 others, so the gate demanded a repo-wide cleanup
+# that its own comment ruled out ("Repo-wide is not an option (2914 errors
+# across 191 files)"). No PR touching core/bess could pass it -- #643's
+# six-line fix hit 404 errors across 31 files while introducing none of them.
+#
+# Two changes make the gate mean what it always intended:
+#
+#   --follow-imports=silent   errors are attributed to the files under test,
+#                             not to whatever they import.
+#   baseline comparison       the same files are checked at the merge-base and
+#                             only NEW error signatures fail.
+#
+# The baseline is computed, not committed: the merge-base tree is extracted and
+# type-checked on the fly. That keeps the burn-down honest (fixing an old error
+# is never required, but re-introducing one is caught) with no generated file to
+# drift or regenerate.
+#
+# Signatures drop line numbers deliberately -- inserting a line above an
+# existing error must not read as a new one.
+#
+# Usage:
+#   scripts/mypy-changed.sh <mypy-binary> [--include-worktree]
+#
+# --include-worktree also considers uncommitted and untracked files, which is
+# what a local pre-commit run wants and CI does not (CI has only the commit).
+#
+# Exit: 0 clean or only pre-existing errors; 1 new errors; 2 setup failure.
+
+set -uo pipefail
+
+MYPY="${1:?usage: mypy-changed.sh <mypy-binary> [--include-worktree]}"
+INCLUDE_WORKTREE="${2:-}"
+
+# Resolved to an absolute path up front: the baseline pass runs from inside the
+# extracted tree, where a relative ".venv/bin/mypy" does not exist. Left
+# relative, that pass silently produced NO baseline and every pre-existing
+# error read as newly introduced.
+if [ -x "$MYPY" ]; then
+    MYPY=$(cd "$(dirname "$MYPY")" && pwd)/$(basename "$MYPY")
+elif ! MYPY=$(command -v "$MYPY"); then
+    echo "❌ mypy binary not found: ${1}"
+    exit 2
+fi
+
+MYPY_ARGS=(--explicit-package-bases --ignore-missing-imports --follow-imports=silent)
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "❌ Not a git repository — mypy checked nothing."
+    exit 2
+}
+cd "$repo_root" || exit 2
+
+# origin/main may be absent in a fresh CI checkout; FETCH_HEAD covers the
+# `git fetch --no-tags origin main` the workflow runs just before this.
+base=""
+for ref in origin/main FETCH_HEAD; do
+    if base=$(git merge-base "$ref" HEAD 2>/dev/null) && [ -n "$base" ]; then
+        break
+    fi
+    base=""
+done
+if [ -z "$base" ]; then
+    echo "❌ Cannot resolve a merge-base against main — mypy checked nothing."
+    echo "   Run: git fetch origin main"
+    exit 2
+fi
+
+# sort -u is load-bearing: a file changed on the branch AND dirty in the
+# working tree appears in both diffs, and mypy fails with "Duplicate module
+# named ..." when handed the same path twice.
+collect() {
+    git diff --name-only --diff-filter=d "$base" HEAD
+    if [ "$INCLUDE_WORKTREE" = "--include-worktree" ]; then
+        git diff --name-only --diff-filter=d HEAD
+        git ls-files --others --exclude-standard
+    fi
+}
+
+changed=()
+while IFS= read -r f; do
+    case "$f" in *.py) [ -e "$f" ] && changed+=("$f") ;; esac
+done <<EOF
+$(collect | sort -u)
+EOF
+
+if [ ${#changed[@]} -eq 0 ]; then
+    echo "✅ mypy OK (no changed Python files)"
+    exit 0
+fi
+
+# file:code:message — no line number, so unrelated insertions above an existing
+# error do not masquerade as new ones.
+signatures() {
+    sed -E 's/^([^:]+):[0-9]+:([0-9]+:)? /\1: /' \
+        | grep -E ' error: ' \
+        | sort
+}
+
+head_errors=$("$MYPY" "${MYPY_ARGS[@]}" "${changed[@]}" 2>/dev/null | signatures)
+
+# Baseline: the same paths as they stand at the merge-base. A file added on
+# this branch has no baseline entry, so all of its errors count as new — a new
+# file is expected to be clean.
+#
+# Extracted with `git archive` rather than `git worktree add`: this repo is
+# shared with other checkouts and agent sessions, and registering/removing a
+# worktree as a side effect of a lint gate is not worth the blast radius. The
+# whole tree is extracted, not just the changed files, because
+# --follow-imports=silent still has to RESOLVE imports to silence them.
+base_errors=""
+tmp_tree=$(mktemp -d)
+cleanup() { rm -rf "$tmp_tree"; }
+trap cleanup EXIT
+
+if git archive "$base" | tar -x -C "$tmp_tree" 2>/dev/null; then
+    base_files=()
+    for f in "${changed[@]}"; do
+        [ -e "$tmp_tree/$f" ] && base_files+=("$f")
+    done
+    if [ ${#base_files[@]} -gt 0 ]; then
+        # Exit status is checked, not discarded. mypy exits 0 (clean) or 1
+        # (errors found); anything else is a crash or a usage error, and
+        # treating that as "no baseline errors" would flag the entire
+        # pre-existing backlog as newly introduced.
+        base_raw=$(cd "$tmp_tree" && "$MYPY" "${MYPY_ARGS[@]}" "${base_files[@]}" 2>&1)
+        base_status=$?
+        if [ "$base_status" -gt 1 ]; then
+            echo "❌ Baseline mypy run failed (exit ${base_status}) at ${base}:"
+            printf '%s\n' "$base_raw" | tail -5
+            echo "   Refusing to guess — every pre-existing error would read as new."
+            exit 2
+        fi
+        base_errors=$(printf '%s\n' "$base_raw" | signatures)
+    fi
+else
+    echo "❌ Could not extract the baseline tree at ${base}."
+    echo "   Refusing to guess — every pre-existing error would read as new."
+    exit 2
+fi
+
+new_errors=$(comm -13 <(printf '%s\n' "$base_errors") <(printf '%s\n' "$head_errors"))
+new_count=$(printf '%s\n' "$new_errors" | grep -c ' error: ')
+
+if [ "$new_count" -gt 0 ]; then
+    echo "❌ mypy: ${new_count} new type error(s) introduced by this branch:"
+    printf '%s\n' "$new_errors" | grep ' error: ' | sed 's/^/   /'
+    echo
+    echo "   Pre-existing errors in these files are not your problem — only"
+    echo "   the ones above are. Reproduce with:"
+    printf '   %s %s %s\n' "$MYPY" "${MYPY_ARGS[*]}" "${changed[*]}"
+    exit 1
+fi
+
+pre_existing=$(printf '%s\n' "$head_errors" | grep -c ' error: ')
+if [ "$pre_existing" -gt 0 ]; then
+    echo "✅ mypy OK (no new errors; ${pre_existing} pre-existing in touched files)"
+else
+    echo "✅ mypy OK (changed files)"
+fi

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -114,40 +114,21 @@ if find . -name "*.py" -not -path "./build/*" -not -path "./.venv/*" -not -path 
     # A file deleted on this branch still appears in the diff, hence the -e
     # test. No changed Python files is a pass, not a skip-with-warning.
     #
-    # An unresolvable origin/main is an ERROR, not a warning: warnings exit
-    # 0, so a run that type-checked nothing would print "Errors: 0" and
-    # report success for a check that never happened.
     if MYPY=$(py_tool mypy); then
         echo "🔸 Checking mypy on changed files..."
-        base=$(git merge-base origin/main HEAD 2>/dev/null || echo "")
-        if [ -z "$base" ]; then
-            echo "❌ Cannot resolve origin/main — mypy checked nothing."
-            echo "   Run: git fetch origin main"
+        # Delegated so CI and this script run byte-identical logic. The
+        # script owns merge-base resolution, file collection and the
+        # baseline comparison -- see scripts/mypy-changed.sh for why it is a
+        # ratchet rather than a clean-files check. Exit 2 (setup failure,
+        # e.g. an unresolvable main) is an ERROR here for the same reason an
+        # unresolvable base always was: a run that type-checked nothing must
+        # not report success.
+        # Resolved against this script's own location, not the cwd: the
+        # gate is run from the repo root in practice but not in its tests,
+        # and a cwd-relative path silently turns "gate passed" into "gate
+        # never ran".
+        if ! "$(dirname "${BASH_SOURCE[0]}")/mypy-changed.sh" "$MYPY" --include-worktree; then
             ERRORS=$((ERRORS + 1))
-        else
-            # sort -u is load-bearing: a file changed on the branch AND dirty
-            # in the working tree appears in both diffs, and mypy fails with
-            # "Duplicate module named ..." when handed the same path twice.
-            #
-            # An array, not a space-joined string: a path containing a space
-            # or a glob character would otherwise be split into two arguments
-            # or expanded against the working tree.
-            changed=()
-            while IFS= read -r f; do
-                case "$f" in *.py) [ -e "$f" ] && changed+=("$f") ;; esac
-            done <<EOF
-$( { git diff --name-only "$base" HEAD; git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u)
-EOF
-            if [ ${#changed[@]} -eq 0 ]; then
-                echo "✅ mypy OK (no changed Python files)"
-            elif ! "$MYPY" --explicit-package-bases --ignore-missing-imports "${changed[@]}" >/dev/null 2>&1; then
-                echo "❌ mypy errors in changed files. Run:"
-                printf '   %s --explicit-package-bases --ignore-missing-imports %s\n' \
-                    "$MYPY" "${changed[*]}"
-                ERRORS=$((ERRORS + 1))
-            else
-                echo "✅ mypy OK (changed files)"
-            fi
         fi
     else
         echo "❌ mypy not found in .venv/bin or on PATH — cannot verify types."


### PR DESCRIPTION
## Scope assessment

**Local**, not structural. The gate already had one owner — the mypy step — invoked from two places with duplicated inline logic. This consolidates that logic into a single script both callers delegate to, rather than giving it a new owner.

The diff adds no parameter, flag, default-fallback, second construction site, or extra trigger whose job is to route around an ordering/timing/dependency problem. Two alternatives were considered and rejected with reasons recorded in the script header: a committed baseline file (drifts, needs regenerating) and `git worktree add` for baseline extraction (side effects on a repo shared with live agent sessions).

Every failure path fails closed — unresolvable merge-base, unextractable baseline, and a crashed baseline mypy run all exit 2 rather than reporting a pass.

## Summary

- `--follow-imports=silent` so mypy errors are attributed to the files under test, not to everything they import
- A merge-base baseline, so only errors this branch **introduces** fail the gate
- CI and `quality-check.sh` now share one script, so a green local gate and a green CI gate mean the same thing

## Root cause

#614 scoped mypy to changed files, intending that "the legacy backlog burns down as files get edited". As written the gate could not be satisfied at all: **mypy reports errors in the modules a checked file imports**, not only in the file named on the command line. Handing it one `core/bess` file pulls in `ha_api_controller.py` and 30 others — so the gate demanded exactly the repo-wide cleanup its own comment ruled out ("Repo-wide is not an option (2914 errors across 191 files)").

Measured on #643's six-line fix: **404 errors across 31 files, none introduced by that branch.** No PR touching `core/bess` could pass. It went unnoticed because #614 merged Aug 19, after the last `core/bess` PRs (#618, #619) had already landed — #643 was simply the first to hit it.

## Fix

`scripts/mypy-changed.sh` owns the logic; `ci.yml` and `quality-check.sh` both call it.

The baseline is **computed, not committed** — the merge-base tree is extracted with `git archive` and type-checked on the fly. No generated file to drift or regenerate, and deliberately not `git worktree add`: this repo is shared with other checkouts and live agent sessions, and a lint gate should not register and remove worktrees as a side effect.

Error signatures drop line numbers, so inserting a line above an existing error does not read as a new one. A file added on this branch has no baseline entry, so new files are still expected to be clean.

Two bugs found while building it, both now pinned by tests:

- The baseline pass runs from inside the extracted tree, where a relative `.venv/bin/mypy` no longer resolves. It silently produced an **empty** baseline, turning all 61 pre-existing errors in one file into "newly introduced". Fixed by resolving mypy to an absolute path, and by checking the baseline run's exit status rather than discarding it.
- `quality-check.sh` invoked the script by a cwd-relative path — correct from the repo root, but it meant the gate silently never ran from anywhere else. Now resolved against `quality-check.sh`'s own location.

## Test plan

- [x] `./scripts/quality-check.sh` — fast suite 2190 passed / 50 skipped, frontend 125 passed, mypy gate green on its own diff
- [x] Slow suite: 554 passed, 8 skipped
- [x] **Run against the real #643 diff**: `✅ mypy OK (no new errors; 85 pre-existing in touched files)`, exit 0 — where the old gate failed it on 404 errors
- [x] A genuinely new error still fails with exactly one finding
- [x] Inserting lines at the top of a legacy file (shifting every error's line number) does not manufacture new errors
- [x] A brand-new untracked file carrying an error fails
- [ ] `shellcheck` not run — not installed locally

## Evidence the test discriminates

- Reverted: the baseline arm, by pointing the `git archive` shim at a well-typed source while HEAD keeps the ill-typed one
- Result: `test_a_preexisting_error_does_not_fail_the_gate` and `test_newly_introduced_type_error_fails_the_gate` use the **identical HEAD source** and differ only in the baseline — so a pass cannot come from mypy never running
- Separately: the empty-baseline bug was caught by a real run reporting 61 new errors for a comment-only edit, before any test existed for it; `test_an_uncomputable_baseline_fails_the_gate` now pins the fail-closed behaviour
- Restored: tree clean

## Outcome-level coverage

`backend/tests/test_quality_check_mypy_gate.py`, rewritten rather than extended — its cases pinned the old "changed files must be clean" semantics. Every guard it had is kept (vacuity, unresolvable ref, spaced paths); the two new ones are the halves that matter now: a pre-existing error must pass, and an uncomputable baseline must fail closed. 6/6.

## Documentation

`docs/agents/rules.md` claimed all code must pass mypy "with zero errors/warnings". That was never true — there is a ~2900-error backlog — and it is now explicitly not the rule. It documents the ratchet instead.

No `CHANGELOG.md` entry: internal tooling with no user-visible effect, consistent with #656/#654/#651.

## Note

This PR proves itself — CI runs the new gate on the diff that changes it. It also unblocks `fix/issue-643-grid-charge-read`, pushed and waiting on this to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EswRHZDV575RZYPBq7L7o
