### PR TITLE
fix: backlog pass — dead worktrees, merged-PR association, Analysis WIP, stalled Stage 2

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -281,6 +281,18 @@ comparison over the digest, so a quiet backlog costs one process instead of a
 model pass, and `RHYTHM: nothing due.` is a legitimate noop tick. **Do not
 re-derive these by reading issues; act on what it lists.**
 
+**Board data is always live** (the digest reads `gh`), but the pass *logic* —
+this script, `backlog-digest.sh`, this skill — runs from the checkout the loop
+started in and is never refreshed mid-loop. Each tick does a read-only
+`git fetch` and prints
+
+    TOOLING 6 commit(s) behind origin/main -- restart the loop from an updated checkout
+
+when the backlog tooling paths are behind. It never pulls (wrong in a
+worktree; swapping the skill under a live tick is worse than one stale tick) —
+stop the loop and restart it from an up-to-date checkout. `RHYTHM_SKIP_FETCH=1`
+skips just the network call; `RHYTHM_TOOLING_REF` overrides the ref.
+
 Why it exists: every follow-up rule in this skill had been written down and
 **none had ever fired.** They each needed a model to notice them and nothing
 scheduled one, so the 14-day chase, the 28-day park and the reporter-replied

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -88,6 +88,13 @@ scope must not read as progress. The one artifact it does **not** override is
 `In Review`: a PR that is out of draft is genuinely in the loop, and the
 rhythm pass ranks the wait separately there.
 
+"Back" is literal — the wait is a **floor-lower, never a promotion**. It only
+moves an item *left*, toward `Analysis`; it never moves one *right*. A
+`discussion` / `blocked` tag on a raw `Backlog` musing (no worktree, no PR, no
+`analyzed` label — #703) stays in `Backlog`. Promoting it manufactured a
+`board_status` ≠ `column` mismatch every pass, so `move_card` yanked the card
+back to `Analysis` minutes after a human moved it to `Backlog`, forever.
+
 And a **draft PR is not `In Review`** (#707): an open PR only means `In Review`
 once it is out of draft. A draft PR with no review is `In Progress` — the
 branch and PR exist, nothing is reviewing them yet.
@@ -101,7 +108,7 @@ intermediate PR plus an active follow-up branch reads as `In Progress`.
 | Status | Means | Exit |
 |---|---|---|
 | `Backlog` | captured, not analysed | analysis lands |
-| `Analysis` | scope or approach unsettled, **or a recorded wait over a worktree / draft PR** | Definition of Ready met and priority set |
+| `Analysis` | scope or approach unsettled, **or a recorded wait pulling an item back from a column right of Analysis** (not from Backlog) | Definition of Ready met and priority set |
 | `Ready for Dev` | analysed, prioritised, unblocked | dispatch |
 | `In Progress` | branch exists — no open PR, or a draft PR with no review | the PR goes out of draft |
 | `In Review` | one or more **non-draft** open PRs, loop running | all its PRs merge |
@@ -179,8 +186,9 @@ caused a real misclassification:
 — deliberately (#707).** An item with a recorded wait reports *Analysis* even
 when a worktree is checked out, a draft PR is open, or a fix has merged to
 main, because unsettled scope must not read as progress. It does *not* outrank
-a non-draft PR (*In Review*) — that work is genuinely in the review loop. The
-worktree / PR is still reported on the item (`worktree`, `worktree_branch`,
+a non-draft PR (*In Review*) — that work is genuinely in the review loop — and
+it does *not* promote a bare *Backlog* item (nothing to pull back from; #703).
+The worktree / PR is still reported on the item (`worktree`, `worktree_branch`,
 `prs`, `merged_pr`), so active or landed code stays visible — the wait changes
 the column, not the evidence. Check those fields before assuming an *Analysis*
 item has no code behind it.

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -171,7 +171,7 @@ caused a real misclassification:
 | `awaiting_source` | `board` or `label`. A `label` source with no board value is a triage action: set the field. |
 | `awaiting_suggested` | What the labels imply, so an unset field can be reconciled without guessing. |
 | `last_comment` | `{author, days, is_reporter, is_bot}`. **The reporter-replied signal.** A comment count and a last-activity date cannot tell "the reporter answered us" from "we posted a nudge", which is why the follow-up chase never fired. |
-| `stale_worktree` | The worktree's own branch has already merged, so it is rot, not progress. Hand it to `sweep-prs`. |
+| `stale_worktree` | The worktree's own branch is dead — already merged, **or its PR was closed unmerged** (an abandoned attempt, #428) — so it is rot, not progress. `stale_worktree_reason` says which. Hand it to `sweep-prs`. |
 | `blocked` | `blocked` label, or a `Blocked by #N` whose blocker is **still open**. Fails Ready outright. |
 | `blocked_by` / `blocked_by_open` | Every parsed reference, and the subset still open. Only the latter blocks — a `Blocked by #N` line is never edited out once N lands, so treating the raw scan as unresolved pins an item out of Ready forever. |
 
@@ -246,8 +246,9 @@ nothing needs a second `gh project item-list` call. Act on each mismatch:
 |---|---|
 | `board_status: null` | the issue has **no card at all**. It carries no Priority, and *Ready for Dev* requires one — so it can never become dispatchable however well it is analysed, while reading as an ordinary Backlog item. Add the card, then triage it normally. Also listed under `orphans` as `issue_no_card` |
 | card *In Progress*, no worktree, no PR | abandoned — move to *Ready for Dev*, report it |
-| `stale_worktree: true` | the branch already merged; the worktree is rot, not work. Hand to `sweep-prs`, and do not read it as progress |
-| worktree present, no session, no PR | the session died mid-issue. The branch's commits survive — resuming is `/implement-issue <n>`, whose Step 0 detects the prior work and re-enters at the right step. **Never silently relaunch**: a session that died twice is telling you something, and a background dispatch that reports `working` may have written nothing at all — verify by work product (`git -C <wt> log`, file mtimes), never by session state |
+| `stale_worktree: true` | the branch is dead — merged, or its PR closed unmerged (`stale_worktree_reason` says which); the worktree is rot, not work. Hand to `sweep-prs`, and do not read it as progress |
+| worktree present, no session, no PR, **not `stale_worktree`** | the session died mid-issue. The branch's commits survive — resuming is `/implement-issue <n>`, whose Step 0 detects the prior work and re-enters at the right step. **Never silently relaunch**: a session that died twice is telling you something, and a background dispatch that reports `working` may have written nothing at all — verify by work product (`git -C <wt> log`, file mtimes), never by session state |
+| worktree present but `stale_worktree: true` | its branch is dead (merged, or its PR closed unmerged — `stale_worktree_reason`). Not resumable — `prune_worktree` / hand to `sweep-prs`. #428 sat here: an abandoned branch behind closed PR #437 while a different branch shipped the issue |
 | `last_comment.is_reporter` and `awaiting: reporter` | the reporter answered. Re-check the Definition of Ready — this wait may be satisfied, and it is the transition nothing used to notice |
 | PR `CONFLICTING`, draft | hand to `/advance-pr <n>` — it owns the board write for a conflict escalation |
 | PR `CONFLICTING`, not a draft | hand to `sweep-prs` |
@@ -298,8 +299,10 @@ than sorted alphabetically, and printed in that order. Who does what:
 | `rework_review` | out of draft with changes requested: hand back to `/implement-issue <n>` — the issue that PR belongs to, resolved from its linked issue — to address them, then a fresh review |
 | `resolve_conflict` | `CONFLICTING`, which also means the PR produced **no CI run at all**. A conflicted **draft** routes to `/advance-pr <n>` — only it performs the board write that records a semantic-conflict escalation, where `sweep-prs` would only report into a chat transcript and write nothing. A conflicted **non-draft** PR has already left the review loop, so it still goes to `sweep-prs`, or resolve directly if the diff is ours |
 | `undiffable_pr` | `gh pr diff` failed for this PR, so the in-flight file set is incomplete. Dispatch is held **fleet-wide** until it clears — not just for this PR's own issue. Re-run the digest; if it recurs, the PR itself needs attention (deleted fork head, rate limit) |
-| `resume_implementation` | One action name, three shapes, routed to the cheapest tool that is actually safe. A **worktree with no PR** (a session died mid-issue) is `/implement-issue <n>` — a real session, because the implementation itself is unfinished, and Step 0 resumes the branch from the earliest incomplete step. A **draft PR whose next step is mechanical** — no review yet, a review still in flight, or an approved draft with checks not yet green — is `/advance-pr <n>` directly: request the review, resolve a conflict, or flip it ready, in one cheap step, no session. A **draft PR carrying `CHANGES_REQUESTED`** is `/implement-issue <n>` — the one PR shape that stays there, because only that session holds the Step 2 diagnosis and Step 3 scope assessment needed to tell a real review finding apart from a decision Step 3 already made and rejected on purpose; `advance-pr` itself always hands a `CHANGES_REQUESTED` draft straight back to `/implement-issue <n>` too, whatever caller invoked it, so dispatching there directly from here just skips the redundant round trip through `advance-pr`. Never restart any of the three, the branch commits are the only copy |
-| `prune_worktree` | the worktree's own branch already merged; it is rot, not progress. Hand to `sweep-prs` |
+| `resume_implementation` | One action name, three shapes, routed to the cheapest tool that is actually safe. A **live worktree with no PR** (a session died mid-issue — and `stale_worktree` is false; a dead branch is `prune_worktree`, not this) is `/implement-issue <n>` — a real session, because the implementation itself is unfinished, and Step 0 resumes the branch from the earliest incomplete step. A **draft PR whose next step is mechanical** — no review yet, a review still in flight, or an approved draft with checks not yet green — is `/advance-pr <n>` directly: request the review, resolve a conflict, or flip it ready, in one cheap step, no session. A **draft PR carrying `CHANGES_REQUESTED`** is `/implement-issue <n>` — the one PR shape that stays there, because only that session holds the Step 2 diagnosis and Step 3 scope assessment needed to tell a real review finding apart from a decision Step 3 already made and rejected on purpose; `advance-pr` itself always hands a `CHANGES_REQUESTED` draft straight back to `/implement-issue <n>` too, whatever caller invoked it, so dispatching there directly from here just skips the redundant round trip through `advance-pr`. Never restart any of the three, the branch commits are the only copy |
+| `prune_worktree` | the worktree's own branch is dead — merged, or its PR closed unmerged (the `why` line quotes `stale_worktree_reason`); it is rot, not progress. Hand to `sweep-prs` |
+| `refire_analyze` | a `@claude-bot analyze` trigger is on the issue but Stage 2 never completed — still `ready-for-analysis`, no `analyzed` / `needs-human-review` label, and the trigger is older than the staleness window (`RHYTHM_ANALYZE_STALE_HOURS`, default 6h). The usual cause is the workflow being out of API credit at the time. Under `/loop` this is a plain retry: re-post `@claude-bot analyze` as the PO. **Not** a maintainer escalation. A trigger younger than the window is a run that may still be working — the pass fires neither this nor `autonomous_analyze` and just waits |
+| `analysis_deferred` | a tier-1 bug is ready to analyse but the Analysis column is at its WIP limit (`RHYTHM_ANALYSIS_WIP_LIMIT`, default 8). Do **not** fire Stage 2 — groom Analysis toward *Ready for Dev* first; the item is still counted and listed, and `autonomous_analyze` re-proposes once Analysis is back under the limit |
 | `dispatchable` | propose for dispatch — needs the maintainer's go-ahead, and only fires when `predicted_files` is set (see the touch-set gate under Dispatch) |
 | `queued_behind` | do nothing; it is correctly waiting on an in-flight PR that already touches one of its predicted files. Recheck once that PR lands |
 | `cluster` | dispatch the named items as **one** unit of work — one branch, one PR. Two Ready items that predict overlapping files cost less merged into one dispatch than as two PRs plus a conflict |
@@ -308,7 +311,7 @@ than sorted alphabetically, and printed in that order. Who does what:
 | `surface_discussion` | summarise the thread, put the open question to the maintainer. **Never auto-park an open conversation** |
 | `nudge_reporter` | one nudge, as the PO identity |
 | `park` | move to *Backlog* — the chase went unanswered |
-| `autonomous_analyze` | the tier-1 carve-out, computed from evidence not the board field: post `@claude-bot analyze` as the PO (`scripts/gh-agent.sh --as po issue comment <n> --body "@claude-bot analyze"`), after confirming no prior analyze on the issue. Fires even when a stale `Awaiting` would otherwise quiet the item, because `ready-for-analysis` already proves the log is in; stands down when the item has Stage 2 history (`analyzed` / `needs-human-review`) or the card holds `Awaiting: maintainer` (see Autonomous spend) |
+| `autonomous_analyze` | the tier-1 carve-out, computed from evidence not the board field: post `@claude-bot analyze` as the PO (`scripts/gh-agent.sh --as po issue comment <n> --body "@claude-bot analyze"`). The no-prior-analyze check is now **in the script** (`last_analyze_comment`) — this fires only when the issue has *never* been analyzed; a stalled prior run is `refire_analyze` instead. Fires even when a stale `Awaiting` would otherwise quiet the item, because `ready-for-analysis` already proves the log is in; stands down when the item has Stage 2 history (`analyzed` / `needs-human-review`), the card holds `Awaiting: maintainer` (see Autonomous spend), or the Analysis column is at its WIP limit (`analysis_deferred`) |
 | `set_awaiting` / `set_priority` / `triage_labels` | grooming debt: write the board field or label |
 | `add_card` | open issue, no card on the board at all — add it to Project #1 first, **then** set `Priority`; until both exist it is unrankable and invisible to every board pass |
 | `move_card` | the card sits somewhere the evidence does not support — always move it to match `column`, never re-derive `column` to match the card |
@@ -453,6 +456,24 @@ anything new starts. A limit low enough to hold also makes same-file
 collisions rare on its own, without the touch-set gate having to catch every
 one of them.
 
+### The Analysis WIP limit: 8
+
+The same rule one column to the left. Analysis is only worth anything once its
+output reaches *Ready for Dev*, so an Analysis column holding 18 items is 18
+pieces of half-finished work, not progress — and every tick the pass was still
+pulling a new bug in for Stage 2 on top of them. At or above
+`RHYTHM_ANALYSIS_WIP_LIMIT` (default 8), `autonomous_analyze` is suppressed —
+the held bugs surface as `analysis_deferred`, counted and listed, never
+dropped — and the pass reports it on every path:
+
+    ANALYSIS 18/8 -- promote analysed items to Ready for Dev before analysing more
+
+It does **not** gate `refire_analyze`: re-poking a Stage 2 run that stalled
+finishes an item already in Analysis rather than adding one. And `bug` still
+pre-empts `feature` — the WIP limit only decides *whether* new analysis starts;
+Rule 2 and `Verb: next` decide *what* does when it can. Do not propose a
+feature request for analysis while Analysis is over the limit.
+
 ## Verb: next
 
 Rank Backlog and Ready items in this order:
@@ -562,12 +583,19 @@ stale wait values (`reporter`, `upstream`, `discussion`) but stands down on
 `Awaiting: maintainer`, where the loop is deliberately held for your
 decision; and the same evidence makes the `park` / `nudge_reporter` /
 `surface_discussion` chases stand down, so the pass never tells the PO to
-bury what it just un-hid. Still confirm there is no prior `@claude-bot
-analyze` comment already on the issue before posting — check by reading the
-issue's comments from the digest (or `gh issue view` if the digest's comment
-count needs confirming), never a local file: an in-flight analyze keeps
-`ready-for-analysis` until it completes, so the action may re-propose during
-that window. This is a check against the item itself, not a ranking pass: an
+bury what it just un-hid.
+
+The no-prior-analyze guard is now **in the script**: `last_analyze_comment`
+carries the most recent `@claude-bot analyze` trigger and its age.
+`autonomous_analyze` fires only when that is absent — the issue has never been
+analyzed. A trigger younger than `RHYTHM_ANALYZE_STALE_HOURS` (default 6h) is
+an analyze that may still be running: the pass fires neither `autonomous_analyze`
+nor `refire_analyze` and waits. Once it ages past that window with the item
+still `ready-for-analysis` and unstamped, the run is treated as failed —
+almost always an out-of-credit workflow — and `refire_analyze` re-posts the
+trigger. Under `/loop` that just retries until Stage 2 lands; it is never a
+maintainer escalation. This is a check against the item itself, not a ranking
+pass: an
 item entering Analysis is never a member of the Backlog/Ready list that
 `next` ranks, so it cannot "rank" into a tier. Every other item entering
 Analysis gets a proposal instead.

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -118,13 +118,17 @@ def _gh_shim(
     merged_prs: list | None = None,
     pr_files: dict[int, list[str]] | None = None,
     fail_pr_diff: list[int] | None = None,
+    closed_prs: list | None = None,
 ) -> str:
     """A `gh` that answers the subcommands the digest calls.
 
-    `pr list` is called twice with different `--state` values, so this shim
-    branches on the whole argument string rather than just `$1 $2`. Matching
-    only the subcommand returned the OPEN list for both calls, which made every
-    open PR look merged and reported every issue as having landed.
+    `pr list` is called three times with different `--state` values (open,
+    merged, closed), so this shim branches on the whole argument string rather
+    than just `$1 $2`. Matching only the subcommand returned the OPEN list for
+    every call, which made every open PR look merged and reported every issue as
+    having landed. `closed_prs` feeds the `--state closed` call that
+    `worktree_is_stale` reads to spot a worktree abandoned behind a
+    closed-unmerged PR.
 
     `pr diff <n> --name-only` answers from `pr_files`, keyed by PR number. The
     match requires `--name-only` literally in the call -- a shim that answered
@@ -142,6 +146,10 @@ def _gh_shim(
     return f"""
 merged=$(cat <<'EOF'
 {json.dumps(merged_prs or [])}
+EOF
+)
+closed=$(cat <<'EOF'
+{json.dumps(closed_prs or [])}
 EOF
 )
 pr_files_json=$(cat <<'EOF'
@@ -163,6 +171,7 @@ EOF
     ;;
   *"pr diff"*) echo "gh pr diff missing --name-only: $*" >&2; exit 1 ;;
   *"pr list"*"--state merged"*) printf '%s\\n' "$merged" ;;
+  *"pr list"*"--state closed"*) printf '%s\\n' "$closed" ;;
   *"pr list"*) cat <<'EOF'
 {json.dumps(prs)}
 EOF
@@ -426,6 +435,7 @@ EOF
     ;;
   *"pr diff "*"--name-only"*) : ;;
   *"pr list"*"--state merged"*) printf '%s\\n' '[]' ;;
+  *"pr list"*"--state closed"*) printf '%s\\n' '[]' ;;
   *"pr list"*)
     case "$*" in
       *isDraft*) : ;;
@@ -702,6 +712,111 @@ def test_worktree_on_an_unmerged_branch_is_in_progress(bin_dir: Path) -> None:
 
     assert item["stale_worktree"] is False
     assert item["column"] == "In Progress"
+
+
+def test_worktree_abandoned_behind_a_closed_unmerged_pr_is_stale(
+    bin_dir: Path,
+) -> None:
+    """#428: the branch never merged, but its PR (#437) was closed unmerged and
+    a differently-named branch shipped the issue. A worktree left on that dead
+    branch is an abandoned attempt, not resumable work -- the same as a merged
+    branch for staleness, with a reason string that says which."""
+    issue = _issue(428, labels=[{"name": "enhancement"}])
+    closed = [
+        {
+            "number": 437,
+            "headRefName": "feat/issue-428-consumption-forecast-series",
+            "mergedAt": None,
+        }
+    ]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], [], closed_prs=closed))
+    _write_shim(
+        bin_dir,
+        "git",
+        _git_shim(
+            _porcelain(("/repo/wt/428", "feat/issue-428-consumption-forecast-series"))
+        ),
+    )
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["stale_worktree"] is True
+    assert item["stale_worktree_reason"] == "was the head of closed-unmerged PR #437"
+    assert item["column"] != "In Progress"
+
+
+def test_a_merged_pr_on_the_issue_branch_reads_as_in_verification(
+    bin_dir: Path,
+) -> None:
+    """#428/#705: the shipping PR merged on `feat/issue-428-consumption-overlay`
+    and, under the no-auto-close rule, its body links the issue only as a bare
+    `#428` -- no work verb. Branch convention plus a non-cross-ref body mention
+    of the same number is enough to place the issue In Verification, so a board
+    pass stops reading a shipped-to-beta issue as un-started."""
+    issue = _issue(428, labels=[{"name": "enhancement"}])
+    merged = [
+        {
+            "number": 705,
+            "headRefName": "feat/issue-428-consumption-overlay",
+            "body": "Redesign from the discussion on #428. Ships the overlay.",
+        }
+    ]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], merged))
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["merged_pr"] == 705
+    assert item["merged_prs"] == [705]
+    assert item["column"] == "In Verification"
+
+
+def test_a_merged_pr_on_the_issue_branch_with_only_a_cross_ref_does_not_flip(
+    bin_dir: Path,
+) -> None:
+    """The `mentions` guard: a merged PR on `fix/issue-403-logging` whose body
+    only cross-references #403 ("Related to #403. Not closing it") still must
+    not move #403 -- branch convention alone is not trusted on the merged path,
+    the same caution `test_a_merged_cross_ref_does_not_move_an_issue...` pins."""
+    issue = _issue(403, labels=[{"name": "bug"}])
+    merged = [
+        {
+            "number": 453,
+            "headRefName": "fix/issue-403-logging",
+            "body": "Related to #403. Not closing it -- leaving it open until "
+            "#456 and #457 land.",
+        }
+    ]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], [], merged))
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["merged_pr"] is None
+    assert item["column"] != "In Verification"
+
+
+def test_last_analyze_comment_reports_the_trigger_age(bin_dir: Path) -> None:
+    """`refire_analyze` and the no-double-spend guard on `autonomous_analyze`
+    both read this: the most recent `@claude-bot analyze` comment and how long
+    ago it landed. Absent when the issue was never analyzed."""
+    never = _issue(600, labels=[{"name": "bug"}])
+    _write_shim(bin_dir, "gh", _gh_shim([never], [], []))
+    assert _run(bin_dir)["items"][0]["last_analyze_comment"] is None
+
+    fired = _issue(
+        601,
+        labels=[{"name": "bug"}],
+        comments=[
+            {
+                "body": "@claude-bot analyze",
+                "author": {"login": "bess-product-owner"},
+                "createdAt": "2000-01-01T00:00:00Z",
+            }
+        ],
+    )
+    _write_shim(bin_dir, "gh", _gh_shim([fired], [], []))
+    lac = _run(bin_dir)["items"][0]["last_analyze_comment"]
+    assert lac is not None
+    assert lac["hours"] > 24 and lac["days"] > 1
 
 
 def test_a_draft_pr_with_no_review_is_in_progress_not_in_review(bin_dir: Path) -> None:
@@ -1051,6 +1166,7 @@ EOF
     ;;
   *"pr diff "*"--name-only"*) : ;;
   *"pr list"*"--state merged"*) printf '%s\\n' '[]' ;;
+  *"pr list"*"--state closed"*) printf '%s\\n' '[]' ;;
   *"pr list"*)
     if [ -f '{counter}' ]; then
       cat <<'EOF'

--- a/backend/tests/test_backlog_digest.py
+++ b/backend/tests/test_backlog_digest.py
@@ -540,6 +540,32 @@ def test_board_awaiting_overrides_analyzed(bin_dir: Path) -> None:
     assert item["awaiting_source"] == "board"
 
 
+def test_board_awaiting_does_not_promote_a_backlog_item(bin_dir: Path) -> None:
+    """#703: a raw "to consider" enhancement with `Awaiting: discussion` on its
+    card and nothing else -- no worktree, no PR, no `analyzed` label. The wait
+    is a floor-lower, not a set (#707 says "pulls BACK to Analysis"), so from
+    Backlog it is a no-op. Before this, `column` came back `Analysis`, which did
+    not match the card's `Backlog`, so `move_card` yanked the card to Analysis
+    minutes after a human moved it back -- forever.
+    """
+    issue = _issue(703, labels=[{"name": "enhancement"}])
+    board = [
+        {
+            "content": {"number": 703},
+            "status": "Backlog",
+            "priority": "P3",
+            "awaiting": "discussion",
+        }
+    ]
+    _write_shim(bin_dir, "gh", _gh_shim([issue], [], board))
+
+    item = _run(bin_dir)["items"][0]
+
+    assert item["column"] == "Backlog"
+    assert item["board_status"] == "Backlog"  # no mismatch -> no move_card fight
+    assert item["awaiting"] == "discussion"  # the wait is still recorded
+
+
 def test_analyzed_with_priority_is_ready_for_dev(bin_dir: Path) -> None:
     issue = _issue(700, labels=[{"name": "analyzed"}])
     board = [{"content": {"number": 700}, "priority": "P1"}]
@@ -1093,7 +1119,12 @@ def test_needs_debug_log_is_awaiting_reporter(bin_dir: Path) -> None:
 
     digest = _run(bin_dir)
 
-    assert digest["items"][0]["column"] == "Analysis"
+    # `needs-debug-log` sets `awaiting: reporter`. It does NOT move the column:
+    # the wait override is a floor-lower (#707 says "pulls BACK to Analysis"),
+    # and there is nothing to pull back -- no worktree, no PR, no `analyzed`
+    # label -- so the item stays in Backlog. The nudge/park timers key off
+    # `.awaiting`, not the column, so nothing downstream regresses.
+    assert digest["items"][0]["column"] == "Backlog"
     assert digest["items"][0]["awaiting"] == "reporter"
 
 

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -45,7 +45,13 @@ def _item(number: int, **over: object) -> dict:
         # pre-existing stalled-work tests keep asserting what they always did.
         "worktree_locked": False,
         "stale_worktree": False,
+        # Why a worktree is stale ("merged in #N" / "was the head of
+        # closed-unmerged PR #N"); None unless stale_worktree is True.
+        "stale_worktree_reason": None,
         "session": None,
+        # The last `@claude-bot analyze` trigger and its age, or None. None =
+        # never analyzed, which is what lets autonomous_analyze fire.
+        "last_analyze_comment": None,
         "blocked_by": [],
         "blocked_by_open": [],
         "blocked": False,
@@ -371,6 +377,31 @@ def test_a_stale_worktree_is_pruned_not_resumed(tmp_path: Path) -> None:
     assert "resume_implementation" not in actions
 
 
+def test_a_worktree_abandoned_behind_a_closed_pr_is_pruned_not_resumed(
+    tmp_path: Path,
+) -> None:
+    """#428: its branch never merged, but its PR (#437) was closed unmerged and
+    a different branch shipped the issue. The leftover worktree is an abandoned
+    attempt -- prune it, do not propose `/implement-issue` against the dead
+    branch. The digest sets `stale_worktree` for this now; the why-line quotes
+    the reason so the pass says closed-unmerged rather than merged."""
+    item = _item(
+        428,
+        worktree="/repo/wt/428",
+        worktree_branch="feat/issue-428-consumption-forecast-series",
+        stale_worktree=True,
+        stale_worktree_reason="was the head of closed-unmerged PR #437",
+        session=None,
+        last_comment=_comment(1),
+    )
+    result = _run(tmp_path, [item])
+    actions = _actions_for(result, 428)
+    assert "prune_worktree" in actions
+    assert "resume_implementation" not in actions
+    prune = next(a for a in result["actions"] if a["action"] == "prune_worktree")
+    assert "closed-unmerged PR #437" in prune["why"]
+
+
 def test_work_with_a_pr_is_reported_once_by_the_pr_branch(tmp_path: Path) -> None:
     """Both halves could fire on the same work. The PR branch owns the handoff
     once a PR exists, so the issue rule stands down to avoid listing it twice."""
@@ -565,6 +596,72 @@ def test_a_tier1_bug_in_discussion_is_analyzed_not_surfaced(tmp_path: Path) -> N
     actions = _actions_for(_run(tmp_path, [item]), 692)
     assert "autonomous_analyze" in actions
     assert "surface_discussion" not in actions
+
+
+def test_a_stalled_stage2_run_is_refired_not_escalated(tmp_path: Path) -> None:
+    """#704: `@claude-bot analyze` was posted ~34h ago, the item is still
+    `ready-for-analysis` with no analyzed/needs-human-review label -- the run
+    never completed (commonly: the workflow had no API credit). Under the loop
+    that is a plain retry: `refire_analyze`, not a maintainer escalation.
+    `autonomous_analyze` stands down because a prior analyze comment exists."""
+    item = _item(
+        704,
+        labels=["bug", "ready-for-analysis"],
+        author="valexi7",
+        column="Analysis",
+        board_status="Analysis",
+        last_analyze_comment={"days": 1, "hours": 34},
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 704)
+    assert "refire_analyze" in actions
+    assert "autonomous_analyze" not in actions
+    assert "escalated" not in actions
+
+
+def test_an_analyze_still_in_flight_fires_neither(tmp_path: Path) -> None:
+    """A trigger younger than the staleness window is a run that may still be
+    working. Neither re-fire it nor start a fresh one -- wait."""
+    item = _item(
+        705,
+        labels=["bug", "ready-for-analysis"],
+        author="valexi7",
+        column="Analysis",
+        board_status="Analysis",
+        last_analyze_comment={"days": 0, "hours": 2},
+    )
+    actions = _actions_for(_run(tmp_path, [item]), 705)
+    assert "refire_analyze" not in actions
+    assert "autonomous_analyze" not in actions
+
+
+def test_analysis_wip_limit_holds_new_autonomous_analysis(tmp_path: Path) -> None:
+    """Empty the board from the right, one column further left: an Analysis
+    column already at its WIP limit does not pull a new bug in for analysis.
+    The tier-1 bug is still counted and listed (`analysis_deferred`), never
+    dropped, and `autonomous_analyze` does not fire until Analysis drains."""
+    fillers = [
+        _item(100 + n, column="Analysis", board_status="Analysis") for n in range(8)
+    ]
+    bug = _item(
+        720,
+        labels=["bug", "ready-for-analysis"],
+        author="valexi7",
+    )
+    result = _run(tmp_path, [*fillers, bug], RHYTHM_ANALYSIS_WIP_LIMIT="8")
+    assert result["analysis"] == {"count": 8, "limit": 8, "over": True}
+    actions = _actions_for(result, 720)
+    assert "autonomous_analyze" not in actions
+    assert "analysis_deferred" in actions
+
+
+def test_analysis_under_the_limit_still_analyses(tmp_path: Path) -> None:
+    fillers = [
+        _item(100 + n, column="Analysis", board_status="Analysis") for n in range(3)
+    ]
+    bug = _item(721, labels=["bug", "ready-for-analysis"], author="valexi7")
+    result = _run(tmp_path, [*fillers, bug], RHYTHM_ANALYSIS_WIP_LIMIT="8")
+    assert result["analysis"]["over"] is False
+    assert "autonomous_analyze" in _actions_for(result, 721)
 
 
 # --- the PR half: reaching a READY PR ------------------------------------

--- a/backend/tests/test_backlog_rhythm.py
+++ b/backend/tests/test_backlog_rhythm.py
@@ -1386,6 +1386,19 @@ def test_grooming_actions_rank_together_after_dispatchable(tmp_path: Path) -> No
     assert grooming_rank > rank_by_action["dispatchable"]
 
 
+# --- tooling freshness ---------------------------------------------------
+
+
+def test_tooling_freshness_check_is_inert_under_the_test_seam(tmp_path: Path) -> None:
+    """`RHYTHM_DIGEST_FILE` is set here, so the fetch + behind-count is skipped
+    entirely -- `behind` is null and no TOOLING line can print. This pins that
+    `--argjson tooling_behind null` round-trips and the every-path print stays
+    guarded; the live behind-count is exercised by the git plumbing, not here
+    (it would need a network fetch)."""
+    result = _run(tmp_path, [_item(1, labels=["bug"], last_comment=_comment(1))])
+    assert result["tooling"] == {"behind": None, "ref": "origin/main"}
+
+
 # --- the WIP limit --------------------------------------------------------
 
 

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -550,11 +550,20 @@ jq -n \
   #
   # PHASE COMES FROM ARTIFACTS, with one override a wait DOES rewrite (#707).
   # `Status` is the stage, `Awaiting` is the wait -- mostly orthogonal, but a
-  # recorded wait (or `blocked`) pulls the item back to Analysis over a bare
+  # recorded wait (or `blocked`) pulls the item BACK to Analysis over a bare
   # worktree or a still-draft PR, because unsettled scope must not read as
   # progress. It does NOT override In Review -- a PR that is out of draft is
   # genuinely in the review loop -- and the rhythm pass ranks the wait
   # separately.
+  #
+  # "Back" is literal: the wait is a FLOOR-LOWER, never a set. It can only move
+  # an item LEFT (toward Analysis), never right. A `discussion` / `blocked` tag
+  # on a raw Backlog musing (no worktree, no PR, no `analyzed` label -- #703)
+  # must NOT be promoted to Analysis: that manufactured a `board_status` !=
+  # `column` mismatch every pass, so `move_card` yanked the card to Analysis
+  # minutes after a human moved it to Backlog, forever. The artifact/label
+  # column is computed first as `$natural`; the wait only rewrites it when
+  # `$natural` is already right of Analysis.
   #
   # DRAFT IS NOT IN REVIEW (#707). An open PR only means In Review once it is
   # out of draft -- the review loop has actually started. A draft PR is In
@@ -572,13 +581,21 @@ jq -n \
   def column($labels; $open_prs; $merged_pr; $wt_live; $awaiting; $priority; $blocked):
       (any($open_prs[]; .isDraft != true)) as $in_review
       | (($wt_live) or (any($open_prs[]; .isDraft == true))) as $in_progress
-      | if $in_review then "In Review"
-        elif $blocked or $awaiting != null then "Analysis"
-        elif $in_progress then "In Progress"
-        elif $merged_pr != null then "In Verification"
-        elif ($labels | index("analyzed")) and $priority != null then "Ready for Dev"
-        elif ($labels | index("analyzed")) then "Analysis"
-        else "Backlog" end;
+      # The column the artifacts and labels imply, before any wait override.
+      | (if $in_review then "In Review"
+         elif $in_progress then "In Progress"
+         elif $merged_pr != null then "In Verification"
+         elif ($labels | index("analyzed")) and $priority != null then "Ready for Dev"
+         elif ($labels | index("analyzed")) then "Analysis"
+         else "Backlog" end) as $natural
+      # A recorded wait / block pulls back to Analysis -- but only from a column
+      # right of Analysis, and never out of In Review (#707). From Backlog it is
+      # a no-op: a wait cannot promote un-analysed work.
+      | if ($blocked or $awaiting != null)
+           and $natural != "In Review"
+           and $natural != "Backlog"
+        then "Analysis"
+        else $natural end;
 
   {
     counts: {

--- a/scripts/backlog-digest.sh
+++ b/scripts/backlog-digest.sh
@@ -149,8 +149,41 @@ merged_prs=$(gh pr list --repo "$repo" --state merged --limit 200 \
       # own fix with the literal line `- Blocked by #100 -- part of #409` and
       # that example bounced issue #409 to In Verification. A real linkage
       # declaration is never in code markup.
-      refs: [ (.body // "") | strip_code_spans | scan("(?i)(?:fixes|closes|resolves|refs|part of|tracking|tracks) #([0-9]+)") | .[0] | tonumber ]
+      refs: [ (.body // "") | strip_code_spans | scan("(?i)(?:fixes|closes|resolves|refs|part of|tracking|tracks) #([0-9]+)") | .[0] | tonumber ],
+      # Any `#N` LEFT in the body once code spans and the cross-reference
+      # phrases ("Related to", "See also", "Blocked by", ...) are stripped --
+      # the same phrase list `linkage_body` uses in the digest program. Used
+      # ONLY to corroborate a branch-convention match in `merged_pr_for`: the
+      # branch name alone is not trusted to flip a column (a merged PR on
+      # `fix/issue-403-logging` whose body says "Related to #403. Not closing
+      # it" must not), but branch convention PLUS a non-cross-ref body mention
+      # of the same number is the #428/#705 case -- a merged PR that genuinely
+      # implemented the issue but, under the no-auto-close rule, carries no
+      # closing verb.
+      mentions: [ (.body // "")
+                  | strip_code_spans
+                  | gsub("(?i)(blocked by|depends on|unblocks?(?:ing)?|related to|relationship to|follow[- ]?up to|see also|see|not part of) #[0-9]+"; "")
+                  | scan("#([0-9]+)") | .[0] | tonumber ]
     } ]')
+
+# Closed-but-UNMERGED PRs, by branch. A worktree whose own branch is the exact
+# head of a PR the maintainer closed without merging is an ABANDONED attempt,
+# not resumable work: #428 shipped via merged PR #705 while its earlier branch
+# `feat/issue-428-consumption-forecast-series` -- the head of closed PR #437 --
+# still sat on disk, so `worktree_is_stale` (merged-only) read it as live and
+# the rhythm pass proposed `/implement-issue 428` against the dead branch on
+# every tick. Exact `headRefName` comparison only, the same discipline
+# `worktree_is_stale` applies to the merged list and for the same reason -- a
+# fuzzy issue-number match would strand a live follow-up branch the moment any
+# same-issue PR closed.
+#
+# `--state closed` returns BOTH closed-unmerged and merged PRs, so the
+# `mergedAt == null` filter is load-bearing: without it every merged branch
+# would also land here and `stale_worktree_reason` would misreport why a
+# worktree is dead.
+closed_prs=$(gh pr list --repo "$repo" --state closed --limit 200 \
+  --json number,headRefName,mergedAt \
+  | jq -c '[ .[] | select(.mergedAt == null) | {number, headRefName} ]')
 
 # Emits, per worktree, a JSON object of {path, branch, locked}. `git worktree
 # list` always emits the main checkout as its first record, and it is excluded
@@ -221,6 +254,7 @@ jq -n \
   --argjson issues "$issues" \
   --argjson prs "$prs" \
   --argjson merged_prs "$merged_prs" \
+  --argjson closed_prs "$closed_prs" \
   --argjson worktrees "$worktrees" \
   --argjson sessions "$sessions" \
   --argjson board "$board" \
@@ -319,23 +353,32 @@ jq -n \
     ([ $worktrees[] | select(matches_issue(.; $n)) ]) as $matches
     | if ($matches | length) == 0 then null else $matches[0] end;
 
-  # A worktree is STALE when its own branch has already been merged. This is an
-  # exact branch-name comparison against the merged-PR list, deliberately not
-  # the fuzzy issue-number match used to associate a worktree with an issue:
+  # A worktree is STALE when the PR for its own branch is GONE -- merged, or
+  # closed without merging. Either way the branch will never produce a merge from
+  # here, so the worktree is rot for `sweep-prs` to prune and never resumable
+  # work. Both are an exact branch-name comparison against a PR list,
+  # deliberately not the fuzzy issue-number match used to associate a worktree
+  # with an issue:
   #
   #   - fuzzy matching is right for "which issue does this worktree belong to",
   #     since branch names embed the issue number in several shapes
-  #   - it is WRONG for "has this work landed", because a merged PR whose branch
-  #     merely mentions the issue number proves nothing about THIS branch
+  #   - it is WRONG for "has the work on THIS branch ended", because another PR whose
+  #     branch merely mentions the issue number proves nothing about THIS branch
   #
   # Getting that distinction wrong reclassified 7 open issues as Done, including
   # #118, #120 and #403 whose fixes had not shipped. It also contradicts this
   # project`s rule that a beta PR never carries `Closes #N` — an open issue with
   # a merged PR is the NORMAL state during beta graduation, not a finished one.
+  # (A stale worktree does NOT by itself close its issue -- it only stops the
+  # worktree reading as live work; the column still comes from the merged-PR
+  # scan and the labels.)
+  def worktree_dead_pr($wt):
+    if $wt == null or ($wt.branch // "") == "" then null
+    else ( [ $merged_prs[] | select(.headRefName == $wt.branch) | {number, why: "merged in #\(.number)"} ]
+         + [ $closed_prs[] | select(.headRefName == $wt.branch) | {number, why: "was the head of closed-unmerged PR #\(.number)"} ]
+         )[0] // null end;
   def worktree_is_stale($wt):
-    $wt != null
-    and ($wt.branch // "") != ""
-    and ([ $merged_prs[] | select(.headRefName == $wt.branch) ] | length) > 0;
+    worktree_dead_pr($wt) != null;
 
   def session_for($n):
     ([ $sessions[] | select(.name? == "issue-\($n)") | .name ]) as $matches
@@ -392,6 +435,25 @@ jq -n \
       }
       end;
 
+  # The most recent `@claude-bot analyze` trigger on the issue, and how long ago
+  # it was posted. Stage 2 normally finishes in minutes and stamps `analyzed` or
+  # `needs-human-review` (removing `ready-for-analysis`); a trigger that is hours
+  # old with the item still `ready-for-analysis` and unstamped means the run
+  # never completed -- most often because the workflow had no API credit. The
+  # rhythm pass reads this two ways: `autonomous_analyze` stands down while ANY
+  # analyze comment exists (so it never double-spends), and `refire_analyze`
+  # re-posts the trigger once this ages past its staleness window. Matched on the
+  # comment BODY, any author, since the PO identity posts it via gh-agent.sh.
+  def last_analyze_comment($comments):
+    ([ $comments[]? | select((.body // "") | test("@claude-bot[[:space:]]+analyze"; "i")) ]
+     | sort_by(.createdAt) | last) as $c
+    | if $c == null then null
+      else {
+        days: days_since($c.createdAt),
+        hours: ((($now | tonumber) - ($c.createdAt | fromdateiso8601)) / 3600 | floor)
+      }
+      end;
+
   # BLOCKING waits, derived from labels. Each of these means development
   # genuinely cannot start, so each one holds an item in Analysis.
   #
@@ -445,13 +507,36 @@ jq -n \
   # A worktree only means work-in-progress while nothing has superseded it.
   # A merged PR for the same issue means the branch already landed and the
   # worktree is just un-pruned rot.
-  # Merged PRs that explicitly CLOSE this issue. Matches only on the extracted
-  # closing references, never on a branch name — see worktree_is_stale for why
-  # branch-name matching is unsafe here. Reported for information; it does not
-  # move a column, because an open issue with a merged fix is the expected state
-  # until the fix graduates to a stable release.
+  #
+  # A merged PR belongs to an issue when EITHER:
+  #   (a) its body carries a work-verb reference (`fixes|closes|resolves|refs|
+  #       part of|tracking` #N -- the `refs` list), OR
+  #   (b) its head branch follows the dispatch convention `.../issue-<n>-...`
+  #       (which `run-agent.sh` and implement-issue Step 4 enforce) AND the
+  #       body still mentions `#n` once cross-reference phrases are stripped
+  #       (the `mentions` list).
+  #
+  # (b) exists because dropping the branch signal the instant a PR merges is
+  # the bug that left #428 reading `Backlog` after PR #705
+  # (`feat/issue-428-consumption-overlay`) shipped it to beta -- #705 links the
+  # issue only as a bare `#428` and a comment URL, no work verb, which is
+  # legitimate under the no-auto-close rule. The `mentions` half is what keeps
+  # (b) narrow: a merged PR on `fix/issue-403-logging` whose body says "Related
+  # to #403. Not closing it" still must NOT flip #403 -- the branch matches but
+  # the only body reference is a cross-ref phrase, which `mentions` has
+  # stripped. `prs_for` trusts the bare branch convention for OPEN PRs; the
+  # merged path is deliberately one notch stricter, because a merged PR moves a
+  # column and an open one does not.
+  #
+  # It still does not CLOSE the issue -- an open issue with a merged fix is the
+  # expected state through beta graduation. It drives the `In Verification`
+  # column and the `merged_prs` visibility list.
+  def merged_matches_issue($p; $n):
+    (($p.refs | index($n)) != null)
+    or (((($p.headRefName // "") | test("issue-\($n)(\\D|$)")))
+        and (($p.mentions | index($n)) != null));
   def merged_pr_for($n):
-    ([ $merged_prs[] | select((.refs | index($n)) != null) ]) as $matches
+    ([ $merged_prs[] | select(merged_matches_issue(.; $n)) ]) as $matches
     | if ($matches | length) == 0 then null else $matches[0].number end;
 
   # Column names match the board`s Status options exactly (Backlog, Analysis,
@@ -550,16 +635,24 @@ jq -n \
                             else "label" end),
           awaiting_suggested: $aw_label,
           last_comment: last_comment(.comments; .author.login),
+          # The last `@claude-bot analyze` trigger and its age -- `{days, hours}`
+          # or null. Drives `refire_analyze` (re-post a Stage 2 run that never
+          # completed) and stands `autonomous_analyze` down while any analyze
+          # comment exists.
+          last_analyze_comment: last_analyze_comment(.comments),
           priority: $prio,
           prs: $open_prs,
-          # Every merged PR whose body references this issue with a WORK verb
-          # (`fixes/closes/resolves/refs/part of/tracking`) -- the visibility
-          # list. `merged_pr` above is the first in the order `gh` returns
-          # (the most recent merge) and drives the In Verification column; this
-          # plural exposes all of them, sorted, so a merged
+          # Every merged PR that belongs to this issue -- a WORK-verb body
+          # reference (`fixes/closes/resolves/refs/part of/tracking`) OR the
+          # `issue-<n>` dispatch branch convention, the same association
+          # `merged_pr_for` uses. `merged_pr` above is the first in the order
+          # `gh` returns (the most recent merge) and drives the In Verification
+          # column; this plural exposes all of them, sorted, so a merged
           # intermediate PR (`Part of #N`, which must not close the issue)
           # stays visible even alongside later PRs.
-          merged_prs: ([ $merged_prs[] | select((.refs | index($i.number)) != null) | .number ] | sort),
+          merged_prs: ([ $merged_prs[]
+                         | select(merged_matches_issue(.; $i.number))
+                         | .number ] | sort),
           merged_pr: $merged_pr,
           worktree: ($wt.path // null),
           worktree_branch: ($wt.branch // null),
@@ -567,12 +660,16 @@ jq -n \
           # what says whether anyone is on the item — see the note where the
           # worktree list is built.
           worktree_locked: ($wt.locked // false),
-          # A worktree whose own branch has already merged is rot, and
-          # `sweep-prs` is what removes it. Flagged so a board pass reports it
-          # instead of reading it as active work: #593, #571, #542 and #466 all
-          # showed "In progress" for exactly this reason while their PRs (#618,
-          # #579, #591, #517) had already merged.
+          # A worktree whose branch has no live PR -- merged, OR closed
+          # unmerged -- is rot, and `sweep-prs` is what removes it. Flagged so a
+          # board pass reports it instead of reading it as active work: #593,
+          # #571, #542 and #466 all showed "In progress" for exactly this reason
+          # while their PRs (#618, #579, #591, #517) had already merged; #428
+          # showed it while its abandoned branch sat behind closed PR #437.
           stale_worktree: $wt_stale,
+          # Why it is stale, ready for the rhythm pass to quote verbatim:
+          # "merged in #N" or "was the head of closed-unmerged PR #N".
+          stale_worktree_reason: ((worktree_dead_pr($wt)).why // null),
           session: session_for(.number),
           resume_count: resume_count(.comments),
           blocked_by: $bb,

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -61,6 +61,32 @@ ANALYSIS_WIP_LIMIT="${RHYTHM_ANALYSIS_WIP_LIMIT:-8}"
 # clears on its own -- so this is a loop retry, not a maintainer escalation.
 ANALYZE_STALE_HOURS="${RHYTHM_ANALYZE_STALE_HOURS:-6}"
 
+# TOOLING FRESHNESS. The board data this pass reads is always live (gh API),
+# but the pass ITSELF -- this script, backlog-digest.sh and the backlog
+# SKILL.md -- runs from whatever checkout the loop was started in, and that is
+# never refreshed mid-loop. The local `main` checkout is routinely stale, so a
+# long-running `/loop /backlog` can be executing week-old logic without a hint
+# of it. A read-only fetch plus a behind-count against origin/main for the
+# tooling paths makes it visible on every path, the same way `WIP n/3` does --
+# it never pulls (wrong in a worktree, and swapping the skill under a live tick
+# is worse than running one tick stale). `RHYTHM_SKIP_FETCH=1` skips only the
+# network call and compares against whatever origin/main is already local;
+# `RHYTHM_TOOLING_REF` overrides the ref. Skipped entirely under the test seam.
+TOOLING_REF="${RHYTHM_TOOLING_REF:-origin/main}"
+tooling_behind=null
+if [ -z "${RHYTHM_DIGEST_FILE:-}" ] \
+   && root=$(git -C "$here" rev-parse --show-toplevel 2>/dev/null); then
+    if [ -z "${RHYTHM_SKIP_FETCH:-}" ]; then
+        git -C "$root" fetch --quiet "${TOOLING_REF%%/*}" 2>/dev/null || true
+    fi
+    if git -C "$root" rev-parse --verify --quiet "$TOOLING_REF" >/dev/null 2>&1; then
+        tooling_behind=$(git -C "$root" rev-list --count \
+            "HEAD..$TOOLING_REF" -- \
+            scripts/backlog-digest.sh scripts/backlog-rhythm.sh \
+            .claude/skills/backlog/ 2>/dev/null || echo null)
+    fi
+fi
+
 # `RHYTHM_DIGEST_FILE` and `RHYTHM_PRS_FILE` are test seams, the same shape as
 # `BESS_ENV_FILE` in gh-agent.sh: they let the rules be exercised against
 # fixtures without a network round-trip or a live board. Unset in normal use.
@@ -94,6 +120,8 @@ actions=$(printf '%s' "$digest" | jq \
     --argjson wip_limit "$WIP_LIMIT" \
     --argjson analysis_wip_limit "$ANALYSIS_WIP_LIMIT" \
     --argjson analyze_stale_hours "$ANALYZE_STALE_HOURS" \
+    --argjson tooling_behind "$tooling_behind" \
+    --arg tooling_ref "$TOOLING_REF" \
     --argjson prs "$prs" \
     --arg owner "$owner" '
   # Board cards for PRs, keyed by number. Absent on an older digest, so this
@@ -715,6 +743,11 @@ actions=$(printf '%s' "$digest" | jq \
       # for the same reason as `wip`: when the pass pulls nothing new into
       # analysis, the operator needs to see it is because the column is full.
       analysis: {count: $analysis_wip, limit: $analysis_wip_limit, over: $analysis_over},
+      # Commits on `$tooling_ref` not in HEAD that touch the backlog scripts or
+      # SKILL.md -- i.e. how far behind the logic running right now is. null
+      # when the check was skipped (test seam, not a git repo, ref not present,
+      # or the fetch/rev-list failed). Reported on every path like `wip`.
+      tooling: {behind: $tooling_behind, ref: $tooling_ref},
       # PRs whose diff could not be read this pass -- see $collision_unknown
       # above. Reported the same way $wip is: a count and the list, on every
       # path, because a suppressed dispatch queue that does not say why is
@@ -791,6 +824,15 @@ analysis_line=$(printf '%s' "$actions" | jq -r '.analysis
                   + " -- promote analysed items to Ready for Dev before analysing more"
     else "  ANALYSIS " + (.count|tostring) + "/" + (.limit|tostring) end')
 
+# Also every-path: the logic running this tick is behind origin/main. Empty
+# unless the check ran AND found the backlog tooling stale -- a fresh or
+# skipped check says nothing.
+tooling_line=$(printf '%s' "$actions" | jq -r '.tooling
+  | if (.behind // 0) > 0
+    then "  TOOLING " + (.behind|tostring) + " commit(s) behind " + .ref
+         + " -- restart the loop from an updated checkout"
+    else "" end')
+
 # Also reported on every path, same reasoning as $wip_line: a non-empty
 # undiffable set silently holds every dispatchable action shut, and that is
 # exactly the moment the operator needs to be told why.
@@ -805,6 +847,7 @@ if [ "$due" -eq 0 ]; then
     echo "RHYTHM: nothing due."
     printf '%s\n' "$wip_line"
     printf '%s\n' "$analysis_line"
+    [ -n "$tooling_line" ] && printf '%s\n' "$tooling_line"
     [ -n "$undiffable_line" ] && printf '%s\n' "$undiffable_line"
     [ -n "$deferred_line" ] && printf '%s\n' "$deferred_line"
     exit 0
@@ -813,6 +856,7 @@ fi
 echo "RHYTHM: $due action(s) due"
 printf '%s\n' "$wip_line"
 printf '%s\n' "$analysis_line"
+[ -n "$tooling_line" ] && printf '%s\n' "$tooling_line"
 [ -n "$undiffable_line" ] && printf '%s\n' "$undiffable_line"
 printf '%s' "$actions" | jq -r '
   "",

--- a/scripts/backlog-rhythm.sh
+++ b/scripts/backlog-rhythm.sh
@@ -44,6 +44,23 @@ PARK_DAYS="${RHYTHM_PARK_DAYS:-28}"
 # variable so the tests can drive the boundary.
 WIP_LIMIT="${RHYTHM_WIP_LIMIT:-3}"
 
+# FLOW POLICY: the Analysis WIP limit. The same "empty the board from the right"
+# rule one column further left -- analysis is only useful once its output
+# reaches Ready for Dev, so an Analysis column carrying 18 items is 18 pieces of
+# half-finished work, not progress. At or above this, the pass stops pulling new
+# items in: `autonomous_analyze` is suppressed (still counted and listed, like a
+# deferred PR) and the pass reports `ANALYSIS n/limit` on every path. It does
+# NOT gate `refire_analyze` -- re-poking a Stage 2 run that never completed
+# finishes an item already in Analysis rather than adding one.
+ANALYSIS_WIP_LIMIT="${RHYTHM_ANALYSIS_WIP_LIMIT:-8}"
+
+# How long a `@claude-bot analyze` trigger may sit with the item still
+# `ready-for-analysis` and unstamped before the pass treats the run as failed
+# and re-fires it. Stage 2 normally completes in minutes; the common cause of a
+# no-op run is the workflow being out of API credit, which a later re-fire
+# clears on its own -- so this is a loop retry, not a maintainer escalation.
+ANALYZE_STALE_HOURS="${RHYTHM_ANALYZE_STALE_HOURS:-6}"
+
 # `RHYTHM_DIGEST_FILE` and `RHYTHM_PRS_FILE` are test seams, the same shape as
 # `BESS_ENV_FILE` in gh-agent.sh: they let the rules be exercised against
 # fixtures without a network round-trip or a live board. Unset in normal use.
@@ -75,6 +92,8 @@ actions=$(printf '%s' "$digest" | jq \
     --argjson nudge "$NUDGE_DAYS" \
     --argjson park "$PARK_DAYS" \
     --argjson wip_limit "$WIP_LIMIT" \
+    --argjson analysis_wip_limit "$ANALYSIS_WIP_LIMIT" \
+    --argjson analyze_stale_hours "$ANALYZE_STALE_HOURS" \
     --argjson prs "$prs" \
     --arg owner "$owner" '
   # Board cards for PRs, keyed by number. Absent on an older digest, so this
@@ -87,6 +106,13 @@ actions=$(printf '%s' "$digest" | jq \
   # and its PR. Counting them separately would silently double the limit.
   ([ .items[] | select(.column == "In Progress" or .column == "In Review") ] | length) as $wip
   | ($wip >= $wip_limit) as $over_wip
+  |
+
+  # The Analysis column, counted the same way -- one flow-policy step to the
+  # left of the dispatch WIP limit. At or above the limit, no new item enters
+  # analysis until analysed ones are promoted to Ready for Dev.
+  ([ .items[] | select(.column == "Analysis") ] | length) as $analysis_wip
+  | ($analysis_wip >= $analysis_wip_limit) as $analysis_over
   |
 
   # The collision gate. $in_flight is the EXACT half -- every open PRs
@@ -230,13 +256,40 @@ actions=$(printf '%s' "$digest" | jq \
     # the pass entirely -- the #681/#680 failure, where the carve-out was only
     # ever evaluated on items the pass surfaced. Stage 2 removes
     # `ready-for-analysis` when it runs, so this fires at most until analysis
-    # lands; confirming there is no prior `@claude-bot analyze` comment stays
-    # a PO-time check in the backlog skill before the spend, which is also
-    # what catches an analyze that is still in flight.
-    (if tier1_ready
+    # lands.
+    #
+    # The no-prior-analyze check is now IN THE SCRIPT (`last_analyze_comment`),
+    # not left to the PO to remember: `autonomous_analyze` fires only when the
+    # issue has never been analyzed. A prior trigger that is still in flight
+    # (younger than the staleness window) means neither this nor `refire_analyze`
+    # fires -- the pass simply waits. `$analysis_over` suppresses it too: the
+    # Analysis column is full, so nothing new is pulled in until analysed items
+    # reach Ready for Dev (the item stays visible in `analysis_wip` below).
+    (if tier1_ready and .last_analyze_comment == null and ($analysis_over | not)
      then {issue: .number, action: "autonomous_analyze",
-           why: "tier-1 bug: \(.author), debug log attached, no analyzed/needs-human-review label",
-           detail: "fire Stage 2 as the PO, after confirming no prior @claude-bot analyze comment: scripts/gh-agent.sh --as po issue comment \(.number) --body \"@claude-bot analyze\""}
+           why: "tier-1 bug: \(.author), debug log attached, no analyzed/needs-human-review label, never analyzed",
+           detail: "fire Stage 2 as the PO: scripts/gh-agent.sh --as po issue comment \(.number) --body \"@claude-bot analyze\""}
+     elif tier1_ready and .last_analyze_comment == null and $analysis_over
+     then {issue: .number, action: "analysis_deferred",
+           why: "tier-1 bug ready to analyse, held: Analysis WIP \($analysis_wip)/\($analysis_wip_limit)",
+           detail: "do not fire Stage 2 -- promote an analysed item to Ready for Dev first; this re-proposes once Analysis is under the limit"}
+     else empty end),
+
+    # A Stage 2 run that never landed. `tier1_ready` still holds (Stage 2 would
+    # have removed `ready-for-analysis` and stamped a label), a `@claude-bot
+    # analyze` trigger is on the issue, and it has aged past the staleness
+    # window -- so the workflow accepted the trigger and produced nothing,
+    # almost always because it had no API credit at the time. Under `/loop`
+    # this is a plain retry: re-post the trigger as the PO. NOT a maintainer
+    # escalation, and not gated by `$analysis_over` -- the item is already in
+    # Analysis, this finishes it rather than adding new work.
+    (if tier1_ready
+        and .last_analyze_comment != null
+        and (.last_analyze_comment.hours >= $analyze_stale_hours)
+        and ((.prs | length) == 0)
+     then {issue: .number, action: "refire_analyze",
+           why: "@claude-bot analyze fired \(.last_analyze_comment.hours)h ago, still ready-for-analysis with no analyzed/needs-human-review label -- Stage 2 did not complete",
+           detail: "re-fire as the PO (a no-op run is usually an out-of-credit workflow; the loop retries): scripts/gh-agent.sh --as po issue comment \(.number) --body \"@claude-bot analyze\""}
      else empty end),
 
     # Grooming debt: the board field is unset while a label implies a wait, so
@@ -272,10 +325,12 @@ actions=$(printf '%s' "$digest" | jq \
            detail: "move the card to \(.column)"}
      else empty end),
 
-    # Un-pruned worktrees are what made four issues read as In Progress.
+    # Un-pruned worktrees are what made four issues read as In Progress. The
+    # branch is dead either because it merged or because its PR was closed
+    # unmerged -- `stale_worktree_reason` from the digest says which.
     (if .stale_worktree
      then {issue: .number, action: "prune_worktree",
-           why: "worktree \(.worktree_branch) already merged",
+           why: "worktree \(.worktree_branch) \(.stale_worktree_reason // "already landed")",
            detail: "hand to sweep-prs"}
      else empty end),
 
@@ -634,12 +689,16 @@ actions=$(printf '%s' "$digest" | jq \
        elif .action == "resume_implementation" or .action == "prune_worktree" then 3
        elif .action == "dispatchable" or .action == "queued_behind"
             or .action == "cluster" or .action == "needs_touch_set" then 4
+       # refire_analyze finishes an Analysis item that stalled; it ranks with
+       # the other Analysis-column actions. (A given item is either this or
+       # autonomous_analyze, never both -- a prior analyze comment decides.)
        elif .action == "recheck_ready" or .action == "surface_discussion"
             or .action == "nudge_reporter" or .action == "park"
+            or .action == "refire_analyze"
             or .action == "autonomous_analyze" then 5
        elif .action == "set_awaiting" or .action == "add_card"
             or .action == "set_priority" or .action == "move_card"
-            or .action == "archive_pr_card"
+            or .action == "archive_pr_card" or .action == "analysis_deferred"
             or .action == "triage_labels" then 6
        # Rank 9 is not a column. It is the catch-all for an action name
        # this function does not know about -- its rank branch is missing,
@@ -652,6 +711,10 @@ actions=$(printf '%s' "$digest" | jq \
   | {
       due: length,
       wip: {count: $wip, limit: $wip_limit, over: $over_wip},
+      # The Analysis column against its own WIP limit, reported the same way and
+      # for the same reason as `wip`: when the pass pulls nothing new into
+      # analysis, the operator needs to see it is because the column is full.
+      analysis: {count: $analysis_wip, limit: $analysis_wip_limit, over: $analysis_over},
       # PRs whose diff could not be read this pass -- see $collision_unknown
       # above. Reported the same way $wip is: a count and the list, on every
       # path, because a suppressed dispatch queue that does not say why is
@@ -721,6 +784,13 @@ wip_line=$(printf '%s' "$actions" | jq -r '.wip
                   + " -- finish before starting; dispatch suppressed"
     else "  WIP " + (.count|tostring) + "/" + (.limit|tostring) end')
 
+# Same contract as $wip_line: printed on every path, including "nothing due", so
+# a pass that pulls nothing new into analysis says why.
+analysis_line=$(printf '%s' "$actions" | jq -r '.analysis
+  | if .over then "  ANALYSIS " + (.count|tostring) + "/" + (.limit|tostring)
+                  + " -- promote analysed items to Ready for Dev before analysing more"
+    else "  ANALYSIS " + (.count|tostring) + "/" + (.limit|tostring) end')
+
 # Also reported on every path, same reasoning as $wip_line: a non-empty
 # undiffable set silently holds every dispatchable action shut, and that is
 # exactly the moment the operator needs to be told why.
@@ -734,6 +804,7 @@ due=$(printf '%s' "$actions" | jq -r '.due')
 if [ "$due" -eq 0 ]; then
     echo "RHYTHM: nothing due."
     printf '%s\n' "$wip_line"
+    printf '%s\n' "$analysis_line"
     [ -n "$undiffable_line" ] && printf '%s\n' "$undiffable_line"
     [ -n "$deferred_line" ] && printf '%s\n' "$deferred_line"
     exit 0
@@ -741,6 +812,7 @@ fi
 
 echo "RHYTHM: $due action(s) due"
 printf '%s\n' "$wip_line"
+printf '%s\n' "$analysis_line"
 [ -n "$undiffable_line" ] && printf '%s\n' "$undiffable_line"
 printf '%s' "$actions" | jq -r '
   "",


### PR DESCRIPTION
## Why

A shipped-in-beta issue (#428) kept being reported as `resume_implementation` on every rhythm tick, and the board pass read it as un-started work. Root cause: the digest associated #428 with the abandoned earlier branch behind **closed** PR #437, and never associated it with **merged** PR #705 (which shipped it). Plus three adjacent asks from the same review:

- an **Analysis WIP limit** — 18 items were sitting in Analysis while the pass kept pulling a new bug in for Stage 2;
- a **stalled Stage 2** (`@claude-bot analyze` fired, no result ~34h later — normally an out-of-credit workflow) should just **re-fire** in the loop, not tell the maintainer to investigate;
- the loop should surface when **its own logic is stale** — board data is live, but the scripts/skill are whatever the checkout was at when the loop started;
- a recorded wait (`Awaiting: discussion`, `blocked`) was **promoting** raw Backlog items into Analysis and then fighting a human who moved them back (#703).

## Changes

### `scripts/backlog-digest.sh`
- **New `closed_prs` gather.** `worktree_is_stale` now also covers a worktree whose branch is the exact head of a PR closed **without merging** — an abandoned attempt, not resumable work. New `stale_worktree_reason`: `"merged in #N"` / `"was the head of closed-unmerged PR #N"`.
- **`merged_pr_for` associates a merged PR by the `issue-<n>` dispatch branch convention**, but only when a non-cross-ref `#n` body mention corroborates it (new `mentions` list). #705 shipped #428 with no closing verb (no-auto-close rule) → now maps to #428 → **In Verification**. The `mentions` guard keeps `"Related to #403. Not closing it"` from flipping #403 (both pre-existing guard tests still pass).
- **New `last_analyze_comment`** field — most recent `@claude-bot analyze` trigger + `{days, hours}`.
- **`column()` wait override is now a floor-lower, not a set (#703).** The #707 rule ("a recorded wait pulls the item *back* to Analysis") was applied unconditionally, so `Awaiting: discussion` on a bare Backlog musing promoted it to Analysis — creating a `board_status != column` mismatch that made `move_card` yank the card back to Analysis minutes after a human moved it to Backlog. Now the artifact/label column is computed first (`$natural`); the wait rewrites it only when `$natural` is right of Analysis. Backlog + wait is a no-op; the `awaiting` field still drives the nudge/park/surface timers. The #96 demotion case (analyzed + priority + wait → Analysis) is unchanged.

### `scripts/backlog-rhythm.sh`
- `stale_worktree` → `prune_worktree` (not `resume_implementation`); why-line quotes `stale_worktree_reason`.
- **Analysis WIP limit** (`RHYTHM_ANALYSIS_WIP_LIMIT`, default **8**). At/over the limit `autonomous_analyze` is suppressed; the held tier-1 bug surfaces as **`analysis_deferred`** (counted, listed, never dropped). New `ANALYSIS n/limit` line on every path.
- **New `refire_analyze`** — trigger older than `RHYTHM_ANALYZE_STALE_HOURS` (default **6h**) with the item still `ready-for-analysis` and unstamped → re-post the trigger as the PO. Not a maintainer escalation. Younger than the window: fire neither `refire_analyze` nor `autonomous_analyze`.
- `autonomous_analyze` self-checks "never analyzed" via `last_analyze_comment == null` (was a manual PO step).
- **Tooling-freshness warning.** Each tick does a read-only `git fetch` and counts commits on `origin/main` not in `HEAD` touching `scripts/backlog-*.sh` / `.claude/skills/backlog/`, printing `TOOLING n commit(s) behind origin/main -- restart the loop from an updated checkout` on every path. It **never pulls** (wrong in a worktree; swapping the skill under a live tick is worse than one stale tick). `RHYTHM_SKIP_FETCH=1` skips the network call, `RHYTHM_TOOLING_REF` overrides the ref; inert under the test seam.

### `.claude/skills/backlog/SKILL.md`
Stale-worktree rows, new action-table entries (`refire_analyze`, `analysis_deferred`), "The Analysis WIP limit: 8" section, Autonomous-spend rewrite, tooling-freshness note.

## Testing
- `backend/tests/test_backlog_digest.py` / `test_backlog_rhythm.py`: **+11 test functions, 183 pass**.
- `./scripts/quality-check.sh`: fast tests, Black, Ruff, mypy(changed), permission surface, bot-workflow contracts, markdown — all green. The one `❌ Frontend tests failed` is pre-existing (`git diff --stat HEAD -- frontend/` is empty).

## Tunables
`RHYTHM_ANALYSIS_WIP_LIMIT=8` and `RHYTHM_ANALYZE_STALE_HOURS=6` are env-overridable defaults — adjust in `backlog-rhythm.sh` if the values don't feel right in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
