### PR TITLE
fix: make two CI tests hermetic to the wall-clock window

### DIFF
--- a/backend/tests/test_app_startup.py
+++ b/backend/tests/test_app_startup.py
@@ -51,6 +51,14 @@ def _load_real_app_module(monkeypatch):
     monkeypatch.setenv("HA_URL", "http://ha.local")
     monkeypatch.delenv("HASSIO_TOKEN", raising=False)
 
+    # Real app.py's BESSController.__init__ calls time_utils.set_timezone()
+    # from the mocked HA config, permanently mutating the shared module-global
+    # TIMEZONE. Restore it on teardown so this file doesn't leak UTC into the
+    # rest of the test session (e.g. the historical-data dashboard tests).
+    import core.bess.time_utils as time_utils
+
+    monkeypatch.setattr(time_utils, "TIMEZONE", time_utils.TIMEZONE, raising=False)
+
     app_path = os.path.join(backend_dir, "app.py")
     spec = importlib.util.spec_from_file_location("real_backend_app", app_path)
     module = importlib.util.module_from_spec(spec)

--- a/e2e/tests/inverter-schedule-control-model.spec.ts
+++ b/e2e/tests/inverter-schedule-control-model.spec.ts
@@ -137,8 +137,11 @@ test.describe('Inverter schedule display branches on controlModel', () => {
     await expect(page.getByRole('columnheader', { name: 'Discharge %' })).toHaveCount(0);
     await expect(page.getByRole('columnheader', { name: 'Grid Charge' })).toHaveCount(0);
 
-    // Signed percent value renders.
-    await expect(page.getByText('+35%')).toBeVisible();
+    // Signed percent value renders in the schedule table's VPP column. Scoped
+    // to a table cell because the Current Strategy card also shows the current
+    // group's percent (e.g. "+35% (Remote)") when the wall clock falls inside
+    // that group's time window — a strict getByText() then resolves to 2.
+    await expect(page.getByRole('cell', { name: '+35%' })).toBeVisible();
   });
 
   test('period_list install shows neither Mode nor VPP Power columns', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fix a Fast-tests flake: `test_app_startup.py` loads the real `app.py`, whose
  `BESSController.__init__` calls `set_timezone("UTC")` from the mocked HA
  config — leaking the shared module-global `time_utils.TIMEZONE` into the
  rest of the test session. At UTC hour 0 the historical-data endpoint then
  computes zero "missing" hours, so `test_dismiss_persists_across_requests`
  always gets `dismissed: False`. Restore `TIMEZONE` on teardown.
- Fix an E2E flake: the `vpp_power` schedule spec mocks a `00:00–01:00`
  period group, which the page treats as "current" whenever the real wall
  clock falls in that window — the Current Strategy card then renders a
  second "+35% (Remote)" and the strict `getByText('+35%')` resolves to 2
  elements. Scope the assertion to the schedule table's VPP cell.

## Root cause
Both are the same class: tests not hermetic to the wall clock, plus CI runs
landing in the 00:00–01:00 UTC window. Neither is caused by #671 or #672 —
both PRs hit the identical failures on their own CI runs.

## Verification
- `pytest backend/tests/test_app_startup.py backend/tests/test_dashboard_api.py::TestHistoricalDataStatus`
  failed before (1 failed) and passes after (8 passed).
- Full `pytest -m "not slow"`: 2225 passed / 0 failed.
- E2E fix verified by locator analysis (single cell match); full E2E suite
  requires the mock-HA/podman stack and runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)