### PR TITLE
Compute the tier-1 analyze carve-out from issue evidence, so a stale Awaiting cannot hide a qualifying bug

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -110,6 +110,14 @@ loud, not quiet.
 | `reporter`, `upstream`, `discussion` | they owe us | quiet — suppressed from actions, still counted and listed |
 | `maintainer` | we owe them nothing; you owe us a decision | **loud — ranked above every other action (rank 0), with the open question attached** |
 
+The one carve-out: `autonomous_analyze` fires from evidence (`bug` +
+`ready-for-analysis` + non-maintainer author, and no `analyzed` /
+`needs-human-review` label) and overrides the stale wait values — `reporter`,
+`upstream`, `discussion` — so one of those cannot hide an item that is
+actually waiting on analysis. The `maintainer` hold is NOT overridden: that
+row means you owe a decision, so the carve-out stands down and the escalation
+stays loudest — see Autonomous spend.
+
 `analysis` is the fifth value and is not in the signed table above because it
 means the same thing the digest's `awaiting_source: label` marks — a triage
 gap, not a completed wait: set the field to what the item is actually waiting
@@ -276,6 +284,7 @@ than sorted alphabetically, and printed in that order. Who does what:
 | `surface_discussion` | summarise the thread, put the open question to the maintainer. **Never auto-park an open conversation** |
 | `nudge_reporter` | one nudge, as the PO identity |
 | `park` | move to *Backlog* — the chase went unanswered |
+| `autonomous_analyze` | the tier-1 carve-out, computed from evidence not the board field: post `@claude-bot analyze` as the PO (`scripts/gh-agent.sh --as po issue comment <n> --body "@claude-bot analyze"`), after confirming no prior analyze on the issue. Fires even when a stale `Awaiting` would otherwise quiet the item, because `ready-for-analysis` already proves the log is in; stands down when the item has Stage 2 history (`analyzed` / `needs-human-review`) or the card holds `Awaiting: maintainer` (see Autonomous spend) |
 | `set_awaiting` / `set_priority` / `triage_labels` | grooming debt: write the board field or label |
 | `add_card` | open issue, no card on the board at all — add it to Project #1 first, **then** set `Priority`; until both exist it is unrankable and invisible to every board pass |
 | `move_card` | the card sits somewhere the evidence does not support — always move it to match `column`, never re-derive `column` to match the card |
@@ -505,20 +514,32 @@ wrote, and hiding which decisions were the agent's. An automation decision
 carries the automation's face. If this ever fails the gate, **that is the
 finding** — report it; do not route around it with plain `gh`.
 
-It fires on an item entering Analysis that meets the
-tier-1 bar from `Verb: next` directly — labelled `bug`, opened by someone
-other than the maintainer, with its debug log attached — **and that has no
-prior `@claude-bot analyze` comment already on the issue**. Check this by
-reading the issue's comments from the digest (or `gh issue view` if the
-digest's comment count needs confirming) — never a local file. This is a
-check against the item itself, not a ranking pass: an item entering Analysis
-is never a member of the Backlog/Ready list that `next` ranks, so it cannot
-"rank" into a tier. The no-prior-analyze condition exists because the digest
-is a stateless snapshot with no notion of "entering" — without it, an item
-that Stage 2 already failed to reach a conclusion on (`needs-human-review`)
-would keep matching every pass under `/loop`, firing Stage 2 again each time
-at $0.50–2 a shot. Every other item entering Analysis gets a proposal
-instead.
+The rhythm pass surfaces the qualifying items as `autonomous_analyze`
+(ranked with the other Analysis actions) — a check against the item's
+**evidence**, not the board field: labelled `bug`, opened by someone other
+than the maintainer, with its debug log attached. `ready-for-analysis` is the
+debug-log proof and the no-prior-analyze guard in one: triage sets it only
+when it has confirmed the log is attached, and Stage 2 removes it (replacing
+it with `analyzed` or `needs-human-review`). The rule itself also refuses an
+item carrying either Stage 2 label — triage re-stamps `ready-for-analysis`
+on an edited issue even after an inconclusive run, so without that check the
+spend would re-fire on items analysis has already settled. A stale `Awaiting`
+field must not quiet it — #681/#680 was a `bug` + `ready-for-analysis` item
+whose card still said `Awaiting: reporter`, and the old carve-out, evaluated
+only on items the pass surfaced, never saw it. The carve-out overrides the
+stale wait values (`reporter`, `upstream`, `discussion`) but stands down on
+`Awaiting: maintainer`, where the loop is deliberately held for your
+decision; and the same evidence makes the `park` / `nudge_reporter` /
+`surface_discussion` chases stand down, so the pass never tells the PO to
+bury what it just un-hid. Still confirm there is no prior `@claude-bot
+analyze` comment already on the issue before posting — check by reading the
+issue's comments from the digest (or `gh issue view` if the digest's comment
+count needs confirming), never a local file: an in-flight analyze keeps
+`ready-for-analysis` until it completes, so the action may re-propose during
+that window. This is a check against the item itself, not a ranking pass: an
+item entering Analysis is never a member of the Backlog/Ready list that
+`next` ranks, so it cannot "rank" into a tier. Every other item entering
+Analysis gets a proposal instead.
 
 ## Close the loop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **A stale `Awaiting` field no longer hides a qualifying bug from autonomous analysis** — the tier-1 carve-out is now computed from the issue's own evidence instead of the board field. ([#681](https://github.com/johanzander/bess-manager/issues/681))
 - **Backlog digest now links a PR to its issue on any `#N` reference, not just closing keywords** — a "Part of #N" PR no longer leaves its issue showing In Progress. ([#652](https://github.com/johanzander/bess-manager/issues/652))
 - **Beta release changelog merges no longer absorb the new section into the previous one** — the merge is now resolved deterministically instead of by hand. ([#648](https://github.com/johanzander/bess-manager/issues/648))
 

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -401,6 +401,171 @@ def test_ready_for_dev_is_reported_as_dispatchable(tmp_path: Path) -> None:
     assert "dispatchable" in _actions_for(_run(tmp_path, [item]), 10)
 
 
+# --- the autonomous Stage 2 carve-out --------------------------------------
+
+
+def test_a_tier1_bug_is_surfaced_for_autonomous_analysis_even_when_awaiting_reporter(
+    tmp_path: Path,
+) -> None:
+    """#681: a stale `Awaiting: reporter` hid #680 from the autonomous Stage 2
+    carve-out, because the carve-out was only ever evaluated against items the
+    rhythm pass surfaced, and the stale field suppressed the item entirely.
+    The tier-1 check must run against the evidence (bug + ready-for-analysis +
+    non-maintainer author), never the board field — `ready-for-analysis` is
+    triage's own confirmation that the debug log is attached, so the item is
+    waiting on analysis, not the reporter. And the same evidence must suppress
+    the chases for that item: with the log attached the ball is NOT with the
+    reporter, so parking or nudging it in the same pass would bury the exact
+    bug the carve-out just un-hid."""
+    item = _item(
+        681,
+        labels=["bug", "bot-analyzed", "ready-for-analysis"],
+        author="ridax67",
+        awaiting="reporter",
+        awaiting_source="board",
+        awaiting_suggested="analysis",
+        last_comment=None,
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 681)
+    assert "autonomous_analyze" in actions
+    assert "park" not in actions
+    assert "nudge_reporter" not in actions
+    assert "surface_discussion" not in actions
+
+
+def test_a_qualifying_bug_fires_even_when_the_card_is_otherwise_quiet(
+    tmp_path: Path,
+) -> None:
+    """The carve-out must not depend on the item producing some other action
+    first — a fresh, reconciled, correctly-groomed card would otherwise be
+    silent and never reach the PO."""
+    item = _item(
+        682,
+        labels=["bug", "ready-for-analysis"],
+        author="ridax67",
+        column="Analysis",
+        board_status="Analysis",
+        awaiting=None,
+        priority="P2",
+    )
+    assert "autonomous_analyze" in _actions_for(_run(tmp_path, [item]), 682)
+
+
+def test_a_bug_still_waiting_for_its_log_does_not_fire(tmp_path: Path) -> None:
+    """`needs-debug-log` means the reporter still owes the bundle — not yet a
+    tier-1 bug, whatever the author."""
+    item = _item(
+        683,
+        labels=["bug", "needs-debug-log"],
+        author="ridax67",
+        awaiting="reporter",
+        awaiting_source="label",
+    )
+    assert "autonomous_analyze" not in _actions_for(_run(tmp_path, [item]), 683)
+
+
+def test_a_bug_opened_by_the_maintainer_does_not_fire(tmp_path: Path) -> None:
+    item = _item(684, labels=["bug", "ready-for-analysis"], author="johanzander")
+    assert "autonomous_analyze" not in _actions_for(_run(tmp_path, [item]), 684)
+
+
+def test_an_already_analyzed_bug_does_not_fire(tmp_path: Path) -> None:
+    """`ready-for-analysis` is consumed by Stage 2 (replaced with `analyzed` or
+    `needs-human-review`), so an analysed item must not match again — otherwise
+    the pass would re-fire Stage 2 at $0.50-2 a shot under /loop."""
+    analyzed = _item(685, labels=["bug", "analyzed"], author="ridax67")
+    inconclusive = _item(686, labels=["bug", "needs-human-review"], author="ridax67")
+    result = _run(tmp_path, [analyzed, inconclusive])
+    assert "autonomous_analyze" not in _actions_for(result, 685)
+    assert "autonomous_analyze" not in _actions_for(result, 686)
+
+
+def test_autonomous_analyze_ranks_with_the_analysis_column(tmp_path: Path) -> None:
+    """Analysis-column work, so it sorts with the other Analysis actions — not
+    with the rank-9 catch-all an unnamed action would fall to."""
+    item = _item(687, labels=["bug", "ready-for-analysis"], author="ridax67")
+    result = _run(tmp_path, [item])
+    action = next(a for a in result["actions"] if a.get("issue") == 687)
+    assert action["action"] == "autonomous_analyze"
+    assert action["rank"] == 5
+
+
+def test_a_tier1_bug_at_nudge_threshold_is_analyzed_not_nudged(
+    tmp_path: Path,
+) -> None:
+    """The same stale-field suppression at the nudge boundary: with the debug
+    log attached, `nudge_reporter` would chase the reporter for something they
+    already supplied — the two actions contradict, so the chase must stand
+    down whenever the carve-out fires."""
+    item = _item(
+        688,
+        labels=["bug", "ready-for-analysis"],
+        author="ridax67",
+        awaiting="reporter",
+        last_comment=_comment(14),
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 688)
+    assert "autonomous_analyze" in actions
+    assert "nudge_reporter" not in actions
+    assert "park" not in actions
+
+
+def test_a_tier1_bug_with_stage2_history_does_not_fire(tmp_path: Path) -> None:
+    """`ready-for-analysis` is consumed by Stage 2 (replaced with `analyzed` or
+    `needs-human-review`), but triage re-runs on an edited issue and re-stamps
+    `ready-for-analysis` even after an inconclusive run, so the two can coexist
+    on one item. The carve-out is for items with NO Stage 2 history at all —
+    an item analysis has already settled must not re-fire the $0.50-2 spend
+    every /loop tick, whatever labels have since accrued."""
+    analyzed = _item(
+        689, labels=["bug", "ready-for-analysis", "analyzed"], author="ridax67"
+    )
+    inconclusive = _item(
+        690,
+        labels=["bug", "ready-for-analysis", "needs-human-review"],
+        author="ridax67",
+    )
+    result = _run(tmp_path, [analyzed, inconclusive])
+    assert "autonomous_analyze" not in _actions_for(result, 689)
+    assert "autonomous_analyze" not in _actions_for(result, 690)
+
+
+def test_a_tier1_bug_awaiting_the_maintainer_escalates_instead_of_firing(
+    tmp_path: Path,
+) -> None:
+    """`Awaiting: maintainer` is the one deliberate board hold — the loop
+    cannot advance without a decision, so the spend is not the point. The
+    carve-out must stand down and let the escalation be the loudest (rank 0)
+    action."""
+    item = _item(
+        691,
+        labels=["bug", "ready-for-analysis"],
+        author="ridax67",
+        awaiting="maintainer",
+        awaiting_source="board",
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 691)
+    assert "escalated" in actions
+    assert "autonomous_analyze" not in actions
+
+
+def test_a_tier1_bug_in_discussion_is_analyzed_not_surfaced(tmp_path: Path) -> None:
+    """`discussion` is a "someone else owes us" state like `reporter`, so it is
+    stale-field material too: the evidence says ready, so the carve-out fires
+    and the surface-to-maintainer action stands down rather than contradicting
+    it."""
+    item = _item(
+        692,
+        labels=["bug", "ready-for-analysis"],
+        author="ridax67",
+        awaiting="discussion",
+        last_comment=_comment(40),
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 692)
+    assert "autonomous_analyze" in actions
+    assert "surface_discussion" not in actions
+
+
 # --- the PR half: reaching a READY PR ------------------------------------
 
 

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -60,6 +60,10 @@ fi
 # in the issue digest, and both were invisible in practice: three PRs sat green
 # and reviewed with nobody flipping them, and #619 was never reviewed at all.
 repo="${REPO:-johanzander/bess-manager}"
+# The repo owner is the maintainer for the tier-1 carve-out: an issue opened
+# by anyone else is an external report, and external bug reports with a debug
+# log are exactly what the autonomous Stage 2 spend is for.
+owner="${repo%%/*}"
 if [ -n "${RHYTHM_PRS_FILE:-}" ]; then
     prs=$(cat "$RHYTHM_PRS_FILE")
 else
@@ -71,7 +75,8 @@ actions=$(printf '%s' "$digest" | jq \
     --argjson nudge "$NUDGE_DAYS" \
     --argjson park "$PARK_DAYS" \
     --argjson wip_limit "$WIP_LIMIT" \
-    --argjson prs "$prs" '
+    --argjson prs "$prs" \
+    --arg owner "$owner" '
   # Board cards for PRs, keyed by number. Absent on an older digest, so this
   # defaults to empty rather than failing -- a rhythm run against a stale
   # digest then simply defers nothing, which is the pre-existing behaviour.
@@ -99,6 +104,21 @@ actions=$(printf '%s' "$digest" | jq \
   # change, a board move or a bot touch all bump updatedAt, so an issue nobody
   # has spoken on for a month can look active and never age into a chase.
   def quiet_days: if .last_comment == null then .age_days else .last_comment.days end;
+
+  # TIER-1 READY: the evidence basis for the autonomous Stage 2 carve-out
+  # below, and (negated) the suppressor of the reporter/discussion chases for
+  # the same items. Every condition is EVIDENCE, never the board field: the
+  # three label checks are triage and Stage 2 stamps (bug confirmed,
+  # ready-for-analysis = the debug log is attached, and no analyzed or
+  # needs-human-review label = no Stage 2 history), the author check is the
+  # external-reporter bar, and the awaiting check keeps a deliberate
+  # `maintainer` hold from being overridden by the carve-out.
+  def tier1_ready: (.labels | index("bug")) != null
+     and (.labels | index("ready-for-analysis")) != null
+     and (.labels | index("analyzed")) == null
+     and (.labels | index("needs-human-review")) == null
+     and .author != $owner
+     and .awaiting != "maintainer";
 
   (.items) as $items
   | [ $items[]
@@ -150,14 +170,25 @@ actions=$(printf '%s' "$digest" | jq \
     # and the wait that matters is the PR review, which the PR half of this
     # pass already reports. Nudging the reporter of a 46-day-stale conflicted
     # PR asks the wrong person about the wrong thing.
+    #
+    # A TIER-1 BUG SUPPRESSES THEM TOO, for the opposite reason. When triage
+    # has stamped `ready-for-analysis`, the ball is not with the reporter: the
+    # debug log is attached and the item is waiting on analysis, not on them.
+    # Chasing or parking it would bury the exact bug the autonomous carve-out
+    # exists to surface (#681/#680) -- the stale `Awaiting` field and the
+    # evidence contradict, and the evidence wins. `tier1_ready` is the same
+    # check the carve-out uses, so the carve-out and the chases can never
+    # contradict each other in one pass.
     (if (.prs | length) > 0 then empty
      elif .awaiting == "reporter"
+        and (tier1_ready | not)
         and ((.last_comment.is_reporter // false) | not)
         and quiet_days >= $park
      then {issue: .number, action: "park",
            why: "awaiting reporter, quiet \(quiet_days)d (>= \($park))",
            detail: "move to Backlog; the chase has gone unanswered"}
      elif .awaiting == "reporter"
+        and (tier1_ready | not)
         and ((.last_comment.is_reporter // false) | not)
         and quiet_days >= $nudge
      then {issue: .number, action: "nudge_reporter",
@@ -167,11 +198,39 @@ actions=$(printf '%s' "$digest" | jq \
 
     # A discussion nobody has advanced is a question for the maintainer, not a
     # reason to keep waiting. Never auto-parked: an open conversation is not
-    # the same as an unanswered chase.
-    (if .awaiting == "discussion" and quiet_days >= $nudge
+    # the same as an unanswered chase. A tier-1 bug is never this -- putting an
+    # open question to the maintainer contradicts spending on analysing it in
+    # the same pass, so the carve-out suppresses it.
+    (if .awaiting == "discussion" and (tier1_ready | not) and quiet_days >= $nudge
      then {issue: .number, action: "surface_discussion",
            why: "discussion stalled \(quiet_days)d",
            detail: "summarise the thread and put the open question to the maintainer"}
+     else empty end),
+
+    # THE ONE UNBUDGETED SPEND THIS PASS MAY FIRE WITHOUT ASKING: the
+    # autonomous Stage 2 carve-out, checked against EVIDENCE not the board
+    # field. `tier1_ready` above is all evidence: `ready-for-analysis` is the
+    # debug-log stamp triage applies, the absent `analyzed` /
+    # `needs-human-review` labels mean the item has no Stage 2 history (triage
+    # re-stamps `ready-for-analysis` on an edit even after an inconclusive
+    # run, so coexisting labels would otherwise re-fire the spend on items
+    # analysis has already settled), a non-maintainer author is the
+    # external-report bar, and a deliberate `Awaiting: maintainer` hold beats
+    # the carve-out -- the loop cannot advance without a decision there, so
+    # the spend is not the point.
+    #
+    # The `Awaiting` field must NOT gate this: it can go stale (a card left at
+    # `reporter` after the reporter supplied the log) and hide the item from
+    # the pass entirely -- the #681/#680 failure, where the carve-out was only
+    # ever evaluated on items the pass surfaced. Stage 2 removes
+    # `ready-for-analysis` when it runs, so this fires at most until analysis
+    # lands; confirming there is no prior `@claude-bot analyze` comment stays
+    # a PO-time check in the backlog skill before the spend, which is also
+    # what catches an analyze that is still in flight.
+    (if tier1_ready
+     then {issue: .number, action: "autonomous_analyze",
+           why: "tier-1 bug: \(.author), debug log attached, no analyzed/needs-human-review label",
+           detail: "fire Stage 2 as the PO, after confirming no prior @claude-bot analyze comment: scripts/gh-agent.sh --as po issue comment \(.number) --body \"@claude-bot analyze\""}
      else empty end),
 
     # Grooming debt: the board field is unset while a label implies a wait, so
@@ -533,7 +592,8 @@ actions=$(printf '%s' "$digest" | jq \
        elif .action == "dispatchable" or .action == "queued_behind"
             or .action == "cluster" or .action == "needs_touch_set" then 4
        elif .action == "recheck_ready" or .action == "surface_discussion"
-            or .action == "nudge_reporter" or .action == "park" then 5
+            or .action == "nudge_reporter" or .action == "park"
+            or .action == "autonomous_analyze" then 5
        elif .action == "set_awaiting" or .action == "add_card"
             or .action == "set_priority" or .action == "move_card"
             or .action == "triage_labels" then 6


### PR DESCRIPTION
## Summary
- The autonomous Stage 2 carve-out now fires from the issue's own evidence rather than only on items the rhythm pass had already surfaced, so a board field left stale by grooming can no longer suppress it.
- New `autonomous_analyze` action in `scripts/backlog-rhythm.sh`, ranked with the other Analysis actions (rank 5).
- The same predicate suppresses `park` / `nudge_reporter` / `surface_discussion` for those items, so one pass cannot both un-hide a bug and tell the PO to bury it.

## Root cause
From #681:

> The `Awaiting` field is treated as authoritative by the rhythm pass, but it is a board value set by grooming and can go stale relative to the issue's actual state (labels + debug log + comments). The autonomous-spend rule's conditions are checked against the item only if the rhythm surfaces it, so a stale wait value defeats the rule.

#680 met every tier-1 criterion — `bug`, external reporter (`ridax67`), debug bundle attached, no prior `@claude-bot analyze` — and never fired, because its card said `Awaiting: reporter` and the pass suppresses every "someone else owes us" wait value.

Verifying against current code confirmed the failure is one step broader than the stale field alone: the carve-out was evaluated **only** against items that produced some other action, so a correctly-groomed but otherwise-quiet card was equally invisible. The live board proves it — #680's `Awaiting` has since been corrected to `analysis`, and the pre-fix script *still* does not surface it (see Test plan).

## Fix
`tier1_ready` in the jq program derives the condition from evidence only:

| Condition | What it is evidence of |
|---|---|
| `bug` label | triage confirmed it is a bug |
| `ready-for-analysis` label | triage's own confirmation the debug log is attached |
| no `analyzed` / `needs-human-review` label | no Stage 2 history — triage re-stamps `ready-for-analysis` on an edited issue, so the label alone would re-fire the \$0.50–2 spend every `/loop` tick on items analysis has already settled |
| `author != $owner` | the external-report bar |
| `awaiting != "maintainer"` | the one deliberate hold — the loop cannot advance without a decision there, so the escalation stays rank 0 and the spend stands down |

Two consumers share that single predicate: the `autonomous_analyze` emitter, and (negated) the three chase guards. Sharing it is the point — with the log in hand the ball is not with the reporter, so `park` / `nudge_reporter` / `surface_discussion` chasing them in the same pass would contradict the carve-out. One predicate makes that contradiction impossible rather than merely unlikely.

The no-prior-analyze check deliberately stays a PO-time step (documented in the action's `detail` and in `.claude/skills/backlog/SKILL.md`), because that is also what catches an analyze still in flight — which keeps `ready-for-analysis` until it completes.

## Documentation
- `.claude/skills/backlog/SKILL.md` — updated: the `Awaiting` signed table gains the carve-out note, the action table gains the `autonomous_analyze` row, and the Autonomous-spend section is rewritten to describe the evidence basis.
- `docs/agents/bess-knowledge.md` and `docs/SOFTWARE_DESIGN.md` — checked, neither mentions anything this diff touches (backlog tooling, not BESS behaviour).
- `docs/agents/workflow.md` — checked; its `ready-for-analysis` label row stays accurate as written.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally — 2276 passed, 50 skipped; Black/Ruff/mypy, frontend, permission surface, bot-workflow contracts all green
- [x] `.venv/bin/pytest -m slow` passes — 554 passed, 8 skipped
- [x] `code-review` on the diff — zero findings
- [x] **Step 8, observed against the live board.** Fetched a real `backlog-digest.sh` snapshot and replayed it through the pre-fix and post-fix scripts:

  ```
  === BEFORE (pre-fix script, live digest) ===        === AFTER (fixed script, same digest) ===
  {"issue":409,"action":"move_card"}                  {"issue":409,"action":"move_card"}
  {"issue":409,"action":"rework_review"}              {"issue":409,"action":"rework_review"}
  {"issue":520,"action":"resume_implementation"}      {"issue":520,"action":"resume_implementation"}
  {"issue":602,"action":"move_card"}                  {"issue":602,"action":"move_card"}
                                                      {"issue":680,"action":"autonomous_analyze"}
  {"issue":683,"action":"add_card"}                   {"issue":683,"action":"add_card"}
  {"issue":683,"action":"escalated"}                  {"issue":683,"action":"escalated"}
  ```

  Human-readable output for the new action:

  ```
  ##680 autonomous_analyze
      why: tier-1 bug: ridax67, debug log attached, no analyzed/needs-human-review label
      do : fire Stage 2 as the PO, after confirming no prior @claude-bot analyze comment: ...
  ```

  Not a synthetic positive: `gh issue view 680 --json comments` returns exactly one comment (triage's), so there is no prior analyze and #680 genuinely still needs Stage 2 fired. Every other action is byte-identical before and after, so the change adds the missing action without perturbing the rest of the pass.

## Evidence the test discriminates
Ten new tests. The whole fix reverted, then each guard clause removed individually from the fixed tree:

| Mutation | Result |
|---|---|
| entire `backlog-rhythm.sh` change reverted | **5 failed**, 79 passed |
| removed `and .awaiting != "maintainer"` | `test_a_tier1_bug_awaiting_the_maintainer_escalates_instead_of_firing` FAILED — 1 failed, 83 passed |
| removed `and (.labels \| index("analyzed")) == null` | `test_a_tier1_bug_with_stage2_history_does_not_fire` FAILED — 1 failed, 83 passed |
| removed `and (.labels \| index("needs-human-review")) == null` | `test_a_tier1_bug_with_stage2_history_does_not_fire` FAILED — 1 failed, 83 passed |
| removed `and .author != \$owner` | `test_a_bug_opened_by_the_maintainer_does_not_fire` FAILED — 1 failed, 83 passed |
| removed `and (.labels \| index("ready-for-analysis")) != null` | `test_a_bug_still_waiting_for_its_log_does_not_fire` + `test_quiet_backlog_is_a_noop` FAILED — 2 failed, 82 passed |

Restored: tree clean, 84/84 pass. No guard in the predicate is vacuous — every one of them has a test that goes red when it is deleted, which is the property the negative "does not fire" tests would otherwise only appear to have.

## Outcome-level coverage
Not a DP/intent/control-mapping change, so `run_scenario_realized` does not apply. The outcome pinned is the pass's emitted action set, asserted through the script's real `--json` output via the existing `_run` / `_actions_for` harness in `backend/tests/test_backlog_rhythm.py` — the tests execute `backlog-rhythm.sh` itself against a seeded digest (`RHYTHM_DIGEST_FILE`), not a reimplementation of its rules. Both halves are covered: the action appears (5 tests), and the contradicting chases disappear (3 of those same tests assert `park` / `nudge_reporter` / `surface_discussion` absent).

Refs #681