### PR TITLE
fix: allow negative Export Compensation price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Export Compensation can now be set to a negative value** — needed when a grid operator charges for export instead of paying for it; the field silently allowed only non-negative values. ([#666](https://github.com/johanzander/bess-manager/issues/666))
 - **A brief Nordpool hiccup no longer produces a daily "recovered from an earlier issue" notice** — the health check re-fetched today's prices every five minutes instead of using the ones already held. ([#662](https://github.com/johanzander/bess-manager/issues/662))
 - **Growatt VPP now lets the inverter and BMS sleep through a long idle at minimum SoC** — an empty battery was still held under continuous remote control, which nothing was protecting. ([#592](https://github.com/johanzander/bess-manager/issues/592))
 - **A tiny solar surplus is no longer planned as an export the inverter will absorb** — below the export the plan can express, the battery charged anyway and ran fuller than planned, spilling the difference later. ([#630](https://github.com/johanzander/bess-manager/issues/630))

--- a/frontend/src/components/settings/PricingFormSection.tsx
+++ b/frontend/src/components/settings/PricingFormSection.tsx
@@ -134,7 +134,7 @@ export function PricingFormSection({ form, onChange }: Props) {
                 { unit: 'factor (1.0 = no adjustment)', min: 0.5, max: 2.0, step: 0.0001 })}
               {numField('Export Compensation', form.taxReduction,
                 v => onChange({ ...form, taxReduction: v }),
-                { unit: `${currency}/kWh`, min: 0, step: 0.001 })}
+                { unit: `${currency}/kWh`, step: 0.001 })}
             </div>
             {isEntsoe ? (
               <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/40 px-4 py-3 space-y-3 text-xs text-gray-600 dark:text-gray-400">

--- a/frontend/src/components/settings/__tests__/PricingFormSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/PricingFormSection.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PricingFormSection } from '../PricingFormSection';
+import type { PricingForm } from '../PricingFormSection';
+
+const BASE_FORM: PricingForm = {
+  currency: 'SEK',
+  provider: 'nordpool_official',
+  nordpoolConfigEntryId: '',
+  nordpoolEntity: '',
+  octopusImportTodayEntity: '',
+  octopusImportTomorrowEntity: '',
+  octopusExportTodayEntity: '',
+  octopusExportTomorrowEntity: '',
+  entsoeEntity: '',
+  area: '',
+  markupRate: 0,
+  vatMultiplier: 1.25,
+  additionalCosts: 0,
+  taxReduction: 0,
+  spotMultiplier: 1.0,
+  exportSpotMultiplier: 1.0,
+};
+
+describe('PricingFormSection', () => {
+  it('allows a negative Export Compensation value (nätnytta can be a cost, not just a credit)', () => {
+    const onChange = vi.fn();
+    render(<PricingFormSection form={BASE_FORM} onChange={onChange} />);
+
+    const input = screen.getByLabelText(/Export Compensation/i);
+    expect(input).not.toHaveAttribute('min', '0');
+
+    fireEvent.change(input, { target: { value: '-0.05' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ taxReduction: -0.05 }));
+  });
+
+  it('reflects a negative Export Compensation in the sell price preview', () => {
+    render(<PricingFormSection form={{ ...BASE_FORM, taxReduction: -0.05 }} onChange={vi.fn()} />);
+
+    expect(screen.getByText('0.95 SEK/kWh')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Removed the `min: 0` constraint on the Export Compensation field (Nordpool/ENTSO-e view) — it was UI-only, with no backend enforcement and no downstream code assuming a non-negative sign.

## Root cause
The "Export Compensation" (Nätnytta) field is UI-restricted to non-negative values only, with no backend enforcement and no downstream code that assumes a non-negative sign.

- `frontend/src/components/settings/PricingFormSection.tsx:135-137` — `numField('Export Compensation', form.taxReduction, ..., { min: 0, step: 0.001 })`. The HTML `min` attribute only affects the spinner; there's no `checkValidity()`/`reportValidity()` call before save (confirmed: neither `PricingFormSection.tsx` nor its callers wrap the form in a real `<form>`/`onSubmit`), so it's a soft, misleading restriction.
- No backend validation anywhere in the chain: `core/bess/settings.py`'s `PriceSettings` has no `__post_init__`, `backend/api_dataclasses.py`'s `taxReduction: float | None` has no Pydantic bound, and `backend/api.py`'s `patch_settings` passes the section through with no numeric check.
- The DP/economics chain is sign-agnostic: `core/bess/price_manager.py:467` computes `sell_price = base_price * export_spot_multiplier + tax_reduction` as plain arithmetic; the DP reward math and discharge gate both handle a negative `sell_price` correctly, with no `max(0, ...)` ever applied to price terms. Negative Nordpool spot prices already exercise this same code path today.
- The ENTSO-e variant's own help text right below the same field already said "Use negative values for deductions" — directly contradicting the `min: 0` on the widget it describes. Pre-existing inconsistency, not introduced by this fix.

## Fix
Removed `min: 0` from the "Export Compensation" `numField` call in the Nordpool/ENTSO-e view (`PricingFormSection.tsx:135-137`). No backend change needed — the value already flows correctly end-to-end once the UI stops blocking it. The Octopus "Tax Reduction" field has the identical `min: 0` but is out of scope (issue is specifically about Swedish nätnytta) — left untouched to keep the diff minimal.

## Documentation check
Grepped `docs/agents/bess-knowledge.md` and `docs/SOFTWARE_DESIGN.md` for `tax_reduction`/`export compensation`/`nätnytta`. Found a **pre-existing, unrelated** sign inconsistency: `docs/SOFTWARE_DESIGN.md:201` states `sell_price = spot_price * export_rate - tax_reduction`, but the actual code (`price_manager.py:467`) and this same frontend preview both **add** `tax_reduction`. This predates my change (the sign mismatch existed for any positive `tax_reduction` too) and isn't something this fix's mechanism touches — flagging here rather than silently fixing it out of scope.

## Test plan
- [x] `./scripts/quality-check.sh` — fast suite: 2177 passed. One pre-existing failure unrelated to this diff: `test_dismiss_persists_across_requests` (`backend/tests/test_dashboard_api.py`) fails only under the full suite (test-order pollution), passes standalone (59/59 in that file). This diff touches only frontend files, so it cannot be the cause.
- [x] Slow suite (`.venv/bin/pytest -m slow`): 554 passed, 0 failed.
- [x] TypeScript compilation, ESLint, Black, Ruff, mypy: all clean.
- [ ] Step 8 (local run & observe) was **not run** — this headless dispatch has no podman-socket access (`--with-compose` was not used), so the mock-HA + backend stack could not be brought up. Verification here is limited to the automated test suite below.

## Evidence the test discriminates
- Reverted: the `min: 0` constraint (temporarily restored `{ unit: ..., min: 0, step: 0.001 }` on the Export Compensation field).
- Result: `PricingFormSection.test.tsx > PricingFormSection > allows a negative Export Compensation value (nätnytta can be a cost, not just a credit)` FAILED — `expect(input).not.toHaveAttribute('min', '0')` found `min="0"` present. 1 test failed, 1 passed (2 total).
- Restored: tree clean, both tests pass.

## Outcome-level coverage
- No DP/optimizer/execution-model change — this is a UI input-constraint fix on a value the DP/price-manager chain already handles correctly (sign-agnostic arithmetic, no clamping). The added test asserts both the input constraint (`min` attribute) and the outcome (`onChange` round-trips a negative value; the sell-price preview arithmetic reflects it: `0.95 SEK/kWh` for `taxReduction = -0.05`).

Refs #666