### PR TITLE
fix: report price health from the cache instead of re-fetching every 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **A brief Nordpool hiccup no longer produces a daily "recovered from an earlier issue" notice** — the health check re-fetched today's prices every five minutes instead of using the ones already held. ([#662](https://github.com/johanzander/bess-manager/issues/662))
 - **Growatt VPP now lets the inverter and BMS sleep through a long idle at minimum SoC** — an empty battery was still held under continuous remote control, which nothing was protecting. ([#592](https://github.com/johanzander/bess-manager/issues/592))
 - **A tiny solar surplus is no longer planned as an export the inverter will absorb** — below the export the plan can express, the battery charged anyway and ran fuller than planned, spilling the difference later. ([#630](https://github.com/johanzander/bess-manager/issues/630))
 - **The setup wizard no longer locks you out of an inverter platform it failed to auto-detect** — every platform stays selectable, and a re-scan keeps the one you picked. ([#621](https://github.com/johanzander/bess-manager/issues/621))

--- a/core/bess/price_manager.py
+++ b/core/bess/price_manager.py
@@ -6,6 +6,7 @@ inversion.
 
 import logging
 from datetime import date, datetime, timedelta
+from typing import Any
 
 from . import time_utils
 from .exceptions import PriceDataUnavailableError, SystemConfigurationError
@@ -134,7 +135,7 @@ class HomeAssistantSource(PriceSource):
 
     def __init__(
         self,
-        ha_controller,
+        ha_controller: Any,
         vat_multiplier: float,
         entity: str,
     ) -> None:
@@ -197,7 +198,7 @@ class HomeAssistantSource(PriceSource):
                 message=f"Failed to get price data for {target_date}: {e}",
             ) from e
 
-    def _fetch_sensor_attributes(self, entity_id: str):
+    def _fetch_sensor_attributes(self, entity_id: str) -> dict | None:
         """Fetch attributes from the specified Nordpool sensor entity.
 
         Args:
@@ -214,11 +215,14 @@ class HomeAssistantSource(PriceSource):
             if not response or "attributes" not in response:
                 return None
 
-            return response["attributes"]
+            attributes: dict = response["attributes"]
+            return attributes
         except Exception:
             return None
 
-    def _extract_prices_for_date(self, sensor_attributes, target_date, sensor_name):
+    def _extract_prices_for_date(
+        self, sensor_attributes: dict | None, target_date: date, sensor_name: str
+    ) -> list | None:
         """Extract prices for a specific date from sensor attributes."""
         if not sensor_attributes:
             return None
@@ -251,7 +255,9 @@ class HomeAssistantSource(PriceSource):
         except Exception:
             return None
 
-    def _parse_raw_data_for_date(self, raw_data, target_date):
+    def _parse_raw_data_for_date(
+        self, raw_data: list | None, target_date: date
+    ) -> list | None:
         """Parse raw data and return prices if it matches target_date."""
         if not raw_data or not isinstance(raw_data, list) or not raw_data:
             return None
@@ -290,7 +296,7 @@ class HomeAssistantSource(PriceSource):
         except Exception:
             return None
 
-    def _handle_dst_transitions(self, prices):
+    def _handle_dst_transitions(self, prices: list) -> list:
         """Handle DST transitions for quarterly resolution (92-100 periods).
 
         Nordpool provides quarterly prices (15-minute intervals):
@@ -312,7 +318,9 @@ class HomeAssistantSource(PriceSource):
                 message=f"Unexpected price count: {len(prices)} periods. Expected 92-100 for quarterly resolution with DST."
             )
 
-    def _get_sensor_diagnostic_info(self, sensor_data, sensor_name):
+    def _get_sensor_diagnostic_info(
+        self, sensor_data: dict | None, sensor_name: str
+    ) -> str:
         """Get simple diagnostic information about sensor data availability."""
         if not sensor_data:
             return "no data"
@@ -415,12 +423,12 @@ class PriceManager:
         self._logger = logging.getLogger(__name__)
 
         # Cache for today's prices
-        self._today_prices = None
-        self._today_date = None
+        self._today_prices: list[dict[str, Any]] | None = None
+        self._today_date: date | None = None
 
         # Cache for tomorrow's prices
-        self._tomorrow_prices = None
-        self._tomorrow_date = None
+        self._tomorrow_prices: list[dict[str, Any]] | None = None
+        self._tomorrow_date: date | None = None
 
     def clear_cache(self) -> None:
         """Clear cached price data.
@@ -474,8 +482,10 @@ class PriceManager:
             target_date = time_utils.today()
 
         # Use cached values for today if available
-        if self._today_date == target_date and self._today_prices is not None:
-            return self._today_prices
+        if target_date == time_utils.today():
+            cached_today = self._cached_today_prices()
+            if cached_today is not None:
+                return cached_today
 
         # Use cached values for tomorrow if available
         if self._tomorrow_date == target_date and self._tomorrow_prices is not None:
@@ -698,6 +708,12 @@ class PriceManager:
         except Exception as e:
             self._logger.warning(f"Failed to log price information: {e}")
 
+    def _cached_today_prices(self) -> list | None:
+        """Return today's cached price entries, or None if the cache is cold."""
+        if self._today_date == time_utils.today() and self._today_prices is not None:
+            return self._today_prices
+        return None
+
     def check_health(self) -> list:
         """Check price management capabilities."""
 
@@ -709,6 +725,30 @@ class PriceManager:
             "checks": [],
             "last_run": datetime.now().isoformat(),
         }
+
+        # Today's prices already in hand answer the only question this check
+        # asks — can we optimize? Every source implements perform_health_check()
+        # as a live fetch of today, so probing again would re-request data that
+        # changes once a day, on a five-minute schedule. That is what turned a
+        # transient upstream failure into a daily error/recovery banner (#662).
+        # A cold cache (startup, date rollover, or clear_cache() after a
+        # settings or provider change) still probes for real, below.
+        cached_today = self._cached_today_prices()
+        if cached_today is not None:
+            price_check.update(
+                {
+                    "status": "OK",
+                    "checks": [
+                        {
+                            "name": "Electricity Prices",
+                            "status": "OK",
+                            "error": None,
+                            "value": f"{len(cached_today)} prices available for today",
+                        }
+                    ],
+                }
+            )
+            return [price_check]
 
         # Get health check from price source
         try:

--- a/core/bess/tests/unit/test_price_manager.py
+++ b/core/bess/tests/unit/test_price_manager.py
@@ -2,14 +2,15 @@
 Test the PriceManager implementation.
 """
 
-from datetime import timedelta
+from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 
 from core.bess import time_utils
+from core.bess.exceptions import PriceDataUnavailableError
 from core.bess.price_manager import HomeAssistantSource, MockSource, PriceManager
 
 
-def test_direct_price_initialization():
+def test_direct_price_initialization() -> None:
     """Test initialization with direct prices."""
     mock_source = MockSource([1.0, 2.0, 3.0, 4.0])
     pm = PriceManager(
@@ -36,7 +37,7 @@ def test_direct_price_initialization():
     assert pm.get_sell_prices() == pm.sell_prices
 
 
-def test_spot_multiplier_applied_to_buy_price():
+def test_spot_multiplier_applied_to_buy_price() -> None:
     """Multiplicative spot adjustment must apply before markup/VAT (Luminus-style contracts)."""
     mock_source = MockSource([1.0])
     pm = PriceManager(
@@ -57,7 +58,7 @@ def test_spot_multiplier_applied_to_buy_price():
     assert pm.sell_prices[0] == expected_sell_price
 
 
-def test_spot_multiplier_defaults_to_no_adjustment():
+def test_spot_multiplier_defaults_to_no_adjustment() -> None:
     """Omitting spot_multiplier/export_spot_multiplier must reproduce the additive-only formula."""
     mock_source = MockSource([1.0])
     pm = PriceManager(
@@ -73,7 +74,7 @@ def test_spot_multiplier_defaults_to_no_adjustment():
     assert pm.sell_prices[0] == 1.0 + 0.2
 
 
-def test_controller_price_fetching():
+def test_controller_price_fetching() -> None:
     """Test price fetching from controller."""
     mock_controller = MagicMock()
 
@@ -98,7 +99,7 @@ def test_controller_price_fetching():
         for m in [0, 15, 30, 45]
     ]
 
-    def mock_api_request(method, path):
+    def mock_api_request(method: str, path: str) -> dict | None:
         if "sensor.nordpool_kwh_se4_sek_2_10_025" in path:
             # Return both today and tomorrow data for the same entity
             return {
@@ -156,7 +157,7 @@ def test_controller_price_fetching():
     assert tomorrow_prices[0]["sellPrice"] == tomorrow_expected_sell_price
 
 
-def test_mock_source():
+def test_mock_source() -> None:
     """Test using a MockSource."""
     mock_source = MockSource([1.0, 2.0, 3.0, 4.0])
 
@@ -184,7 +185,7 @@ def test_mock_source():
     assert today_prices[0]["sellPrice"] == expected_sell_price
 
 
-def test_home_assistant_source_vat_parameter():
+def test_home_assistant_source_vat_parameter() -> None:
     """Test that the VAT multiplier parameter in HomeAssistantSource works correctly."""
     mock_controller = MagicMock()
 
@@ -201,7 +202,7 @@ def test_home_assistant_source_vat_parameter():
                 }
             )
 
-    def mock_api_request(method, path):
+    def mock_api_request(method: str, path: str) -> dict | None:
         if "sensor.nordpool_kwh_se4_sek_2_10_025" in path:
             return {"attributes": {"raw_today": raw_today_data}}
         return None
@@ -229,7 +230,7 @@ def test_home_assistant_source_vat_parameter():
     assert round(prices_custom[0], 4) == round(2.0 / 1.20, 4)  # ~1.6667
 
 
-def test_get_available_prices_today_only():
+def test_get_available_prices_today_only() -> None:
     """Should return today's prices at quarterly resolution when tomorrow unavailable."""
     mock_source = MockSource(
         test_prices=[0.5] * 96
@@ -257,7 +258,7 @@ def test_get_available_prices_today_only():
         assert all(b == buy[0] for b in buy)
 
 
-def test_get_available_prices_today_and_tomorrow():
+def test_get_available_prices_today_and_tomorrow() -> None:
     """Should return today + tomorrow at quarterly resolution when both available."""
     mock_source = MockSource(
         test_prices=[0.5] * 96
@@ -290,7 +291,7 @@ def test_get_available_prices_today_and_tomorrow():
         assert all(b == pm._calculate_buy_price(0.6) for b in buy[96:])
 
 
-def test_get_available_prices_returns_full_arrays_from_midnight():
+def test_get_available_prices_returns_full_arrays_from_midnight() -> None:
     """Should return quarterly arrays starting from 00:00 (not current time)."""
     mock_source = MockSource(test_prices=[0.5] * 96)
     pm = PriceManager(
@@ -325,7 +326,7 @@ def test_get_available_prices_returns_full_arrays_from_midnight():
         assert buy[56] != buy[57]  # Different quarters have different prices
 
 
-def test_get_available_prices_returns_tuple():
+def test_get_available_prices_returns_tuple() -> None:
     """Should return a tuple of (buy_prices, sell_prices)."""
     mock_source = MockSource(
         test_prices=[0.5] * 96
@@ -351,3 +352,94 @@ def test_get_available_prices_returns_tuple():
         assert isinstance(sell, list)
         assert len(buy) == 96
         assert len(sell) == 96
+
+
+class CountingSource(MockSource):
+    """MockSource that records how often it is fetched and probed.
+
+    Both counters are the health check's real cost: every probe is a live
+    service call to Home Assistant (#662).
+    """
+
+    def __init__(self, test_prices: list, fetch_fails: bool = False) -> None:
+        super().__init__(test_prices)
+        self.fetch_count = 0
+        self.probe_count = 0
+        self.fetch_fails = fetch_fails
+
+    def get_prices_for_date(self, target_date: date) -> list:
+        self.fetch_count += 1
+        if self.fetch_fails:
+            raise PriceDataUnavailableError(
+                date=target_date, message="Nordpool service call failed"
+            )
+        return self.test_prices
+
+    def perform_health_check(self) -> dict:
+        self.probe_count += 1
+        if self.fetch_fails:
+            return {
+                "status": "ERROR",
+                "checks": [
+                    {
+                        "name": "CountingSource",
+                        "status": "ERROR",
+                        "error": "Nordpool service call failed",
+                    }
+                ],
+            }
+        return super().perform_health_check()
+
+
+def _counting_price_manager(source: CountingSource) -> PriceManager:
+    return PriceManager(
+        price_source=source,
+        markup_rate=0.0,
+        vat_multiplier=1.0,
+        additional_costs=0.0,
+        tax_reduction=0.0,
+        area="SE4",
+    )
+
+
+def test_health_check_reports_from_cache_without_probing_the_source() -> None:
+    """Holding today's prices leaves nothing for a live call to prove.
+
+    The health check runs every 5 minutes and the source probe is a live Home
+    Assistant service call, so re-proving data that changes once a day is what
+    turned a transient upstream 500 into a daily error/recovery banner (#662).
+    """
+    source = CountingSource([1.0] * 96)
+    pm = _counting_price_manager(source)
+
+    pm.get_today_prices()
+    fetches_after_warmup = source.fetch_count
+
+    for _ in range(3):
+        result = pm.check_health()
+
+    assert result[0]["status"] == "OK"
+    assert source.probe_count == 0
+    assert source.fetch_count == fetches_after_warmup
+
+
+def test_health_check_probes_the_source_when_today_is_not_cached() -> None:
+    """A cold cache has nothing to report from, so the probe must still happen."""
+    source = CountingSource([1.0] * 96)
+    pm = _counting_price_manager(source)
+
+    result = pm.check_health()
+
+    assert result[0]["status"] == "OK"
+    assert source.probe_count == 1
+
+
+def test_health_check_reports_error_when_the_cold_probe_fails() -> None:
+    """Without today's prices the system genuinely cannot optimize — still ERROR."""
+    source = CountingSource([1.0] * 96, fetch_fails=True)
+    pm = _counting_price_manager(source)
+
+    result = pm.check_health()
+
+    assert result[0]["status"] == "ERROR"
+    assert source.probe_count == 1


### PR DESCRIPTION
## Summary

- The price health check made a **live Nordpool service call every 5 minutes** for data that changes once a day — 288 calls/day — so a single transient HA 500 produced a near-daily "recovered from an earlier issue" banner.
- It now reports from `PriceManager`'s own today-cache, and probes the source only when that cache is cold.

## Root cause

`PriceManager.check_health()` delegated unconditionally to `price_source.perform_health_check()`, and every remote source implements that as a **live fetch of today's prices** — `official_nordpool_source.py:207-220`, and identically in `octopus_energy_source.py:257` and `entsoe_source.py:204`. It calls the source directly, bypassing `PriceManager`'s cache.

`refresh_health_check` runs on `CronTrigger(minute="*/5")` (`backend/app.py:442`) and reaches the price source via `health_check.py:372`, so that probe fired 288 times a day. `HealthRecoveryTracker` (#239) fires a banner on every ERROR→OK transition, so one transient upstream 500 — the known-transient failure documented in #583 — flipped the component ERROR at one check and OK at the next, five minutes later. The reporter saw the banner most days for a system that held today's prices throughout and never missed an optimization.

## Fix

Holding today's prices already answers the only question this check asks — *can we optimize?* So `check_health()` reports OK from the cache when it is warm, and probes the source only when it is cold: startup, date rollover, or `clear_cache()` after a settings/provider change. A cold probe that fails is still ERROR, unchanged — without prices the system genuinely cannot optimize, and that is what the banner should mean.

`get_price_data()`'s today branch now goes through the same `_cached_today_prices()` helper, so the two notions of "the cache is warm" cannot drift apart (raised by code review).

**Scope:** local. `PriceSource.perform_health_check()`'s contract is untouched and no source implementation changed — the fix lands at the single site that already owns the cache. No parameter, flag, fallback, extra trigger or second construction site was added; the diff removes redundant work rather than routing around it.

The mypy annotations in `price_manager.py` are #614's changed-files gate pulling this file's legacy backlog into scope (annotations only, no behaviour change).

**Documentation check:** `docs/agents/bess-knowledge.md` has no health-check section, and `docs/SOFTWARE_DESIGN.md`'s "Health Monitoring" section describes the *sensor* severity model (`determine_health_status`, `is_required`/`required_methods`) which this change does not touch. Nothing to update.

## Test plan

- [x] `./scripts/quality-check.sh` passes locally (fast suite 2191 passed, Black, Ruff, mypy, frontend, ESLint). The one remaining gate error is pre-existing and unrelated: `permissions.ask is missing Bash(gh api)` in committed `.claude/settings.json`.
- [x] `.venv/bin/pytest -m slow` — 554 passed, 8 skipped.
- [x] **Observed live** against the real backend + mock-HA stack (`docker-compose.ci.yml`, scenario dated to today so Nordpool date-anchored calls resolve), counting actual service calls via mock-HA's `/mock/service_log`:
  - **With the fix:** startup issues 3 calls (today ×2, tomorrow ×1); **3 subsequent `POST /api/system-health/recheck` calls issued 0 further `nordpool.get_prices_for_date` calls.** `/api/system-health` reports `Electricity Price Data: OK` → `"96 prices available for today"`.
  - **Control (fix disabled in the same running stack, container restarted):** the same 3 rechecks issued **3 more** `get_prices_for_date` calls — one live call per health check, exactly the reported behaviour.

## Evidence the test discriminates

- Written RED first: `assert source.probe_count == 0` failed as `assert 3 == 0` — three `check_health()` calls, three live probes for prices already held.
- After the fix: `13 passed` in `test_price_manager.py`.
- The live control run above is the same mutation at the system level: 3 rechecks → 3 calls without the fix, 0 with it.

## Outcome-level coverage

- `test_health_check_reports_from_cache_without_probing_the_source` pins the outcome that matters (zero live source calls when the cache is warm), not the shape of the returned dict.
- `test_health_check_probes_the_source_when_today_is_not_cached` and `test_health_check_reports_error_when_the_cold_probe_fails` pin that the cold path still probes and still reports ERROR — both passed before the fix and must keep passing, which is what stops this becoming "never probe".
- No fixture/golden/VPP-baseline changes: the diff touches no DP, intent classification, or control mapping, so no `R == P` scenario applies.

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kf5wtkJiPQQ5tJnmfxQA3j