### PR TITLE
fix: dispatch via run-agent.sh; strip inline-code from linkage scan

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -443,10 +443,16 @@ maintainer's go-ahead.
 
 Only after approval, and only for an item that meets the Definition of Ready:
 
-    claude --bg -n "issue-<n>" "/implement-issue <n>"
+    scripts/run-agent.sh <n>
+    scripts/run-agent.sh --with-compose <n>   # when Step 8 (local run & observe) applies
 
-**Never create a worktree.** That session's Step 4 creates its own from a
-fresh `origin/main`.
+**Never create a worktree or a clone.** `run-agent.sh` owns the isolation: a
+private clone at `.agent-clones/issue-<n>`, the dev-role gh token, a restricted
+egress allowlist, and permissions skipped inside the disposable container — the
+boundary is the container, not an allowlist entry. That is what keeps a headless
+dispatch from ever stopping to ask for a permission nobody can answer (the old
+`claude --bg` path hung exactly there). Implement-issue's Step 4 creates the
+branch in that clone directly.
 
 Gated three ways, and any one of them holds `dispatchable` shut:
 

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -790,6 +790,34 @@ def test_a_backticked_worked_example_does_not_flip_an_issue(bin_dir: Path) -> No
     assert item["column"] != "In Verification"
 
 
+def test_a_backticked_worked_example_does_not_link_an_open_pr(
+    bin_dir: Path,
+) -> None:
+    """The same rule holds for the OPEN-PR scan, which is a separate code path
+    (`linkage_body`/`pr_matches_issue`) from the merged one. `part of #N` is
+    deliberately not a stripped cross-reference phrase -- it is real linkage on
+    a real intermediate PR -- so without code-span stripping a PR that merely
+    QUOTES that phrase as an example links itself to the quoted issue and
+    reports it In Review. PR #684 did exactly that to issue #409 while
+    describing the merged-scan fix."""
+    issue = _issue(409, labels=[{"name": "bug"}])
+    pr = _pr(
+        684,
+        body="Stripping the phrase (not the line) keeps combined "
+        "references like `- Blocked by #100 -- part of #409` working.",
+        headRefName="fix/backlog-dispatch-and-linkage-regex",
+        isDraft=False,
+        mergeable="MERGEABLE",
+    )
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [pr], []))
+
+    digest = _run(bin_dir)
+    item = digest["items"][0]
+
+    assert item["prs"] == []
+    assert item["column"] != "In Review"
+
+
 def test_an_open_pr_outranks_a_merged_one(bin_dir: Path) -> None:
     """A graduation PR still open means the work is In Review, not verified."""
     issue = _issue(512, labels=[{"name": "bug"}])

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -762,6 +762,34 @@ def test_a_merged_cross_ref_does_not_move_an_issue_to_in_verification(
     assert item["column"] != "In Verification"
 
 
+def test_a_backticked_worked_example_does_not_flip_an_issue(bin_dir: Path) -> None:
+    """Inline-code spans in a PR body are examples, not linkage declarations.
+    PR #679 explained its own linkage fix with the literal line
+    `- Blocked by #100 -- part of #409` (a worked example inside backticks),
+    and the merged scan read `part of #409` as a work reference -- bouncing
+    issue #409 to In Verification for work it never did. A real `Part of #N`
+    intermediate PR
+    (test_a_merged_intermediate_pr_keeps_the_issue_in_verification) carries
+    no code markup, so stripping backticked spans before scanning leaves that
+    linkage intact."""
+    issue = _issue(409, labels=[{"name": "bug"}])
+    merged = [
+        _pr(
+            679,
+            body="Stripping the phrase (not the line) keeps combined "
+            "references like `- Blocked by #100 -- part of #409` working.",
+            headRefName="fix/backlog-digest-linkage",
+        )
+    ]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], merged))
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["merged_pr"] is None
+    assert item["merged_prs"] == []
+    assert item["column"] != "In Verification"
+
+
 def test_an_open_pr_outranks_a_merged_one(bin_dir: Path) -> None:
     """A graduation PR still open means the work is In Review, not verified."""
     issue = _issue(512, labels=[{"name": "bug"}])

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -133,7 +133,13 @@ merged_prs=$(gh pr list --repo "$repo" --state merged --limit 200 \
       # ("until #456 and #457 are also resolved"), and a merged PR must not
       # flip an unrelated issue to In Verification. Drives both `merged_pr`
       # (the column) and `merged_prs` (the visibility list).
-      refs: [ (.body // "") | scan("(?i)(?:fixes|closes|resolves|refs|part of|tracking|tracks) #([0-9]+)") | .[0] | tonumber ]
+      #
+      # Inline-code spans are stripped BEFORE scanning, so `#N` inside a
+      # backticked worked example cannot flip an issue: PR #679 explained its
+      # own fix with the literal line `- Blocked by #100 -- part of #409` and
+      # that example bounced issue #409 to In Verification. A real linkage
+      # declaration is never in code markup.
+      refs: [ (.body // "") | gsub("`[^`]*`"; "") | scan("(?i)(?:fixes|closes|resolves|refs|part of|tracking|tracks) #([0-9]+)") | .[0] | tonumber ]
     } ]')
 
 # Emits, per worktree, a JSON object of {path, branch, locked}. `git worktree

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -122,9 +122,19 @@ done
 # several KB each. Only the closing references and the branch name are needed to
 # decide whether a merged PR belongs to an issue, so extract those here and hand
 # jq a few hundred bytes instead of a megabyte.
+# Inline-code spans carry EXAMPLES, never linkage declarations, so a `#N`
+# inside backticks must not associate a PR with an issue. Defined once, here,
+# because BOTH linkage scans need it and they are separate jq programs -- the
+# merged-PR scan immediately below, and `linkage_body` in the digest program
+# further down. Fixing only one of them is how PR #684 shipped: it stripped
+# code spans in the merged scan while its own body, quoting
+# `- Blocked by #100 -- part of #409` as the worked example, went on linking
+# itself to issue #409 through the open-PR scan it had not touched.
+jq_strip_code_spans='def strip_code_spans: gsub("`[^`]*`"; "");'
+
 merged_prs=$(gh pr list --repo "$repo" --state merged --limit 200 \
   --json number,headRefName,body \
-  | jq -c '[ .[] | {
+  | jq -c "$jq_strip_code_spans"'[ .[] | {
       number,
       headRefName,
       # WORK references only -- the closing verbs plus the no-auto-close
@@ -139,7 +149,7 @@ merged_prs=$(gh pr list --repo "$repo" --state merged --limit 200 \
       # own fix with the literal line `- Blocked by #100 -- part of #409` and
       # that example bounced issue #409 to In Verification. A real linkage
       # declaration is never in code markup.
-      refs: [ (.body // "") | gsub("`[^`]*`"; "") | scan("(?i)(?:fixes|closes|resolves|refs|part of|tracking|tracks) #([0-9]+)") | .[0] | tonumber ]
+      refs: [ (.body // "") | strip_code_spans | scan("(?i)(?:fixes|closes|resolves|refs|part of|tracking|tracks) #([0-9]+)") | .[0] | tonumber ]
     } ]')
 
 # Emits, per worktree, a JSON object of {path, branch, locked}. `git worktree
@@ -216,7 +226,7 @@ jq -n \
   --argjson board "$board" \
   --argjson in_flight "$in_flight_files" \
   --argjson undiffable_prs "$undiffable_prs" \
-  --arg now "$(date -u +%s)" '
+  --arg now "$(date -u +%s)" "$jq_strip_code_spans"'
   def days_since($ts): (($now | tonumber) - ($ts | fromdateiso8601)) / 86400 | floor;
 
   def label_names: [.labels[].name];
@@ -256,8 +266,15 @@ jq -n \
   # working: only the blocker phrase disappears and #409 still links. The
   # remaining test is still any `#N`, so the no-auto-close spellings
   # (`Part of #N`, `tracking #N`, `Refs #N`, bare `#N`) all link.
+  #
+  # Inline-code spans go first, for the same reason the merged scan strips
+  # them: a backticked worked example is not a declaration. The phrase list
+  # below cannot cover this on its own -- `part of #N` is REAL linkage and so
+  # is deliberately absent from it, which means a quoted example carrying that
+  # phrase links unless the markup is removed before matching.
   def linkage_body($body):
     ($body // "")
+    | strip_code_spans
     | gsub("(?i)(blocked by|depends on|unblocks?(?:ing)?|related to|relationship to|follow[- ]?up to|see also|see|not part of) #[0-9]+"; "");
 
   def pr_matches_issue($p; $n):


### PR DESCRIPTION
## Summary
- The backlog skill's Dispatch verb now routes through `scripts/run-agent.sh` instead of `claude --bg`. A headless dispatch runs in a disposable container with the dev-role token, a restricted egress allowlist, and permissions skipped inside the container — so it can never stop to ask for a permission nobody is there to answer (the old path's exact hang).
- The merged-PR linkage scan strips inline-code spans before matching. PR #679's own body carried `` `- Blocked by #100 -- part of #409` `` as a backticked worked example, and that bounced issue #409 to In Verification for work it never did. A real linkage declaration is never in code markup. Genuine `Part of #N` / `tracking #N` intermediate PRs still keep their issue In Verification (existing behavior pinned by `test_a_merged_intermediate_pr_keeps_the_issue_in_verification`).

## Test plan
- New regression test `test_a_backticked_worked_example_does_not_flip_an_issue` — fails on the pre-fix scan, passes now
- `.venv/bin/pytest backend/tests/test_backlog_digest.py` (69) + `test_backlog_rhythm.py`/`test_backlog_board_init.py` (77) — all pass
- black / ruff / mypy on changed files — clean
- Full fast suite: 2261 passed; the 6 `test_quality_check_mypy_gate.py` failures are sandbox artifacts (pass unsandboxed — the ratchet's `git archive|tar` runs under `/var/folders`)
- The quality gate's one remaining error is environmental, not this PR: Black flags untracked `scratch_*.py` in `.claude/worktrees/bench-pwl-everywhere/` (CI checks a clean checkout)