### PR TITLE
Fix schedule-log bloat and per-device banner spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **The add-on no longer runs out of memory and stops restarting when the optimizer refines a near-tied decision** — the exact re-solve now runs within a bounded memory footprint. ([#697](https://github.com/johanzander/bess-manager/issues/697))
 - **The battery now keeps a sensible overnight reserve instead of all-or-nothing** — end-of-horizon energy is valued by how much the house needs before sunrise, so midnight charge no longer flips between empty and full. ([#602](https://github.com/johanzander/bess-manager/issues/602))
 - **Sub-period discharge authorization now values stored energy accurately** — the gate read the battery's marginal value from a single grid cell, which mis-priced it in both directions, so it both held and released the battery in the wrong periods. ([#683](https://github.com/johanzander/bess-manager/issues/683))
+- **The daily log no longer balloons to multiple megabytes** — the schedule and optimization tables are now logged only when the battery schedule actually changes, not re-dumped verbatim every 15-minute cycle.
+- **The dashboard banner reports one line per affected device instead of one per component** — a single device outage previously lit up the banner with separate lines for Battery Control, Battery Monitoring and Energy Monitoring (and one recovery line per component afterwards); all now collapse to one device line, with per-sensor detail still on the System Health page.
 
 ## [10.1.0] - 2026-08-22
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,19 @@
 **Description**: `sample_live_power()` early-returns on `if not self.power_sensors`, but `power_sensors` comes from `_resolve_power_sensor_ids()`, which deliberately *excludes* shared signed entities (their direction is unrecoverable from an InfluxDB period mean). The sampling loop itself never touches `power_sensors` — it calls the sign-splitting getters, which handle those entities fine. So an install whose only mapped power sensors are the shared signed ones gets no live sampling at all, silently disabling the `PowerSampleBuffer` path that `_shared_signed_power_entities()`'s docstring names as the covering fallback for exactly those installs. The guard should test the flow map / getters instead. Pre-existing; found during the #604 review, which widens the set of installs hitting the exclusion.
 
 
+### **`describe_failing_checks()` is dead code after the device-grouping banner**
+
+**Impact**: Low | **Effort**: Low | **Dependencies**: `health_check.py`, `test_describe_failing_checks.py`
+
+**Description**: PR #701 replaced the only two production call sites of `describe_failing_checks()` (in `api.py` and `battery_system_manager.py`) with the new device-grouping helpers, leaving it exercised only by its own `test_describe_failing_checks.py`. Not wrong, just dead weight — a follow-up removal (function plus its dedicated test file) should land separately from the banner PR.
+
+### **DP-results/schedule log can be dropped by an unexpected exception after `should_apply`**
+
+**Impact**: Low | **Effort**: Medium | **Dependencies**: `battery_system_manager.py`
+
+**Description**: PR #701 moved `print_optimization_results`/`log_battery_schedule` to run after `_apply_period_schedule()` inside `if should_apply:`. `update_battery_schedule`'s outer `except Exception` (logs + returns False) now sits between the optimization and the log block, so an exception raised in the `should_apply=True` path before the log calls (e.g. a genuine bug in `_apply_period_schedule`/`_capture_prediction_snapshot`) would silently drop the DP-results/schedule tables for that cycle — the diagnostic you'd want when something downstream breaks. No concrete repro: the realistic failure surfaces (discharge-inhibit read, `apply_period`, hardware write) are already internally guarded. Design observation from the #701 review, not a demonstrated bug.
+
+
 ## 🔴 **CRITICAL PRIORITY** (System Reliability)
 
 ### 0. **Fix Battery Discharge Power Control Bug**

--- a/backend/api.py
+++ b/backend/api.py
@@ -7,6 +7,7 @@ import dataclasses
 import threading
 from datetime import date as date_cls
 from datetime import datetime, timedelta
+from typing import Any
 
 from api_conversion import (
     BATTERY_MODEL_ATTRS as _BATTERY_MODEL_ATTRS,
@@ -36,10 +37,10 @@ from fastapi import APIRouter, HTTPException, Query
 from loguru import logger
 
 from core.bess import time_utils
+from core.bess.exceptions import SystemConfigurationError
 from core.bess.health_check import (
     group_components_by_device,
     run_system_health_checks,
-    safe_device_maps,
 )
 from core.bess.savings_aggregator import DEFAULT_COUNTS, build_buckets
 from core.bess.settings_store import VALID_PLATFORMS, flatten_sensors
@@ -1666,6 +1667,24 @@ async def recheck_system_health():
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+def _device_maps_from(controller: Any) -> tuple[dict, dict]:
+    """Resolve HA entity/device registry maps for banner grouping.
+
+    A registry query failure is a data outage, not a banner outage: the
+    banner must still report the critical failure, so degrade to empty maps
+    (component-name grouping) and log it rather than drop the banner.
+    """
+    try:
+        entity_to_device, device_names = controller.get_device_maps()
+        return entity_to_device, device_names
+    except SystemConfigurationError as e:
+        logger.warning(
+            "HA device registry unavailable, grouping banner by component name: %s",
+            e,
+        )
+        return {}, {}
+
+
 @router.get("/api/dashboard-health-summary")
 async def get_dashboard_health_summary():
     """Get lightweight health summary for dashboard alert banner - only critical issues."""
@@ -1707,7 +1726,7 @@ async def get_dashboard_health_summary():
                 components_by_name.get(failure) or {"name": failure, "status": "ERROR"}
                 for failure in critical_failures
             ]
-            entity_to_device, device_names = safe_device_maps(
+            entity_to_device, device_names = _device_maps_from(
                 bess_controller.ha_controller
             )
             critical_issues = [
@@ -1768,7 +1787,7 @@ async def get_dashboard_health_summary():
             entities_by_name = {
                 component.get("name"): component for component in non_ok
             }
-            entity_to_device, device_names = safe_device_maps(
+            entity_to_device, device_names = _device_maps_from(
                 bess_controller.ha_controller
             )
             critical_issues = []

--- a/backend/api.py
+++ b/backend/api.py
@@ -36,7 +36,11 @@ from fastapi import APIRouter, HTTPException, Query
 from loguru import logger
 
 from core.bess import time_utils
-from core.bess.health_check import describe_failing_checks, run_system_health_checks
+from core.bess.health_check import (
+    group_components_by_device,
+    run_system_health_checks,
+    safe_device_maps,
+)
 from core.bess.savings_aggregator import DEFAULT_COUNTS, build_buckets
 from core.bess.settings_store import VALID_PLATFORMS, flatten_sensors
 from core.bess.time_utils import get_period_count
@@ -1696,17 +1700,27 @@ async def get_dashboard_health_summary():
                 component.get("name"): component
                 for component in cached_results.get("checks", [])
             }
-            critical_issues = []
-            for failure in critical_failures:
-                component = components_by_name.get(failure, {})
-                critical_issues.append(
-                    {
-                        "component": failure,
-                        "description": "Critical sensor configuration issue detected",
-                        "detail": describe_failing_checks(component),
-                        "status": "ERROR",
-                    }
+            # One device outage fails several components at once (Battery
+            # Control, Battery Monitoring, ...) — show ONE banner line per
+            # underlying device, not one per component.
+            failing_components = [
+                components_by_name.get(failure) or {"name": failure, "status": "ERROR"}
+                for failure in critical_failures
+            ]
+            entity_to_device, device_names = safe_device_maps(
+                bess_controller.ha_controller
+            )
+            critical_issues = [
+                {
+                    "component": group["device"],
+                    "description": "Critical sensor configuration issue detected",
+                    "detail": ", ".join(group["component_names"]),
+                    "status": "ERROR",
+                }
+                for group in group_components_by_device(
+                    failing_components, entity_to_device, device_names
                 )
+            ]
 
             summary = {
                 "has_critical_errors": True,
@@ -1737,35 +1751,43 @@ async def get_dashboard_health_summary():
                 }
                 return convert_keys_to_camel_case(summary)
 
-            # Extract critical and warning information
+            # Extract critical and warning information, grouped per device so
+            # one device outage shows as one banner line. has_critical_error is
+            # decided before grouping, from the raw components: it must stay
+            # true whenever a REQUIRED component is in ERROR, even if that
+            # component shares its device with optional WARNING-only ones.
+            non_ok = [
+                component
+                for component in health_results.get("checks", [])
+                if component.get("status") in ("WARNING", "ERROR")
+            ]
+            has_critical_error = any(
+                component.get("required") and component.get("status") == "ERROR"
+                for component in non_ok
+            )
+            entities_by_name = {
+                component.get("name"): component for component in non_ok
+            }
+            entity_to_device, device_names = safe_device_maps(
+                bess_controller.ha_controller
+            )
             critical_issues = []
-            has_critical_error = False
-
-            for component in health_results.get("checks", []):
-                status = component.get("status", "UNKNOWN")
-                is_required = component.get("required", False)
-
-                # Show required components with ERROR status as critical
-                if is_required and status == "ERROR":
-                    has_critical_error = True
-                    critical_issues.append(
-                        {
-                            "component": component.get("name", "Unknown"),
-                            "description": component.get("description", ""),
-                            "detail": describe_failing_checks(component),
-                            "status": status,
-                        }
-                    )
-                # Show all components (required or not) with WARNING or ERROR status
-                elif status in ["WARNING", "ERROR"]:
-                    critical_issues.append(
-                        {
-                            "component": component.get("name", "Unknown"),
-                            "description": component.get("description", ""),
-                            "detail": describe_failing_checks(component),
-                            "status": status,
-                        }
-                    )
+            for group in group_components_by_device(
+                non_ok, entity_to_device, device_names
+            ):
+                members = [entities_by_name[n] for n in group["component_names"]]
+                critical_issues.append(
+                    {
+                        "component": group["device"],
+                        "description": members[0].get("description", ""),
+                        "detail": ", ".join(group["component_names"]),
+                        "status": (
+                            "ERROR"
+                            if any(s == "ERROR" for s in group["statuses"])
+                            else "WARNING"
+                        ),
+                    }
+                )
 
             has_warnings = any(
                 issue["status"] == "WARNING" for issue in critical_issues

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -807,10 +807,20 @@ class TestHistoricalDataStatus:
         resp = _client.post("/api/historical-data-status/dismiss")
         assert resp.status_code == 503
 
-    def test_dismiss_persists_across_requests(self):
+    def test_dismiss_persists_across_requests(self, monkeypatch):
         """A dismissal for today's missing hours suppresses the banner on
         the next GET, matching the runtime-failures/health-recoveries
         dismiss-then-refetch pattern the frontend relies on."""
+        # Freeze the clock to a non-boundary hour. The endpoint only expects
+        # periods before the current hour (current_period = hour * 4), so at
+        # 00:xx current_period == 0 and is_incomplete is False — the dismissal
+        # can never show as active, and the test would deterministically fail
+        # for one wall-clock hour each day.
+        monkeypatch.setattr(
+            time_utils,
+            "now",
+            lambda: datetime(2026, 1, 15, 14, 30, tzinfo=time_utils.TIMEZONE),
+        )
         ctrl = _make_started_controller()
         system = BatterySystemManager.__new__(BatterySystemManager)
         system._dismissed_historical_warning_signature = None

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 from core.bess import time_utils
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.daily_view_builder import DailyView
+from core.bess.exceptions import SystemConfigurationError
 from core.bess.models import DecisionData, EconomicData, EnergyData, PeriodData
 
 _test_app = FastAPI()
@@ -150,7 +151,7 @@ def _make_started_controller() -> MagicMock:
     sm.get_all_tou_segments.return_value = []
     sm.tou_intervals = []
 
-    ctrl.ha_controller.get_device_maps.return_value = None
+    ctrl.ha_controller.get_device_maps.return_value = ({}, {})
     ctrl.ha_controller.get_battery_soc.return_value = 75.0
     ctrl.ha_controller.get_pv_power.return_value = 0.0
     ctrl.ha_controller.get_local_load_power.return_value = 0.0
@@ -735,6 +736,48 @@ class TestDashboardHealthSummary:
         assert issues[0]["detail"] == "Battery Control, Battery Monitoring"
         assert issues[1]["component"] == "Energy Meter"
         assert issues[1]["detail"] == "Energy Monitoring"
+        assert resp.json()["totalCriticalIssues"] == 2
+
+    def test_critical_issues_group_by_component_when_registry_unavailable(
+        self,
+    ) -> None:
+        """A registry query failure must not drop the critical banner — it
+        degrades to component-name grouping, one line per failing component."""
+        ctrl = _make_started_controller()
+        ctrl.system.has_critical_sensor_failures.return_value = True
+        ctrl.system.get_critical_sensor_failures.return_value = [
+            "Battery Control",
+            "Battery Monitoring",
+        ]
+        ctrl.system.get_cached_health_results.return_value = {
+            "checks": [
+                {
+                    "name": "Battery Control",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [],
+                },
+                {
+                    "name": "Battery Monitoring",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [],
+                },
+            ]
+        }
+        ctrl.ha_controller.get_device_maps.side_effect = SystemConfigurationError(
+            "registry down"
+        )
+        sys.modules["app"].bess_controller = ctrl  # type: ignore[attr-defined]
+
+        resp = _client.get("/api/dashboard-health-summary")
+
+        issues = resp.json()["criticalIssues"]
+        assert len(issues) == 2
+        assert {i["component"] for i in issues} == {
+            "Battery Control",
+            "Battery Monitoring",
+        }
         assert resp.json()["totalCriticalIssues"] == 2
 
 

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -807,7 +807,9 @@ class TestHistoricalDataStatus:
         resp = _client.post("/api/historical-data-status/dismiss")
         assert resp.status_code == 503
 
-    def test_dismiss_persists_across_requests(self, monkeypatch):
+    def test_dismiss_persists_across_requests(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A dismissal for today's missing hours suppresses the banner on
         the next GET, matching the runtime-failures/health-recoveries
         dismiss-then-refetch pattern the frontend relies on."""
@@ -816,11 +818,11 @@ class TestHistoricalDataStatus:
         # 00:xx current_period == 0 and is_incomplete is False — the dismissal
         # can never show as active, and the test would deterministically fail
         # for one wall-clock hour each day.
-        monkeypatch.setattr(
-            time_utils,
-            "now",
-            lambda: datetime(2026, 1, 15, 14, 30, tzinfo=time_utils.TIMEZONE),
-        )
+
+        def _fixed_now() -> datetime:
+            return datetime(2026, 1, 15, 14, 30, tzinfo=time_utils.TIMEZONE)
+
+        monkeypatch.setattr(time_utils, "now", _fixed_now)
         ctrl = _make_started_controller()
         system = BatterySystemManager.__new__(BatterySystemManager)
         system._dismissed_historical_warning_signature = None

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -150,6 +150,7 @@ def _make_started_controller() -> MagicMock:
     sm.get_all_tou_segments.return_value = []
     sm.tou_intervals = []
 
+    ctrl.ha_controller.get_device_maps.return_value = None
     ctrl.ha_controller.get_battery_soc.return_value = 75.0
     ctrl.ha_controller.get_pv_power.return_value = 0.0
     ctrl.ha_controller.get_local_load_power.return_value = 0.0
@@ -631,7 +632,7 @@ class TestDashboardHealthSummary:
         resp = _client.get("/api/dashboard-health-summary")
         assert resp.status_code == 503
 
-    def test_critical_issue_names_the_failing_sensor(self):
+    def test_critical_issue_names_the_failing_component(self):
         ctrl = _make_started_controller()
         ctrl.system.has_critical_sensor_failures.return_value = True
         ctrl.system.get_critical_sensor_failures.return_value = ["Battery Control"]
@@ -658,9 +659,83 @@ class TestDashboardHealthSummary:
         resp = _client.get("/api/dashboard-health-summary")
 
         issue = resp.json()["criticalIssues"][0]
-        assert issue["detail"] == (
-            "Battery Charging Power Rate (number.growatt_battery_charging_power_rate)"
+        # Without a resolvable device the component name is the group key,
+        # and detail names the component rather than its individual sensors.
+        assert issue["detail"] == "Battery Control"
+
+    def test_critical_issues_grouped_by_device(self) -> None:
+        """A single-device outage (three components, two devices) shows one
+        banner line per device, not one per component."""
+        ctrl = _make_started_controller()
+        ctrl.system.has_critical_sensor_failures.return_value = True
+        ctrl.system.get_critical_sensor_failures.return_value = [
+            "Battery Control",
+            "Battery Monitoring",
+            "Energy Monitoring",
+        ]
+        ctrl.system.get_cached_health_results.return_value = {
+            "checks": [
+                {
+                    "name": "Battery Control",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Power Setpoint",
+                            "entity_id": "sensor.device_a_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+                {
+                    "name": "Battery Monitoring",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Battery SOC",
+                            "entity_id": "sensor.device_b_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+                {
+                    "name": "Energy Monitoring",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Energy Today",
+                            "entity_id": "sensor.device_c_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+            ],
+            "system_mode": "degraded",
+        }
+        ctrl.ha_controller.get_device_maps.return_value = (
+            {
+                "sensor.device_a_sensor": "device-a",
+                "sensor.device_b_sensor": "device-a",
+                "sensor.device_c_sensor": "device-b",
+            },
+            {"device-a": "Power Inverter", "device-b": "Energy Meter"},
         )
+        # Direct assignment matches the rest of this file; the mypy
+        # attr-defined is pre-existing ratchet debt, so suppress it here
+        # rather than add another occurrence.
+        sys.modules["app"].bess_controller = ctrl  # type: ignore[attr-defined]
+
+        resp = _client.get("/api/dashboard-health-summary")
+
+        issues = resp.json()["criticalIssues"]
+        assert len(issues) == 2
+        assert issues[0]["component"] == "Power Inverter"
+        assert issues[0]["detail"] == "Battery Control, Battery Monitoring"
+        assert issues[1]["component"] == "Energy Meter"
+        assert issues[1]["detail"] == "Energy Monitoring"
+        assert resp.json()["totalCriticalIssues"] == 2
 
 
 # ===========================================================================

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -34,7 +34,6 @@ from .ha_api_controller import HomeAssistantAPIController
 from .health_check import (
     resolve_component_device,
     run_system_health_checks,
-    safe_device_maps,
 )
 from .health_recovery_tracker import HealthRecovery, HealthRecoveryTracker
 from .historical_data_store import HistoricalDataStore
@@ -3276,7 +3275,18 @@ class BatterySystemManager:
         if not previous_results:
             return
 
-        entity_to_device, device_names = safe_device_maps(self._controller)
+        # Health checks (the caller of this method) already dereference
+        # self._controller, so it is never None here.
+        assert self._controller is not None
+        try:
+            entity_to_device, device_names = self._controller.get_device_maps()
+        except SystemConfigurationError as e:
+            logger.warning(
+                "HA device registry unavailable, grouping recoveries by "
+                "component name: %s",
+                e,
+            )
+            entity_to_device, device_names = {}, {}
 
         previous_components_by_name = {
             component["name"]: component

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -31,7 +31,11 @@ from .execution_model import PlatformCapabilities, intra_period_discharge_gate
 from .growatt_min_controller import GrowattMinController
 from .growatt_sph_controller import GrowattSphController
 from .ha_api_controller import HomeAssistantAPIController
-from .health_check import describe_failing_checks, run_system_health_checks
+from .health_check import (
+    resolve_component_device,
+    run_system_health_checks,
+    safe_device_maps,
+)
 from .health_recovery_tracker import HealthRecovery, HealthRecoveryTracker
 from .historical_data_store import HistoricalDataStore
 from .huawei_controller import HuaweiController
@@ -773,7 +777,21 @@ class BatterySystemManager:
                     format_period(current_period),
                 )
 
-            self.log_battery_schedule(current_period)
+            # Log the applied schedule tables and the DP results table only
+            # when the schedule actually changed. On quiet keep cycles both
+            # are byte-identical to what was already logged, and re-dumping
+            # them every 15 minutes is what grew the daily log to 2.3MB.
+            if should_apply:
+                # Reaching here means prices were non-empty (guarded above),
+                # and prices are derived from price_entries — so it is safe.
+                assert price_entries is not None
+                remaining_entries = price_entries[optimization_period:]
+                buy_prices, sell_prices = self._extract_buy_sell_prices(
+                    remaining_entries
+                )
+                print_optimization_results(optimization_result, buy_prices, sell_prices)
+                self.log_battery_schedule(current_period)
+
             return True
 
         except Exception as e:
@@ -2065,6 +2083,19 @@ class BatterySystemManager:
 
         return derated_limits
 
+    def _extract_buy_sell_prices(
+        self, entries: list[dict[str, Any]]
+    ) -> tuple[list[float], list[float]]:
+        """Split pre-calculated price entries into buy and sell price lists.
+
+        Mirrors the extraction inside ``_run_optimization`` so the apply path
+        can reproduce the DP results table when the schedule changes.
+        """
+        return (
+            [entry["buyPrice"] for entry in entries],
+            [entry["sellPrice"] for entry in entries],
+        )
+
     def _run_optimization(
         self,
         optimization_period: int,
@@ -2116,8 +2147,7 @@ class BatterySystemManager:
             # Get buy and sell prices from pre-calculated price entries
             # This preserves direct sell prices from sources like Octopus Energy
             remaining_entries = price_entries[optimization_period:]
-            buy_prices = [entry["buyPrice"] for entry in remaining_entries]
-            sell_prices = [entry["sellPrice"] for entry in remaining_entries]
+            buy_prices, sell_prices = self._extract_buy_sell_prices(remaining_entries)
 
             # Scope the arbitrage-consistency cap to sell prices on the
             # terminal boundary's own calendar day (#422): on a 48h-extended
@@ -2169,9 +2199,6 @@ class BatterySystemManager:
             self._add_timestamps_to_period_data(
                 result, optimization_period, next_day=prepare_next_day
             )
-
-            # Print results table with strategic intents
-            print_optimization_results(result, buy_prices, sell_prices)
 
             # Store full day data in result for UI
             result.input_data["full_home_consumption"] = optimization_data[
@@ -3237,35 +3264,67 @@ class BatterySystemManager:
     def _update_health_recoveries(
         self, previous_results: dict[str, Any] | None, new_results: dict[str, Any]
     ) -> None:
-        """Detect per-component ERROR/WARNING -> OK transitions and record them.
+        """Detect device-level ERROR/WARNING -> OK transitions and record them.
 
-        A component still in ERROR/WARNING clears any stale pending recovery
-        for itself, since the live banner already covers it.
+        A single underlying device outage fails several health components at
+        once, so recoveries are tracked per device, not per component: one
+        recovery line per recovered device, naming the components that
+        recovered. A device any of whose components still fails clears any
+        stale pending recovery for itself — the live banner already covers
+        that device.
         """
         if not previous_results:
             return
+
+        entity_to_device, device_names = safe_device_maps(self._controller)
 
         previous_components_by_name = {
             component["name"]: component
             for component in previous_results.get("checks", [])
         }
 
+        def _device_of(component: dict) -> str:
+            return resolve_component_device(component, entity_to_device, device_names)
+
+        # Devices with a component still failing: their live banner lines
+        # supersede any pending "recovered" note, which must not linger.
+        failing_devices = {
+            _device_of(component)
+            for component in new_results.get("checks", [])
+            if component.get("status") in ("ERROR", "WARNING")
+        }
+        for device in failing_devices:
+            self._health_recovery_tracker.clear_for_component(device)
+
+        # Components that recovered. Resolve the device from the PREVIOUS
+        # component, which still carries the failing entity_ids — the new OK
+        # component may have empty checks.
+        recovered_by_device: dict[str, list[dict]] = {}
         for component in new_results.get("checks", []):
-            name = component["name"]
-            new_status = component["status"]
-            previous_component = previous_components_by_name.get(name)
+            previous_component = previous_components_by_name.get(component["name"])
             previous_status = (
                 previous_component["status"] if previous_component else None
             )
+            if (
+                previous_component is not None
+                and previous_status in ("ERROR", "WARNING")
+                and component["status"] == "OK"
+            ):
+                device = _device_of(previous_component)
+                recovered_by_device.setdefault(device, []).append(component)
 
-            if previous_status in ("ERROR", "WARNING") and new_status == "OK":
-                self._health_recovery_tracker.record_recovery(
-                    component=name,
-                    previous_status=previous_status,
-                    detail=describe_failing_checks(previous_component),
-                )
-            elif new_status in ("ERROR", "WARNING"):
-                self._health_recovery_tracker.clear_for_component(name)
+        for device, components in recovered_by_device.items():
+            if device in failing_devices:
+                continue
+            previous_statuses = [
+                previous_components_by_name[c["name"]]["status"] for c in components
+            ]
+            worst = "ERROR" if "ERROR" in previous_statuses else "WARNING"
+            self._health_recovery_tracker.record_recovery(
+                component=device,
+                previous_status=worst,
+                detail=", ".join(c["name"] for c in components),
+            )
 
     def get_health_recoveries(self) -> list[HealthRecovery]:
         """Get all pending (unacknowledged) health-check recoveries."""

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -690,6 +690,15 @@ class BatterySystemManager:
                 logger.error("Failed to optimize battery schedule")
                 return False
 
+            # Capture the full-horizon economic summary before
+            # _create_updated_schedule rescopes result.economic_summary to
+            # today-only in place (see _create_updated_schedule). The DP
+            # results table logs the full extended horizon, so the Summary
+            # block must come from the full-horizon summary, not the
+            # today-scoped one — otherwise table and Summary silently
+            # disagree in the same log block.
+            full_horizon_summary = optimization_result.economic_summary
+
             # Create new schedule
             temp_schedule = self._create_updated_schedule(
                 optimization_period,
@@ -788,7 +797,12 @@ class BatterySystemManager:
                 buy_prices, sell_prices = self._extract_buy_sell_prices(
                     remaining_entries
                 )
-                print_optimization_results(optimization_result, buy_prices, sell_prices)
+                print_optimization_results(
+                    optimization_result,
+                    buy_prices,
+                    sell_prices,
+                    economic_summary=full_horizon_summary,
+                )
                 self.log_battery_schedule(current_period)
 
             return True

--- a/core/bess/dp_battery_algorithm.py
+++ b/core/bess/dp_battery_algorithm.py
@@ -1083,16 +1083,22 @@ def _build_period_data(
     )
 
 
-def print_optimization_results(results, buy_prices, sell_prices):
+def print_optimization_results(results, buy_prices, sell_prices, economic_summary=None):
     """Log a detailed results table with strategic intents - new format version.
 
     Args:
         results: OptimizationResult object with period_data and economic_summary
         buy_prices: List of buy prices
         sell_prices: List of sell prices
+        economic_summary: Optional override for the Summary block. Defaults to
+            results.economic_summary. Callers pass the full-horizon summary
+            when the result's own summary has been rescoped to today-only,
+            so the Summary block matches the full-horizon table above it.
     """
     period_data_list = results.period_data
-    economic_results = results.economic_summary
+    economic_results = (
+        economic_summary if economic_summary is not None else results.economic_summary
+    )
 
     # Initialize totals
     total_consumption = 0

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -142,6 +142,12 @@ class HomeAssistantAPIController:
         # get_battery_discharge_power).
         self.battery_power_polarity = battery_power_polarity or ""
 
+        # Cached entity->device and device->name registry maps for health
+        # banner grouping, refreshed on a TTL so the 5-minute health check
+        # does not re-fetch the full HA registries every run.
+        self._device_maps_cache: tuple | None = None
+        self._device_maps_cache_ts: float | None = None
+
         # Runtime failure tracker (injected by BatterySystemManager)
         self.failure_tracker = None
 
@@ -2885,6 +2891,47 @@ class HomeAssistantAPIController:
             return results
         finally:
             ws.close()
+
+    def get_device_maps(self, ttl_seconds: int = 900) -> tuple[dict, dict] | None:
+        """Return ``entity_id -> device_id`` and ``device_id -> name`` maps.
+
+        Fetches the HA entity and device registries in one WebSocket
+        connection and builds both maps. Results are cached for
+        ``ttl_seconds`` so the 5-minute health check does not re-fetch the
+        full registries every run; the TTL self-heals after a sensor is
+        reconfigured. Returns ``None`` on any failure — the banner-grouping
+        caller then falls back to component-name grouping rather than
+        surfacing a registry error.
+        """
+        now = time.time()
+        if (
+            self._device_maps_cache is not None
+            and now - (self._device_maps_cache_ts or 0) < ttl_seconds
+        ):
+            return self._device_maps_cache
+        try:
+            results = self._ws_query(
+                [
+                    {"type": "config/entity_registry/list"},
+                    {"type": "config/device_registry/list"},
+                ]
+            )
+            entity_to_device = {
+                entry["entity_id"]: entry.get("device_id")
+                for entry in results[0]
+                if entry.get("entity_id") and entry.get("device_id")
+            }
+            device_names = {
+                device["id"]: device.get("name") or device["id"]
+                for device in results[1]
+                if device.get("id")
+            }
+            self._device_maps_cache = (entity_to_device, device_names)
+            self._device_maps_cache_ts = now
+            return self._device_maps_cache
+        except Exception as e:
+            logger.warning("Failed to fetch HA device maps: %s", e)
+            return None
 
     def get_statistics_during_period(
         self,

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -2892,16 +2892,19 @@ class HomeAssistantAPIController:
         finally:
             ws.close()
 
-    def get_device_maps(self, ttl_seconds: int = 900) -> tuple[dict, dict] | None:
+    def get_device_maps(self, ttl_seconds: int = 900) -> tuple[dict, dict]:
         """Return ``entity_id -> device_id`` and ``device_id -> name`` maps.
 
         Fetches the HA entity and device registries in one WebSocket
         connection and builds both maps. Results are cached for
         ``ttl_seconds`` so the 5-minute health check does not re-fetch the
         full registries every run; the TTL self-heals after a sensor is
-        reconfigured. Returns ``None`` on any failure — the banner-grouping
-        caller then falls back to component-name grouping rather than
-        surfacing a registry error.
+        reconfigured.
+
+        Raises:
+            SystemConfigurationError: If the HA registries cannot be
+                queried — the banner call site decides explicitly whether a
+                registry failure degrades the grouping or surfaces.
         """
         now = time.time()
         if (
@@ -2930,8 +2933,9 @@ class HomeAssistantAPIController:
             self._device_maps_cache_ts = now
             return self._device_maps_cache
         except Exception as e:
-            logger.warning("Failed to fetch HA device maps: %s", e)
-            return None
+            raise SystemConfigurationError(
+                f"Failed to query Home Assistant device/entity registries: {e}"
+            ) from e
 
     def get_statistics_during_period(
         self,

--- a/core/bess/health_check.py
+++ b/core/bess/health_check.py
@@ -35,14 +35,25 @@ def resolve_component_device(
 ) -> str:
     """Resolve the underlying device a health component reports about.
 
-    The first sub-check that carries a resolvable ``entity_id`` wins: the
-    entity maps through ``entity_to_device`` to a device id, which
-    ``device_names`` renders as a human label. If no sub-check resolves (the
-    component is not sensor-backed, or the registry maps are unavailable),
-    fall back to the component's own name — unresolvable components group
-    under that name, which is a data limit rather than a workaround.
+    Failing sub-checks resolve first (mirroring ``describe_failing_checks``'s
+    ``status not in ("OK", None)`` filter): a component's checks span several
+    underlying devices — e.g. Energy Monitoring reads smart-meter, PV-inverter
+    and battery sensors — so a healthy first entry must not win over a failing
+    one. If no failing sub-check carries a resolvable ``entity_id``, fall back
+    to any resolvable sub-check; if none resolves (the component is not
+    sensor-backed, or the registry maps are unavailable), fall back to the
+    component's own name — unresolvable components group under that name,
+    which is a data limit rather than a workaround.
     """
-    for check in component.get("checks", []):
+    checks = component.get("checks", [])
+    failing = [check for check in checks if check.get("status") not in ("OK", None)]
+    for check in failing:
+        entity_id = check.get("entity_id")
+        if entity_id and entity_id != "Not mapped":
+            device_id = entity_to_device.get(entity_id)
+            if device_id:
+                return str(device_names.get(device_id, device_id))
+    for check in checks:
         entity_id = check.get("entity_id")
         if entity_id and entity_id != "Not mapped":
             device_id = entity_to_device.get(entity_id)

--- a/core/bess/health_check.py
+++ b/core/bess/health_check.py
@@ -1,7 +1,6 @@
 import logging
 import math
 from datetime import datetime
-from typing import Any
 
 from .influxdb_helper import (
     get_influxdb_config,
@@ -76,23 +75,6 @@ def group_components_by_device(
         group["component_names"].append(component["name"])
         group["statuses"].append(component.get("status"))
     return list(groups.values())
-
-
-def safe_device_maps(controller: Any) -> tuple[dict, dict]:
-    """Return entity->device and device->name registry maps, or empty dicts.
-
-    The controller may be a test mock whose ``get_device_maps`` returns
-    something other than a 2-tuple, or a real controller mid-registry-
-    failure. Treat any such return as empty maps so banner grouping falls
-    back to component names.
-    """
-    try:
-        maps = controller.get_device_maps()
-    except Exception:
-        return {}, {}
-    if not isinstance(maps, tuple) or len(maps) != 2:
-        return {}, {}
-    return maps[0] or {}, maps[1] or {}
 
 
 def format_sensor_value_with_unit(value, method_name: str, controller) -> str:

--- a/core/bess/health_check.py
+++ b/core/bess/health_check.py
@@ -1,6 +1,7 @@
 import logging
 import math
 from datetime import datetime
+from typing import Any
 
 from .influxdb_helper import (
     get_influxdb_config,
@@ -28,6 +29,70 @@ def describe_failing_checks(component: dict) -> str:
         entity_id = check.get("entity_id")
         parts.append(f"{check['name']} ({entity_id})" if entity_id else check["name"])
     return "; ".join(parts)
+
+
+def resolve_component_device(
+    component: dict, entity_to_device: dict, device_names: dict
+) -> str:
+    """Resolve the underlying device a health component reports about.
+
+    The first sub-check that carries a resolvable ``entity_id`` wins: the
+    entity maps through ``entity_to_device`` to a device id, which
+    ``device_names`` renders as a human label. If no sub-check resolves (the
+    component is not sensor-backed, or the registry maps are unavailable),
+    fall back to the component's own name — unresolvable components group
+    under that name, which is a data limit rather than a workaround.
+    """
+    for check in component.get("checks", []):
+        entity_id = check.get("entity_id")
+        if entity_id and entity_id != "Not mapped":
+            device_id = entity_to_device.get(entity_id)
+            if device_id:
+                return str(device_names.get(device_id, device_id))
+    return str(component["name"])
+
+
+def group_components_by_device(
+    components: list[dict],
+    entity_to_device: dict | None = None,
+    device_names: dict | None = None,
+) -> list[dict]:
+    """Bucket health components by the underlying device they report about.
+
+    Returns one dict per distinct device: ``device`` (the label), ordered
+    ``component_names``, and each member's ``statuses``. Collapses the
+    per-component banner spam from a single-device outage into one line per
+    device; ``None`` registry maps are treated as empty so the helpers stay
+    usable when the registry is unreachable.
+    """
+    entity_to_device = entity_to_device or {}
+    device_names = device_names or {}
+    groups: dict[str, dict] = {}
+    for component in components:
+        device = resolve_component_device(component, entity_to_device, device_names)
+        group = groups.setdefault(
+            device, {"device": device, "component_names": [], "statuses": []}
+        )
+        group["component_names"].append(component["name"])
+        group["statuses"].append(component.get("status"))
+    return list(groups.values())
+
+
+def safe_device_maps(controller: Any) -> tuple[dict, dict]:
+    """Return entity->device and device->name registry maps, or empty dicts.
+
+    The controller may be a test mock whose ``get_device_maps`` returns
+    something other than a 2-tuple, or a real controller mid-registry-
+    failure. Treat any such return as empty maps so banner grouping falls
+    back to component names.
+    """
+    try:
+        maps = controller.get_device_maps()
+    except Exception:
+        return {}, {}
+    if not isinstance(maps, tuple) or len(maps) != 2:
+        return {}, {}
+    return maps[0] or {}, maps[1] or {}
 
 
 def format_sensor_value_with_unit(value, method_name: str, controller) -> str:

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -645,10 +645,15 @@ class TestHealthRecoveryTracking:
     banner when it happened. See #215.
     """
 
-    def _run(self, system, result):
-        with patch(
-            "core.bess.battery_system_manager.run_system_health_checks",
-            return_value=result,
+    def _run(self, system, result, device_maps=None):
+        with (
+            patch(
+                "core.bess.battery_system_manager.run_system_health_checks",
+                return_value=result,
+            ),
+            patch.object(
+                system._controller, "get_device_maps", return_value=device_maps
+            ),
         ):
             system.refresh_health_check()
 
@@ -723,10 +728,10 @@ class TestHealthRecoveryTracking:
 
         recoveries = system.get_health_recoveries()
         assert len(recoveries) == 1
-        assert (
-            recoveries[0].detail
-            == "Battery Charging Power Rate (number.growatt_battery_charging_power_rate)"
-        )
+        # Recoveries are per-device now; without a resolvable device the
+        # component name is the group key, and detail names the recovered
+        # component rather than its individual sensors.
+        assert recoveries[0].detail == "Battery Control"
 
     def test_no_recovery_recorded_when_first_check_is_ok(self, system):
         self._run(
@@ -807,6 +812,131 @@ class TestHealthRecoveryTracking:
                 ],
             },
         )
+        assert system.get_health_recoveries() == []
+
+    def test_recovery_grouped_one_per_device(
+        self, system: BatterySystemManager
+    ) -> None:
+        """Two components on the same device recovering together yield ONE
+        recovery line naming both — the banner is per device, not per
+        component."""
+        device_maps = (
+            {
+                "sensor.device_a_sensor": "device-a",
+                "sensor.device_b_sensor": "device-a",
+            },
+            {"device-a": "Power Inverter"},
+        )
+        outage = {
+            "status": "ERROR",
+            "checks": [
+                {
+                    "name": "Battery Control",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Power Setpoint",
+                            "entity_id": "sensor.device_a_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+                {
+                    "name": "Battery Monitoring",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Battery SOC",
+                            "entity_id": "sensor.device_b_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+            ],
+        }
+        recovered = {
+            "status": "OK",
+            "checks": [
+                {"name": "Battery Control", "status": "OK", "required": True},
+                {"name": "Battery Monitoring", "status": "OK", "required": True},
+            ],
+        }
+        self._run(system, outage, device_maps)
+        self._run(system, recovered, device_maps)
+
+        recoveries = system.get_health_recoveries()
+        assert len(recoveries) == 1
+        assert recoveries[0].component == "Power Inverter"
+        assert recoveries[0].previous_status == "ERROR"
+        assert recoveries[0].detail == "Battery Control, Battery Monitoring"
+
+    def test_recovery_cleared_when_any_component_still_failing(
+        self, system: BatterySystemManager
+    ) -> None:
+        """If only part of a device's components recovered, the device is
+        still failing — no recovery is recorded, and any stale one is
+        cleared."""
+        device_maps = (
+            {
+                "sensor.device_a_sensor": "device-a",
+                "sensor.device_b_sensor": "device-a",
+            },
+            {"device-a": "Power Inverter"},
+        )
+        outage = {
+            "status": "ERROR",
+            "checks": [
+                {
+                    "name": "Battery Control",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Power Setpoint",
+                            "entity_id": "sensor.device_a_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+                {
+                    "name": "Battery Monitoring",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Battery SOC",
+                            "entity_id": "sensor.device_b_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+            ],
+        }
+        still_failing = {
+            "status": "ERROR",
+            "checks": [
+                {"name": "Battery Control", "status": "OK", "required": True},
+                {
+                    "name": "Battery Monitoring",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [
+                        {
+                            "name": "Battery SOC",
+                            "entity_id": "sensor.device_b_sensor",
+                            "status": "ERROR",
+                        }
+                    ],
+                },
+            ],
+        }
+        self._run(system, outage, device_maps)
+        self._run(system, still_failing, device_maps)
+
+        # The device never fully recovered: B is still down, so the (would-be)
+        # A recovery must not be recorded and nothing stale lingers.
         assert system.get_health_recoveries() == []
 
     def test_acknowledge_health_recoveries_clears_them(self, system):
@@ -1081,6 +1211,9 @@ class TestNotApplyBranchRefreshesCurrentSchedule:
                 system, "_gather_optimization_data", return_value=(0, MagicMock())
             ),
             patch.object(system, "_run_optimization", return_value=MagicMock()),
+            # The apply path now prints the DP results table from the caller;
+            # the optimization result is a MagicMock here, so intercept it.
+            patch("core.bess.battery_system_manager.print_optimization_results"),
             patch.object(
                 system,
                 "_create_updated_schedule",
@@ -1115,6 +1248,77 @@ class TestNotApplyBranchRefreshesCurrentSchedule:
 
         assert system._inverter_controller.current_schedule is second_schedule
         assert system._inverter_controller.current_schedule.actions == [5.0, 6.0]
+
+    def test_apply_cycle_logs_schedule_and_results(
+        self, system: BatterySystemManager
+    ) -> None:
+        """An apply cycle logs both the DP results table and the schedule tables."""
+        schedule = MagicMock(actions=[1.0], strategic_intents=["IDLE"])
+        optimization_result = MagicMock()
+
+        with (
+            patch.object(system, "_handle_special_cases"),
+            patch.object(
+                system, "_get_price_data", return_value=([1.0], [MagicMock()])
+            ),
+            patch.object(system, "_update_energy_data"),
+            patch.object(system, "_get_current_battery_soc", return_value=50.0),
+            patch.object(
+                system, "_gather_optimization_data", return_value=(0, MagicMock())
+            ),
+            patch.object(system, "_run_optimization", return_value=optimization_result),
+            patch.object(system, "_create_updated_schedule", return_value=schedule),
+            patch.object(
+                system, "_should_apply_schedule", return_value=(True, "changed")
+            ),
+            patch.object(system, "_apply_schedule"),
+            patch.object(system, "_apply_period_schedule"),
+            patch.object(system, "_capture_prediction_snapshot"),
+            patch.object(system, "log_battery_schedule") as mock_log,
+            patch(
+                "core.bess.battery_system_manager.print_optimization_results"
+            ) as mock_print,
+        ):
+            assert system.update_battery_schedule(0, prepare_next_day=False) is True
+
+        mock_log.assert_called_once_with(0)
+        mock_print.assert_called_once()
+        # print_optimization_results receives the optimization result plus the
+        # buy/sell price lists derived from the mocked price entry.
+        assert mock_print.call_args.args[0] is optimization_result
+        assert len(mock_print.call_args.args[1]) == 1
+        assert len(mock_print.call_args.args[2]) == 1
+
+    def test_keep_cycle_logs_neither(self, system: BatterySystemManager) -> None:
+        """A quiet keep cycle must not re-dump the schedule or results tables."""
+        schedule = MagicMock(actions=[1.0], strategic_intents=["IDLE"])
+
+        with (
+            patch.object(system, "_handle_special_cases"),
+            patch.object(
+                system, "_get_price_data", return_value=([1.0], [MagicMock()])
+            ),
+            patch.object(system, "_update_energy_data"),
+            patch.object(system, "_get_current_battery_soc", return_value=50.0),
+            patch.object(
+                system, "_gather_optimization_data", return_value=(0, MagicMock())
+            ),
+            patch.object(system, "_run_optimization", return_value=MagicMock()),
+            patch.object(system, "_create_updated_schedule", return_value=schedule),
+            patch.object(
+                system, "_should_apply_schedule", return_value=(False, "no change")
+            ),
+            patch.object(system, "_apply_period_schedule"),
+            patch.object(system, "_capture_prediction_snapshot"),
+            patch.object(system, "log_battery_schedule") as mock_log,
+            patch(
+                "core.bess.battery_system_manager.print_optimization_results"
+            ) as mock_print,
+        ):
+            assert system.update_battery_schedule(0, prepare_next_day=False) is True
+
+        mock_log.assert_not_called()
+        mock_print.assert_not_called()
 
 
 class TestLoadTodayFromDisk:

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -645,7 +645,7 @@ class TestHealthRecoveryTracking:
     banner when it happened. See #215.
     """
 
-    def _run(self, system, result, device_maps=None):
+    def _run(self, system, result, device_maps=({}, {})):
         with (
             patch(
                 "core.bess.battery_system_manager.run_system_health_checks",
@@ -871,6 +871,45 @@ class TestHealthRecoveryTracking:
         assert recoveries[0].component == "Power Inverter"
         assert recoveries[0].previous_status == "ERROR"
         assert recoveries[0].detail == "Battery Control, Battery Monitoring"
+
+    def test_recovery_grouped_by_component_when_registry_unavailable(
+        self, system: BatterySystemManager
+    ) -> None:
+        """A registry query failure must not drop the recovery — grouping
+        degrades to component names, one recovery per recovered component."""
+        outage = {
+            "status": "ERROR",
+            "checks": [
+                {
+                    "name": "Battery Control",
+                    "status": "ERROR",
+                    "required": True,
+                    "checks": [],
+                }
+            ],
+        }
+        recovered = {
+            "status": "OK",
+            "checks": [{"name": "Battery Control", "status": "OK", "required": True}],
+        }
+        for result in (outage, recovered):
+            with (
+                patch(
+                    "core.bess.battery_system_manager.run_system_health_checks",
+                    return_value=result,
+                ),
+                patch.object(
+                    system._controller,
+                    "get_device_maps",
+                    side_effect=SystemConfigurationError("registry down"),
+                ),
+            ):
+                system.refresh_health_check()
+
+        recoveries = system.get_health_recoveries()
+        assert len(recoveries) == 1
+        assert recoveries[0].component == "Battery Control"
+        assert recoveries[0].previous_status == "ERROR"
 
     def test_recovery_cleared_when_any_component_still_failing(
         self, system: BatterySystemManager

--- a/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
+++ b/core/bess/tests/unit/test_bsm_settings_and_lifecycle.py
@@ -14,6 +14,7 @@ from core.bess import time_utils
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.exceptions import SystemConfigurationError
 from core.bess.models import (
+    EconomicSummary,
     EnergyData,
     OptimizationResult,
     PeriodData,
@@ -1327,6 +1328,91 @@ class TestNotApplyBranchRefreshesCurrentSchedule:
         assert mock_print.call_args.args[0] is optimization_result
         assert len(mock_print.call_args.args[1]) == 1
         assert len(mock_print.call_args.args[2]) == 1
+
+    def test_apply_cycle_logs_full_horizon_summary_not_rescoped(
+        self, system: BatterySystemManager
+    ) -> None:
+        """An apply cycle must log the full-horizon Summary, not the today-only
+        rescope _create_updated_schedule leaves on the result.
+
+        _create_updated_schedule rescopes result.economic_summary in place
+        (battery_system_manager.py, ``not prepare_next_day`` branch), but
+        print_optimization_results prints the full extended-horizon table. The
+        Summary block must come from the full-horizon summary captured before
+        that mutation, or table and Summary silently disagree in the same log
+        block.
+        """
+        schedule = MagicMock(actions=[1.0], strategic_intents=["IDLE"])
+
+        full_horizon_summary = EconomicSummary(
+            grid_only_cost=100.0,
+            solar_only_cost=90.0,
+            battery_solar_cost=80.0,
+            grid_to_solar_savings=10.0,
+            grid_to_battery_solar_savings=20.0,
+            solar_to_battery_solar_savings=10.0,
+            grid_to_battery_solar_savings_pct=20.0,
+            total_charged=1.0,
+            total_discharged=1.0,
+        )
+        today_rescoped_summary = EconomicSummary(
+            grid_only_cost=50.0,
+            solar_only_cost=45.0,
+            battery_solar_cost=40.0,
+            grid_to_solar_savings=5.0,
+            grid_to_battery_solar_savings=10.0,
+            solar_to_battery_solar_savings=5.0,
+            grid_to_battery_solar_savings_pct=20.0,
+            total_charged=0.5,
+            total_discharged=0.5,
+        )
+
+        optimization_result = MagicMock()
+        optimization_result.economic_summary = full_horizon_summary
+
+        def _create_updated_schedule_side_effect(
+            *_args: object, **_kwargs: object
+        ) -> MagicMock:
+            # Emulate the real _create_updated_schedule: rescope the result's
+            # economic_summary to today-only in place, then return the schedule.
+            optimization_result.economic_summary = today_rescoped_summary
+            return schedule
+
+        with (
+            patch.object(system, "_handle_special_cases"),
+            patch.object(
+                system, "_get_price_data", return_value=([1.0], [MagicMock()])
+            ),
+            patch.object(system, "_update_energy_data"),
+            patch.object(system, "_get_current_battery_soc", return_value=50.0),
+            patch.object(
+                system, "_gather_optimization_data", return_value=(0, MagicMock())
+            ),
+            patch.object(system, "_run_optimization", return_value=optimization_result),
+            patch.object(
+                system,
+                "_create_updated_schedule",
+                side_effect=_create_updated_schedule_side_effect,
+            ),
+            patch.object(
+                system, "_should_apply_schedule", return_value=(True, "changed")
+            ),
+            patch.object(system, "_apply_schedule"),
+            patch.object(system, "_apply_period_schedule"),
+            patch.object(system, "_capture_prediction_snapshot"),
+            patch.object(system, "log_battery_schedule") as mock_log,
+            patch(
+                "core.bess.battery_system_manager.print_optimization_results"
+            ) as mock_print,
+        ):
+            assert system.update_battery_schedule(0, prepare_next_day=False) is True
+
+        mock_log.assert_called_once_with(0)
+        mock_print.assert_called_once()
+        # The Summary block must come from the full-horizon summary captured
+        # before _create_updated_schedule rescoped it — never the today-only
+        # value left on the result.
+        assert mock_print.call_args.kwargs["economic_summary"] is full_horizon_summary
 
     def test_keep_cycle_logs_neither(self, system: BatterySystemManager) -> None:
         """A quiet keep cycle must not re-dump the schedule or results tables."""

--- a/core/bess/tests/unit/test_describe_failing_checks.py
+++ b/core/bess/tests/unit/test_describe_failing_checks.py
@@ -1,9 +1,12 @@
 """Tests for health_check.describe_failing_checks — shared by the health
 recovery tracker and the dashboard health summary API to name the specific
 sensor(s)/entity behind a component's ERROR/WARNING status (#215).
+
+Also covers resolve_component_device, the sibling helper that resolves the
+underlying device a component reports about, reused by the same two callers.
 """
 
-from core.bess.health_check import describe_failing_checks
+from core.bess.health_check import describe_failing_checks, resolve_component_device
 
 
 def test_names_the_single_failing_check():
@@ -81,3 +84,81 @@ def test_empty_when_no_checks_present():
 
 def test_empty_when_checks_key_missing():
     assert describe_failing_checks({"name": "X", "status": "ERROR"}) == ""
+
+
+def test_resolve_component_device_prefers_failing_check_over_healthy_first() -> None:
+    """A component's device is the failing sub-check's device, not the first
+    resolvable entry. A mixed-status component (e.g. Energy Monitoring reads
+    smart-meter and PV-inverter sensors) must not attribute its failure to a
+    healthy device that happens to be listed first."""
+    component = {
+        "name": "Energy Monitoring",
+        "status": "ERROR",
+        "checks": [
+            {
+                "name": "Grid Import",
+                "entity_id": "sensor.meter_import",
+                "status": "OK",
+            },
+            {
+                "name": "Solar Production",
+                "entity_id": "sensor.inverter_solar",
+                "status": "ERROR",
+                "error": "Method call failed",
+            },
+        ],
+    }
+    entity_to_device = {
+        "sensor.meter_import": "dev-meter",
+        "sensor.inverter_solar": "dev-inverter",
+    }
+    device_names = {"dev-meter": "Smart Meter", "dev-inverter": "Solar Inverter"}
+
+    assert (
+        resolve_component_device(component, entity_to_device, device_names)
+        == "Solar Inverter"
+    )
+
+
+def test_resolve_component_device_falls_back_to_resolvable_check() -> None:
+    """When no failing sub-check carries a resolvable entity, fall back to any
+    resolvable sub-check before giving up on the component's own name."""
+    component = {
+        "name": "Battery Control",
+        "status": "ERROR",
+        "checks": [
+            {
+                "name": "Grid Charge Enabled",
+                "entity_id": None,
+                "status": "ERROR",
+            },
+            {
+                "name": "Battery Charging Power Rate",
+                "entity_id": "number.growatt_battery_charging_power_rate",
+                "status": "OK",
+            },
+        ],
+    }
+    entity_to_device = {"number.growatt_battery_charging_power_rate": "dev-inverter"}
+    device_names = {"dev-inverter": "Growatt Inverter"}
+
+    assert (
+        resolve_component_device(component, entity_to_device, device_names)
+        == "Growatt Inverter"
+    )
+
+
+def test_resolve_component_device_unmapped_falls_back_to_component_name() -> None:
+    component = {
+        "name": "Historical Data Access",
+        "status": "ERROR",
+        "checks": [
+            {
+                "name": "Data Retrieval",
+                "entity_id": "Not mapped",
+                "status": "ERROR",
+            }
+        ],
+    }
+
+    assert resolve_component_device(component, {}, {}) == "Historical Data Access"

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from core.bess.exceptions import SystemConfigurationError
 from core.bess.ha_api_controller import HomeAssistantAPIController
 from core.bess.runtime_failure_tracker import RuntimeFailureTracker
 from core.bess.settings_store import SettingsStore
@@ -1249,3 +1250,50 @@ class TestSensorsLiveView:
         store.data["sensors"] = {"battery_soc": "sensor.battery_soc_v2"}
 
         assert c.sensors == {"battery_soc": "sensor.battery_soc_v2"}
+
+
+class TestGetDeviceMaps:
+    """The registry maps feed banner grouping. A registry query failure must
+    surface as an explicit ``SystemConfigurationError`` (the banner call site
+    decides how to degrade), and successful queries build both maps and cache
+    them for the TTL."""
+
+    def test_raises_on_registry_query_failure(
+        self, ctrl: HomeAssistantAPIController, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = MagicMock()
+        ws.side_effect = RuntimeError("auth failed")
+        monkeypatch.setattr(ctrl, "_ws_query", ws)
+        with pytest.raises(SystemConfigurationError, match="device/entity registries"):
+            ctrl.get_device_maps()
+
+    def test_builds_maps_from_registries(
+        self, ctrl: HomeAssistantAPIController, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = MagicMock()
+        ws.return_value = [
+            [
+                {"entity_id": "sensor.a", "device_id": "dev-1"},
+                {"entity_id": "sensor.b", "device_id": "dev-1"},
+                {"entity_id": "sensor.unmapped"},
+            ],
+            [
+                {"id": "dev-1", "name": "Power Inverter"},
+                {"id": "dev-2"},
+            ],
+        ]
+        monkeypatch.setattr(ctrl, "_ws_query", ws)
+        entity_to_device, device_names = ctrl.get_device_maps()
+        assert entity_to_device == {"sensor.a": "dev-1", "sensor.b": "dev-1"}
+        assert device_names == {"dev-1": "Power Inverter", "dev-2": "dev-2"}
+
+    def test_caches_maps_within_ttl(
+        self, ctrl: HomeAssistantAPIController, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = MagicMock()
+        ws.return_value = [[], []]
+        monkeypatch.setattr(ctrl, "_ws_query", ws)
+        first = ctrl.get_device_maps()
+        second = ctrl.get_device_maps()
+        assert ws.call_count == 1
+        assert second is first

--- a/e2e/tests/health-recovery.spec.ts
+++ b/e2e/tests/health-recovery.spec.ts
@@ -47,17 +47,19 @@ test.describe('Health-check recovery banner (#215)', () => {
     expect(summary.hasCriticalErrors).toBe(true);
     const issue = summary.criticalIssues.find((i: { component: string }) => i.component === 'Battery Control');
     expect(issue).toBeTruthy();
-    expect(issue.detail).toContain(SENSOR);
+    // One banner line per device: detail names the component, not the sensor.
+    expect(issue.detail).toContain('Battery Control');
 
     await page.goto('/');
     await expect(page.getByText('Critical System Issues Detected')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText('Battery Control')).toBeVisible();
-    await expect(page.getByText(SENSOR)).toBeVisible();
+    // Per-sensor detail lives on the System Health page, not the banner.
+    await expect(page.getByText(SENSOR)).not.toBeVisible();
     // Active issues are not dismissible.
     await expect(page.getByRole('button', { name: /dismiss/i })).not.toBeVisible();
   });
 
-  test('fixing it records a recovery with the specific sensor and previous status', async ({ request }) => {
+  test('fixing it records a recovery with the component and previous status', async ({ request }) => {
     await breakSensor(request);
     await fixSensor(request);
 
@@ -65,7 +67,7 @@ test.describe('Health-check recovery banner (#215)', () => {
     const recovery = recoveries.find((r: { component: string }) => r.component === 'Battery Control');
     expect(recovery).toBeTruthy();
     expect(recovery.previousStatus).toBe('ERROR');
-    expect(recovery.detail).toContain(SENSOR);
+    expect(recovery.detail).toContain('Battery Control');
   });
 
   test('acknowledging clears the recovery', async ({ request }) => {

--- a/e2e/tests/health-recovery.spec.ts
+++ b/e2e/tests/health-recovery.spec.ts
@@ -55,7 +55,9 @@ test.describe('Health-check recovery banner (#215)', () => {
     // The outage collapses to one banner line per device: the device label and
     // detail render together on that single line (both "Battery Control" here,
     // since the mock stack has no device registry to resolve a device name).
-    await expect(page.getByText(/Battery Control: Critical sensor configuration issue detected/)).toBeVisible();
+    // The component span and description span sit on separate JSX lines, so no
+    // whitespace node separates "Battery Control:" from "Critical" — match \s*.
+    await expect(page.getByText(/Battery Control:\s*Critical sensor configuration issue detected/)).toBeVisible();
     // Per-sensor detail lives on the System Health page, not the banner.
     await expect(page.getByText(SENSOR)).not.toBeVisible();
     // Active issues are not dismissible.

--- a/e2e/tests/health-recovery.spec.ts
+++ b/e2e/tests/health-recovery.spec.ts
@@ -52,7 +52,10 @@ test.describe('Health-check recovery banner (#215)', () => {
 
     await page.goto('/');
     await expect(page.getByText('Critical System Issues Detected')).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText('Battery Control')).toBeVisible();
+    // The outage collapses to one banner line per device: the device label and
+    // detail render together on that single line (both "Battery Control" here,
+    // since the mock stack has no device registry to resolve a device name).
+    await expect(page.getByText(/Battery Control: Critical sensor configuration issue detected/)).toBeVisible();
     // Per-sensor detail lives on the System Health page, not the banner.
     await expect(page.getByText(SENSOR)).not.toBeVisible();
     // Active issues are not dismissible.


### PR DESCRIPTION
Two fixes from analyzing the 2026-08-26 debug bundle (`docs/bess-debug-2026-08-26-210050.md`, 2.3MB):

1. **Schedule-log bloat.** Every 15-minute keep cycle re-dumped the byte-identical schedule and DP-results tables (up to 96 rows each). Both INFO tables now log only when the schedule actually changes — first run, next-day prep, hardware-write retry, and comparison-error paths still log.
2. **Banner spam.** A single device outage produced one line per component in the red critical banner (Battery Control, Battery Monitoring, Energy Monitoring) and one recovery line per component afterwards. Both banners now collapse to one line per underlying device, resolved via the HA entity/device registries (cached 15 min); per-sensor detail stays on the System Health page.

## Scope assessment

Both fixes are local by `docs/agents/rules.md` Debugging Protocol step 8 / checklist item 5:

1. **Fix 1 (log gate)** is a single-method change — `update_battery_schedule` now logs the schedule and DP-results tables only on the change path (`should_apply`). No shared surface changes.
2. **Fix 2 (device-grouped banner)** spans four backend modules, but the split is structural, one new primitive per owner: `get_device_maps` (registry fetch + cache) in `ha_api_controller.py`, two pure grouping helpers in `health_check.py`, and two consumers — `api.py` (banner) and `battery_system_manager.py` (recovery tracker) — that call the same helpers. No public API or output shape changes.

**Verification:** fast suite 2292 passed, slow suite 564 passed, frontend 127 passed, mypy ratchet clean. No frontend change.

**Docs check:** `bess-knowledge.md` has no matches for anything this diff touches; `SOFTWARE_DESIGN.md` is unaffected (it only mentions the unchanged `update_battery_schedule` signature and the untouched `has_critical_errors` banner severity model) — no documentation update needed.

Note: pre-existing on `main` (not touched here) — `backend/tests/test_quality_check_mypy_gate.py` fails with a missing `.github/workflows/issue-analyze.yml` from an unguarded read in `quality-check.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
