### PR TITLE
fix: make the PR reviewer approve when nothing blocks

### DIFF
--- a/.claude/skills/advance-pr/SKILL.md
+++ b/.claude/skills/advance-pr/SKILL.md
@@ -114,18 +114,24 @@ reopens the failure it fixed.
 - **CI must be green, not merely unconflicted, before `gh pr ready`.** A
   `MERGEABLE` PR with checks still running is not ready — `mergeable` only
   says the diff applies cleanly, it says nothing about whether it passes.
-- **`COMMENTED` is ambiguous, and `request-pr-review.sh` resolves it for
-  you — do not second-guess it.** The bot posts an early placeholder review
-  as `COMMENTED` before its real summary, so a `COMMENTED` seen while the
-  review run is still going decides nothing. The script asks whether the
+- **`COMMENTED` is not a verdict, and `request-pr-review.sh` resolves it for
+  you — do not second-guess it.** `pr-review.yml` has exactly two legal
+  verdicts, `APPROVE` and `REQUEST_CHANGES`; findings that do not block merge
+  are an approval with the nits in the body, because a `COMMENTED` review
+  leaves GitHub's `reviewDecision` showing the previous round's
+  `CHANGES_REQUESTED`. The bot also posts an early placeholder review as
+  `COMMENTED` before its real summary, so a `COMMENTED` seen while the review
+  run is still going decides nothing. The script asks whether the
   workflow run is still live, not how long has elapsed, because no fixed
-  timer is both short enough to return a real `COMMENT` verdict promptly and
+  timer is both short enough to report a finished `COMMENTED` promptly and
   long enough to never pre-empt a summary — this was tried and measured
   wrong in both directions (see the script's own comments for the incident
   history: #617, #622, #615, #636, #623). A `COMMENTED` that reaches you from
-  the script arrived *after* the run finished, and that **is** the verdict:
-  treat it exactly like `CHANGES_REQUESTED` — collect findings, do not flip
-  the PR ready.
+  the script arrived *after* the run finished, so it is the reviewer's last
+  word without being a verdict: treat it exactly like `CHANGES_REQUESTED` —
+  collect findings, do not flip the PR ready — and say in your report that
+  the bot broke its own two-verdict contract, because the stale
+  `reviewDecision` will still be blocking the merge.
 - **On `APPROVED`, re-check mergeability before doing anything else** — do
   not trust whatever mergeability you read at the top of this invocation.
   A review round takes minutes, other PRs merge during it, and a

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -84,12 +84,12 @@ jobs:
 
                  **Submit EXACTLY ONE review per run — the summary in step 4.**
                  This is a hard constraint, not a style preference.
-                 `scripts/request-pr-review.sh` waits for your verdict, and any
-                 extra submitted review is indistinguishable by state from a
-                 real `COMMENT` verdict. That ambiguity left PR #615 approved
-                 but stuck in draft overnight, and a stray "test permission
-                 check" review was submitted to PR #622 while probing what was
-                 available.
+                 `scripts/request-pr-review.sh` waits for your verdict, and an
+                 extra submitted review lands as a `COMMENTED` review that no
+                 caller can tell apart from your real summary until the run
+                 ends. That ambiguity left PR #615 approved but stuck in draft
+                 overnight, and a stray "test permission check" review was
+                 submitted to PR #622 while probing what was available.
 
                  So: never call `gh pr review` except once, in step 4. Never
                  call it to probe permissions — it submits.
@@ -105,20 +105,46 @@ jobs:
                  and the real code quoted. A complete summary review is a fine
                  outcome; a second submitted review is not.
 
-              4. End with a single summary review using `gh pr review`:
-                   - APPROVE  — no blockers, only nits or none
-                   - REQUEST_CHANGES — at least one rule violation or correctness bug
-                   - COMMENT  — questions/observations only
+              4. End with a single summary review using `gh pr review`.
+                 There are exactly TWO verdicts, and the choice between them
+                 is mechanical, not a matter of tone:
+
+                   - REQUEST_CHANGES — you can name at least one BLOCKER: a
+                     violation of a rule in `docs/agents/rules.md`, or a
+                     correctness bug stated as a concrete failure scenario
+                     (inputs/state → wrong output or crash), with `file:line`
+                     and the real code quoted.
+                   - APPROVE — everything else, INCLUDING when you have
+                     findings. Nits, style preferences, design questions,
+                     asymmetries you cannot demonstrate as failures, "worth a
+                     look before this lands" — every one of those is an
+                     APPROVE with the finding written into the body. The
+                     author decides which to act on; that call is theirs, not
+                     yours.
+
+                 **`COMMENT` is not a verdict in this repo. Never submit one.**
+                 If you catch yourself writing "not blocking", "worth a look",
+                 or "neither finding blocks merge", you have already decided:
+                 the verdict is APPROVE. Approving does not mean the PR is
+                 perfect — it means you found nothing that MUST change before
+                 merge. Say what you would still change, then APPROVE.
+
+                 This is not bookkeeping. GitHub shows the last explicit
+                 verdict, and a `COMMENTED` review is not one, so a
+                 REQUEST_CHANGES from an earlier round keeps blocking the
+                 merge no matter how many clean rounds follow — only the
+                 maintainer can clear it by hand. PR #687 ran four rounds:
+                 every substantive finding was fixed, the last two rounds said
+                 in their own words that nothing blocked, and the PR still sat
+                 blocked on a stale round-2 review needing a manual dismissal.
 
                  **Submitting this review is mandatory in every case,
                  including when you find nothing wrong.** Finishing the run
                  without calling `gh pr review` is a failed run, not a clean
                  one. Silence is indistinguishable from a crash to everything
-                 downstream, and it has a concrete cost: GitHub keeps showing
-                 the LAST explicit verdict, so a prior REQUEST_CHANGES goes on
-                 blocking the merge no matter how many clean runs follow, and
-                 the review can never be cleared by re-running. If the diff is
-                 clean, say so in one line and APPROVE.
+                 downstream, and it leaves the same stale verdict in place as
+                 a `COMMENTED` does. If the diff is clean, say so in one line
+                 and APPROVE.
 
               5. The summary must include:
                  - Whether the fix matches the linked issue's root-cause

--- a/backend/tests/test_request_pr_review.py
+++ b/backend/tests/test_request_pr_review.py
@@ -223,13 +223,14 @@ def test_commented_while_running_is_not_a_verdict(
     assert "the review is running" in proc.stderr
 
 
-def test_commented_after_the_run_finished_is_the_verdict(
+def test_commented_after_the_run_finished_is_reported(
     bin_dir: Path, env_file: Path
 ) -> None:
-    """The opposite failure. `pr-review.yml` lists COMMENT as one of three final
-    verdicts, so once the run is over a COMMENTED last word IS the answer —
-    swallowing it made the script report "no summary" while findings sat on the
-    PR."""
+    """The opposite failure. COMMENT is no longer a legal verdict —
+    `pr-review.yml` allows only APPROVE and REQUEST_CHANGES — but once the run
+    is over, a COMMENTED last word is still the reviewer's last word and must
+    reach the caller. Swallowing it made the script report "no summary" while
+    findings sat on the PR."""
     _gh(bin_dir, [_review("COMMENTED")], "finished")
     proc = _run(bin_dir, env_file)
 

--- a/scripts/request-pr-review.sh
+++ b/scripts/request-pr-review.sh
@@ -23,12 +23,18 @@
 # trigger is a real signal, including one the maintainer submits by hand while
 # the bot is still thinking. The caller decides what to do with it.
 #
-# THE COMMENTED PROBLEM. `pr-review.yml` gives the bot three final verdicts:
-# APPROVE, REQUEST_CHANGES and COMMENT ("questions/observations only"). But the
-# bot ALSO posts its inline notes as a separate review before the summary, and
-# that one is `COMMENTED` too -- body "Inline notes below; summary review to
-# follow.". So `COMMENTED` is ambiguous: either a placeholder that decides
-# nothing, or a legitimate final verdict. The state alone cannot tell them apart.
+# THE COMMENTED PROBLEM. `pr-review.yml` now gives the bot exactly two final
+# verdicts, APPROVE and REQUEST_CHANGES: findings that do not block merge are an
+# APPROVE with the nits in the body, because a COMMENTED review does not clear
+# GitHub's `reviewDecision` and so leaves an earlier REQUEST_CHANGES blocking
+# the merge (measured on #687: four rounds, the last two explicitly
+# non-blocking, still needing a manual dismissal). COMMENT used to be a third
+# legal verdict, which is why everything below exists -- and the ambiguity does
+# not disappear with it, because the bot may still post inline notes as a
+# separate `COMMENTED` review before its summary, body "Inline notes below;
+# summary review to follow.". So `COMMENTED` remains ambiguous from state
+# alone: either a placeholder that decides nothing, or a run that ended without
+# ever giving a legal verdict.
 #
 # Getting this wrong in either direction has been observed:
 #   - Treating COMMENTED as terminal returns the placeholder. Measured on #617
@@ -36,9 +42,9 @@
 #     08:49:14Z -- 16s). `implement-issue` Step 11 then saw a non-APPROVED
 #     verdict and skipped `gh pr ready`: that is how #615 sat approved-but-draft
 #     overnight with only the merge left to do.
-#   - Treating COMMENTED as never-terminal swallows a real COMMENT verdict. The
-#     loop waits out the full timeout and reports "no summary landed", which is
-#     false when a summary with findings is sitting on the PR.
+#   - Treating COMMENTED as never-terminal swallows a run whose last word was
+#     COMMENTED. The loop waits out the full timeout and reports "no summary
+#     landed", which is false when a summary with findings sits on the PR.
 #
 # So COMMENTED is resolved by asking whether the REVIEWER IS STILL WORKING, not
 # by parsing its body and not by a timer. Body text is bot-generated prose with
@@ -46,12 +52,14 @@
 # from those 16s/50s gaps, it still pre-empted a summary, because the gap that
 # matters is not placeholder-to-summary but placeholder-to-END-OF-RUN — the bot
 # posts an early permission check within a couple of minutes and works for five
-# to eight more. No fixed number is both short enough to return a real COMMENT
-# promptly and long enough never to pre-empt.
+# to eight more. No fixed number is both short enough to report a finished
+# COMMENTED promptly and long enough never to pre-empt.
 #
 # APPROVED/CHANGES_REQUESTED return immediately. A COMMENTED is held while the
-# run is live and accepted as the verdict once the run has finished, which is
-# exactly what COMMENT means in pr-review.yml's own three-verdict contract.
+# run is live and returned once the run has finished -- not because it is a
+# verdict (it no longer is) but because the reviewer has stopped talking, and
+# reporting its last word beats timing out. Callers treat anything that is not
+# APPROVED the same way: collect findings, do not flip the PR ready.
 #
 # `pr-review.yml` step 3 is also changed so inline notes post via `gh api`
 # instead of `gh pr review`, which stops the placeholder being submitted as a
@@ -247,14 +255,16 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
             # Treating "I could not tell" as "it finished" re-opens the exact
             # race this script exists to close, gated on API flakiness instead
             # of timing. Not knowing must never promote a placeholder to a
-            # verdict; waiting costs one more poll, and a genuine COMMENT
-            # verdict still returns as soon as the state resolves.
+            # verdict; waiting costs one more poll, and a run that ends on
+            # COMMENTED still returns as soon as the state resolves.
             echo "COMMENTED seen but the review is ${state} — waiting." >&2
         else
-            # The run has finished and its last word was COMMENTED, so that IS
-            # the verdict: `pr-review.yml` lists COMMENT as one of three final
-            # verdicts ("questions/observations only").
-            echo "Review finished with COMMENTED as its last word — that is the verdict." >&2
+            # The run has finished and its last word was COMMENTED. Under the
+            # current two-verdict contract that is a protocol violation, not a
+            # verdict -- but it is still the reviewer's last word, and the
+            # caller must be told rather than left to time out. Returned as-is;
+            # every caller treats a non-APPROVED as "do not flip ready".
+            echo "Review finished with COMMENTED as its last word — no legal verdict; returning it." >&2
             echo "VERDICT ${commented}"
             exit 0
         fi


### PR DESCRIPTION
## What

Cuts the PR reviewer's verdict menu from three options to two, so that "I found nits but nothing blocks" comes back as an **APPROVE with the nits in the body** instead of a `COMMENTED` review that leaves the merge blocked.

## Why

A `COMMENTED` review does not set GitHub's `reviewDecision`. It cannot clear an earlier `CHANGES_REQUESTED` — that block stands until a human dismisses the stale review by hand.

`pr-review.yml` nonetheless offered `COMMENT — questions/observations only` alongside `APPROVE — no blockers, only nits or none`. With findings in hand but none of them blocking, the bot reached for the option that felt honest rather than the one its own contract specified. Measured on #687:

| round | state | the bot's own words |
|---|---|---|
| 2 | `CHANGES_REQUESTED` | real findings, since fixed |
| 3 | `COMMENTED` | "Neither finding blocks merge on its own" |
| 4 | `COMMENTED` | "One finding, not blocking merge but worth a look" |

Two approvals submitted as comments. Four rounds in, every substantive finding fixed, and `reviewDecision` was still `CHANGES_REQUESTED` from round 2.

## What changed

- **`.github/workflows/pr-review.yml`** — two verdicts, chosen mechanically. `REQUEST_CHANGES` requires a nameable blocker: a `rules.md` violation, or a correctness bug stated as a concrete failure scenario (inputs/state → wrong output or crash) with `file:line` and the real code quoted. Everything else — nits, style, design questions, undemonstrable asymmetries, "worth a look before this lands" — is `APPROVE` with the finding written into the body; the author decides what to act on, and that call is theirs. `COMMENT` is banned outright, with the tell spelled out: if you are writing "not blocking" or "worth a look", you have already decided.
- **`scripts/request-pr-review.sh`** — **behaviour unchanged.** A `COMMENTED` is still held while the run is live and still returned once the run ends, so no caller hangs and the placeholder race stays closed. Only the documentation moves: a terminal `COMMENTED` is now a protocol violation to report, not a legal verdict.
- **`.claude/skills/advance-pr/SKILL.md`** — same reframing. Still treated exactly like `CHANGES_REQUESTED` (collect findings, do not flip ready), and now says to report that the bot broke its own contract, because the stale `reviewDecision` will still be blocking.
- **`backend/tests/test_request_pr_review.py`** — one docstring that asserted the old three-verdict contract. Assertions unchanged.

## Verification

- `pytest -m "not slow"`: 2281 passed, 50 skipped. (The 6 `test_quality_check_mypy_gate.py` failures in the sandboxed run are the known `mktemp`-under-`/var/folders` denial; all 6 pass unsandboxed.)
- `black --check` / `ruff check` clean on the one touched Python file; the workflow YAML parses.
- The script's own suite (`test_request_pr_review.py`, `test_agent_permissions.py`): 61 passed — the unchanged behaviour is what those tests pin.

## Note

This does not unblock #687 by itself. That PR's stale round-2 review still needs dismissing by hand; this is about the next PR, not that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kSsdTKDSrvnDB6ZnMb8b3
