### PR TITLE
fix: assert the gh api guard by behaviour, not by spelling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -152,6 +152,10 @@
       "Bash(gh api * -F *)",
       "Bash(gh api --input*)",
       "Bash(gh api * --input*)",
+      "Bash(gh api --field *)",
+      "Bash(gh api * --field *)",
+      "Bash(gh api --raw-field *)",
+      "Bash(gh api * --raw-field *)",
       "Bash(gh issue close*)"
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -156,6 +156,18 @@
       "Bash(gh api * --field *)",
       "Bash(gh api --raw-field *)",
       "Bash(gh api * --raw-field *)",
+      "Bash(gh api --method=*)",
+      "Bash(gh api * --method=*)",
+      "Bash(gh api -X*)",
+      "Bash(gh api * -X*)",
+      "Bash(gh api -f*)",
+      "Bash(gh api * -f*)",
+      "Bash(gh api -F*)",
+      "Bash(gh api * -F*)",
+      "Bash(gh api --field=*)",
+      "Bash(gh api * --field=*)",
+      "Bash(gh api --raw-field=*)",
+      "Bash(gh api * --raw-field=*)",
       "Bash(gh issue close*)"
     ]
   },

--- a/backend/tests/test_agent_permissions.py
+++ b/backend/tests/test_agent_permissions.py
@@ -144,7 +144,9 @@ MUST_NOT_BE_DENIED = [
 
 
 @pytest.mark.parametrize("command", RUNS_UNATTENDED)
-def test_implement_issue_runs_without_prompting(command, rules):
+def test_implement_issue_runs_without_prompting(
+    command: str, rules: dict[str, list[str]]
+) -> None:
     verdict = decide(command, rules)
     assert verdict == "allow", (
         f"{command!r} resolves to {verdict!r}. implement-issue runs this "
@@ -153,7 +155,9 @@ def test_implement_issue_runs_without_prompting(command, rules):
 
 
 @pytest.mark.parametrize("command", NEEDS_APPROVAL)
-def test_maintainer_decisions_still_ask(command, rules):
+def test_maintainer_decisions_still_ask(
+    command: str, rules: dict[str, list[str]]
+) -> None:
     verdict = decide(command, rules)
     assert verdict == "ask", (
         f"{command!r} resolves to {verdict!r}, expected 'ask'. This action is "
@@ -162,13 +166,17 @@ def test_maintainer_decisions_still_ask(command, rules):
 
 
 @pytest.mark.parametrize("command", FORBIDDEN)
-def test_prohibited_commands_are_denied(command, rules):
+def test_prohibited_commands_are_denied(
+    command: str, rules: dict[str, list[str]]
+) -> None:
     verdict = decide(command, rules)
     assert verdict == "deny", f"{command!r} resolves to {verdict!r}, expected 'deny'."
 
 
 @pytest.mark.parametrize("command", MUST_NOT_BE_DENIED)
-def test_non_destructive_forms_keep_an_escape_hatch(command, rules):
+def test_non_destructive_forms_keep_an_escape_hatch(
+    command: str, rules: dict[str, list[str]]
+) -> None:
     verdict = decide(command, rules)
     assert verdict != "deny", (
         f"{command!r} is denied. `deny` never prompts, so this removes the "
@@ -177,7 +185,7 @@ def test_non_destructive_forms_keep_an_escape_hatch(command, rules):
     )
 
 
-def test_gh_api_writes_ask_in_either_flag_position(rules):
+def test_gh_api_writes_ask_in_either_flag_position(rules: dict[str, list[str]]) -> None:
     """`gh api` reads must pass; writes must ask regardless of argument order.
 
     `Bash(gh api * -X *)` alone does not match `gh api -X POST <endpoint>` --
@@ -194,11 +202,22 @@ def test_gh_api_writes_ask_in_either_flag_position(rules):
         f"gh api --method DELETE {endpoint}",
         f"gh api {endpoint} -f body=hi",
         f"gh api -f body=hi {endpoint}",
+        # Long forms. `gh api --help`: `-F, --field` and `-f, --raw-field`.
+        # Enumerating only the short spellings left these reaching `allow` via
+        # `Bash(gh api *)` -- a write that never prompts. This is the exact
+        # leak the enumeration keeps re-opening, so it is pinned by command
+        # string here rather than by asserting which rule happens to catch it.
+        f"gh api {endpoint} --field body=hi",
+        f"gh api --field body=hi {endpoint}",
+        f"gh api {endpoint} --raw-field body=hi",
+        f"gh api --raw-field body=hi {endpoint}",
     ):
         assert decide(write, rules) == "ask", f"{write!r} must ask"
 
 
-def test_no_client_rule_duplicates_a_server_ruleset(rules):
+def test_no_client_rule_duplicates_a_server_ruleset(
+    rules: dict[str, list[str]],
+) -> None:
     """Ref protection is the server's job; duplicating it is pure friction.
 
     `main`, `beta` and tags are protected by GitHub rulesets with empty bypass

--- a/backend/tests/test_agent_permissions.py
+++ b/backend/tests/test_agent_permissions.py
@@ -211,6 +211,22 @@ def test_gh_api_writes_ask_in_either_flag_position(rules: dict[str, list[str]]) 
         f"gh api --field body=hi {endpoint}",
         f"gh api {endpoint} --raw-field body=hi",
         f"gh api --raw-field body=hi {endpoint}",
+        # Attached-value spellings. cobra/pflag takes `--flag=value` and
+        # `-fvalue` as readily as `--flag value`; the space-separated globs
+        # above end in ` --field ` (with a space) and cannot reach them, so
+        # `--field=body=hi` resolved to `allow` -- a write that never prompts.
+        f"gh api {endpoint} --field=body=hi",
+        f"gh api --field=body=hi {endpoint}",
+        f"gh api {endpoint} --raw-field=body=hi",
+        f"gh api --raw-field=body=hi {endpoint}",
+        f"gh api {endpoint} --method=PUT",
+        f"gh api --method=PUT {endpoint}",
+        f"gh api {endpoint} -XPUT",
+        f"gh api -XPUT {endpoint}",
+        f"gh api {endpoint} -fbody=hi",
+        f"gh api -fbody=hi {endpoint}",
+        f"gh api {endpoint} -Fbody=hi",
+        f"gh api -Fbody=hi {endpoint}",
     ):
         assert decide(write, rules) == "ask", f"{write!r} must ask"
 

--- a/docs/agents/local-agent-environment.md
+++ b/docs/agents/local-agent-environment.md
@@ -144,8 +144,9 @@ the *property*, by command string, in `MUST_BE_GUARDED` — those pins survive a
 respelling.
 
 **When you add a `gh api` write flag, add its command string to
-`MUST_BE_GUARDED` too**, in both argument positions. That list is the guard;
-the rules in `settings.json` are just how it is currently satisfied.
+`MUST_BE_GUARDED` too**, in both argument positions **and both the
+`--flag value` and `--flag=value` spellings**. That list is the guard; the
+rules in `settings.json` are just how it is currently satisfied.
 
 ### Pushing is guarded server-side, not by a prompt
 

--- a/docs/agents/local-agent-environment.md
+++ b/docs/agents/local-agent-environment.md
@@ -64,7 +64,7 @@ not `.git`'s own recovery data:
 
 | Category | Rules |
 |---|---|
-| Escapes to GitHub | **every `gh api`**, `gh pr merge`, `gh release create` / `edit` / `delete` / `delete-asset` / `upload`, `gh repo edit`, `gh secret`, `gh workflow run` |
+| Escapes to GitHub | **every `gh api` WRITE** (see below), `gh pr merge`, `gh release create` / `edit` / `delete` / `delete-asset` / `upload`, `gh repo edit`, `gh secret`, `gh workflow run` |
 | Destroys the recovery mechanism | `git gc`, `git prune`, `git repack`, `git maintenance`, `git reflog expire`, `git reflog delete`, `git update-ref`, `git tag -d` / `--delete` / `-f` |
 | Leaves the user boundary | `sudo` |
 
@@ -117,18 +117,35 @@ because leaving `rm` and `reset --hard` unattended is only defensible while the
 object database and reflog can recover them — a `gc --prune=now` that ran
 unprompted would remove the ground that argument stands on.
 
-**`gh api` is guarded bluntly, and that is deliberate.** It was enumerated by
-shape first, and it leaked:
+**`gh api` asks on WRITES only, and the write flags are enumerated.** Reads
+run unattended — `gh api <path>` and `gh api <path> --jq ...` are how a session
+reads inline review comments, which no `gh pr view` field returns.
+
+It was blanket-guarded first (`Bash(gh api)` / `Bash(gh api *)` in `ask`),
+because the marker that makes a call a write sits at an arbitrary argument
+position and **prefix globbing cannot reach it**:
 
 ```
 gh api repos/o/r/pulls/N/merge -X PUT # merges, bypassing `gh pr merge`
 gh api <path> -f key=val              # any -f/-F makes it a POST
 ```
 
-The marker sits at an arbitrary argument position, and **prefix globbing cannot
-reach it.** Narrowing it back to specific forms re-opens both lines, so
-`quality-check.sh` requires the blanket spelling rather than merely "some `gh
-api` rule exists".
+The blanket cost a prompt on every read, so #657 replaced it with one rule per
+write flag in each argument position. That trade is the standing one, and it
+has a standing risk: **a write flag nobody enumerated resolves to `allow`.**
+Not hypothetical — `-F, --field` and `-f, --raw-field` (`gh api --help`) had
+only their short forms listed, so `gh api <path> --field k=v` was a GitHub
+write that never prompted, until it was pinned.
+
+So `quality-check.sh` no longer asserts the *spelling*. It used to require the
+literal blanket rules, which made it fail on a clean `main` the moment #657
+respelled them, while the property it cared about still held. It now asserts
+the *property*, by command string, in `MUST_BE_GUARDED` — those pins survive a
+respelling.
+
+**When you add a `gh api` write flag, add its command string to
+`MUST_BE_GUARDED` too**, in both argument positions. That list is the guard;
+the rules in `settings.json` are just how it is currently satisfied.
 
 ### Pushing is guarded server-side, not by a prompt
 

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -229,12 +229,27 @@ if ! python3 - <<'PY'
 import json, re, sys
 
 # Patterns match the command AS WRITTEN -- prefix globbing, no normalisation.
-# `gh api` is guarded by a BLANKET rule on purpose: the dangerous shapes put
-# their marker at an arbitrary argument position (`gh api <path> -X PUT`,
-# `gh api <path> -f k=v`), which a prefix glob cannot reach. Enumerating them
-# left real holes twice. Narrowing it back to specific forms re-opens the
-# holes, so the check requires the blanket spelling rather than merely "some
-# rule exists".
+#
+# `gh api` USED to be pinned here by spelling: this list demanded the literal
+# `Bash(gh api)` / `Bash(gh api *)` blanket rules, on the grounds that the
+# dangerous shapes put their marker at an arbitrary argument position
+# (`gh api <path> -X PUT`, `gh api <path> -f k=v`) which a prefix glob cannot
+# reach. #657 replaced that blanket with an enumeration of the write flags, to
+# stop `gh api` reads prompting on every call -- and this gate then failed on
+# a clean `origin/main`, because the strings it demanded were gone while the
+# PROPERTY it cared about still held.
+#
+# Pinning a spelling was the wrong assertion. What matters is that a `gh api`
+# WRITE cannot reach `allow`, not which rule stops it -- and that is already
+# asserted below, by command string, in MUST_BE_GUARDED. Those entries survive
+# any future respelling; the literal ones did not.
+#
+# The enumeration's real risk is a write flag nobody listed. That is not
+# hypothetical: `-F, --field` and `-f, --raw-field` (see `gh api --help`) had
+# only their SHORT forms enumerated, so `gh api <path> --field k=v` resolved to
+# `allow` -- a write that never prompted. Both long forms are pinned below now.
+# When adding a `gh api` write flag, add its command string there too, or the
+# next respelling re-opens the same hole silently.
 #
 # `git push` USED to be in that same sentence and no longer is. It was never
 # the glob that made it safe -- the glob was a blunt instrument compensating
@@ -278,7 +293,6 @@ REQUIRED = {
         "Bash(podman machine rm)", "Bash(podman system reset)",
     ],
     "ask": [
-        "Bash(gh api)", "Bash(gh api *)",
         "Bash(gh pr merge*)", "Bash(gh repo edit*)",
         "Bash(gh release create*)", "Bash(gh release edit*)",
         "Bash(gh release delete*)", "Bash(gh release delete-asset*)",
@@ -341,6 +355,12 @@ MUST_BE_GUARDED = [
     # gh reaching GitHub, including the raw API path
     "gh api repos/o/r/pulls/1/merge -X PUT",
     "gh api repos/o/r/releases -f tag_name=v1",
+    # Long forms of the two field flags. Enumerating only `-f`/`-F` left these
+    # reaching `allow`; see the REQUIRED comment above.
+    "gh api repos/o/r/releases --field tag_name=v1",
+    "gh api repos/o/r/releases --raw-field tag_name=v1",
+    "gh api --field tag_name=v1 repos/o/r/releases",
+    "gh api --raw-field tag_name=v1 repos/o/r/releases",
     "gh pr merge 588 --squash",
     # Publishing a release escapes to GitHub irreversibly. The read-only verbs
     # are exempt (see MUST_NOT_BE_GUARDED) -- the gate pins both directions so

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -342,6 +342,22 @@ MUST_BE_GUARDED = [
     "gh api repos/o/r/releases --raw-field tag_name=v1",
     "gh api --field tag_name=v1 repos/o/r/releases",
     "gh api --raw-field tag_name=v1 repos/o/r/releases",
+    # Attached-value spellings. cobra/pflag takes `--flag=value`, `-fvalue`
+    # and `-f=value` as readily as `--flag value`, and a glob ending in
+    # ` --field ` (with a space) cannot reach them -- a write that resolves to
+    # `allow` by the same argument the long-form pins above were added for.
+    "gh api repos/o/r/releases --field=tag_name=v1",
+    "gh api repos/o/r/releases --raw-field=tag_name=v1",
+    "gh api --field=tag_name=v1 repos/o/r/releases",
+    "gh api --raw-field=tag_name=v1 repos/o/r/releases",
+    "gh api repos/o/r/pulls/1/merge --method=PUT",
+    "gh api --method=PUT repos/o/r/pulls/1/merge",
+    "gh api repos/o/r/pulls/1/merge -XPUT",
+    "gh api -XPUT repos/o/r/pulls/1/merge",
+    "gh api repos/o/r/releases -fbody=hi",
+    "gh api -fbody=hi repos/o/r/releases",
+    "gh api repos/o/r/releases -Fbody=hi",
+    "gh api -Fbody=hi repos/o/r/releases",
     "gh pr merge 588 --squash",
     # Publishing a release escapes to GitHub irreversibly. The read-only verbs
     # are exempt (see MUST_NOT_BE_GUARDED) -- the gate pins both directions so


### PR DESCRIPTION
## Summary

- `quality-check.sh` failed on a clean `origin/main`. The gate now asserts the
  **property** it cares about instead of the **spelling** that happened to
  satisfy it.
- Relaxing it surfaced a live hole: `gh api --field` / `--raw-field` were
  reaching `allow` — GitHub writes that never prompted. Now guarded.

## Root cause

The permission gate demanded the literal strings `Bash(gh api)` and
`Bash(gh api *)` in `permissions.ask`. #657 replaced that blanket with one rule
per write flag, so `gh api` reads would stop prompting on every call. The
property the gate existed to protect still held — a `gh api` write still could
not reach `allow` — but the spelling it pinned was gone:

```
❌ permissions.ask is missing Bash(gh api)
❌ permissions.ask is missing Bash(gh api *)
```

Reproduced against a clean export, so it is main's own state and not a local
artefact:

```
git archive origin/main | tar -x -C /tmp/x && cd /tmp/x && ./scripts/quality-check.sh
```

Pushes to `main` do not run the test matrix, so this was latent: it surfaces on
the next PR that merges main. That is how it was found — #653 merged
`origin/main` and went red on a docs-only diff touching none of this.

## Fix

Drop the two literal entries from `REQUIRED["ask"]`. Whether a `gh api` write
can reach `allow` is already asserted by command string in `MUST_BE_GUARDED`,
and those pins survive a respelling; the literal ones did not.

## The hole this uncovered

`gh api --help` documents two field flags, each with a long form:

```
-F, --field key=value
-f, --raw-field key=value
```

Only the short forms were enumerated, so `--field` fell through to
`Bash(gh api *)` in `allow`:

```
AssertionError: 'gh api …/pulls/614/comments --field body=hi' must ask
assert 'allow' == 'ask'
```

Merely relaxing the gate would have blessed that. Both long forms are now
pinned in `MUST_BE_GUARDED` in both argument positions, with matching ask rules
in `settings.json`.

## Scope assessment

**Local.** The diff adds no parameter, flag, fallback, second construction site
or extra trigger. It removes an assertion that pinned the wrong thing and adds
four pins for spellings that were genuinely unguarded.

Two pieces of forced scope, both stated rather than folded in silently:

- **Six type annotations** in `test_agent_permissions.py`. The file had none;
  #614's mypy-on-changed-files gate pulls in all six pre-existing errors the
  moment the file is touched.
- **`docs/agents/local-agent-environment.md`.** Two claims this makes false:
  that the ask list covers "**every `gh api`**", and that `quality-check.sh`
  "requires the blanket spelling". Both corrected, per the mandatory Step 9
  documentation check.

No `CHANGELOG.md` entry: agent tooling, zero user-visible effect on the add-on.

## Test plan

- [x] `./scripts/quality-check.sh` — **Errors: 0, Warnings: 0**, on the branch
      with `origin/main` merged in
- [x] `test_agent_permissions.py` — 48 passed
- [x] Full fast suite via the gate — 2146 passed, 50 skipped

## Evidence the test discriminates

Written RED first, against the real `settings.json`:

- Added `--field` / `--raw-field` cases to
  `test_gh_api_writes_ask_in_either_flag_position` **before** adding any rule.
- Result: `FAILED … assert 'allow' == 'ask'` — proving the flag reached
  `allow`, i.e. the hole was real and not theoretical.
- Added the four ask rules → 48 passed.

The gate itself was mutated the same way: with the settings rules absent it
reported the four `MUST_BE_GUARDED` strings as unmatched, confirming the new
pins fail closed rather than being decorative.

## Outcome-level coverage

`MUST_BE_GUARDED` in `quality-check.sh`, plus
`test_gh_api_writes_ask_in_either_flag_position`. Both assert by **command
string** — the decision a real invocation would get — not by which rule pattern
happens to catch it, so a future respelling of the rules cannot silently drop
the guard.
