### PR TITLE
feat: exclude a managed load from the ha_statistics baseline (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - **Tell BESS what consumption is coming with Planned Consumption Changes** — declare an EV session or a skipped pool pump in a template sensor, and it applies on top of whichever consumption forecast you already use. ([#428](https://github.com/johanzander/bess-manager/issues/428))
+- **Managed Loads — exclude a regular habit like EV charging from the `ha_statistics` baseline** — name the load's own cumulative energy sensor and BESS learns your normal usage without it, so you can announce it separately via Planned Consumption Changes. ([#706](https://github.com/johanzander/bess-manager/issues/706))
 
 ### Fixed
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -201,6 +201,30 @@ def _validate_consumption_strategy(home_section: dict, active_sensors: dict) -> 
         )
 
 
+def _validate_managed_load_sensors(home_section: dict) -> None:
+    """Raise HTTPException(422) if managed_load_sensors isn't a list of entity IDs.
+
+    ``sensors`` section values are validated against ``_ENTITY_ID_RE`` before
+    persisting (see the PATCH handler); managed_load_sensors lives in
+    ``home`` instead, since it is a list rather than a single sensor_key ->
+    entity_id mapping, so it needs the same check applied here.
+    """
+    sensors = home_section.get("managed_load_sensors")
+    if sensors is None:
+        return
+    if not isinstance(sensors, list):
+        raise HTTPException(
+            status_code=422,
+            detail="managed_load_sensors must be a list of entity IDs",
+        )
+    for entity_id in sensors:
+        if not isinstance(entity_id, str) or not _ENTITY_ID_RE.match(entity_id):
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid entity ID format in managed_load_sensors: {entity_id!r}",
+            )
+
+
 def _require_configured_system(bess_controller) -> None:
     """Raise HTTP 503 if the BESS system has not been configured yet.
 
@@ -371,6 +395,7 @@ async def patch_settings(updates: dict):
                 }
                 _validate_power_monitoring_sensors(section, effective_sensors)
                 _validate_consumption_strategy(section, effective_sensors)
+                _validate_managed_load_sensors(section)
 
             if store_key == "sensors":
                 # A sensor removal (e.g. unmapping a phase-current sensor) can
@@ -3143,6 +3168,7 @@ async def setup_complete(payload: APISetupCompletePayload):
             "safetyMarginFactor": "safety_margin",
             "phaseCount": "phase_count",
             "powerMonitoringEnabled": "power_monitoring_enabled",
+            "managedLoadSensors": "managed_load_sensors",
         }
         if any(getattr(payload, f) is not None for f in _HOME_MAP):
             home = bess_controller.settings_store.get_section("home")
@@ -3155,6 +3181,7 @@ async def setup_complete(payload: APISetupCompletePayload):
             }
             _validate_power_monitoring_sensors(home, effective_sensors)
             _validate_consumption_strategy(home, effective_sensors)
+            _validate_managed_load_sensors(home)
             sections["home"] = home
 
         # --- electricity price ---
@@ -3294,6 +3321,7 @@ async def setup_complete(payload: APISetupCompletePayload):
                     "safety_margin": payload.safetyMarginFactor,
                     "phase_count": payload.phaseCount,
                     "power_monitoring_enabled": payload.powerMonitoringEnabled,
+                    "managed_load_sensors": payload.managedLoadSensors,
                 }
             )
         if "electricity_price" in sections:

--- a/backend/api_dataclasses.py
+++ b/backend/api_dataclasses.py
@@ -1136,6 +1136,7 @@ class APISetupCompletePayload(BaseModel):
     safetyMarginFactor: float | None = None
     phaseCount: int | None = None
     powerMonitoringEnabled: bool | None = None
+    managedLoadSensors: list[str] | None = None
     # Electricity price settings
     area: str | None = None
     markupRate: float | None = None

--- a/backend/tests/test_settings_contracts.py
+++ b/backend/tests/test_settings_contracts.py
@@ -349,9 +349,10 @@ _BATTERY_OPTIONAL_FIELDS = frozenset(
     }
 )
 # min_valid is an internal algorithm parameter, never read from the settings
-# store or written by the wizard — the one field HOME_MODEL_ATTRS has that
-# HOME_REQUIRED_FIELDS doesn't.
-_HOME_OPTIONAL_FIELDS = frozenset({"min_valid"})
+# store or written by the wizard. managed_load_sensors defaults to an empty
+# list and must stay absent-tolerant for every settings.json persisted before
+# issue #706 — requiring it at startup would break every existing install.
+_HOME_OPTIONAL_FIELDS = frozenset({"min_valid", "managed_load_sensors"})
 
 
 @pytest.mark.parametrize(

--- a/core/bess/battery_system_manager.py
+++ b/core/bess/battery_system_manager.py
@@ -27,6 +27,7 @@ from .exceptions import (
     ConsumptionOverlayError,
     HAStatisticsUnavailableError,
     HistoricalDataUnavailableError,
+    ManagedLoadsError,
     SystemConfigurationError,
 )
 from .execution_model import PlatformCapabilities, intra_period_discharge_gate
@@ -42,6 +43,7 @@ from .historical_data_store import HistoricalDataStore
 from .huawei_controller import HuaweiController
 from .influxdb_helper import get_power_sensor_data_batch, is_influxdb_configured
 from .inverter_controller import InverterController
+from .managed_loads import subtract_managed_loads
 from .models import (
     DecisionData,
     EconomicData,
@@ -1339,7 +1341,7 @@ class BatterySystemManager:
                     "HA_STATISTICS_FALLBACK"
                 )
                 return result
-            except HAStatisticsUnavailableError as e:
+            except (HAStatisticsUnavailableError, ManagedLoadsError) as e:
                 quarterly = self.home_settings.default_hourly / 4.0
                 logger.warning(
                     "HA statistics unavailable (%s), falling back to fixed "
@@ -1431,6 +1433,53 @@ class BatterySystemManager:
 
         return avg_profile
 
+    def _fetch_recorder_change_stats(
+        self, entity_id: str, start_dt: datetime, end_dt: datetime
+    ) -> tuple[str, list[dict]]:
+        """Fetch one entity's raw hourly 'change' statistics for [start_dt, end_dt).
+
+        Shared by the main load-consumption sensor and each managed-load
+        sensor in _fetch_ha_statistics_raw — both are HA Recorder long-term
+        statistics reads with the same discovery fallback.
+
+        Returns:
+            (statistic_id, stats) — stats is the raw HA Recorder list of
+            {"start": ..., "change": ...} entries, or [] if none exist.
+        """
+        if not entity_id.startswith("sensor."):
+            entity_id = f"sensor.{entity_id}"
+
+        # Try direct entity_id first, then discover the correct statistic_id
+        # (external integrations may register statistics under a different ID)
+        statistic_id = entity_id
+        result = self._controller.get_statistics_during_period(
+            statistic_ids=[statistic_id],
+            start_time=start_dt.isoformat(),
+            end_time=end_dt.isoformat(),
+            period="hour",
+            types=["change"],
+        )
+        stats = result.get(statistic_id, [])
+        if not stats:
+            discovered_id = self._controller.find_statistic_id(entity_id)
+            if discovered_id and discovered_id != statistic_id:
+                logger.info(
+                    "Statistic ID for %s is %s (differs from entity_id)",
+                    entity_id,
+                    discovered_id,
+                )
+                statistic_id = discovered_id
+                result = self._controller.get_statistics_during_period(
+                    statistic_ids=[statistic_id],
+                    start_time=start_dt.isoformat(),
+                    end_time=end_dt.isoformat(),
+                    period="hour",
+                    types=["change"],
+                )
+                stats = result.get(statistic_id, [])
+
+        return statistic_id, stats
+
     def _fetch_ha_statistics_raw(self) -> tuple[str, list[dict]]:
         """Resolve the load-consumption statistic_id and fetch its raw 7-day stats.
 
@@ -1438,12 +1487,20 @@ class BatterySystemManager:
         time-of-day profile) and get_ha_statistics_for_debug_export (which
         exports it verbatim for exact-fidelity mock replay).
 
+        If managed_load_sensors is configured, each one's own 7-day stats are
+        fetched the same way and subtracted before returning — the residual
+        is what both callers see, so the debug export stays consistent with
+        what the forecast actually uses (issue #706).
+
         Returns:
             (statistic_id, stats) — stats is the raw HA Recorder
-            list of {"start": ..., "change": ...} entries.
+            list of {"start": ..., "change": ...} entries, residual of any
+            configured managed loads.
 
         Raises:
             HAStatisticsUnavailableError: sensor not configured, or no
+                statistics data available for it in the past 7 days.
+            ManagedLoadsError: a configured managed-load sensor has no
                 statistics data available for it in the past 7 days.
         """
         from datetime import time
@@ -1470,42 +1527,39 @@ class BatterySystemManager:
         start_dt = datetime.combine(start_date, time(0, 0), tzinfo=tz)
         end_dt = datetime.combine(today_date, time(0, 0), tzinfo=tz)
 
-        # Try direct entity_id first, then discover the correct statistic_id
-        # (external integrations may register statistics under a different ID)
-        statistic_id = target_sensor
-        result = self._controller.get_statistics_during_period(
-            statistic_ids=[statistic_id],
-            start_time=start_dt.isoformat(),
-            end_time=end_dt.isoformat(),
-            period="hour",
-            types=["change"],
+        statistic_id, stats = self._fetch_recorder_change_stats(
+            target_sensor, start_dt, end_dt
         )
-
-        stats = result.get(statistic_id, [])
-        if not stats:
-            # Entity_id didn't match — discover the correct statistic_id
-            discovered_id = self._controller.find_statistic_id(target_sensor)
-            if discovered_id and discovered_id != statistic_id:
-                logger.info(
-                    "Statistic ID for %s is %s (differs from entity_id)",
-                    target_sensor,
-                    discovered_id,
-                )
-                statistic_id = discovered_id
-                result = self._controller.get_statistics_during_period(
-                    statistic_ids=[statistic_id],
-                    start_time=start_dt.isoformat(),
-                    end_time=end_dt.isoformat(),
-                    period="hour",
-                    types=["change"],
-                )
-                stats = result.get(statistic_id, [])
-
         if not stats:
             raise HAStatisticsUnavailableError(
                 f"No statistics data returned for {target_sensor} "
                 f"(statistic_id: {statistic_id}) in the past 7 days"
             )
+
+        managed_load_sensors = self.home_settings.managed_load_sensors
+        if managed_load_sensors:
+            managed_stats = []
+            for sensor_entity_id in managed_load_sensors:
+                _, m_stats = self._fetch_recorder_change_stats(
+                    sensor_entity_id, start_dt, end_dt
+                )
+                if not m_stats:
+                    raise ManagedLoadsError(
+                        f"No statistics data returned for managed-load sensor "
+                        f"'{sensor_entity_id}' in the past 7 days"
+                    )
+                managed_stats.append(m_stats)
+
+            stats, clamped_hours = subtract_managed_loads(stats, managed_stats)
+            if clamped_hours:
+                logger.warning(
+                    "Managed-load subtraction clamped %d/%d hours to 0 for %s "
+                    "(a managed load's own historical draw exceeded the total "
+                    "load sensor's for those hours)",
+                    clamped_hours,
+                    len(stats),
+                    target_sensor,
+                )
 
         return statistic_id, stats
 
@@ -1523,7 +1577,7 @@ class BatterySystemManager:
             return None
         try:
             statistic_id, stats = self._fetch_ha_statistics_raw()
-        except HAStatisticsUnavailableError:
+        except (HAStatisticsUnavailableError, ManagedLoadsError):
             return None
         return {"statistic_id": statistic_id, "stats": stats}
 

--- a/core/bess/exceptions.py
+++ b/core/bess/exceptions.py
@@ -102,3 +102,14 @@ class ConsumptionOverlayError(BESSException):
     EV session and got half of it applied is worse off than one told their
     template is wrong.
     """
+
+
+class ManagedLoadsError(BESSException):
+    """A managed-load sensor's historical statistics could not be fetched.
+
+    Raised rather than silently forecasting on the un-subtracted baseline: a
+    user who excluded their EV charger from "normal" load and got no
+    subtraction applied is worse off than one told their sensor is
+    unreadable, since the forecast would silently overstate consumption by
+    the missing residual.
+    """

--- a/core/bess/managed_loads.py
+++ b/core/bess/managed_loads.py
@@ -1,0 +1,85 @@
+"""Managed loads — exclude a declared load from the consumption forecast baseline.
+
+Issue #706. The `ha_statistics` strategy learns "normal" load from history,
+which bakes in any managed load (typically EV charging) that happened during
+the training window: an EV session that occurred yesterday reads as part of
+today's expected pattern. Managed loads is the exclusion mechanism — the
+user names the load's own cumulative/lifetime energy sensor, its energy is
+subtracted from the historical data before the baseline is computed, and the
+learned "normal" becomes the residual (house load with managed loads
+excluded). The user then re-declares any expected managed-load energy via
+Planned Consumption Changes (`consumption_overlay`), which composes on top
+of this residual baseline exactly as it does today.
+
+Scoped to `ha_statistics` only: `influxdb_7d_avg` pulls instantaneous power
+samples from InfluxDB, a different data source/shape than HA Recorder's
+cumulative `change` values, and needs its own subtraction mechanism.
+"""
+
+from .exceptions import ManagedLoadsError
+
+# HA Recorder statistics entries are {"start": <epoch-ms int, or ISO string>,
+# "change": <float>}. Same query (same statistic_id set, start_time, end_time,
+# period="hour") returns identical "start" values across calls, so matching
+# by the raw "start" value -- whatever type it is -- is exact; no parsing
+# needed.
+StatEntry = dict
+
+
+def subtract_managed_loads(
+    base_stats: list[StatEntry],
+    managed_stats: list[list[StatEntry]],
+) -> tuple[list[StatEntry], int]:
+    """Subtract each managed load's per-hour energy from the base sensor's.
+
+    Args:
+        base_stats: The `lifetime_load_consumption` sensor's raw
+            {"start", "change"} entries for the training window.
+        managed_stats: One raw entry list per managed-load sensor, fetched
+            over the identical window (same statistic query parameters as
+            ``base_stats``, so "start" values line up exactly).
+
+    Returns:
+        (adjusted_stats, clamped_hours) -- adjusted_stats has the same
+        "start" values as base_stats, with "change" reduced by the sum of
+        matching managed-load hours. A managed load can only ever reduce
+        recorded load, never invert it, so any hour where the subtraction
+        would go negative is floored at 0.0 and counted in clamped_hours --
+        this means the managed load's own historical draw exceeded the total
+        load sensor's for that hour, which points at a sensor/entity
+        mismatch worth surfacing, not silently absorbing.
+
+    Raises:
+        ManagedLoadsError: A managed-load entry is missing "start" or
+            "change" -- never skipped, since silently dropping an hour would
+            silently understate the subtraction for that hour.
+    """
+    managed_by_start: dict[object, float] = {}
+    for stats in managed_stats:
+        for entry in stats:
+            if "start" not in entry or "change" not in entry:
+                raise ManagedLoadsError(
+                    f"managed-load statistics entry is missing 'start' or "
+                    f"'change': {entry!r}"
+                )
+            change = entry["change"]
+            if change is None:
+                continue
+            start = entry["start"]
+            managed_by_start[start] = managed_by_start.get(start, 0.0) + float(change)
+
+    adjusted: list[StatEntry] = []
+    clamped_hours = 0
+    for entry in base_stats:
+        change = entry.get("change")
+        if change is None:
+            adjusted.append(entry)
+            continue
+        managed = managed_by_start.get(entry.get("start"), 0.0)
+        residual = float(change) - managed
+        if residual < 0:
+            residual = 0.0
+            clamped_hours += 1
+        adjusted.append({**entry, "change": residual})
+
+    return adjusted, clamped_hours

--- a/core/bess/settings.py
+++ b/core/bess/settings.py
@@ -215,6 +215,7 @@ class HomeSettings:
     currency: str = DEFAULT_CURRENCY
     consumption_strategy: str = "fixed"
     power_monitoring_enabled: bool = False
+    managed_load_sensors: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         assert self.phase_count in (

--- a/core/bess/tests/unit/test_ha_statistics_forecast.py
+++ b/core/bess/tests/unit/test_ha_statistics_forecast.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from core.bess.battery_system_manager import BatterySystemManager
-from core.bess.exceptions import HAStatisticsUnavailableError
+from core.bess.exceptions import HAStatisticsUnavailableError, ManagedLoadsError
 from core.bess.runtime_failure_tracker import RuntimeFailureTracker
 from core.bess.settings import BatterySettings, HomeSettings
 from core.bess.tests.conftest import MockHomeAssistantController
@@ -316,3 +316,66 @@ class TestHAStatisticsDispatch:
 
         assert len(result) == 96
         assert all(v == 4.0 / 4.0 for v in result)
+
+
+class TestManagedLoadsSubtraction:
+    """Issue #706: managed_load_sensors excludes a load from the baseline."""
+
+    def test_forecast_reflects_residual_after_subtracting_managed_load(self):
+        """A flat managed load subtracted from a flat base halves the forecast."""
+        hourly_kwh = [2.0] * 24
+        ev_hourly_kwh = [1.0] * 24
+
+        base_stats = _make_hourly_stats(hourly_kwh)
+        ev_stats = _make_hourly_stats(ev_hourly_kwh)
+
+        controller = MockHomeAssistantController()
+        stat_id = "sensor.load_energy_total"
+        ev_stat_id = "sensor.ev_charger_energy_total"
+        manager = _create_manager_with_stats(
+            controller, {stat_id: base_stats, ev_stat_id: ev_stats}
+        )
+        manager.home_settings.managed_load_sensors = [ev_stat_id]
+
+        with patch("core.bess.battery_system_manager.time_utils") as mock_tu:
+            mock_tu.today.return_value = datetime(2026, 5, 12, tzinfo=TIMEZONE).date()
+            mock_tu.TIMEZONE = TIMEZONE
+            result = manager._get_ha_statistics_forecast()
+
+        # 2.0 kWh/h base - 1.0 kWh/h EV = 1.0 kWh/h residual = 0.25 kWh/quarter
+        assert len(result) == 96
+        assert all(v == pytest.approx(0.25) for v in result)
+
+    def test_no_managed_loads_leaves_forecast_unchanged(self):
+        """Baseline behaviour is unaffected when managed_load_sensors is empty."""
+        hourly_kwh = [2.0] * 24
+        stats = _make_hourly_stats(hourly_kwh)
+        controller = MockHomeAssistantController()
+        stat_id = "sensor.load_energy_total"
+        manager = _create_manager_with_stats(controller, {stat_id: stats})
+        assert manager.home_settings.managed_load_sensors == []
+
+        with patch("core.bess.battery_system_manager.time_utils") as mock_tu:
+            mock_tu.today.return_value = datetime(2026, 5, 12, tzinfo=TIMEZONE).date()
+            mock_tu.TIMEZONE = TIMEZONE
+            result = manager._get_ha_statistics_forecast()
+
+        assert all(v == pytest.approx(0.5) for v in result)
+
+    def test_missing_managed_load_statistics_raises(self):
+        """A configured managed-load sensor with no statistics data is a hard error,
+        not a silent skip -- the residual would otherwise silently overstate load."""
+        hourly_kwh = [2.0] * 24
+        base_stats = _make_hourly_stats(hourly_kwh)
+
+        controller = MockHomeAssistantController()
+        stat_id = "sensor.load_energy_total"
+        # No entry for the EV sensor's statistic_id in the mock response.
+        manager = _create_manager_with_stats(controller, {stat_id: base_stats})
+        manager.home_settings.managed_load_sensors = ["sensor.ev_charger_energy_total"]
+
+        with patch("core.bess.battery_system_manager.time_utils") as mock_tu:
+            mock_tu.today.return_value = datetime(2026, 5, 12, tzinfo=TIMEZONE).date()
+            mock_tu.TIMEZONE = TIMEZONE
+            with pytest.raises(ManagedLoadsError):
+                manager._get_ha_statistics_forecast()

--- a/core/bess/tests/unit/test_ha_statistics_forecast.py
+++ b/core/bess/tests/unit/test_ha_statistics_forecast.py
@@ -321,7 +321,7 @@ class TestHAStatisticsDispatch:
 class TestManagedLoadsSubtraction:
     """Issue #706: managed_load_sensors excludes a load from the baseline."""
 
-    def test_forecast_reflects_residual_after_subtracting_managed_load(self):
+    def test_forecast_reflects_residual_after_subtracting_managed_load(self) -> None:
         """A flat managed load subtracted from a flat base halves the forecast."""
         hourly_kwh = [2.0] * 24
         ev_hourly_kwh = [1.0] * 24
@@ -346,7 +346,7 @@ class TestManagedLoadsSubtraction:
         assert len(result) == 96
         assert all(v == pytest.approx(0.25) for v in result)
 
-    def test_no_managed_loads_leaves_forecast_unchanged(self):
+    def test_no_managed_loads_leaves_forecast_unchanged(self) -> None:
         """Baseline behaviour is unaffected when managed_load_sensors is empty."""
         hourly_kwh = [2.0] * 24
         stats = _make_hourly_stats(hourly_kwh)
@@ -362,7 +362,7 @@ class TestManagedLoadsSubtraction:
 
         assert all(v == pytest.approx(0.5) for v in result)
 
-    def test_missing_managed_load_statistics_raises(self):
+    def test_missing_managed_load_statistics_raises(self) -> None:
         """A configured managed-load sensor with no statistics data is a hard error,
         not a silent skip -- the residual would otherwise silently overstate load."""
         hourly_kwh = [2.0] * 24

--- a/core/bess/tests/unit/test_managed_loads.py
+++ b/core/bess/tests/unit/test_managed_loads.py
@@ -1,0 +1,98 @@
+"""Unit tests for managed-load subtraction (issue #706)."""
+
+import pytest
+
+from core.bess.exceptions import ManagedLoadsError
+from core.bess.managed_loads import subtract_managed_loads
+
+
+def test_subtracts_one_managed_load_hour_by_hour() -> None:
+    base_stats = [
+        {"start": 1000, "change": 5.0},
+        {"start": 2000, "change": 3.0},
+        {"start": 3000, "change": 1.0},
+    ]
+    ev_stats = [
+        {"start": 1000, "change": 2.0},
+        {"start": 2000, "change": 0.0},
+        {"start": 3000, "change": 0.5},
+    ]
+
+    adjusted, clamped = subtract_managed_loads(base_stats, [ev_stats])
+
+    assert clamped == 0
+    assert [e["change"] for e in adjusted] == pytest.approx([3.0, 3.0, 0.5])
+    # start values are preserved unchanged
+    assert [e["start"] for e in adjusted] == [1000, 2000, 3000]
+
+
+def test_sums_multiple_managed_loads_for_the_same_hour() -> None:
+    base_stats = [{"start": 1000, "change": 10.0}]
+    car1 = [{"start": 1000, "change": 3.0}]
+    car2 = [{"start": 1000, "change": 4.0}]
+
+    adjusted, clamped = subtract_managed_loads(base_stats, [car1, car2])
+
+    assert clamped == 0
+    assert adjusted[0]["change"] == pytest.approx(3.0)  # 10 - 3 - 4
+
+
+def test_clamps_negative_residual_to_zero_and_counts_it() -> None:
+    # A managed load reporting more than the total load sensor for that hour
+    # -- e.g. a sensor/entity mismatch -- must not go negative.
+    base_stats = [
+        {"start": 1000, "change": 1.0},
+        {"start": 2000, "change": 5.0},
+    ]
+    ev_stats = [
+        {"start": 1000, "change": 4.0},  # exceeds base -> clamp
+        {"start": 2000, "change": 2.0},  # within base -> no clamp
+    ]
+
+    adjusted, clamped = subtract_managed_loads(base_stats, [ev_stats])
+
+    assert clamped == 1
+    assert [e["change"] for e in adjusted] == pytest.approx([0.0, 3.0])
+
+
+def test_hours_with_no_matching_managed_load_entry_are_unaffected() -> None:
+    base_stats = [
+        {"start": 1000, "change": 5.0},
+        {"start": 2000, "change": 5.0},
+    ]
+    # Managed load only reports for the first hour.
+    ev_stats = [{"start": 1000, "change": 1.0}]
+
+    adjusted, clamped = subtract_managed_loads(base_stats, [ev_stats])
+
+    assert clamped == 0
+    assert [e["change"] for e in adjusted] == pytest.approx([4.0, 5.0])
+
+
+def test_base_entries_with_no_change_pass_through_unchanged() -> None:
+    base_stats = [{"start": 1000, "change": None}]
+    ev_stats = [{"start": 1000, "change": 2.0}]
+
+    adjusted, clamped = subtract_managed_loads(base_stats, [ev_stats])
+
+    assert clamped == 0
+    assert adjusted == [{"start": 1000, "change": None}]
+
+
+def test_malformed_managed_load_entry_raises_rather_than_silently_understating() -> (
+    None
+):
+    base_stats = [{"start": 1000, "change": 5.0}]
+    malformed = [{"start": 1000}]  # missing 'change'
+
+    with pytest.raises(ManagedLoadsError):
+        subtract_managed_loads(base_stats, [malformed])
+
+
+def test_no_managed_loads_returns_base_stats_unchanged() -> None:
+    base_stats = [{"start": 1000, "change": 5.0}]
+
+    adjusted, clamped = subtract_managed_loads(base_stats, [])
+
+    assert clamped == 0
+    assert adjusted == base_stats

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -346,6 +346,16 @@ Requires the `lifetime_load_consumption` sensor configured in the **Sensors** ta
 
 This is the recommended strategy for most users — it adapts to your actual usage patterns with no extra integrations or configuration beyond a cumulative load sensor.
 
+#### Managed Loads — excluding a regular habit from the baseline
+
+The trimmed mean above filters out an occasional spike, but not a *regular* one — if you charge your EV most nights, `ha_statistics` learns that as part of your normal pattern and forecasts it every night, whether or not you're actually charging. **Managed Loads** is how you tell BESS to exclude a load entirely and announce it yourself instead.
+
+In the **Home** settings tab, under `ha_statistics`, add the load's own cumulative/lifetime energy sensor (e.g. `sensor.ev_charger_energy_total` — most EV chargers expose one; tools like evcc can synthesize one for chargers that don't) to **Managed load sensors**. BESS subtracts that sensor's energy from the historical data before computing the baseline, so the learned "normal" becomes the residual — your house load with the managed load excluded.
+
+With the load excluded, it simply isn't forecast at all unless you say otherwise — the recommended setup is to exclude it here, then announce expected sessions via **Planned Consumption Changes** below (e.g. "EV needs 8 kWh by 06:30"). This is the same residual-plus-announcement pattern EMHASS uses for controllable loads.
+
+Only `ha_statistics` supports this today — `influxdb_7d_avg` draws from a different data source and would need its own mechanism.
+
 #### Comparing Strategies
 
 The **Insights** page includes a **Consumption Forecast Comparison** section that evaluates all available strategies against your actual consumption. Each strategy shows its hourly profile overlaid on actual data, along with a Mean Absolute Error (MAE) metric. Use this to verify which strategy best matches your real consumption patterns before committing to one.

--- a/docs/agents/bess-knowledge.md
+++ b/docs/agents/bess-knowledge.md
@@ -857,7 +857,8 @@ The optimizer needs a consumption forecast.  Four strategies exist:
   does **not** strip out a regular/nightly EV charging habit — if most of
   the 7 samples for an hour are elevated together, the average stays high
   and the forecast correctly bakes that load in.  Higher during evening
-  peaks, lower overnight.
+  peaks, lower overnight.  A regular habit can be excluded deliberately via
+  **Managed Loads**, below.
 - **influxdb_7d_avg**: Same concept but queries InfluxDB instead of HA.
 - **sensor**: Reads a 48-hour rolling average sensor.  Produces a flat
   prediction (same value all day).
@@ -927,6 +928,36 @@ a block removing more load than the base forecast holds clamps that period to
 zero (negative consumption is not physical) and records a
 `CONSUMPTION_OVERLAY_CLAMPED` runtime failure, so it is surfaced rather than
 silent.
+
+
+### Managed Loads (issue #706)
+
+`ha_statistics`'s trimmed mean (above) discounts a one-off spike but bakes in
+a *regular* habit — a nightly EV charge reads as part of "normal" load, so
+the learned baseline overstates typical consumption by however much of that
+habit occurred in the 7-day training window.  Managed Loads is the
+deliberate-exclusion mechanism: the user names the load's own
+cumulative/lifetime energy sensor (`home.managed_load_sensors`, a list), and
+its per-hour energy is subtracted from `lifetime_load_consumption`'s raw HA
+Recorder statistics *before* the hour-of-day buckets are built, so the
+learned "normal" becomes the residual — house load with the managed load
+excluded.  The user then re-declares any expected managed-load energy via
+Planned Consumption Changes (`add` mode), which composes on top of the
+residual exactly as it does on top of any other baseline.
+
+Scoped to `ha_statistics` only: `influxdb_7d_avg` pulls instantaneous power
+samples from InfluxDB, a different data source/shape than HA Recorder's
+cumulative `change` values, and needs its own subtraction mechanism if ever
+added.
+
+**Failure behaviour** (`managed_loads.subtract_managed_loads`): a configured
+managed-load sensor with no statistics data raises `ManagedLoadsError` rather
+than silently forecasting on the un-subtracted baseline — the forecast would
+otherwise quietly overstate consumption by the missing residual. Subtraction
+can only reduce recorded load, never invert it: an hour where the managed
+load's own draw exceeds the total load sensor's (a sensor/entity mismatch) is
+clamped to zero and logged, the same "surface it, don't absorb it" pattern
+the overlay uses for over-subtraction.
 
 
 ## Savings Calculation

--- a/frontend/src/components/settings/HomeFormSection.tsx
+++ b/frontend/src/components/settings/HomeFormSection.tsx
@@ -9,6 +9,66 @@ export interface HomeForm {
   safetyMarginFactor: number;
   phaseCount: number;
   powerMonitoringEnabled: boolean;
+  /** Cumulative/lifetime energy sensors for loads (typically EV chargers)
+   * to exclude from the ha_statistics baseline before it is computed —
+   * see issue #706. Empty by default; only meaningful for that strategy. */
+  managedLoadSensors: string[];
+}
+
+/** Add/remove list of managed-load sensor entity IDs. Only shown for the
+ * ha_statistics strategy, since it is the only baseline this subtracts from
+ * today (issue #706) — influxdb_7d_avg needs its own mechanism. */
+function ManagedLoadSensorsField({
+  sensors,
+  onChange,
+}: {
+  sensors: string[];
+  onChange: (_: string[]) => void;
+}) {
+  return (
+    <div className="pt-2">
+      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        Managed load sensors
+      </span>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+        Cumulative/lifetime energy sensors (e.g. an EV charger) to exclude from
+        the learned baseline above. Re-declare their expected energy via
+        Planned Consumption Changes in the <strong>Sensors</strong> tab.
+      </p>
+      <div className="space-y-2">
+        {sensors.map((entityId, index) => (
+          <div key={index} className="flex gap-2">
+            <input
+              type="text"
+              value={entityId}
+              placeholder="sensor.ev_charger_energy_total"
+              onChange={e => {
+                const next = [...sensors];
+                next[index] = e.target.value;
+                onChange(next);
+              }}
+              className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-1.5 text-sm font-mono text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="button"
+              onClick={() => onChange(sensors.filter((_, i) => i !== index))}
+              className="px-2 text-xs text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400"
+              aria-label={`Remove managed load sensor ${index + 1}`}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => onChange([...sensors, ''])}
+          className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          + Add managed load sensor
+        </button>
+      </div>
+    </div>
+  );
 }
 
 interface Props {
@@ -82,12 +142,18 @@ export function HomeFormSection({ form, onChange, sensors }: Props) {
           </p>
         )}
         {form.consumptionStrategy === 'ha_statistics' && (
-          <p className="text-xs text-gray-500 dark:text-gray-400 pt-1">
-            Uses Home Assistant's built-in long-term statistics to build a time-of-day consumption profile
-            from the past 7 days. Captures daily patterns (morning/evening peaks, overnight baseline) using
-            a trimmed average that filters out outlier spikes like EV charging. No extra integrations needed.
-            Configure the load consumption sensor in the <strong>Sensors</strong> tab under Consumption Forecast.
-          </p>
+          <div className="pt-1">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Uses Home Assistant's built-in long-term statistics to build a time-of-day consumption profile
+              from the past 7 days. Captures daily patterns (morning/evening peaks, overnight baseline) using
+              a trimmed average that filters out outlier spikes like EV charging. No extra integrations needed.
+              Configure the load consumption sensor in the <strong>Sensors</strong> tab under Consumption Forecast.
+            </p>
+            <ManagedLoadSensorsField
+              sensors={form.managedLoadSensors}
+              onChange={v => onChange({ ...form, managedLoadSensors: v })}
+            />
+          </div>
         )}
       </SectionCard>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -47,6 +47,7 @@ const EMPTY_HOME: HomeForm = {
   consumption: 3.5, consumptionStrategy: 'fixed',
   maxFuseCurrent: 25, voltage: 230, safetyMarginFactor: 1.0,
   phaseCount: 3, powerMonitoringEnabled: true,
+  managedLoadSensors: [],
 };
 const EMPTY_PRICING: PricingForm = {
   currency: 'SEK',
@@ -187,6 +188,7 @@ const SettingsPage: React.FC = () => {
         safetyMarginFactor: home_s.safetyMargin ?? 1.0,
         phaseCount: home_s.phaseCount ?? 3,
         powerMonitoringEnabled: home_s.powerMonitoringEnabled ?? true,
+        managedLoadSensors: home_s.managedLoadSensors ?? [],
       };
       setHomeForm(h);
       savedHome.current = JSON.stringify(h);
@@ -396,6 +398,9 @@ const SettingsPage: React.FC = () => {
           safetyMargin: homeForm.safetyMarginFactor,
           phaseCount: homeForm.phaseCount,
           powerMonitoringEnabled: homeForm.powerMonitoringEnabled,
+          // Drop blank rows left by "+ Add managed load sensor" — the API
+          // rejects an empty string as an invalid entity ID.
+          managedLoadSensors: homeForm.managedLoadSensors.filter(Boolean),
           currency: pricingForm.currency,
         },
       });

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -96,6 +96,7 @@ const SetupWizardPage: React.FC = () => {
     // Turned on in handleScan only once its required sensors are actually
     // detected on a new install -- see wizardNeededRef.
     powerMonitoringEnabled: false,
+    managedLoadSensors: [],
   });
 
   const [pricingForm, setPricingForm] = useState<PricingForm>({
@@ -312,6 +313,7 @@ const SetupWizardPage: React.FC = () => {
         safetyMarginFactor:     home.safetyMargin           ?? f.safetyMarginFactor,
         phaseCount:             home.phaseCount             ?? f.phaseCount,
         powerMonitoringEnabled: home.powerMonitoringEnabled ?? f.powerMonitoringEnabled,
+        managedLoadSensors:     home.managedLoadSensors     ?? f.managedLoadSensors,
       }));
       setPricingForm(f => ({
         ...f,
@@ -397,6 +399,7 @@ const SetupWizardPage: React.FC = () => {
         safetyMarginFactor: homeForm.safetyMarginFactor,
         phaseCount: homeForm.phaseCount,
         powerMonitoringEnabled: homeForm.powerMonitoringEnabled,
+        managedLoadSensors: homeForm.managedLoadSensors.filter(Boolean),
         // Electricity
         area: discovery.nordpoolArea || discovery.nordpoolCustomArea || pricingForm.area,
         provider: pricingForm.provider,


### PR DESCRIPTION
## Summary
- `home.managed_load_sensors` (list of entity IDs) — cumulative/lifetime energy sensors for loads (typically EV chargers) to exclude from the `ha_statistics` consumption-forecast baseline.
- New module `core/bess/managed_loads.py`: subtracts each managed load's own HA Recorder statistics from the main load sensor's, hour-by-hour, before the baseline's hour-of-day buckets are built. Floors at 0 and counts any clamped hours (sensor/entity mismatch) rather than going negative.
- New exception `ManagedLoadsError` (subclasses `BESSException` per the project convention).
- Frontend: add/remove list editor for managed-load sensor entity IDs in `HomeFormSection.tsx`, shown only under the `ha_statistics` strategy, wired into both the Settings page and the setup wizard.

## Root cause
`ha_statistics` learns "normal" load purely from the past 7 days of history. Its trimmed mean discounts a one-off spike but bakes in a *regular* habit — a nightly EV charge reads as part of normal usage, so the baseline overstates typical consumption by however much of that habit occurred in the training window. There was no way to tell BESS "this load isn't part of my normal pattern, I'll announce it myself instead."

## Design background
Follows the three-concept design from the [#428 revised proposal](https://github.com/johanzander/bess-manager/issues/428#issuecomment-5445224631) (Consumption Forecast / Managed Loads / Planned Consumption Changes). Planned Consumption Changes shipped in #705; this is Managed Loads, concept #2.

## Scope assessment
- **Placement**: subtraction happens in `_fetch_ha_statistics_raw`/new `_fetch_recorder_change_stats` helper — the single point both `_get_ha_statistics_forecast` and the debug export already funnel through, so both stay consistent with the residual.
- **Workaround check**: this is a real new mechanism (residual computation before the baseline is built), not a flag/branch routing around an existing ordering/timing problem.
- **Category**: structural — new settings field shape (`home.managed_load_sensors: list[str]`, the first list-shaped field on `HomeSettings`), new backend module + exception class, new frontend list-editor UI.
- **New classes**: `ManagedLoadsError`, and the `managed_loads.py` module — parallel in shape to `consumption_overlay.py`/`ConsumptionOverlayError` from #705.
- **Deliberately out of scope**: `influxdb_7d_avg` — it pulls instantaneous power samples from InfluxDB, a different data source/shape than HA Recorder's cumulative `change` values, and would need its own subtraction mechanism. Flagged as a possible follow-up, not required by this issue.

## Test plan
- [x] `./scripts/quality-check.sh` passes locally (aside from ~6 known pre-existing, unrelated failures in `test_quality_check_mypy_gate.py` — a gap between that test's synthetic stub project and the bot-workflow-contract checks, confirmed pre-existing on this branch and unrelated to consumption/managed-loads work)
- [x] `.venv/bin/pytest -m slow`: 564 passed, 10 skipped, 0 failed
- [x] Independent code review (background agent): one CONFIRMED finding — `ManagedLoadsError` wasn't caught alongside `HAStatisticsUnavailableError` at two call sites, so a misconfigured managed-load sensor would either crash instead of falling back to the fixed profile, or break the debug export. Fixed at both sites.
- [x] Local mock-HA verification (real backend, real HTTP API, faked container clock): configured `home.managed_load_sensors` with an EV sensor, set 7 days of hourly HA Recorder statistics for both the main load sensor (2.0 kWh/h) and the EV sensor (1.0 kWh/h) via the mock, and observed the real `ha_statistics` forecast log line change from `48.0 kWh/day` (raw baseline) to `24.0 kWh/day` (residual) purely by adding the managed-load sensor to settings — no code changes between runs.
- [x] Confirmed the no-managed-loads path is unaffected: same scenario with `managed_load_sensors: []` reproduced the original `48.0 kWh/day` exactly.

## Evidence the test discriminates
- Reverted: the `residual = float(change) - managed` line in `subtract_managed_loads`.
- Result: 4 of 7 unit tests in `test_managed_loads.py` FAILED (`test_subtracts_one_managed_load_hour_by_hour`, `test_sums_multiple_managed_loads_for_the_same_hour`, `test_clamps_negative_residual_to_zero_and_counts_it`, `test_hours_with_no_matching_managed_load_entry_are_unaffected`).
- Restored: tree clean, all 7 pass.
- Separately, disabled the `_fetch_ha_statistics_raw` wiring (`if managed_load_sensors:` → `if False and managed_load_sensors:`): 2 of 3 integration tests in `TestManagedLoadsSubtraction` (`test_ha_statistics_forecast.py`) FAILED. Restored, all pass.

## Outcome-level coverage
- Unit coverage: `core/bess/tests/unit/test_managed_loads.py` (subtraction arithmetic, clamping, malformed-entry handling).
- Integration coverage: `TestManagedLoadsSubtraction` in `core/bess/tests/unit/test_ha_statistics_forecast.py` (wiring through `BatterySystemManager._get_ha_statistics_forecast`, including the missing-managed-load-statistics error path).
- E2E: manually verified against a real running backend + mock-HA over HTTP, per Test plan above (not committed as an automated fixture — no existing automated e2e scenario exercises the `ha_statistics` HA-Recorder-statistics path at all yet, and building one was out of scope for this PR).

Refs #706, #428