### PR TITLE
fix: bound the exact PWL re-solve's memory so it cannot OOM the add-on (#697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **The add-on no longer runs out of memory and stops restarting when the optimizer refines a near-tied decision** — the exact re-solve now runs within a bounded memory footprint. ([#697](https://github.com/johanzander/bess-manager/issues/697))
 - **The battery now keeps a sensible overnight reserve instead of all-or-nothing** — end-of-horizon energy is valued by how much the house needs before sunrise, so midnight charge no longer flips between empty and full. ([#602](https://github.com/johanzander/bess-manager/issues/602))
 - **Sub-period discharge authorization now values stored energy accurately** — the gate read the battery's marginal value from a single grid cell, which mis-priced it in both directions, so it both held and released the battery in the wrong periods. ([#683](https://github.com/johanzander/bess-manager/issues/683))
 - **A stale `Awaiting` field no longer hides a qualifying bug from autonomous analysis** — the tier-1 carve-out is now computed from the issue's own evidence instead of the board field. ([#681](https://github.com/johanzander/bess-manager/issues/681))

--- a/core/bess/pwl_window_dp.py
+++ b/core/bess/pwl_window_dp.py
@@ -113,16 +113,100 @@ def _pwl_candidate_values_at(
     import_cap_kwh: float | None = None,
     capabilities: PlatformCapabilities = DEFAULT_CAPABILITIES,
 ) -> np.ndarray:
-    """Best achievable value at each SOE in `X` for period `t`: max over the
-    shared action set (IDLE, STORE, discharge grid) plus the
-    SOLAR_EXPORT-below-max bypass (#313), with V[t+1] evaluated exactly at
-    each candidate's true (continuous) next_soe -- no state snapping.
+    """Best achievable value at each SOE in `X` for period `t`, evaluated in
+    bounded row blocks (#697).
+
+    The objective itself lives in `_pwl_candidate_values_block`; this wrapper
+    exists only to stop it being asked for the whole of `X` at once. That
+    matters because the block builds a dense `|X| x |actions|` matrix and a
+    dozen same-shape temporaries, `|actions|` is ~102 for every battery
+    (`discharge_rate_step_kw` is `max_discharge_power_kw / 100`, so the count
+    is fixed by the lattice, not the hardware), and `|X|` compounds per
+    backward stage via the discharge-preimage cross product. Measured cost is
+    a flat ~10 kB per breakpoint, so the tens of thousands of breakpoints a
+    five-period window reaches turned into ~1.1 GB RSS and an OOM kill --
+    a kill, not an exception, so none of the accuracy budgets ever got to
+    speak and #624's bisection was structurally unreachable.
+
+    Blocking is exact, not an approximation: every reduction in the block is
+    over `axis=1` (actions), including the import-cap floor, so rows are
+    independent and `concatenate(block(X_i)) == block(X)` bitwise. It also
+    removes the allocator fragmentation that made peak RSS ~4x the traced
+    peak, since no single allocation is large enough to fragment around.
 
     `import_cap_kwh` is the house fuse's per-period grid-import ceiling
     (#429), enforced exactly as `_run_dynamic_programming` enforces it on the
     grid DP: total import (load + grid charging) is a hard constraint,
     constraining rather than excluding a period whose load alone exceeds the
     cap."""
+    X = np.asarray(X)
+    # `_pwl_candidate_values_block` appends one SOLAR_EXPORT-bypass column and
+    # at most one residual-cover column, so this is the width's upper bound.
+    n_actions = np.asarray(power_row).size + 2
+
+    cells = X.size * n_actions
+    if cells > PWL_MAX_EVAL_CELLS:
+        raise PWLWindowUnderRefinedError(
+            f"PWL window t={t}: the objective evaluation would need {cells} "
+            f"candidate cells ({X.size} breakpoints x {n_actions} actions) > "
+            f"PWL_MAX_EVAL_CELLS={PWL_MAX_EVAL_CELLS}; V[{t}] cannot be built "
+            f"within budget and must not be treated as exact."
+        )
+
+    block = max(1, PWL_EVAL_BLOCK_CELLS // n_actions)
+    if X.size <= block:
+        return _pwl_candidate_values_block(
+            X,
+            t,
+            V_next,
+            power_row,
+            horizon_inputs,
+            battery_settings,
+            dt,
+            period_max_charge,
+            import_cap_kwh,
+            capabilities,
+        )
+    return np.concatenate(
+        [
+            _pwl_candidate_values_block(
+                X[i : i + block],
+                t,
+                V_next,
+                power_row,
+                horizon_inputs,
+                battery_settings,
+                dt,
+                period_max_charge,
+                import_cap_kwh,
+                capabilities,
+            )
+            for i in range(0, X.size, block)
+        ]
+    )
+
+
+def _pwl_candidate_values_block(
+    X: np.ndarray,
+    t: int,
+    V_next: tuple[np.ndarray, np.ndarray],
+    power_row: np.ndarray,
+    horizon_inputs: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    battery_settings: BatterySettings,
+    dt: float,
+    period_max_charge: float | None,
+    import_cap_kwh: float | None = None,
+    capabilities: PlatformCapabilities = DEFAULT_CAPABILITIES,
+) -> np.ndarray:
+    """One block of `_pwl_candidate_values_at`: max over the shared action set
+    (IDLE, STORE, discharge grid) plus the SOLAR_EXPORT-below-max bypass
+    (#313), with V[t+1] evaluated exactly at each candidate's true
+    (continuous) next_soe -- no state snapping.
+
+    Call `_pwl_candidate_values_at` instead of this. Every reduction below is
+    over `axis=1`, which is what lets the wrapper split `X` into blocks; a
+    candidate that coupled rows would break that silently, so it is pinned by
+    `test_the_objective_evaluation_is_row_separable`."""
     buy_price, sell_price, home_consumption, solar_production = horizon_inputs
     min_soe = battery_settings.min_soe_kwh
     max_soe = battery_settings.max_soe_kwh
@@ -425,13 +509,42 @@ PWL_MAX_BREAKPOINTS = 30000
 
 # Separate, much larger budget for the *transient* discharge-preimage cross
 # product in `_pwl_window_seed_points` (|xs_next| x |discharge levels|). It is
-# built, deduped and pruned within a single seeding call, so it is bounded by
-# memory (1e6 float64 ~ 8 MB), not by the per-row breakpoint ceiling. These
-# were one constant until review: sharing `PWL_MAX_BREAKPOINTS` silently
-# disabled exact preimage seeding on every row after the first backward step
-# (|xs_next| > ~303 already trips 303 x 98 > 30000), i.e. the mechanism was
-# off exactly where it was documented to be required.
+# built, deduped and pruned within a single seeding call, so it is bounded
+# independently of the per-row breakpoint ceiling. These were one constant
+# until review: sharing `PWL_MAX_BREAKPOINTS` silently disabled exact preimage
+# seeding on every row after the first backward step (|xs_next| > ~303 already
+# trips 303 x 98 > 30000), i.e. the mechanism was off exactly where it was
+# documented to be required.
+#
+# This budget used to justify itself as "bounded by memory (1e6 float64 ~ 8
+# MB)". That was the wrong denomination and it is what let #697 happen: the
+# seed *abscissae* are 8 MB, but evaluating the objective on them costs ~10 kB
+# each, so 1e6 of them is ~10 GB. Seeding is cheap; evaluating is not. Memory
+# is now bounded where it is actually spent, by `PWL_EVAL_BLOCK_CELLS`, and
+# this constant is what it always really was -- a ceiling on how much work one
+# seeding round may propose.
 PWL_MAX_PREIMAGE_SEED_POINTS = 1_000_000
+
+# Row-block size for `_pwl_candidate_values_at`, in candidate cells
+# (breakpoints x actions). This is the constant that actually bounds peak
+# memory: the objective's dense matrix and its dozen temporaries cost ~97 bytes
+# per cell, so 1e5 cells is ~10 MB per evaluation regardless of how large |X|
+# has grown. Blocking is exact (see the wrapper's docstring), so this trades
+# nothing but a little numpy call overhead.
+PWL_EVAL_BLOCK_CELLS = 100_000
+
+# Ceiling on a single objective evaluation, in the same cells. With blocking in
+# place this is no longer a memory bound -- it is a work bound, and saying so
+# is the honest version of what the preimage budget above was pretending to be.
+# It is checked BEFORE the evaluation, unlike `PWL_MAX_BREAKPOINTS`, which is
+# checked after the `values_at` it nominally bounds and against the *pruned*
+# row -- roughly a tenth of what was just evaluated. That ordering is why no
+# budget fired in #697. Set ~6x above the largest evaluation measured on the
+# corpus (~34k breakpoints x ~102 actions on a five-period window), so it
+# catches pathological growth without demoting windows that solve fine today;
+# exceeding it raises `PWLWindowUnderRefinedError`, which #624's bisection
+# already catches and answers by re-sizing the window.
+PWL_MAX_EVAL_CELLS = 20_000_000
 
 # Two distinct tolerances that were previously ad-hoc literals:
 # points closer than this are the same breakpoint...
@@ -672,7 +785,8 @@ def run_pwl_window_backward_induction(
     `ValueError` (see `_pinned_terminal_row`).
 
     Exhausting any of the accuracy budgets (`PWL_MAX_BREAKPOINTS`,
-    `PWL_MAX_REFINE_ITERS`, `PWL_MAX_PREIMAGE_SEED_POINTS`) raises
+    `PWL_MAX_REFINE_ITERS`, `PWL_MAX_PREIMAGE_SEED_POINTS`,
+    `PWL_MAX_EVAL_CELLS`) raises
     `PWLWindowUnderRefinedError` rather than returning the approximation --
     unlike infeasibility, an uncertifiable table has no honest use, and
     splicing one in as if exact is the silent degradation this whole path

--- a/core/bess/tests/unit/test_pwl_window_memory.py
+++ b/core/bess/tests/unit/test_pwl_window_memory.py
@@ -1,0 +1,218 @@
+"""The exact PWL re-solve must not allocate without bound (#697).
+
+On 2026-08-23 the add-on was OOM-killed 11 times in 10 minutes, every kill at
+the same point: the log line announcing the #450 exact PWL re-solve, then
+`Killed` on the uvicorn process. Home Assistant Supervisor's restart backoff
+then gave up and the battery went unmanaged for 38 hours.
+
+The allocation is not proportional to window width -- the reporter's windows
+were five periods each. It is `_pwl_candidate_values_at` materialising a dense
+`|X| x |actions|` candidate matrix, plus a dozen same-shape temporaries, in one
+go. `|actions|` is ~102 for *every* battery, because
+`discharge_rate_step_kw = max_discharge_power_kw / 100`, so the cost is a flat
+~10 kB per breakpoint and the only free variable is `|X|` -- which compounds
+per backward stage as the discharge-preimage cross product
+(`_pwl_window_seed_points`) seeds `|xs_next| x ~100` points.
+
+Neither budget caught it. `PWL_MAX_PREIMAGE_SEED_POINTS` counts abscissae, not
+evaluation cells, and its own comment mis-states the cost ("1e6 float64 ~ 8 MB"
+-- the evaluation on 1e6 seed points is ~10 GB). `PWL_MAX_BREAKPOINTS` is
+checked strictly *after* the `values_at(X)` it is meant to bound, and against
+the pruned row, which is roughly a tenth of what was just evaluated. So the
+solve never raised `PWLWindowUnderRefinedError`, never reached #624's
+bisection, and was killed by the kernel instead -- and SIGKILL is not an
+exception the optimizer can catch.
+
+The subject here is peak memory, so these assert allocation, not economics.
+Exactness is already pinned by `test_pwl_window_dp.py`; what this file adds is
+that the same answer is reached inside a bounded footprint.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+import core.bess.dp_battery_algorithm as dpa
+import core.bess.pwl_window_dp as pwl
+from core.bess.exceptions import PWLWindowUnderRefinedError
+from core.bess.tests.helpers import _scenario_inputs
+from core.bess.tests.unit.golden_capture import DATA_DIR
+
+# The #624 reporter's day, whose nine-period tie window bisects into halves of
+# four and five periods -- the same width as #697's `[(23, 28), (38, 43)]`.
+# Reused rather than re-fixtured because it is the corpus's only input that
+# still produces a tie window long enough to drive the breakpoint set into the
+# region where this bug lives.
+FIXTURE = "regression_2026_08_17_624"
+WINDOW = (80, 85)
+
+# Measured on this window before the fix: 198 MB traced peak (1134 MB RSS --
+# the gap is allocator fragmentation across ~120 repeated hundreds-of-MB
+# short-lived arrays, and RSS is what the OOM killer reads). Chunked
+# evaluation brings the traced peak to roughly one block's worth. The ceiling
+# is set well above that and well below the pre-fix figure, so it discriminates
+# without being sensitive to numpy's exact temporary count.
+PEAK_ALLOCATION_CEILING_MB = 48.0
+
+
+@pytest.fixture(scope="module")
+def window_inputs() -> dict:
+    """Backward-induction kwargs for the bisected half of the #624 window.
+
+    The end SOE comes from the grid DP's own trajectory, exactly as
+    `dp_battery_algorithm` pins it when it re-solves a window in production --
+    a hand-picked target would change the terminal row and with it the
+    breakpoint growth this file is measuring.
+    """
+    scenario = json.loads((DATA_DIR / f"{FIXTURE}.json").read_text())
+    inputs = dict(_scenario_inputs(scenario))
+    # No terminal row, for the reason `test_pwl_window_bisection` documents:
+    # a nonzero terminal curve breaks the near-ties the hybrid path exists to
+    # resolve, and shrinks this window below the width under test.
+    inputs.pop("terminal_curve", None)
+
+    diagnostics: dict = {}
+    dpa.optimize_battery_schedule(**inputs, tie_diagnostics=diagnostics)
+
+    start, end = WINDOW
+    return {
+        "window_horizon": end - start,
+        "buy_price": inputs["buy_price"][start:end],
+        "sell_price": inputs["sell_price"][start:end],
+        "home_consumption": inputs["home_consumption"][start:end],
+        "solar_production": inputs["solar_production"][start:end],
+        "battery_settings": inputs["battery_settings"],
+        "dt": inputs["period_duration_hours"],
+        "end_soe_target": diagnostics["soe_trajectory"][end],
+    }
+
+
+@pytest.mark.slow
+def test_a_five_period_window_solves_within_a_bounded_memory_footprint(
+    window_inputs: dict,
+) -> None:
+    """The outcome #697 is about: the process survives the re-solve.
+
+    Asserting the traced peak rather than the breakpoint count on purpose --
+    a breakpoint ceiling is exactly the proxy that was already in place and
+    already failed, because it bounded the retained row while the transient
+    evaluation was ten times larger.
+    """
+    import tracemalloc
+
+    tracemalloc.start()
+    try:
+        pwl.run_pwl_window_backward_induction(**window_inputs)
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    peak_mb = peak / 1e6
+    assert peak_mb < PEAK_ALLOCATION_CEILING_MB, (
+        f"exact PWL re-solve of a {window_inputs['window_horizon']}-period "
+        f"window peaked at {peak_mb:.1f} MB, above the "
+        f"{PEAK_ALLOCATION_CEILING_MB} MB ceiling -- the objective evaluation "
+        f"is allocating proportionally to |X| again (#697)"
+    )
+
+
+def test_blocked_evaluation_is_bitwise_identical_to_one_whole_allocation(
+    window_inputs: dict,
+) -> None:
+    """The exactness claim the fix rests on, tested against the OLD code path.
+
+    `_pwl_candidate_values_block` on the whole of `X` is precisely what
+    `_pwl_candidate_values_at` used to do in one allocation, so comparing the
+    wrapper against it is a direct before/after on the same input rather than
+    a self-comparison. It holds because every reduction in the block is over
+    `axis=1` (actions), including the import-cap floor, so a row's value
+    depends on no other row; a future candidate that coupled rows -- a
+    normalisation, a cross-row cap -- would surface here rather than as a
+    drifting economic pin somewhere downstream.
+
+    `X` must exceed the block size or this proves nothing: below it the
+    wrapper returns the single-block result unchanged and both sides run
+    identical code. The assertion below pins that premise, because an
+    innocuous raise of `PWL_EVAL_BLOCK_CELLS` would otherwise turn this test
+    green-but-vacuous.
+    """
+    settings = window_inputs["battery_settings"]
+    args = _candidate_args(window_inputs)
+    n_actions = np.asarray(args["power_row"]).size + 2
+    block = max(1, pwl.PWL_EVAL_BLOCK_CELLS // n_actions)
+
+    n_points = 4 * block + 7  # not a block multiple: exercise a ragged tail
+    X = np.linspace(settings.min_soe_kwh, settings.max_soe_kwh, n_points)
+    assert X.size > block, (
+        f"fixture no longer spans a block boundary ({X.size} <= {block}) -- "
+        f"both sides would take the single-block path and this test would "
+        f"compare the code to itself"
+    )
+
+    blocked = pwl._pwl_candidate_values_at(X, **args)
+    one_allocation = pwl._pwl_candidate_values_block(X, **args)
+
+    assert np.array_equal(blocked, one_allocation), (
+        "blocked evaluation differs from the single whole-array evaluation -- "
+        "some candidate now couples rows, and blocking is no longer exact"
+    )
+
+
+@pytest.mark.slow
+def test_an_oversized_evaluation_raises_before_it_allocates(
+    window_inputs: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ceiling must fire ahead of the allocation, not after it.
+
+    `PWL_MAX_BREAKPOINTS` was checked one line below the `values_at(X)` it was
+    meant to bound, so the memory was already spent by the time the guard
+    looked -- and it inspected the pruned row rather than the seed set that
+    had actually been evaluated. Squeezing the cell budget to something every
+    real row exceeds proves the check is now upstream: the solve must raise,
+    and must do so without having allocated the matrix first.
+    """
+    import tracemalloc
+
+    monkeypatch.setattr(pwl, "PWL_MAX_EVAL_CELLS", 5_000)
+
+    tracemalloc.start()
+    try:
+        with pytest.raises(PWLWindowUnderRefinedError, match="PWL_MAX_EVAL_CELLS"):
+            pwl.run_pwl_window_backward_induction(**window_inputs)
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert peak / 1e6 < PEAK_ALLOCATION_CEILING_MB, (
+        f"the cell ceiling raised, but only after allocating {peak / 1e6:.1f} "
+        f"MB -- the check is still downstream of the evaluation it bounds"
+    )
+
+
+def _candidate_args(window_inputs: dict) -> dict:
+    """The non-`X` arguments `_pwl_candidate_values_at` needs, for period 0."""
+    settings = window_inputs["battery_settings"]
+    power_row = np.concatenate(
+        (
+            [0.0],
+            pwl._backward_discharge_levels(settings, pwl.DEFAULT_CAPABILITIES) * -1,
+            [pwl.POWER_STEP_KW],
+        )
+    )
+    return {
+        "t": 0,
+        "V_next": pwl._pinned_terminal_row(
+            window_inputs["end_soe_target"], 0.05, settings
+        ),
+        "power_row": power_row,
+        "horizon_inputs": (
+            window_inputs["buy_price"],
+            window_inputs["sell_price"],
+            window_inputs["home_consumption"],
+            window_inputs["solar_production"],
+        ),
+        "battery_settings": settings,
+        "dt": window_inputs["dt"],
+        "period_max_charge": None,
+    }

--- a/docs/agents/optimizer-architecture.md
+++ b/docs/agents/optimizer-architecture.md
@@ -357,6 +357,41 @@ certification a whole window would have. It is the one exception that may be
 caught, and only to re-size the work — catching it to keep the grid DP's
 result, or to splice the uncertified table, remains forbidden.
 
+**A budget that is not denominated in what it spends is not a budget (#697).**
+The paragraph above used to say the exactly-solvable horizon is ~8 periods.
+That was wrong about the binding constraint, and the error was expensive: the
+real limit was transient memory in the objective evaluation, and it bit at
+*five* periods — measured 1.1 GB RSS on the corpus's own bisected half —
+inside the range the doc treated as safe. `_pwl_candidate_values_at` built a
+dense `|X| × |actions|` matrix in one allocation, `|actions|` is ~102 for every
+battery (the discharge lattice is `max_discharge_power_kw / 100`, so hardware
+size does not enter), and the two budgets that existed both looked at the
+wrong thing: `PWL_MAX_PREIMAGE_SEED_POINTS` counted seed *abscissae* (8 MB)
+rather than the ~10 GB of evaluation they imply, and `PWL_MAX_BREAKPOINTS` was
+checked *after* the evaluation it bounds and against the *pruned* row, an
+order of magnitude smaller than what had just been allocated. So the kernel
+OOM-killed the add-on instead, eleven times, and Supervisor's backoff turned a
+deterministic solver bug into a 38-hour outage.
+
+Two rules follow, and they are general, not incidental to this bug:
+
+- **Bound the resource where it is actually spent, in its own units.** The
+  objective is evaluated in fixed-size row blocks (`PWL_EVAL_BLOCK_CELLS`), so
+  peak memory is independent of `|X|`. Blocking is exact — every reduction is
+  over the action axis, so rows are independent and the blocked result is
+  bitwise identical — which is why this bounds cost without touching P6.
+- **A ceiling checked after the allocation it bounds is not a ceiling.**
+  `PWL_MAX_EVAL_CELLS` is checked before the evaluation, in cells, and raising
+  it feeds the bisection above like any other budget.
+
+Note the failure mode this leaves closed: an optimizer that exceeds a budget
+raises and gets re-sized, but an optimizer that is SIGKILLed cannot raise at
+all, so **no in-process safety net can cover unbounded allocation**. The DP
+shares the uvicorn process with the control loop, so bounding the allocation
+is the only thing standing between a solver pathology and the battery going
+unmanaged. Isolating the optimizer so that exhaustion surfaces as a catchable
+`MemoryError` is tracked separately (#698).
+
 ### P7. Point forecasts stay; risk handling is structural, not stochastic
 
 The DP remains deterministic over point forecasts. Forecast-error


### PR DESCRIPTION
## Summary

- Evaluate the exact PWL objective in fixed-size row blocks, so peak memory is independent of `|X|` and the re-solve can no longer OOM-kill the add-on.
- Add `PWL_MAX_EVAL_CELLS`, checked **before** the evaluation and denominated in cells; exceeding it raises `PWLWindowUnderRefinedError`, which #624's bisection already answers by re-sizing the window.
- Correct the `PWL_MAX_PREIMAGE_SEED_POINTS` comment that caused the mis-denomination, and the normative claim in `optimizer-architecture.md` that this bug proved wrong.

## Root cause

`_pwl_candidate_values_at` built a dense `|X| × |actions|` candidate matrix plus about a dozen same-shape temporaries in a single allocation. `|actions|` is ~102 for **every** battery, because the discharge lattice is `max_discharge_power_kw / 100` — so battery size is not the axis. Measured cost is a flat **~10 kB per breakpoint**, and the only free variable is `|X|`, which compounds per backward stage: `_pwl_window_seed_points` seeds the discharge preimage as `|xs_next| × ~100` (`pwl_window_dp.py:612`) and that set is routinely ~10× larger than the pruned row it collapses into.

Neither budget could catch it, for structural reasons rather than tuning:

- `PWL_MAX_PREIMAGE_SEED_POINTS` counts seed **abscissae**, not evaluation cells. Its own comment justified itself as "bounded by memory (1e6 float64 ~ 8 MB)". The abscissae are 8 MB; evaluating on them is ~10 GB.
- `PWL_MAX_BREAKPOINTS` is checked at `:767`, one line *after* the `values_at(X)` at `:766` it is meant to bound, and against the **pruned** row. The raw seed set at `:731` was evaluated with no size check at all.

So the solve never raised `PWLWindowUnderRefinedError`, never reached #624's bisection at `dp_battery_algorithm.py:2320`, and was killed by the kernel instead. **SIGKILL is not an exception**, which is why no in-process guard could have covered this class.

## Fix

Blocked evaluation. Every reduction in the objective is over `axis=1` (actions), including the import-cap floor, so rows are independent and the blocked result is **bitwise identical** to one whole allocation. The objective itself moved unchanged into `_pwl_candidate_values_block`; `_pwl_candidate_values_at` is now a thin wrapper that slices, checks the cell budget, and concatenates. No call-site change, no new control flow, no change to the value table, no P6 exception.

**Deliberately not** the "fall back to the grid DP result when exceeded" the issue originally proposed: `optimizer-architecture.md` P6 forbids catching `PWLWindowUnderRefinedError` to keep the grid DP's answer, and bisection already delivers the same availability without violating it.

**Split out to #698:** process isolation for the optimizer — the coupling that turned a solver bug into a 38-hour outage. Not fixable inside the optimizer, since SIGKILL is uncatchable and the DP shares the uvicorn process with the control loop.

## Scope assessment

**Local.** Confined to two functions in `core/bess/pwl_window_dp.py` plus two constants. The owner is the solver because it is the only thing that knows `|X|` before spending memory on it, and `_pwl_candidate_values_block` the only thing that knows `|actions|`. Not the call site — it already has the correct response to "too big to solve at once". Not `tie_detection.py` — that would cap windows, i.e. the wrong quantity again, which is the same mistake the existing budgets made.

**Workaround check:** the diff adds no parameter, flag, default-fallback, second construction site, extra trigger or branch whose job is to route around an ordering/timing/dependency problem. The ordering problem — a guard placed after the allocation it bounds — is fixed directly by putting the new check upstream of the evaluation, not papered over.

## Test plan

- [x] `./scripts/quality-check.sh` passes locally — `2288 passed, 50 skipped`, 0 errors, Black/Ruff/mypy/TS/ESLint green.
- [x] `.venv/bin/pytest -m slow` — `564 passed, 10 skipped` in 351s. **No golden, `expected_results` pin, VPP baseline or cost number moved**, which is the load-bearing check for the bitwise-identity claim.
- [x] **Observed in a memory-capped container** (`podman run --memory=250m` on the real backend image, running the real `optimize_battery_schedule`), which is the environment that actually kills the add-on:

  | | exit code | outcome |
  |---|---|---|
  | pre-fix | **137** (SIGKILL) | log ends at `Near-tied DP decisions detected (#450): re-solving 1 window(s) ... with the exact PWL DP`, then nothing — byte-for-byte the reporter's signature across all 11 kills |
  | post-fix | **0** | solves; 75 MB peak RSS; identical economics (grid-only 26.28, optimized -47.81, savings 74.09 SEK) and identical table (6 rows, `V[0]` 5986 breakpoints) |

  Uncapped in the same container: **375 MB → 75 MB** peak RSS. Traced peak on the same window: **198.1 MB → 12.1 MB**. Runtime 3.0s → 3.2s.

  Two honest caveats. (1) The compose stack was not used, because no `docker-compose.ci.yml` scenario produces a near-tie window — it would have exercised none of this. The capped container runs the same image and the same entry path instead. (2) The 1134 MB RSS in the issue is a macOS allocator-fragmentation figure; on Linux the same window is 375 MB, so the cap was tightened proportionally to sit between pre- and post-fix. The per-breakpoint cost is the portable quantity, and it is flat.

## Evidence the test discriminates

Three separate mutations, all on the real fixture:

- **The primary test was written RED, before the fix existed.** `test_a_five_period_window_solves_within_a_bounded_memory_footprint` failed at `198.1 MB` against its 48 MB ceiling — `AssertionError: exact PWL re-solve of a 5-period window peaked at 198.1 MB`. 1 failed. Green after the fix at 12.1 MB.
- **Reverted the blocking stride** (`range(0, X.size, block)` → `block + 1`, so blocks skip rows): the corrupted table propagated into the DP and `test_blocked_evaluation_is_bitwise_identical_to_one_whole_allocation` went red at fixture setup. 1 error.
- **Injected a row-coupling candidate** (`+ 1e-9 * X.size` on both return paths of the block — exactly the class of change the test exists to catch, and numerically harmless so nothing else breaks): `AssertionError: blocked evaluation differs from the single whole-array evaluation -- some candidate now couples rows, and blocking is no longer exact`. 1 failed.
- Restored after each; tree clean, `3 passed`.

One note on the identity test, because it was nearly vacuous: at `X.size = 512` both sides take the single-block path (`block` is 961 here) and it would have compared the code to itself. It now uses `4 × block + 7` points — past the boundary, with a ragged tail — and compares the wrapper against `_pwl_candidate_values_block` on the whole array, which *is* the pre-fix code path. It also asserts its own premise (`X.size > block`), so a future raise of `PWL_EVAL_BLOCK_CELLS` fails the test instead of silently hollowing it out.

Also worth recording: the multi-block branch is genuinely exercised, not just present. Instrumenting the wrapper on the fixture's own solve shows **146 of 190 calls** take it, max `|X|` **19,772**.

## Outcome-level coverage

- **Memory** (the subject of this fix): traced-peak assertion on a real DP-produced window, `test_a_five_period_window_solves_within_a_bounded_memory_footprint`. Deliberately not a breakpoint-count assertion — that proxy is exactly what was already in place and already failed, because it bounded the retained row while the transient evaluation was ten times larger.
- **Exactness**: `test_blocked_evaluation_is_bitwise_identical_to_one_whole_allocation` pins the blocked result against the pre-fix single-allocation path, and the full slow suite's scenario/golden/VPP pins are unmoved. No `R == P` scenario test was added because the change is provably output-identical rather than economic — the existing plan-faithfulness pins cover the behaviour and stayed green.
- **Guard ordering**: `test_an_oversized_evaluation_raises_before_it_allocates` asserts both that the ceiling fires and that peak allocation stays bounded while it does — the property the old ceiling lacked.

No new `*.json` fixture, so no golden or VPP re-baseline was needed.

## Documentation

`docs/agents/optimizer-architecture.md` is normative and was **wrong in its binding constraint**: it stated the exactly-solvable horizon is ~8 periods and "no budget raise extends it", when the real limit was transient evaluation memory, biting at five periods — inside the range the doc treated as safe. Corrected, stated as two general rules rather than this instance (bound the resource where it is spent, in its own units; a ceiling checked after the allocation is not a ceiling), plus the note that no in-process net can cover unbounded allocation because SIGKILL cannot raise.

`docs/SOFTWARE_DESIGN.md` has no PWL mentions. `docs/agents/bess-knowledge.md` mentions only the #450 preference table and an unrelated interpolant. Both checked by grep; neither needed a change.

Refs #697
