### PR TITLE
fix: switch bot workflows to the Anthropic API key via a BOT_AUTH variable

### DIFF
--- a/.github/workflows/issue-analyze.yml
+++ b/.github/workflows/issue-analyze.yml
@@ -44,7 +44,11 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Auth switch: BOT_AUTH=api_key uses the Anthropic API key (pay-per-token);
+          # unset or 'oauth' uses Claude subscription credits. Change the repo variable
+          # to flip without a code change.
+          anthropic_api_key: ${{ vars.BOT_AUTH == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ vars.BOT_AUTH != 'api_key' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot analyze"
           claude_args: "--max-turns 100 --permission-mode bypassPermissions"

--- a/.github/workflows/issue-fix.yml
+++ b/.github/workflows/issue-fix.yml
@@ -57,7 +57,11 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Auth switch: BOT_AUTH=api_key uses the Anthropic API key (pay-per-token);
+          # unset or 'oauth' uses Claude subscription credits. Change the repo variable
+          # to flip without a code change.
+          anthropic_api_key: ${{ vars.BOT_AUTH == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ vars.BOT_AUTH != 'api_key' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot fix"
           claude_args: "--max-turns 120 --permission-mode bypassPermissions"

--- a/.github/workflows/issue-integrate.yml
+++ b/.github/workflows/issue-integrate.yml
@@ -50,7 +50,11 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Auth switch: BOT_AUTH=api_key uses the Anthropic API key (pay-per-token);
+          # unset or 'oauth' uses Claude subscription credits. Change the repo variable
+          # to flip without a code change.
+          anthropic_api_key: ${{ vars.BOT_AUTH == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ vars.BOT_AUTH != 'api_key' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot integrate"
           claude_args: "--max-turns 200 --permission-mode bypassPermissions"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,7 +45,11 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Auth switch: BOT_AUTH=api_key uses the Anthropic API key (pay-per-token);
+          # unset or 'oauth' uses Claude subscription credits. Change the repo variable
+          # to flip without a code change.
+          anthropic_api_key: ${{ vars.BOT_AUTH == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ vars.BOT_AUTH != 'api_key' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           github_token: ${{ steps.app-token.outputs.token }}
           # Anyone can open an issue, so triage must run for non-collaborators
           # too — otherwise external bug reports never get asked for a debug

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -46,7 +46,11 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Auth switch: BOT_AUTH=api_key uses the Anthropic API key (pay-per-token);
+          # unset or 'oauth' uses Claude subscription credits. Change the repo variable
+          # to flip without a code change.
+          anthropic_api_key: ${{ vars.BOT_AUTH == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ vars.BOT_AUTH != 'api_key' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude-bot"
           # 60 turns was not enough and failed SILENTLY-ish: on PR #623 the run


### PR DESCRIPTION
## Summary
- Bot workflows (triage / analyze / fix / integrate / PR review) authenticated with `CLAUDE_CODE_OAUTH_TOKEN` — Claude subscription credits.
- Those credits ran out ~2026-08-21 19:25 UTC, so every bot run failed on its first model call (`is_error:true`, `num_turns:1`, `$0 cost`) and posted nothing.
- Added a `BOT_AUTH` repo variable: `api_key` uses `ANTHROPIC_API_KEY` (pay-per-token), `oauth` (or unset) uses `CLAUDE_CODE_OAUTH_TOKEN` (subscription credits). Flip the variable to switch — no code change.
- Set `BOT_AUTH=api_key` so the bot works again immediately.

## Files
- `.github/workflows/pr-review.yml`
- `.github/workflows/issue-triage.yml`
- `.github/workflows/issue-analyze.yml`
- `.github/workflows/issue-fix.yml`
- `.github/workflows/issue-integrate.yml`

## Test plan
- YAML validated on all 5 files.
- Requires the `ANTHROPIC_API_KEY` secret (exists, last updated 2026-03-06 — should be confirmed still valid).
- Re-trigger `@claude-bot review` on a PR to confirm a verdict is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)