### PR TITLE
feat: let a consumption forecast be overlaid with declared changes (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Tell BESS what consumption is coming with Planned Consumption Changes** — declare an EV session or a skipped pool pump in a template sensor, and it applies on top of whichever consumption forecast you already use. ([#428](https://github.com/johanzander/bess-manager/issues/428))
+
 ### Fixed
 
 - **The add-on no longer runs out of memory and stops restarting when the optimizer refines a near-tied decision** — the exact re-solve now runs within a bounded memory footprint. ([#697](https://github.com/johanzander/bess-manager/issues/697))

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -13,6 +13,11 @@ from typing import Any, ClassVar
 import requests
 
 from . import time_utils
+from .consumption_overlay import (
+    ConsumptionOverlayError,
+    apply_overlay,
+    period_starts_from,
+)
 from .daily_view_builder import DailyView, DailyViewBuilder
 from .daily_view_store import DailyViewStore
 from .dp_battery_algorithm import (
@@ -1186,6 +1191,94 @@ class BatterySystemManager:
             "actual_hours_available": actual_hours,
         }
 
+    def _apply_consumption_overlay(
+        self,
+        consumption_predictions: list[float],
+        period_count: int,
+        prepare_next_day: bool,
+    ) -> list[float]:
+        """Compose the user's declared consumption changes onto the forecast.
+
+        Args:
+            consumption_predictions: The forecast as the configured strategy
+                produced it, already extended to cover the horizon.
+            period_count: Periods in the horizon.
+            prepare_next_day: Whether this horizon starts at tomorrow 00:00
+                rather than today 00:00 — which day index 0 refers to.
+
+        Returns:
+            The composed forecast, or the input unchanged when no overlay
+            entity is configured.
+
+        """
+        try:
+            blocks = self.controller.get_consumption_overlay_blocks()
+        except ConsumptionOverlayError as e:
+            # The error still propagates — no silent fallback. Recording it
+            # first is what puts it on the dashboard: the caller's blanket
+            # handler logs and returns False, which on its own leaves the
+            # schedule frozen at the last good one with no user-visible signal.
+            logger.error("Planned consumption changes are unusable: %s", e)
+            self._runtime_failure_tracker.record_failure_once(
+                category="CONSUMPTION_OVERLAY",
+                operation=(
+                    "Planned consumption changes entity could not be read — "
+                    "optimization is blocked until the template is fixed"
+                ),
+                error=e,
+            )
+            raise
+        self._runtime_failure_tracker.dismiss_by_category("CONSUMPTION_OVERLAY")
+
+        if not blocks:
+            # Nothing declared today. Dismiss any stale clamp warning first —
+            # deleting the offending block is the obvious way a user expects
+            # to clear it, and returning before the dismiss below made that
+            # impossible.
+            self._runtime_failure_tracker.dismiss_by_category(
+                "CONSUMPTION_OVERLAY_CLAMPED"
+            )
+            return consumption_predictions
+
+        first_period = (
+            time_utils.get_period_count(time_utils.today()) if prepare_next_day else 0
+        )
+        period_starts = period_starts_from(
+            time_utils.period_index_to_timestamp(first_period), period_count
+        )
+
+        result = apply_overlay(
+            consumption_predictions[:period_count], period_starts, blocks
+        )
+
+        logger.info(
+            "Applied planned consumption changes: %d entr(y/ies), %.1f kWh net over the horizon",
+            len(blocks),
+            sum(result.values) - sum(consumption_predictions[:period_count]),
+        )
+
+        if result.clamped_periods:
+            logger.warning(
+                "Planned consumption changes subtracted more than the forecast held in "
+                "%d period(s); those were clamped to zero",
+                result.clamped_periods,
+            )
+            self._runtime_failure_tracker.record_failure_once(
+                category="CONSUMPTION_OVERLAY_CLAMPED",
+                operation=(
+                    f"Planned consumption changes clamped {result.clamped_periods} "
+                    f"period(s) to zero — a subtract block removes more "
+                    f"load than the forecast contains"
+                ),
+                error=ValueError("overlay subtraction exceeded base forecast"),
+            )
+        else:
+            self._runtime_failure_tracker.dismiss_by_category(
+                "CONSUMPTION_OVERLAY_CLAMPED"
+            )
+
+        return result.values
+
     def _get_consumption_forecast(self) -> list[float]:
         """Get consumption forecast based on the configured strategy.
 
@@ -1795,11 +1888,10 @@ class BatterySystemManager:
             self.home_settings.consumption_strategy
             in self._DATE_CACHED_CONSUMPTION_STRATEGIES
         ):
-            consumption_predictions_fresh = (
+            if (
                 self._consumption_predictions is not None
                 and self._consumption_predictions_date == time_utils.today()
-            )
-            if consumption_predictions_fresh:
+            ):
                 consumption_predictions = self._consumption_predictions
             else:
                 consumption_predictions = self._get_consumption_forecast()
@@ -1842,6 +1934,16 @@ class BatterySystemManager:
                     len(tomorrow_solar),
                 )
                 solar_predictions = solar_predictions + tomorrow_solar
+
+        # --- Apply the user's planned consumption changes (issue #428) ---
+        # Deliberately here, not inside _get_consumption_forecast: after the
+        # daily prediction cache, so editing the overlay takes effect on the
+        # next run rather than tomorrow; and after the extension above, so a
+        # block declared for tomorrow lands on tomorrow instead of today's
+        # blocks being duplicated onto it.
+        consumption_predictions = self._apply_consumption_overlay(
+            consumption_predictions, period_count, prepare_next_day
+        )
 
         # --- Build data arrays ---
         consumption_data = [0.0] * period_count

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -13,11 +13,7 @@ from typing import Any, ClassVar
 import requests
 
 from . import time_utils
-from .consumption_overlay import (
-    ConsumptionOverlayError,
-    apply_overlay,
-    period_starts_from,
-)
+from .consumption_overlay import apply_overlay, period_starts_from
 from .daily_view_builder import DailyView, DailyViewBuilder
 from .daily_view_store import DailyViewStore
 from .dp_battery_algorithm import (
@@ -28,6 +24,7 @@ from .dp_battery_algorithm import (
 from .dp_schedule import DPSchedule
 from .entsoe_source import EntsoeSource
 from .exceptions import (
+    ConsumptionOverlayError,
     HAStatisticsUnavailableError,
     HistoricalDataUnavailableError,
     SystemConfigurationError,

--- a/core/bess/consumption_overlay.py
+++ b/core/bess/consumption_overlay.py
@@ -14,20 +14,12 @@ no overlay entity keeps exactly the forecast it has today.
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
+from .exceptions import ConsumptionOverlayError
 from .time_utils import INTERVAL_MINUTES
 
 PERIOD_DURATION = timedelta(minutes=INTERVAL_MINUTES)
 
 VALID_MODES = ("add", "set")
-
-
-class ConsumptionOverlayError(Exception):
-    """The overlay entity could not be read as a set of blocks.
-
-    Raised rather than skipping the offending block: a user who declared an EV
-    session and got half of it applied is worse off than one told their
-    template is wrong.
-    """
 
 
 @dataclass(frozen=True)

--- a/core/bess/consumption_overlay.py
+++ b/core/bess/consumption_overlay.py
@@ -1,0 +1,237 @@
+"""Consumption forecast overlay — user-declared changes to expected load.
+
+Issue #428. BESS optimizes against a consumption forecast; it does not model
+loads. The overlay is how a user tells BESS about the loads their forecast
+cannot know: an EV session tonight, a pool pump they are skipping, a week
+away from home.
+
+It is a post-processing stage on whichever consumption strategy is
+configured, not a strategy of its own — so it composes with ``ha_statistics``,
+``influxdb_7d_avg``, ``sensor`` and ``fixed`` identically, and an install with
+no overlay entity keeps exactly the forecast it has today.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from .time_utils import INTERVAL_MINUTES
+
+PERIOD_DURATION = timedelta(minutes=INTERVAL_MINUTES)
+
+VALID_MODES = ("add", "set")
+
+
+class ConsumptionOverlayError(Exception):
+    """The overlay entity could not be read as a set of blocks.
+
+    Raised rather than skipping the offending block: a user who declared an EV
+    session and got half of it applied is worse off than one told their
+    template is wrong.
+    """
+
+
+@dataclass(frozen=True)
+class OverlayBlock:
+    """One declared change to expected consumption over a time span.
+
+    Attributes:
+        start: When the block begins (timezone-aware).
+        end: When the block ends (timezone-aware, after ``start``).
+        energy_kwh: Total energy across the whole span, apportioned to the
+            periods the span overlaps. Not a per-period value.
+        mode: ``"add"`` to add to the base forecast (a load that will happen
+            on top of normal usage, or negative for one that will not), or
+            ``"set"`` to replace the base forecast across the span.
+
+    """
+
+    start: datetime
+    end: datetime
+    energy_kwh: float
+    mode: str
+
+
+@dataclass
+class OverlayResult:
+    """The composed forecast, plus what had to be corrected to produce it."""
+
+    values: list[float]
+    clamped_periods: int
+
+
+def parse_overlay_blocks(raw: object) -> list[OverlayBlock]:
+    """Parse the overlay entity's ``blocks`` attribute into blocks.
+
+    Args:
+        raw: The attribute value as Home Assistant returned it.
+
+    Returns:
+        The declared blocks, in the order given.
+
+    Raises:
+        ConsumptionOverlayError: If the value is not a list of well-formed
+            blocks. Every failure is explicit — nothing is skipped or
+            defaulted past a missing field.
+
+    """
+    if not isinstance(raw, list):
+        raise ConsumptionOverlayError(
+            f"overlay blocks must be a list, got {type(raw).__name__}"
+        )
+
+    blocks = []
+    for position, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ConsumptionOverlayError(
+                f"overlay block {position} must be a mapping, "
+                f"got {type(entry).__name__}"
+            )
+
+        start = _parse_timestamp(entry, "start", position)
+        end = _parse_timestamp(entry, "end", position)
+        if end <= start:
+            raise ConsumptionOverlayError(
+                f"overlay block {position}: end ({end.isoformat()}) must be "
+                f"after start ({start.isoformat()})"
+            )
+
+        if "energy_kwh" not in entry:
+            raise ConsumptionOverlayError(
+                f"overlay block {position} is missing 'energy_kwh'"
+            )
+        try:
+            energy_kwh = float(entry["energy_kwh"])
+        except (TypeError, ValueError) as e:
+            raise ConsumptionOverlayError(
+                f"overlay block {position}: 'energy_kwh' is not a number "
+                f"({entry['energy_kwh']!r})"
+            ) from e
+
+        mode = entry.get("mode", "add")
+        if mode not in VALID_MODES:
+            raise ConsumptionOverlayError(
+                f"overlay block {position}: unknown mode {mode!r}, "
+                f"expected one of {VALID_MODES}"
+            )
+
+        blocks.append(
+            OverlayBlock(start=start, end=end, energy_kwh=energy_kwh, mode=mode)
+        )
+
+    return blocks
+
+
+def _parse_timestamp(entry: dict, field: str, position: int) -> datetime:
+    """Parse one ISO-8601 field, requiring an explicit UTC offset."""
+    if field not in entry:
+        raise ConsumptionOverlayError(f"overlay block {position} is missing '{field}'")
+
+    try:
+        parsed = datetime.fromisoformat(str(entry[field]))
+    except ValueError as e:
+        raise ConsumptionOverlayError(
+            f"overlay block {position}: '{field}' is not an ISO-8601 timestamp "
+            f"({entry[field]!r})"
+        ) from e
+
+    if parsed.tzinfo is None:
+        raise ConsumptionOverlayError(
+            f"overlay block {position}: '{field}' has no timezone offset "
+            f"({entry[field]!r}) — the block's position on the horizon would "
+            f"be a guess"
+        )
+
+    return parsed
+
+
+def period_starts_from(day_start: datetime, count: int) -> list[datetime]:
+    """Period start timestamps stepping in *real* time from ``day_start``.
+
+    The DP's grid is a contiguous run of quarter-hours, which is why a
+    fall-back day has 100 periods rather than 96. Wall-clock arithmetic
+    (``day_start + timedelta(minutes=15 * i)``) does not produce that grid: on
+    the fall-back day it steps straight over the repeated local hour, so every
+    period after the fold is an hour late and the day's last four indices
+    collide with the next day's first four. Stepping in UTC and converting
+    back gives the grid the period count already implies.
+
+    Args:
+        day_start: Midnight of the first day in the horizon, timezone-aware.
+        count: Number of periods to produce.
+
+    Returns:
+        ``count`` timestamps, 15 real minutes apart, in ``day_start``'s zone.
+
+    """
+    tz = day_start.tzinfo
+    anchor = day_start.astimezone(UTC)
+    return [(anchor + PERIOD_DURATION * i).astimezone(tz) for i in range(count)]
+
+
+def apply_overlay(
+    base: list[float],
+    period_starts: list[datetime],
+    blocks: list[OverlayBlock],
+) -> OverlayResult:
+    """Compose overlay blocks onto a base consumption forecast.
+
+    Args:
+        base: Base forecast, kWh per period.
+        period_starts: Start timestamp of each period in ``base``, same
+            length and order — build them with ``period_starts_from``, which
+            is what makes the DST fall-back day come out right.
+        blocks: Declared changes. Blocks outside the horizon contribute
+            nothing.
+
+    Returns:
+        The composed forecast and the number of periods whose value had to be
+        clamped to zero.
+
+    """
+    values = list(base)
+
+    for block in blocks:
+        span = (block.end - block.start).total_seconds()
+        overlaps = [
+            _overlap_seconds(start, block) for start in period_starts[: len(values)]
+        ]
+        covered = sum(overlaps)
+        if covered <= 0:
+            continue
+
+        for index, overlap in enumerate(overlaps):
+            if overlap <= 0:
+                continue
+            share = block.energy_kwh * (overlap / span)
+            if block.mode == "set":
+                # Replace only the covered fraction of the period, so a block
+                # that starts mid-period does not erase the rest of it.
+                fraction = overlap / PERIOD_DURATION.total_seconds()
+                values[index] = values[index] * (1 - fraction) + share
+            else:
+                values[index] += share
+
+    clamped_periods = sum(1 for value in values if value < 0)
+    if clamped_periods:
+        values = [max(0.0, value) for value in values]
+
+    return OverlayResult(values=values, clamped_periods=clamped_periods)
+
+
+def _overlap_seconds(period_start: datetime, block: OverlayBlock) -> float:
+    """Seconds of ``block`` falling inside the period starting at ``period_start``.
+
+    ``period_end`` must be derived the same way ``period_starts_from`` builds
+    the grid -- by stepping in real (UTC) time, not by adding a timedelta to a
+    local-zone datetime. Naive ``period_start + PERIOD_DURATION`` disagrees
+    with the grid across a DST fall-back: on the repeated local hour it can
+    land ahead of the *next* grid point (inflating overlap) or behind the
+    period's own start (silently zeroing it out via the ``max(0.0, ...)``
+    floor below).
+    """
+    period_end = (period_start.astimezone(UTC) + PERIOD_DURATION).astimezone(
+        period_start.tzinfo
+    )
+    latest_start = max(period_start, block.start)
+    earliest_end = min(period_end, block.end)
+    return max(0.0, (earliest_end - latest_start).total_seconds())

--- a/core/bess/exceptions.py
+++ b/core/bess/exceptions.py
@@ -93,3 +93,12 @@ class PWLEndSoeOutOfRangeError(ValueError):
     it on below-min-SOE recovery trajectories) can select for it by type
     instead of matching a substring of this module's prose error message.
     """
+
+
+class ConsumptionOverlayError(BESSException):
+    """The Planned Consumption Changes entity could not be read as blocks.
+
+    Raised rather than skipping the offending block: a user who declared an
+    EV session and got half of it applied is worse off than one told their
+    template is wrong.
+    """

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -16,13 +16,9 @@ from typing import ClassVar
 import requests
 import websocket
 
-from .consumption_overlay import (
-    ConsumptionOverlayError,
-    OverlayBlock,
-    parse_overlay_blocks,
-)
+from .consumption_overlay import OverlayBlock, parse_overlay_blocks
 from .energy_balance import derive_load_consumption
-from .exceptions import SystemConfigurationError
+from .exceptions import ConsumptionOverlayError, SystemConfigurationError
 from .runtime_failure_tracker import RuntimeFailureTracker
 from .settings_store import SettingsStore, apply_signed_pair_aliases
 

--- a/core/bess/ha_api_controller.py
+++ b/core/bess/ha_api_controller.py
@@ -16,6 +16,11 @@ from typing import ClassVar
 import requests
 import websocket
 
+from .consumption_overlay import (
+    ConsumptionOverlayError,
+    OverlayBlock,
+    parse_overlay_blocks,
+)
 from .energy_balance import derive_load_consumption
 from .exceptions import SystemConfigurationError
 from .runtime_failure_tracker import RuntimeFailureTracker
@@ -285,6 +290,13 @@ class HomeAssistantAPIController:
             "unit": "W",
             "precision": 1,
             "conversion_threshold": 1000,
+        },
+        "get_consumption_overlay_blocks": {
+            "sensor_key": "consumption_overlay",
+            "name": "Planned Consumption Changes",
+            "unit": "list",
+            "precision": None,
+            "conversion_threshold": None,
         },
         # Solar forecast
         "get_solar_forecast": {
@@ -1445,6 +1457,61 @@ class HomeAssistantAPIController:
             return False
         result = self._get_binary_state("discharge_inhibit")
         return result is True
+
+    def get_consumption_overlay_blocks(self) -> list[OverlayBlock]:
+        """Read the user's declared changes to expected consumption (issue #428).
+
+        Returns:
+            The blocks declared on the overlay entity's ``blocks`` attribute,
+            or an empty list when no overlay entity is configured. "No
+            overlay" is a supported configuration, not a degraded one — it is
+            what an install that never sets one up keeps running.
+
+        Raises:
+            ConsumptionOverlayError: If an overlay entity IS configured but
+                its ``blocks`` attribute is absent and the state offers no
+                better explanation, or the blocks it holds are malformed. A
+                user who declared an EV session is better served by an error
+                than by an optimization that quietly ignored it.
+
+        """
+        if not self.sensors.get("consumption_overlay"):
+            return []
+
+        entity_id, _ = self._resolve_entity_id("consumption_overlay")
+        response = self._api_request(
+            "get",
+            f"/api/states/{entity_id}",
+            operation="Read planned consumption changes",
+            category="CONSUMPTION_OVERLAY",
+            context={"entity_id": entity_id},
+        )
+        if not response:
+            raise ConsumptionOverlayError(
+                f"Planned consumption changes entity '{entity_id}' returned no state"
+            )
+
+        # `blocks` is the data; `state` is incidental. A template sensor's
+        # state commonly comes from an unrelated helper (per the docs'
+        # example, an input_boolean) that can itself go "unknown" while
+        # `blocks` still renders correctly -- gating on state alone would
+        # make that documented example a schedule-stopper. Check `blocks`
+        # first, and fall back to reporting the state only when there is no
+        # data to fall back on.
+        attributes = response.get("attributes") or {}
+        if "blocks" in attributes:
+            return parse_overlay_blocks(attributes["blocks"])
+
+        state = response.get("state")
+        if state in ("unavailable", "unknown", None):
+            raise ConsumptionOverlayError(
+                f"Planned consumption changes entity '{entity_id}' is {state}"
+            )
+
+        raise ConsumptionOverlayError(
+            f"Planned consumption changes entity '{entity_id}' has no 'blocks' "
+            f"attribute (found: {sorted(attributes)})"
+        )
 
     def get_estimated_consumption(self):
         """Get estimated consumption in quarterly resolution (96 periods).

--- a/core/bess/health_check.py
+++ b/core/bess/health_check.py
@@ -142,6 +142,7 @@ def perform_health_check(
     controller,
     all_methods: list[str],
     required_methods: list[str] | None = None,
+    empty_list_is_ok: set[str] | None = None,
 ) -> dict:
     """Generic health check function that can be used by any component.
 
@@ -239,12 +240,23 @@ def perform_health_check(
                 if isinstance(value, list):
                     # Handle list values (like predictions)
                     if len(value) == 0:
+                        # For most list sensors an empty reading means the
+                        # source produced nothing and something is wrong. For
+                        # a few it is the normal answer — the consumption
+                        # overlay declares nothing on an ordinary day — so
+                        # those are named by the caller rather than warned on.
+                        empty_is_fine = (
+                            empty_list_is_ok is not None
+                            and method_name in empty_list_is_ok
+                        )
                         check_result.update(
                             {
-                                "status": "WARNING",
-                                "error": "Empty list returned",
+                                "status": "OK" if empty_is_fine else "WARNING",
+                                "error": None if empty_is_fine else "Empty list",
                                 "rawValue": value,
-                                "displayValue": "Empty list",
+                                "displayValue": (
+                                    "None declared" if empty_is_fine else "Empty list"
+                                ),
                             }
                         )
                     else:

--- a/core/bess/sensor_collector.py
+++ b/core/bess/sensor_collector.py
@@ -891,15 +891,31 @@ class SensorCollector:
         if sensor_strategy_active:
             all_methods = ["get_estimated_consumption", *all_methods]
 
+        required_methods = (
+            ["get_estimated_consumption"] if sensor_strategy_active else []
+        )
+
+        # The consumption overlay (#428) is not a strategy, so it is keyed off
+        # configuration rather than the active strategy. Once configured it is
+        # required: every optimization run reads it, and a malformed one stops
+        # schedules being built, so the user needs to see it here rather than
+        # in a failed run.
+        empty_list_is_ok = set()
+        if self.ha_controller.is_sensor_configured("consumption_overlay"):
+            all_methods = [*all_methods, "get_consumption_overlay_blocks"]
+            required_methods = [*required_methods, "get_consumption_overlay_blocks"]
+            # Declaring no blocks is the normal state on an ordinary day, so
+            # an empty list here is a healthy reading rather than a missing one.
+            empty_list_is_ok.add("get_consumption_overlay_blocks")
+
         return perform_health_check(
             component_name="Energy Prediction",
             description="Solar and consumption forecasting for optimization",
-            is_required=sensor_strategy_active,
+            is_required=bool(required_methods),
             controller=self.ha_controller,
             all_methods=all_methods,
-            required_methods=(
-                ["get_estimated_consumption"] if sensor_strategy_active else None
-            ),
+            required_methods=required_methods or None,
+            empty_list_is_ok=empty_list_is_ok or None,
         )
 
     def check_health(self, consumption_strategy: str = "sensor") -> list:

--- a/core/bess/settings_store.py
+++ b/core/bess/settings_store.py
@@ -49,6 +49,7 @@ SHARED_SENSOR_KEYS = frozenset(
         "solar_forecast_today",
         "solar_forecast_tomorrow",
         "48h_avg_grid_import",
+        "consumption_overlay",
         "current_l1",
         "current_l2",
         "current_l3",

--- a/core/bess/tests/unit/test_consumption_overlay.py
+++ b/core/bess/tests/unit/test_consumption_overlay.py
@@ -1,0 +1,527 @@
+"""Tests for the consumption forecast overlay (issue #428).
+
+The overlay is a post-processing stage applied to whichever consumption
+forecast strategy is configured. The user publishes a sparse list of blocks
+describing what differs from their normal usage; BESS composes those onto the
+base forecast.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from core.bess import time_utils
+from core.bess.battery_system_manager import BatterySystemManager
+from core.bess.consumption_overlay import (
+    ConsumptionOverlayError,
+    OverlayBlock,
+    apply_overlay,
+    parse_overlay_blocks,
+    period_starts_from,
+)
+from core.bess.price_manager import MockSource
+from core.bess.tests.conftest import MockHomeAssistantController
+
+TZ = ZoneInfo("Europe/Stockholm")
+
+
+def _period_starts(first: datetime, count: int) -> list[datetime]:
+    """Quarter-hour period start timestamps, as the DP indexes them."""
+    return [first + timedelta(minutes=15 * i) for i in range(count)]
+
+
+# --- Composing blocks onto the base forecast --------------------------------
+
+
+def test_add_block_spreads_its_energy_across_the_periods_it_covers() -> None:
+    """An add block distributes its kWh over the periods its span overlaps."""
+    starts = _period_starts(datetime(2026, 8, 27, 0, 0, tzinfo=TZ), 96)
+    base = [1.0] * 96
+
+    block = OverlayBlock(
+        start=datetime(2026, 8, 27, 22, 0, tzinfo=TZ),
+        end=datetime(2026, 8, 27, 23, 0, tzinfo=TZ),
+        energy_kwh=4.0,
+        mode="add",
+    )
+
+    result = apply_overlay(base, starts, [block])
+
+    # 22:00-23:00 is periods 88..91 -- 4 kWh over 4 periods is +1.0 each.
+    assert result.values[88:92] == [2.0, 2.0, 2.0, 2.0]
+    # Nothing outside the span moved.
+    assert result.values[:88] == [1.0] * 88
+    assert result.values[92:] == [1.0] * 4
+    assert result.clamped_periods == 0
+
+
+def test_set_block_replaces_the_base_forecast_across_its_span() -> None:
+    """A set block overwrites the base rather than adding to it.
+
+    This is the "away for the week" / "force near-zero overnight" case Frank
+    asked for: repeated subtractions cannot express it cleanly, because the
+    user does not know what the baseline holds.
+    """
+    starts = _period_starts(datetime(2026, 8, 27, 0, 0, tzinfo=TZ), 96)
+    base = [1.0] * 96
+
+    block = OverlayBlock(
+        start=datetime(2026, 8, 27, 2, 0, tzinfo=TZ),
+        end=datetime(2026, 8, 27, 3, 0, tzinfo=TZ),
+        energy_kwh=0.4,
+        mode="set",
+    )
+
+    result = apply_overlay(base, starts, [block])
+
+    # 02:00-03:00 is periods 8..11 -- 0.4 kWh over 4 periods is 0.1 each,
+    # replacing the 1.0 that was there, not adding to it.
+    assert result.values[8:12] == [0.1, 0.1, 0.1, 0.1]
+    assert result.values[7] == 1.0
+    assert result.values[12] == 1.0
+
+
+def test_over_subtraction_clamps_at_zero_and_is_reported() -> None:
+    """Subtracting more than the baseline holds cannot make consumption negative.
+
+    "The EV is not home tonight, subtract the usual session" is the intended
+    use, and on a low-baseline day it will occasionally over-subtract.
+    Clamping keeps the forecast physical; the count is what lets the caller
+    surface it instead of hiding it.
+    """
+    starts = _period_starts(datetime(2026, 8, 27, 0, 0, tzinfo=TZ), 96)
+    base = [1.0] * 96
+
+    block = OverlayBlock(
+        start=datetime(2026, 8, 27, 18, 0, tzinfo=TZ),
+        end=datetime(2026, 8, 27, 19, 0, tzinfo=TZ),
+        energy_kwh=-6.0,
+        mode="add",
+    )
+
+    result = apply_overlay(base, starts, [block])
+
+    # 18:00-19:00 is periods 72..75, each losing 1.5 kWh from a 1.0 base.
+    assert result.values[72:76] == [0.0, 0.0, 0.0, 0.0]
+    assert result.clamped_periods == 4
+
+
+def test_set_block_covering_part_of_a_period_only_replaces_that_part() -> None:
+    """A set block that starts or ends mid-period must not erase the whole period.
+
+    Users author blocks in wall-clock terms ("away until 07:10"), which will
+    not land on quarter-hour boundaries. Replacing the entire period would
+    silently discard baseline load the block never claimed to cover.
+    """
+    starts = _period_starts(datetime(2026, 8, 27, 0, 0, tzinfo=TZ), 96)
+    base = [1.0] * 96
+
+    block = OverlayBlock(
+        start=datetime(2026, 8, 27, 2, 0, tzinfo=TZ),
+        end=datetime(2026, 8, 27, 2, 7, 30, tzinfo=TZ),
+        energy_kwh=0.05,
+        mode="set",
+    )
+
+    result = apply_overlay(base, starts, [block])
+
+    # Period 8 is half covered: half the 1.0 base survives, plus the 0.05.
+    assert result.values[8] == 0.55
+    assert result.values[9] == 1.0
+
+
+# --- Parsing the entity attribute -------------------------------------------
+
+
+def test_parse_reads_blocks_with_defaulted_add_mode() -> None:
+    """The declared shape: timestamped spans with a total energy for the span."""
+    raw = [
+        {
+            "start": "2026-08-27T22:00:00+02:00",
+            "end": "2026-08-28T06:00:00+02:00",
+            "energy_kwh": 40.0,
+        },
+        {
+            "start": "2026-08-27T09:00:00+02:00",
+            "end": "2026-08-27T17:00:00+02:00",
+            "energy_kwh": 1.0,
+            "mode": "set",
+        },
+    ]
+
+    blocks = parse_overlay_blocks(raw)
+
+    assert len(blocks) == 2
+    assert blocks[0].energy_kwh == 40.0
+    assert blocks[0].mode == "add"
+    assert blocks[0].start == datetime(
+        2026, 8, 27, 22, 0, tzinfo=timezone(timedelta(hours=2))
+    )
+    assert blocks[1].mode == "set"
+
+
+def test_parse_rejects_a_block_missing_its_end() -> None:
+    """A malformed overlay fails loudly rather than degrading to a partial one.
+
+    rules.md forbids silent fallbacks: half-applying a user's declared load is
+    worse than telling them their template is broken.
+    """
+    raw = [{"start": "2026-08-27T22:00:00+02:00", "energy_kwh": 40.0}]
+
+    with pytest.raises(ConsumptionOverlayError, match="end"):
+        parse_overlay_blocks(raw)
+
+
+def test_parse_rejects_an_unknown_mode() -> None:
+    """Only add and set exist; a typo must not silently become one of them."""
+    raw = [
+        {
+            "start": "2026-08-27T22:00:00+02:00",
+            "end": "2026-08-27T23:00:00+02:00",
+            "energy_kwh": 4.0,
+            "mode": "replace",
+        }
+    ]
+
+    with pytest.raises(ConsumptionOverlayError, match="replace"):
+        parse_overlay_blocks(raw)
+
+
+def test_parse_rejects_a_block_that_ends_before_it_starts() -> None:
+    raw = [
+        {
+            "start": "2026-08-27T23:00:00+02:00",
+            "end": "2026-08-27T22:00:00+02:00",
+            "energy_kwh": 4.0,
+        }
+    ]
+
+    with pytest.raises(ConsumptionOverlayError, match="after"):
+        parse_overlay_blocks(raw)
+
+
+def test_parse_rejects_a_naive_timestamp() -> None:
+    """Without an offset the block's real position on the horizon is a guess."""
+    raw = [
+        {
+            "start": "2026-08-27T22:00:00",
+            "end": "2026-08-27T23:00:00",
+            "energy_kwh": 4.0,
+        }
+    ]
+
+    with pytest.raises(ConsumptionOverlayError, match="timezone"):
+        parse_overlay_blocks(raw)
+
+
+# --- Reaching the optimizer -------------------------------------------------
+#
+# The overlay applies in _gather_optimization_data, after the daily prediction
+# cache and after the tomorrow-horizon extension. Applying it earlier -- inside
+# _get_consumption_forecast -- would bake it into the cached array (so editing
+# the overlay mid-day would do nothing until tomorrow) and would let the
+# extension duplicate today's blocks onto tomorrow. These tests pin the seam,
+# not just the arithmetic.
+
+
+@pytest.fixture
+def system_with_overlay(
+    mock_controller: MockHomeAssistantController,
+) -> BatterySystemManager:
+    """A system on the 'fixed' strategy: 1.0 kWh/h, a flat 0.25 per period."""
+    system = BatterySystemManager(
+        controller=mock_controller,
+        price_source=MockSource([1.0] * 96),
+    )
+    system.home_settings.consumption_strategy = "fixed"
+    system.home_settings.default_hourly = 1.0
+    return system
+
+
+def test_overlay_shapes_the_consumption_the_optimizer_receives(
+    system_with_overlay: BatterySystemManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A declared EV session reaches full_consumption, not just the parser."""
+    system = system_with_overlay
+    period_count = time_utils.get_period_count(time_utils.today())
+
+    block = OverlayBlock(
+        start=time_utils.period_index_to_timestamp(88),
+        end=time_utils.period_index_to_timestamp(92),
+        energy_kwh=4.0,
+        mode="add",
+    )
+    monkeypatch.setattr(
+        system.controller, "get_consumption_overlay_blocks", lambda: [block]
+    )
+
+    result = system._gather_optimization_data(
+        period=0, current_soc=50.0, prepare_next_day=False, period_count=period_count
+    )
+    assert result is not None
+    _, data = result
+
+    consumption = data["full_consumption"]
+    # Base is a flat 0.25/period; the block adds 1.0 to each of 88..91.
+    assert consumption[88:92] == pytest.approx([1.25] * 4)
+    assert consumption[87] == pytest.approx(0.25)
+    assert consumption[92] == pytest.approx(0.25)
+
+
+def test_no_overlay_entity_leaves_the_forecast_untouched(
+    system_with_overlay: BatterySystemManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No overlay configured is a legitimate state, not a degraded one.
+
+    This is what keeps the feature free of a cold start: an install that never
+    configures an overlay entity keeps exactly the forecast it has today.
+    """
+    system = system_with_overlay
+    period_count = time_utils.get_period_count(time_utils.today())
+    monkeypatch.setattr(system.controller, "get_consumption_overlay_blocks", lambda: [])
+
+    result = system._gather_optimization_data(
+        period=0, current_soc=50.0, prepare_next_day=False, period_count=period_count
+    )
+    assert result is not None
+    _, data = result
+
+    assert data["full_consumption"] == pytest.approx([0.25] * period_count)
+
+
+def test_a_block_declared_for_tomorrow_lands_on_tomorrow(
+    system_with_overlay: BatterySystemManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The extension duplicates today's 96 values; the overlay must not follow.
+
+    With a horizon spanning midnight, applying the overlay before the
+    extension would replicate a today block onto tomorrow and drop a tomorrow
+    block entirely. Both halves are asserted here.
+    """
+    system = system_with_overlay
+    today_periods = time_utils.get_period_count(time_utils.today())
+    period_count = today_periods + 8  # horizon runs two hours into tomorrow
+
+    tomorrow_block = OverlayBlock(
+        start=time_utils.period_index_to_timestamp(today_periods + 4),
+        end=time_utils.period_index_to_timestamp(today_periods + 8),
+        energy_kwh=4.0,
+        mode="add",
+    )
+    monkeypatch.setattr(
+        system.controller,
+        "get_consumption_overlay_blocks",
+        lambda: [tomorrow_block],
+    )
+
+    result = system._gather_optimization_data(
+        period=0, current_soc=50.0, prepare_next_day=False, period_count=period_count
+    )
+    assert result is not None
+    _, data = result
+
+    consumption = data["full_consumption"]
+    # The block lands on tomorrow's 01:00-02:00 ...
+    assert consumption[today_periods + 4 : today_periods + 8] == pytest.approx(
+        [1.25] * 4
+    )
+    # ... and today's corresponding periods are untouched.
+    assert consumption[4:8] == pytest.approx([0.25] * 4)
+
+
+def test_editing_the_overlay_takes_effect_without_waiting_for_tomorrow(
+    system_with_overlay: BatterySystemManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A date-cached strategy must not bake the overlay into its cached day.
+
+    'ha_statistics' and 'influxdb_7d_avg' average whole calendar days, so
+    their forecast is cached until the date rolls over. The overlay is not
+    that kind of value: the user edits it precisely because today changed.
+    Applying it inside _get_consumption_forecast would trap it in that cache.
+    """
+    system = system_with_overlay
+    system.home_settings.consumption_strategy = "ha_statistics"
+    monkeypatch.setattr(system, "_get_ha_statistics_forecast", lambda: [0.25] * 96)
+    period_count = time_utils.get_period_count(time_utils.today())
+
+    def _block(period: int) -> OverlayBlock:
+        return OverlayBlock(
+            start=time_utils.period_index_to_timestamp(period),
+            end=time_utils.period_index_to_timestamp(period + 4),
+            energy_kwh=4.0,
+            mode="add",
+        )
+
+    blocks = [_block(88)]
+    monkeypatch.setattr(
+        system.controller, "get_consumption_overlay_blocks", lambda: blocks
+    )
+
+    result_first = system._gather_optimization_data(
+        period=0, current_soc=50.0, prepare_next_day=False, period_count=period_count
+    )
+    assert result_first is not None
+    _, first = result_first
+    assert first["full_consumption"][88:92] == pytest.approx([1.25] * 4)
+
+    # The user moves the EV session earlier, same day.
+    blocks[:] = [_block(60)]
+
+    result_second = system._gather_optimization_data(
+        period=0, current_soc=50.0, prepare_next_day=False, period_count=period_count
+    )
+    assert result_second is not None
+    _, second = result_second
+    assert second["full_consumption"][60:64] == pytest.approx([1.25] * 4)
+    assert second["full_consumption"][88:92] == pytest.approx([0.25] * 4)
+
+
+# --- Review findings --------------------------------------------------------
+
+
+def test_period_starts_stay_contiguous_across_the_dst_fall_back_hour() -> None:
+    """The overlay's grid must be real time, not wall-clock arithmetic.
+
+    On the fall-back day the local clock repeats 02:00-03:00, so
+    `day_start + timedelta(minutes=15*i)` skips a real hour: index 11 lands at
+    UTC 00:45 and index 12 at UTC 02:00, pushing everything after it an hour
+    late, and today's last four indices land on tomorrow's midnight. A block
+    declared for tomorrow would then be counted twice.
+    """
+    day_start = datetime(2026, 10, 25, 0, 0, tzinfo=TZ)
+
+    starts = period_starts_from(day_start, 100)
+
+    # Compared in UTC: two local timestamps either side of the fold are equal
+    # to each other in their own zone (same tzinfo compares naive, ignoring
+    # fold), so only the instants tell the truth here.
+    instants = [s.astimezone(UTC) for s in starts]
+    assert len(set(instants)) == 100
+    deltas = {
+        (instants[i + 1] - instants[i]).total_seconds()
+        for i in range(len(instants) - 1)
+    }
+    assert deltas == {900.0}
+    # The repeated local hour is stepped through, not skipped.
+    assert instants[11].strftime("%H:%M") == "00:45"
+    assert instants[12].strftime("%H:%M") == "01:00"
+    # 100 periods is 25 real hours: the day ends at tomorrow's midnight local.
+    assert (instants[-1] - instants[0]).total_seconds() == 99 * 900
+
+
+def test_apply_overlay_delivers_full_energy_across_the_dst_fall_back_hour() -> None:
+    """`apply_overlay` itself must agree with `period_starts_from`'s grid.
+
+    The earlier fix made `period_starts_from` step in real (UTC) time, but
+    `apply_overlay` measures each period's overlap with
+    `period_start + PERIOD_DURATION` -- wall-clock arithmetic on a
+    `zoneinfo`-aware datetime, which silently disagrees with the grid across
+    the repeated local hour. A block spanning the fold must still deliver
+    exactly its declared energy, not overshoot into one period and vanish
+    from the next few.
+    """
+    day_start = datetime(2026, 10, 25, 0, 0, tzinfo=TZ)
+    starts = period_starts_from(day_start, 100)
+    base = [0.0] * 100
+
+    # 8 kWh across 01:30-03:30 UTC, straddling the 02:00-03:00 local repeat.
+    block = OverlayBlock(
+        start=datetime(2026, 10, 25, 1, 30, tzinfo=UTC),
+        end=datetime(2026, 10, 25, 3, 30, tzinfo=UTC),
+        energy_kwh=8.0,
+        mode="add",
+    )
+
+    result = apply_overlay(base, starts, [block])
+
+    assert result.clamped_periods == 0
+    assert sum(result.values) == pytest.approx(8.0)
+
+    # `set` mode must fully replace every period the block spans (2 hours /
+    # 8 periods of 8 kWh -> 1 kWh each), including the ones on the far side
+    # of the fold -- not leave them at the base value because overlap under
+    # the bug measured as zero or negative, and not clamp from a fraction
+    # driven past 1.0 by an inflated overlap.
+    set_block = OverlayBlock(
+        start=block.start, end=block.end, energy_kwh=8.0, mode="set"
+    )
+    set_result = apply_overlay([9.0] * 100, starts, [set_block])
+    assert set_result.clamped_periods == 0
+    covered = [
+        v
+        for start, v in zip(starts, set_result.values, strict=True)
+        if block.start <= start.astimezone(UTC) < block.end
+    ]
+    assert len(covered) == 8
+    assert all(v == pytest.approx(1.0) for v in covered)
+
+
+def test_a_malformed_overlay_is_recorded_as_a_runtime_failure(
+    system_with_overlay: BatterySystemManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken template must reach the dashboard, not just the log.
+
+    The error propagates into update_battery_schedule's blanket handler, which
+    logs and returns False. Without a recorded failure the schedule silently
+    freezes at the last good one and the user has no signal at all.
+    """
+    system = system_with_overlay
+    period_count = time_utils.get_period_count(time_utils.today())
+
+    def _raise() -> list[OverlayBlock]:
+        raise ConsumptionOverlayError("overlay block 0: unknown mode 'replace'")
+
+    monkeypatch.setattr(system.controller, "get_consumption_overlay_blocks", _raise)
+
+    with pytest.raises(ConsumptionOverlayError):
+        system._gather_optimization_data(
+            period=0,
+            current_soc=50.0,
+            prepare_next_day=False,
+            period_count=period_count,
+        )
+
+    assert system._runtime_failure_tracker.has_active_failure("CONSUMPTION_OVERLAY")
+
+
+def test_removing_the_offending_block_clears_the_clamp_warning(
+    system_with_overlay: BatterySystemManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting the over-subtracting block must dismiss its banner.
+
+    The no-blocks short circuit returned before the dismiss, so the only way
+    to clear a clamp warning was to add a different, non-clamping block.
+    """
+    system = system_with_overlay
+    period_count = time_utils.get_period_count(time_utils.today())
+
+    blocks = [
+        OverlayBlock(
+            start=time_utils.period_index_to_timestamp(72),
+            end=time_utils.period_index_to_timestamp(76),
+            energy_kwh=-6.0,
+            mode="add",
+        )
+    ]
+    monkeypatch.setattr(
+        system.controller, "get_consumption_overlay_blocks", lambda: blocks
+    )
+
+    system._gather_optimization_data(
+        period=0, current_soc=50.0, prepare_next_day=False, period_count=period_count
+    )
+    assert system._runtime_failure_tracker.has_active_failure(
+        "CONSUMPTION_OVERLAY_CLAMPED"
+    )
+
+    blocks.clear()
+
+    system._gather_optimization_data(
+        period=0, current_soc=50.0, prepare_next_day=False, period_count=period_count
+    )
+    assert not system._runtime_failure_tracker.has_active_failure(
+        "CONSUMPTION_OVERLAY_CLAMPED"
+    )

--- a/core/bess/tests/unit/test_consumption_overlay.py
+++ b/core/bess/tests/unit/test_consumption_overlay.py
@@ -14,12 +14,12 @@ import pytest
 from core.bess import time_utils
 from core.bess.battery_system_manager import BatterySystemManager
 from core.bess.consumption_overlay import (
-    ConsumptionOverlayError,
     OverlayBlock,
     apply_overlay,
     parse_overlay_blocks,
     period_starts_from,
 )
+from core.bess.exceptions import ConsumptionOverlayError
 from core.bess.price_manager import MockSource
 from core.bess.tests.conftest import MockHomeAssistantController
 

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -1305,7 +1305,7 @@ class TestConsumptionOverlayBlocksStateGating:
     def test_missing_blocks_attribute_with_unknown_state_reports_the_state(
         self, overlay_ctrl: HomeAssistantAPIController
     ) -> None:
-        from core.bess.consumption_overlay import ConsumptionOverlayError
+        from core.bess.exceptions import ConsumptionOverlayError
 
         with patch.object(
             overlay_ctrl,
@@ -1318,7 +1318,7 @@ class TestConsumptionOverlayBlocksStateGating:
     def test_missing_blocks_attribute_with_a_real_state_reports_missing_blocks(
         self, overlay_ctrl: HomeAssistantAPIController
     ) -> None:
-        from core.bess.consumption_overlay import ConsumptionOverlayError
+        from core.bess.exceptions import ConsumptionOverlayError
 
         with patch.object(
             overlay_ctrl,

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -1249,3 +1249,76 @@ class TestSensorsLiveView:
         store.data["sensors"] = {"battery_soc": "sensor.battery_soc_v2"}
 
         assert c.sensors == {"battery_soc": "sensor.battery_soc_v2"}
+
+
+class TestConsumptionOverlayBlocksStateGating:
+    """The `blocks` attribute is the data; `state` is incidental.
+
+    The documented template example sets `state` from an `input_boolean`,
+    which reads as the literal string "unknown" if that helper is ever
+    missing or renamed -- even though `blocks` renders just fine. Gating
+    solely on `state` would make that documented example a schedule-stopper.
+    """
+
+    @pytest.fixture
+    def overlay_ctrl(self):
+        c = HomeAssistantAPIController(
+            ha_url="http://ha.local:8123",
+            token="test-token",
+            settings_store=_settings_store(
+                {"consumption_overlay": "sensor.bess_consumption_overlay"}
+            ),
+            service_domain="growatt_server",
+        )
+        c.max_attempts = 1
+        c.retry_base_delay = 0
+        c.failure_tracker = RuntimeFailureTracker()
+        return c
+
+    def test_blocks_are_read_even_when_state_is_unknown(self, overlay_ctrl):
+        with patch.object(
+            overlay_ctrl,
+            "_api_request",
+            return_value={
+                "state": "unknown",
+                "attributes": {"blocks": []},
+            },
+        ):
+            assert overlay_ctrl.get_consumption_overlay_blocks() == []
+
+    def test_blocks_are_read_even_when_state_is_unavailable(self, overlay_ctrl):
+        with patch.object(
+            overlay_ctrl,
+            "_api_request",
+            return_value={
+                "state": "unavailable",
+                "attributes": {"blocks": []},
+            },
+        ):
+            assert overlay_ctrl.get_consumption_overlay_blocks() == []
+
+    def test_missing_blocks_attribute_with_unknown_state_reports_the_state(
+        self, overlay_ctrl
+    ):
+        from core.bess.consumption_overlay import ConsumptionOverlayError
+
+        with patch.object(
+            overlay_ctrl,
+            "_api_request",
+            return_value={"state": "unknown", "attributes": {}},
+        ):
+            with pytest.raises(ConsumptionOverlayError, match="is unknown"):
+                overlay_ctrl.get_consumption_overlay_blocks()
+
+    def test_missing_blocks_attribute_with_a_real_state_reports_missing_blocks(
+        self, overlay_ctrl
+    ):
+        from core.bess.consumption_overlay import ConsumptionOverlayError
+
+        with patch.object(
+            overlay_ctrl,
+            "_api_request",
+            return_value={"state": "ok", "attributes": {}},
+        ):
+            with pytest.raises(ConsumptionOverlayError, match="no 'blocks'"):
+                overlay_ctrl.get_consumption_overlay_blocks()

--- a/core/bess/tests/unit/test_ha_api_controller.py
+++ b/core/bess/tests/unit/test_ha_api_controller.py
@@ -1262,7 +1262,7 @@ class TestConsumptionOverlayBlocksStateGating:
     """
 
     @pytest.fixture
-    def overlay_ctrl(self):
+    def overlay_ctrl(self) -> HomeAssistantAPIController:
         c = HomeAssistantAPIController(
             ha_url="http://ha.local:8123",
             token="test-token",
@@ -1276,7 +1276,9 @@ class TestConsumptionOverlayBlocksStateGating:
         c.failure_tracker = RuntimeFailureTracker()
         return c
 
-    def test_blocks_are_read_even_when_state_is_unknown(self, overlay_ctrl):
+    def test_blocks_are_read_even_when_state_is_unknown(
+        self, overlay_ctrl: HomeAssistantAPIController
+    ) -> None:
         with patch.object(
             overlay_ctrl,
             "_api_request",
@@ -1287,7 +1289,9 @@ class TestConsumptionOverlayBlocksStateGating:
         ):
             assert overlay_ctrl.get_consumption_overlay_blocks() == []
 
-    def test_blocks_are_read_even_when_state_is_unavailable(self, overlay_ctrl):
+    def test_blocks_are_read_even_when_state_is_unavailable(
+        self, overlay_ctrl: HomeAssistantAPIController
+    ) -> None:
         with patch.object(
             overlay_ctrl,
             "_api_request",
@@ -1299,8 +1303,8 @@ class TestConsumptionOverlayBlocksStateGating:
             assert overlay_ctrl.get_consumption_overlay_blocks() == []
 
     def test_missing_blocks_attribute_with_unknown_state_reports_the_state(
-        self, overlay_ctrl
-    ):
+        self, overlay_ctrl: HomeAssistantAPIController
+    ) -> None:
         from core.bess.consumption_overlay import ConsumptionOverlayError
 
         with patch.object(
@@ -1312,8 +1316,8 @@ class TestConsumptionOverlayBlocksStateGating:
                 overlay_ctrl.get_consumption_overlay_blocks()
 
     def test_missing_blocks_attribute_with_a_real_state_reports_missing_blocks(
-        self, overlay_ctrl
-    ):
+        self, overlay_ctrl: HomeAssistantAPIController
+    ) -> None:
         from core.bess.consumption_overlay import ConsumptionOverlayError
 
         with patch.object(

--- a/core/bess/tests/unit/test_prediction_health_check.py
+++ b/core/bess/tests/unit/test_prediction_health_check.py
@@ -66,7 +66,7 @@ def _make_controller(
     if overlay_ok:
         controller.get_consumption_overlay_blocks.return_value = []
     else:
-        from core.bess.consumption_overlay import ConsumptionOverlayError
+        from core.bess.exceptions import ConsumptionOverlayError
 
         controller.get_consumption_overlay_blocks.side_effect = ConsumptionOverlayError(
             "overlay block 0 is missing 'end'"

--- a/core/bess/tests/unit/test_prediction_health_check.py
+++ b/core/bess/tests/unit/test_prediction_health_check.py
@@ -24,6 +24,8 @@ def _make_controller(
     estimated_consumption_ok: bool = True,
     solar_forecast_ok: bool = True,
     estimated_consumption_configured: bool = True,
+    overlay_configured: bool = False,
+    overlay_ok: bool = True,
 ):
     """Return a minimal controller stub with configurable sensor behaviour.
 
@@ -49,7 +51,26 @@ def _make_controller(
             "precision": 1,
             "conversion_threshold": None,
         },
+        "get_consumption_overlay_blocks": {
+            "sensor_key": "consumption_overlay",
+            "name": "Planned Consumption Changes",
+            "unit": "list",
+            "precision": None,
+            "conversion_threshold": None,
+        },
     }
+    controller.is_sensor_configured.side_effect = lambda key: (
+        overlay_configured if key == "consumption_overlay" else True
+    )
+
+    if overlay_ok:
+        controller.get_consumption_overlay_blocks.return_value = []
+    else:
+        from core.bess.consumption_overlay import ConsumptionOverlayError
+
+        controller.get_consumption_overlay_blocks.side_effect = ConsumptionOverlayError(
+            "overlay block 0 is missing 'end'"
+        )
 
     def _validate(method_list):
         results = []
@@ -345,3 +366,49 @@ class TestCheckHealthStrategyPropagation:
         prediction = next(c for c in checks if c["name"] == "Energy Prediction")
         method_names = [ch["method_name"] for ch in prediction["checks"]]
         assert "get_estimated_consumption" not in method_names
+
+
+class TestConsumptionOverlay:
+    """The overlay (#428) is checked whenever configured, on any strategy.
+
+    It is not a strategy, so it cannot be keyed off one — and it must not
+    produce a warning on the overwhelming majority of installs that never
+    configure it.
+    """
+
+    def test_omitted_when_no_overlay_entity_is_configured(self) -> None:
+        collector = _make_collector(_make_controller(overlay_configured=False))
+        result = collector.check_prediction_health("ha_statistics")
+        method_names = [ch["method_name"] for ch in result["checks"]]
+        assert "get_consumption_overlay_blocks" not in method_names
+
+    def test_checked_when_an_overlay_entity_is_configured(self) -> None:
+        collector = _make_collector(_make_controller(overlay_configured=True))
+        result = collector.check_prediction_health("ha_statistics")
+        method_names = [ch["method_name"] for ch in result["checks"]]
+        assert "get_consumption_overlay_blocks" in method_names
+
+    def test_an_overlay_with_no_blocks_today_is_healthy(self) -> None:
+        """No blocks declared is the normal steady state, not a fault.
+
+        The documented template emits an empty list whenever none of the
+        user's input_booleans are on — most days. An empty list must not read
+        as "sensor returned nothing useful" the way an empty solar forecast
+        does.
+        """
+        collector = _make_collector(_make_controller(overlay_configured=True))
+        result = collector.check_prediction_health("ha_statistics")
+        assert result["status"] == "OK"
+
+    def test_a_broken_overlay_makes_the_check_fail(self) -> None:
+        """Configured-but-broken is an error, not something to skip past.
+
+        Every optimization run reads the overlay once configured, so a
+        malformed one stops schedules being built. The health check is where
+        the user finds out why.
+        """
+        collector = _make_collector(
+            _make_controller(overlay_configured=True, overlay_ok=False)
+        )
+        result = collector.check_prediction_health("ha_statistics")
+        assert result["status"] == "ERROR"

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -350,6 +350,67 @@ This is the recommended strategy for most users — it adapts to your actual usa
 
 The **Insights** page includes a **Consumption Forecast Comparison** section that evaluates all available strategies against your actual consumption. Each strategy shows its hourly profile overlaid on actual data, along with a Mean Absolute Error (MAE) metric. Use this to verify which strategy best matches your real consumption patterns before committing to one.
 
+#### Planned Consumption Changes — telling BESS what's coming
+
+Every strategy above describes your *normal* usage. None of them can know the EV is charging tonight, that you're skipping the pool pump, or that a heatwave will have the AC running all afternoon. **Planned Consumption Changes** is how you say so.
+
+It is not a fifth strategy — it applies on top of whichever one you use. If you never configure it, nothing changes.
+
+Create a template sensor whose `blocks` attribute lists what differs, then point BESS at it in the **Sensors** tab under **Planned Consumption Changes**.
+
+```yaml
+template:
+  - sensor:
+      - name: "BESS Planned Consumption Changes"
+        # `state` is cosmetic -- BESS reads the `blocks` attribute below
+        # regardless of it, precisely so a helper this depends on going
+        # temporarily "unknown" can't block your schedule. Anything
+        # human-readable works; a fixed literal is simplest.
+        state: "ok"
+        attributes:
+          blocks: >
+            {% set blocks = [] %}
+            {# The EV charges overnight: 40 kWh between 22:00 and 06:00.
+               Anchor to YESTERDAY's 22:00 in the small hours, otherwise
+               today_at('22:00') rolls forward at midnight and the running
+               session vanishes from the forecast exactly when it matters. #}
+            {% if is_state('input_boolean.ev_charging_tonight', 'on') %}
+              {% set ev_start = today_at('22:00') - timedelta(days=1)
+                   if now() < today_at('06:00') else today_at('22:00') %}
+              {% set blocks = blocks + [{
+                'start': ev_start.isoformat(),
+                'end': (ev_start + timedelta(hours=8)).isoformat(),
+                'energy_kwh': 40.0
+              }] %}
+            {% endif %}
+            {# Away for the day: hold the whole daytime near zero #}
+            {% if is_state('input_boolean.away_today', 'on') %}
+              {% set blocks = blocks + [{
+                'start': (today_at('08:00')).isoformat(),
+                'end': (today_at('18:00')).isoformat(),
+                'energy_kwh': 1.0,
+                'mode': 'set'
+              }] %}
+            {% endif %}
+            {{ blocks }}
+```
+
+Each entry is a time span plus the energy for that whole span:
+
+| Field | Meaning |
+|---|---|
+| `start`, `end` | ISO-8601 timestamps. **Must include a UTC offset** — `isoformat()` on a HA template time gives you one. |
+| `energy_kwh` | Total kWh across the span, spread over the periods it covers. Not a per-period value. |
+| `mode` | `add` (default) adds to your normal forecast; a **negative** value subtracts. `set` replaces it across the span. |
+
+Use `add` for things that are happening on top of normal (the EV tonight), a negative `add` for a regular load that *isn't* happening (the EV is away, so subtract the usual evening session), and `set` for the blunt cases where you don't know what the baseline holds — away for a week, or forcing a window near zero.
+
+Entries can be timestamped for tomorrow; BESS places them on the real horizon, so an entry that starts at 22:00 and runs to 06:00 is correctly split across midnight.
+
+**One trap when writing overnight entries:** `today_at()` re-evaluates against the current day, so an entry anchored at `today_at('22:00')` jumps forward a full day the moment midnight passes — taking the still-running session out of the forecast just as the optimizer needs it. Anchor to the previous day while you are still inside the window, as the example above does.
+
+**If the declaration is broken, BESS says so rather than ignoring it.** A missing, unavailable or malformed entity is reported as an error on the system health check — declaring an EV session and having it silently dropped would be worse than a clear failure. The one thing BESS corrects rather than rejects: if a subtraction removes more load than your forecast contains, that period is clamped to zero and a warning is raised, because negative consumption isn't physical.
+
 ### EV Charging and Discharge Inhibit
 
 BESS does not control EV charging — it is designed to work alongside it. Under normal circumstances there is no conflict: when electricity is cheap, both the car and the battery charge at the same time.

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -873,6 +873,61 @@ they're cached and only refetched once the date changes, not on a clock
 timer.  Solar has no cache at all: it's fetched live from the HA forecast
 sensor on every quarterly run.
 
+### Planned Consumption Changes (issue #428)
+
+All four strategies above describe *normal* usage — they are built from
+history, or from a constant.  None of them can know that the EV is charging
+tonight, that the pool pump is being skipped, or that the house is empty for
+a week.  The **overlay** is the input channel for exactly that: the user
+declares what differs from normal, and BESS composes it onto whichever
+strategy is configured.
+
+It is **not a fifth strategy**.  It is a post-processing stage, so it applies
+identically on top of `ha_statistics`, `influxdb_7d_avg`, `sensor` and
+`fixed`.  An install with no overlay entity configured keeps precisely the
+forecast it would have had — "no overlay" is a supported configuration, not a
+degraded one, which is why the feature has no cold-start step.
+
+The user points BESS at a template sensor (`consumption_overlay`) whose
+`blocks` attribute is a sparse list of timestamped spans:
+
+    {start, end, energy_kwh, mode}
+
+`energy_kwh` is the total for the whole span, apportioned across the periods
+the span overlaps — so 15-minute, hourly and arbitrary block boundaries all
+work, and a horizon longer than 96 periods needs no special case.  `mode` is
+`add` (the default; negative values subtract) or `set` (replace the base
+across the span).  A `set` block covering part of a period replaces only that
+fraction, so a block ending at 07:10 does not erase 07:00–07:15 wholesale.
+
+**Where it applies, and why that matters**
+(`battery_system_manager.py::_apply_consumption_overlay`): in
+`_gather_optimization_data`, *after* the daily prediction cache and *after*
+the tomorrow-horizon extension.  Applying it inside `_get_consumption_forecast`
+instead would trap it in the date cache — an overlay edited at noon would do
+nothing until the next day — and would let the extension duplicate today's
+blocks onto tomorrow while dropping blocks genuinely declared for tomorrow.
+
+**DST**: the overlay builds its own period grid with
+`consumption_overlay.period_starts_from`, stepping in UTC and converting back,
+rather than using `time_utils.period_index_to_timestamp`.  That helper does
+wall-clock arithmetic (`day_start + 15min * i`), which on the fall-back day
+steps straight over the repeated local hour: index 11 lands at UTC 00:45 and
+index 12 at UTC 02:00, so every later period is an hour late and the day's
+last four indices collide with the next day's first four.  Harmless for the
+display and logging that helper was written for; not harmless for a consumer
+whose numbers depend on it, which the overlay is the first of.  The helper's
+own flaw is untouched here and still awaits a fix.
+
+**Failure behaviour**: a configured overlay entity that is missing,
+unavailable, or malformed raises `ConsumptionOverlayError` rather than being
+skipped — a user who declared an EV session is worse served by an
+optimization that quietly ignored it.  The one exception is over-subtraction:
+a block removing more load than the base forecast holds clamps that period to
+zero (negative consumption is not physical) and records a
+`CONSUMPTION_OVERLAY_CLAMPED` runtime failure, so it is surfaced rather than
+silent.
+
 
 ## Savings Calculation
 

--- a/frontend/src/components/settings/SensorConfigSection.tsx
+++ b/frontend/src/components/settings/SensorConfigSection.tsx
@@ -140,6 +140,7 @@ function isIntegrationFound(
   }
   if (id === 'weather') return !!shared['weather_entity'];
   if (id === 'consumption_forecast') return !!shared['48h_avg_grid_import'];
+  if (id === 'consumption_overlay') return !!shared['consumption_overlay'];
   if (id === 'discharge_inhibit') return !!shared['discharge_inhibit'];
   return false;
 }

--- a/frontend/src/lib/__tests__/sensorDefinitions.test.ts
+++ b/frontend/src/lib/__tests__/sensorDefinitions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  INTEGRATIONS,
+  VALID_PLATFORMS,
+  SHARED_INTEGRATION_IDS,
+  getActiveSensorsFlat,
+  emptyPerPlatformSensors,
+} from '../sensorDefinitions';
+
+describe('SHARED_INTEGRATION_IDS', () => {
+  // The registry is what routes an integration's sensors into `sensors.shared`,
+  // which is the only non-platform dict the backend ever merges. An
+  // integration that renders but is missing here silently swallows whatever
+  // the user types: it writes to a top-level key nothing reads.
+  it('contains every integration that is not an inverter platform', () => {
+    const platformIds = new Set<string>(VALID_PLATFORMS);
+    const nonPlatform = INTEGRATIONS.map((i) => i.id).filter((id) => !platformIds.has(id));
+
+    const unregistered = nonPlatform.filter((id) => !SHARED_INTEGRATION_IDS.has(id));
+
+    expect(unregistered).toEqual([]);
+  });
+
+  it('routes a shared integration sensor through to the flat backend payload', () => {
+    const sensors = emptyPerPlatformSensors('huawei_solar_luna2000');
+    sensors.shared = { consumption_overlay: 'sensor.bess_consumption_overlay' };
+
+    expect(getActiveSensorsFlat(sensors)['consumption_overlay']).toBe(
+      'sensor.bess_consumption_overlay',
+    );
+  });
+});

--- a/frontend/src/lib/sensorDefinitions.ts
+++ b/frontend/src/lib/sensorDefinitions.ts
@@ -66,7 +66,7 @@ export interface PerPlatformSensors {
 
 /** IDs of non-inverter (shared) integrations. */
 export const SHARED_INTEGRATION_IDS = new Set([
-  'nordpool', 'solar_forecast', 'consumption_forecast',
+  'nordpool', 'solar_forecast', 'consumption_forecast', 'consumption_overlay',
   'phase_current', 'discharge_inhibit', 'weather',
 ]);
 
@@ -537,6 +537,21 @@ export const INTEGRATIONS: IntegrationDef[] = [
         name: 'Consumption',
         sensors: [
           { key: '48h_avg_grid_import', label: '48h Avg Grid Import', required: false },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'consumption_overlay',
+    name: 'Planned Consumption Changes',
+    required: false,
+    description:
+      'Optional. A template sensor whose "blocks" attribute declares consumption you know is coming — an EV session tonight, a pool pump you are skipping. Applies on top of whichever consumption forecast you use.',
+    sensorGroups: [
+      {
+        name: 'Planned Changes',
+        sensors: [
+          { key: 'consumption_overlay', label: 'Planned Consumption Changes', required: false },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Adds **Planned Consumption Changes**: a sparse, timestamped `{start, end, energy_kwh, mode}` overlay applied on top of whichever consumption forecast is configured (`ha_statistics`, `influxdb_7d_avg`, `sensor`, `fixed`) — not a fifth strategy. No overlay entity configured, no change to behaviour.
- `mode: "add"` layers declared energy onto the forecast; `mode: "set"` replaces the forecast across the span (the answer to an absolute/one-off block, and the way to declare a known load without double-counting its own history).
- New `core/bess/consumption_overlay.py`: parsing, composition, and a real-time (UTC-stepped) period grid so DST fall-back days compose correctly.
- Missing/unavailable/malformed overlay entity fails loudly via the runtime failure tracker rather than silently freezing the schedule.

## Design background
This is a deliberate redesign, not the original approach. PR #437 (a hand-authored 96-value series) was closed after a maintainer redesign comment; extensive follow-up discussion on #428 (Frank-Leysen, valexi7, nilaz) converged on the overlay-as-post-processing-stage shape and the `add`/`set` split used here. The updated design, including the residual-baseline (Managed Loads) and battery→EV policy questions intentionally deferred to follow-up issues, is posted on the issue: https://github.com/johanzander/bess-manager/issues/428#issuecomment-5445224631

## Scope assessment
- **Placement**: `_apply_consumption_overlay` is called from `_gather_optimization_data`, *after* the daily prediction cache and *after* the tomorrow-horizon extension. Applying it earlier (e.g. inside `_get_consumption_forecast`) would trap entries behind the date cache on cached strategies, and duplicate/drop them when the horizon extends into tomorrow. Both failure modes are pinned by tests (`test_consumption_overlay.py`).
- **Workaround check**: nothing here routes around an ordering problem with a flag or second construction site — the overlay is a genuine new stage with one call site, positioned where the data is actually final.
- **Category**: local — the change lives entirely inside `BatterySystemManager`'s existing consumption-forecast pipeline; no optimizer-internals (DP, intent classification, control/rate mapping) are touched, confirmed by grep and by review.
- **New classes**: `OverlayBlock` and `OverlayResult` (frozen/plain dataclasses in `consumption_overlay.py`) — the block shape (start, end, energy_kwh, mode) is the design the linked issue discussion converged on and is what's posted at https://github.com/johanzander/bess-manager/issues/428#issuecomment-5445224631; flagging explicitly per the new-class approval checklist item.

## Fix
- `core/bess/consumption_overlay.py` (new): `OverlayBlock`, `parse_overlay_blocks`, `period_starts_from` (UTC-stepped grid), `apply_overlay`.
- `core/bess/battery_system_manager.py`: `_apply_consumption_overlay`, called from `_gather_optimization_data`; runtime-failure reporting via `record_failure_once` (coalesces repeat failures instead of freezing the banner on the first one).
- `core/bess/ha_api_controller.py`: `get_consumption_overlay_blocks()` — returns `[]` when unconfigured, raises `ConsumptionOverlayError` for missing/malformed data. Reads the entity's `blocks` attribute regardless of its `state`, since a template sensor's `state` commonly comes from an unrelated helper that can itself read `unknown` while `blocks` still renders correctly — gating on `state` alone would make the documented example a schedule-stopper.
- `core/bess/sensor_collector.py`, `core/bess/health_check.py`: overlay participates in the prediction health check; an empty declared-blocks list reports OK ("None declared"), not WARNING.
- `frontend/src/lib/sensorDefinitions.ts`, `SensorConfigSection.tsx`: new shared integration, registered in `SHARED_INTEGRATION_IDS` (an earlier omission here was the review's HIGH finding — an unregistered integration silently drops whatever the user configures).
- User-facing naming: **"Planned Consumption Changes"** throughout (backend messages, HA sensor display name, frontend labels, docs) — the name settled on during the design discussion; internal identifiers (`consumption_overlay` sensor key, module/file names) are unchanged.
- Docs: `docs/USER_GUIDE.md` (new section, incl. the midnight-rollover trap for overnight declarations), `docs/agents/bess-knowledge.md` (mechanism + the pre-existing, untouched DST flaw in `period_index_to_timestamp`), `CHANGELOG.md`.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally — Black, Ruff, mypy (changed files), frontend tests, TypeScript, ESLint, permission surface, bot workflow contracts all green. **3 known pre-existing failures** in `backend/tests/test_quality_check_mypy_gate.py` are unrelated to this branch (confirmed: neither that test file nor `quality-check.sh` is touched here) — the test's synthetic stub project lacks `.github/workflows/` and `.claude/settings.json`, which a workflow-contract check added independently of this PR now expects to exist.
- [x] Fast suite: 2305 passed, 50 skipped (+ the 3 known-unrelated failures above). Slow suite: 564 passed, 10 skipped.
- [x] Local mock-HA E2E (`docker-compose.ci.yml`, `ci-normal-day` scenario, `libfaketime` pinned to the scenario's date): configured a `sensor.bess_consumption_overlay` template sensor with a 10 kWh EV block for 20:00–22:00, wired it into settings, and confirmed via container logs that a real `update_battery_schedule` run applied it: `Applied planned consumption changes: 1 entr(y/ies), 10.0 kWh net over the horizon`. The served schedule (`/api/growatt/detailed_schedule`) showed real DP-derived strategic intents afterward (not the empty-schedule fallback). System health reported `Planned Consumption Changes: OK` throughout. Verification-only scenario/settings edits were reverted before commit — not part of this diff.

## Evidence the test discriminates
The DST fix (`_overlap_seconds` measured each period's end via naive `period_start + PERIOD_DURATION`, disagreeing with the UTC-stepped grid across the 2026-10-25 fall-back hour):
- Reverted: the UTC-based `period_end` computation in `_overlap_seconds`, back to `period_start + PERIOD_DURATION`.
- Result: `test_apply_overlay_delivers_full_energy_across_the_dst_fall_back_hour` FAILED — an 8.0 kWh declared block delivered 10.0 kWh (`assert 10.0 == 8.0 ± 8e-06`), matching the exact bug measured during review (overlap inflated on the repeated hour, then zeroed for the following periods).
- Restored: fix reapplied, 17/17 tests in `test_consumption_overlay.py` pass.

State-gating fix (`get_consumption_overlay_blocks` previously required `state` to be a real value before reading `blocks`, which the documented template example — `state` sourced from an `input_boolean` — could itself defeat):
- Reverted: N/A (new test written directly against the pre-fix code path, confirmed RED first).
- Result: `TestConsumptionOverlayBlocksStateGating::test_blocks_are_read_even_when_state_is_unknown` / `..._is_unavailable` FAILED against the original state-first check (raised `ConsumptionOverlayError: ... is unavailable`/`is unknown` even though `blocks` was present and valid).
- Restored: fix applied (check `blocks` first, fall back to reporting `state` only when there's no data), all 4 new tests + full `test_ha_api_controller.py` (149 tests) pass.

## Outcome-level coverage
- `test_consumption_overlay.py` (17 tests): composition arithmetic (`add`/`set`, DST contiguity, clamping), parsing/validation, and four tests exercising `_gather_optimization_data` directly to confirm the overlay's output actually reaches `full_consumption` — not a synthetic-input unit test on the changed function in isolation.
- `test_ha_api_controller.py::TestConsumptionOverlayBlocksStateGating` (4 tests): the state-vs-blocks precedence fix.
- `test_prediction_health_check.py::TestConsumptionOverlay` (4 tests): health-check participation, including the empty-blocks-is-OK regression.
- No `R == P` plan-faithfulness scenario test: this change alters an *input vector* to the DP (`consumption_predictions`, before `_run_optimization`) and touches no DP internals, intent classification, or control/rate mapping. Given an identical input vector, everything downstream behaves exactly as before, so a full scenario pin would re-test unchanged code with no discriminating power here — confirmed independently by the background code-review agent's read of the diff.

Refs #428

